### PR TITLE
test: fuzzing over untrusted inputs, linked security policy

### DIFF
--- a/SECURITY.fr.md
+++ b/SECURITY.fr.md
@@ -6,9 +6,15 @@ Pépin est un outil de sécurité : sa fiabilité est une exigence, pas une opti
 
 ## Signaler une vulnérabilité
 
-Merci de **ne pas** ouvrir d'issue publique pour une vulnérabilité. Utilisez le
-canal privé de signalement des vulnérabilités de GitHub (**Security → Report a
-vulnerability**), ou contactez le mainteneur par un canal privé.
+Merci de **ne pas** ouvrir d'issue publique pour une vulnérabilité.
+
+Signalez-la en privé ici :
+**https://github.com/stephrobert/pepin/security/advisories/new**
+(GitHub → **Security** → **Report a vulnerability**). L'avis reste privé entre
+vous et le mainteneur jusqu'à la publication d'un correctif.
+
+Si ce formulaire ne vous est pas accessible, contactez le mainteneur par un canal
+privé plutôt que par une issue publique.
 
 Merci d'inclure :
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,15 @@ Pépin is a security tool: its reliability is a requirement, not an option.
 
 ## Reporting a vulnerability
 
-Please do **not** open a public issue for a vulnerability. Use GitHub's private
-vulnerability reporting (**Security → Report a vulnerability**), or contact the
-maintainer through a private channel.
+Please do **not** open a public issue for a vulnerability.
+
+Report it privately here:
+**https://github.com/stephrobert/pepin/security/advisories/new**
+(GitHub → **Security** → **Report a vulnerability**). The advisory stays private
+between you and the maintainer until a fix ships.
+
+If that form is unavailable to you, contact the maintainer through any private
+channel rather than a public issue.
 
 Please include:
 

--- a/cmd/fuzz_test.go
+++ b/cmd/fuzz_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// FuzzInventoryWalk — l'export d'inventaire est fourni par un TIERS
+// (`pepin scan <provider> export.json`), décodé en `any`, puis parcouru par
+// resourceTypesOf et attrsByTypeOf avant toute évaluation.
+//
+// Ces deux fonctions décident de ce que le verdict a le droit d'affirmer :
+// attrsByTypeOf alimente le verrou de capacité, celui qui autorise ou non un
+// « pass ». Une panique y ferait tomber le scan sur une entrée choisie par
+// l'audité ; une lecture trop permissive lui ferait affirmer une conformité
+// jamais mesurée. Les deux sont couverts ici : pas de panique, et un attribut
+// n'est jamais compté comme collecté si sa valeur est une collection vide.
+func FuzzInventoryWalk(f *testing.F) {
+	for _, p := range []string{
+		"../examples/scaleway/inventory.json",
+		"../examples/scaleway/inventory-ok.json",
+	} {
+		if b, err := os.ReadFile(p); err == nil {
+			f.Add(b)
+		}
+	}
+	f.Add([]byte(`{"resources":[]}`))
+	f.Add([]byte(`{"resources":null}`))
+	f.Add([]byte(`{"resources":"pas-un-tableau"}`))
+	f.Add([]byte(`{"resources":[{"type":"bucket","attributes":null}]}`))
+	f.Add([]byte(`{"resources":[{"type":"bucket","attributes":"boom"}]}`))
+	f.Add([]byte(`{"resources":[{"type":123,"attributes":{"acl":[]}}]}`))
+	f.Add([]byte(`[]`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`"chaine"`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var input any
+		if err := json.Unmarshal(data, &input); err != nil {
+			return // un JSON invalide est refusé en amont, pas notre sujet
+		}
+
+		// Aucun des deux parcours ne doit paniquer, quelle que soit la forme.
+		_ = resourceTypesOf(input)
+		attrs := attrsByTypeOf(input)
+
+		// Le verrou de capacité repose sur une propriété précise : une valeur
+		// vide n'est PAS une collecte. C'est ce qui empêche `statements: []`,
+		// toujours posé par le collecteur IAM, de faire conclure « conforme »
+		// sur zéro information. On la vérifie ici sur des entrées arbitraires.
+		m, ok := input.(map[string]any)
+		if !ok {
+			return
+		}
+		rs, ok := m["resources"].([]any)
+		if !ok {
+			return
+		}
+		for _, it := range rs {
+			rm, ok := it.(map[string]any)
+			if !ok {
+				continue
+			}
+			typ, ok := rm["type"].(string)
+			if !ok || typ == "" {
+				continue
+			}
+			am, ok := rm["attributes"].(map[string]any)
+			if !ok {
+				continue
+			}
+			for k, v := range am {
+				switch vv := v.(type) {
+				case []any:
+					if len(vv) == 0 && attrs[typ][k] {
+						t.Fatalf("attribut %q de type %q compté comme collecté alors qu'il est une liste vide", k, typ)
+					}
+				case map[string]any:
+					if len(vv) == 0 && attrs[typ][k] {
+						t.Fatalf("attribut %q de type %q compté comme collecté alors qu'il est un objet vide", k, typ)
+					}
+				case nil:
+					if attrs[typ][k] {
+						t.Fatalf("attribut %q de type %q compté comme collecté alors qu'il est nul", k, typ)
+					}
+				}
+			}
+		}
+	})
+}

--- a/internal/tfparse/fuzz_test.go
+++ b/internal/tfparse/fuzz_test.go
@@ -1,0 +1,57 @@
+package tfparse
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// FuzzParsePlan — un plan Terraform est une entrée NON FIABLE : il est produit
+// par le dépôt audité, pas par pepin. CLAUDE.md §5 impose de le parser
+// défensivement et interdit la panique sur une telle entrée.
+//
+// L'audit de livraison a éprouvé neuf formes malformées à la main (null, [],
+// types inversés, imbrication à 8 000 niveaux) sans provoquer de panique. Ce
+// fuzz rend la vérification continue plutôt que ponctuelle : toute forme que
+// personne n'a imaginée est couverte par construction.
+//
+// Le contrat éprouvé est simple et volontairement faible : ParsePlan rend un
+// résultat OU une erreur, jamais une panique, et jamais une ressource sans type.
+// Un plan absurde a le droit d'être refusé ; il n'a pas le droit de faire tomber
+// le scanner, car c'est le tiers audité qui choisit ce fichier.
+func FuzzParsePlan(f *testing.F) {
+	// Graines : les plans réels du dépôt, plus les formes dégénérées connues.
+	for _, p := range []string{
+		"../../examples/scaleway/terraform/plan.json",
+		"../../examples/exoscale/terraform/plan.json",
+		"../../examples/exoscale/lab-imds/plan.json",
+	} {
+		if b, err := os.ReadFile(p); err == nil {
+			f.Add(b)
+		}
+	}
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`[]`))
+	f.Add([]byte(`{"planned_values":null}`))
+	f.Add([]byte(`{"planned_values":{"root_module":{"resources":"pas-un-tableau"}}}`))
+	f.Add([]byte(`{"planned_values":{"root_module":{"child_modules":[{"child_modules":[]}]}}}`))
+	f.Add([]byte(`{"values":{"root_module":{"resources":[{"type":123,"values":null}]}}}`))
+
+	dir := f.TempDir()
+	f.Fuzz(func(t *testing.T, data []byte) {
+		path := filepath.Join(dir, "plan.json")
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Skip() // défaut d'écriture : hors sujet pour ce qu'on mesure
+		}
+		res, err := ParsePlan(path)
+		if err != nil {
+			return // refuser une entrée absurde est le comportement attendu
+		}
+		for i, r := range res {
+			if r.Type == "" {
+				t.Fatalf("ressource %d acceptée sans type : une règle la classerait nulle part", i)
+			}
+		}
+	})
+}

--- a/internal/tfparse/testdata/fuzz/FuzzParsePlan/49d8096f46dba058
+++ b/internal/tfparse/testdata/fuzz/FuzzParsePlan/49d8096f46dba058
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"vAlues\":{\"root_module\":{\"resourCes\":[{}]}}}")

--- a/internal/tfparse/tfparse.go
+++ b/internal/tfparse/tfparse.go
@@ -80,6 +80,16 @@ func ParsePlan(path string) ([]Resource, error) {
 // d'osc-policy sur planned_values).
 func collect(out *[]Resource, m module) {
 	for _, r := range m.Resources {
+		// Une ressource sans type n'est évaluable par AUCUNE règle : toutes
+		// sélectionnent par `resources_of_type(...)`. La laisser entrer ajoute une
+		// entrée que rien ne contrôle et pollue le relevé des types collectés, sur
+		// lequel repose le verrou de capacité. Trouvé par FuzzParsePlan, sur un plan
+		// où `resources: [{}]` — encoding/json apparie les clés sans tenir compte de
+		// la casse, donc un plan forgé atteint ce chemin plus facilement qu'il n'y
+		// paraît.
+		if r.Type == "" {
+			continue
+		}
 		*out = append(*out, Resource{Type: r.Type, Name: r.Name, Address: r.Address, Values: r.Values})
 	}
 	for _, child := range m.ChildModules {


### PR DESCRIPTION
Traite #7 et #8.

## #8 — fuzzing

pepin ingère des entrées qu'il ne contrôle pas : un plan Terraform et un export d'inventaire viennent tous deux du tiers audité. Deux cibles de fuzz couvrent ces deux chemins ; leur corpus de graine rejoue à chaque `go test`, sans configuration de CI.

`FuzzParsePlan` a trouvé un vrai cas en 30 secondes :

```
{"vAlues":{"root_module":{"resourCes":[{}]}}}
```

Deux enseignements. `encoding/json` apparie les tags **sans tenir compte de la casse**, donc un plan forgé atteint ce chemin plus facilement qu'il n'y paraît. Et une ressource sans type n'est évaluable par **aucune** règle — toutes sélectionnent via `resources_of_type` — alors qu'elle compte dans le relevé des types sur lequel s'appuie le verrou de capacité. `collect()` l'ignore désormais, et l'entrée fautive est versionnée en régression.

`FuzzInventoryWalk` couvre l'autre moitié : aucune panique dans `resourceTypesOf`/`attrsByTypeOf`, et la propriété dont dépend le verrou — une collection vide n'est jamais comptée comme collectée, ce qui empêche `statements: []` de conclure « conforme » sur rien.

Après correction : 769 782 et 765 151 exécutions sans crash.

## #7 — politique de sécurité

`SECURITY.md` décrivait le canal de signalement privé sans jamais le lier, d'où le score 4/10. Les deux langues portent maintenant l'URL de l'advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)