### PR TITLE
fix(collect): stop inventing an empty collection for an absent source key

### DIFF
--- a/internal/collect/engine.go
+++ b/internal/collect/engine.go
@@ -290,6 +290,17 @@ func Project(item any, mapping map[string]string, transforms map[string]any) map
 	for attr, path := range mapping {
 		v := lookupCoalesce(item, path)
 		if t, ok := transforms[attr]; ok {
+			// `kv`/`list` fabriquent une COLLECTION VIDE même sur nil, pour préserver
+			// « présent mais vide » (des tags déclarés et vides sont une information).
+			// Cette sémantique ne vaut que si la clé EXISTE réellement dans la source.
+			// Sur un plan Terraform, un attribut encore inconnu (`unknown after apply`)
+			// est simplement ABSENT de `planned_values` : fabriquer `[]` ferait croire
+			// à une collecte réussie, franchirait la garde de capacité de la règle et
+			// produirait un faux positif. C'est le cas d'une instance dont le groupe de
+			// sécurité est créé par le même plan — la configuration la plus courante.
+			if v == nil && !sourcePresent(item, path) {
+				continue
+			}
 			v = applyTransform(v, t)
 		}
 		if v == nil {
@@ -337,6 +348,59 @@ func withParent(it any, parent map[string]any) any {
 }
 
 // lookupCoalesce résout un chemin, avec coalescence "a||b" (premier non-nul).
+// sourcePresent indique que le chemin EXISTE dans la source, indépendamment de sa
+// valeur. C'est la distinction que `lookup` ne fait pas : il rend nil aussi bien
+// pour une clé absente que pour une clé présente à null, alors que les deux ne
+// disent pas la même chose. « Absent » signifie que la source n'expose pas
+// l'information ; « présent et vide » est une information à part entière.
+//
+// Un chemin `a||b` est présent dès que l'une de ses alternatives l'est.
+func sourcePresent(it any, path string) bool {
+	if !strings.Contains(path, "||") {
+		return pathExists(it, path)
+	}
+	for _, p := range strings.Split(path, "||") {
+		if pathExists(it, strings.TrimSpace(p)) {
+			return true
+		}
+	}
+	return false
+}
+
+// pathExists parcourt le chemin comme lookup, mais rend la PRÉSENCE de la
+// dernière clé plutôt que sa valeur.
+func pathExists(v any, path string) bool {
+	if path == "" {
+		return v != nil
+	}
+	keys := strings.Split(path, ".")
+	for i, key := range keys {
+		switch c := v.(type) {
+		case map[string]any:
+			next, ok := c[key]
+			if !ok {
+				return false
+			}
+			if i == len(keys)-1 {
+				return true
+			}
+			v = next
+		case []any:
+			idx, err := strconv.Atoi(key)
+			if err != nil || idx < 0 || idx >= len(c) {
+				return false
+			}
+			if i == len(keys)-1 {
+				return true
+			}
+			v = c[idx]
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 func lookupCoalesce(it any, path string) any {
 	if !strings.Contains(path, "||") {
 		return lookup(it, path)

--- a/internal/collect/engine_test.go
+++ b/internal/collect/engine_test.go
@@ -512,6 +512,56 @@ func TestProjectOmitsAbsentAttributes(t *testing.T) {
 	}
 }
 
+// Un transform de COLLECTION (`list`, `kv`) fabrique une collection vide même sur
+// nil, pour préserver « présent mais vide ». Cette sémantique ne vaut que si la clé
+// existe réellement : sur un plan Terraform, un attribut encore inconnu
+// (`unknown after apply`) est simplement ABSENT de `planned_values`, et fabriquer
+// `[]` faisait croire à une collecte réussie.
+//
+// Conséquence mesurée avant correction : une instance Scaleway dont le groupe de
+// sécurité est créé par le même plan — la configuration la plus courante — recevait
+// un finding CRITICAL « VM sans groupe de sécurité ». Un faux positif sur le cas
+// nominal coûte plus cher qu'un contrôle non évalué : il apprend à ignorer l'outil.
+func TestProjectDistinguishesAbsentFromEmptyCollection(t *testing.T) {
+	mapping := map[string]string{"security_group_ids": "security_group_id"}
+	transforms := map[string]any{"security_group_ids": "list"}
+
+	// Clé ABSENTE (plan Terraform, id encore inconnu) : rien ne doit être projeté,
+	// pour que la garde de capacité de la règle reste fermée.
+	absent := Project(map[string]any{"id": "srv-1"}, mapping, transforms)
+	if _, present := absent["security_group_ids"]; present {
+		t.Errorf("clé absente de la source : ne doit pas être projetée, got %v", absent["security_group_ids"])
+	}
+
+	// Clé PRÉSENTE à nil (l'API dit explicitement « aucun ») : collection vide
+	// projetée, l'information « aucun groupe » est réelle et doit être évaluée.
+	explicitNil := Project(map[string]any{"security_group_id": nil}, mapping, transforms)
+	got, present := explicitNil["security_group_ids"]
+	if !present {
+		t.Fatal("clé présente à nil : la collection vide doit être projetée")
+	}
+	if arr, ok := got.([]any); !ok || len(arr) != 0 {
+		t.Errorf("attendu une collection vide, got %#v", got)
+	}
+
+	// Clé PRÉSENTE avec une valeur : comportement inchangé.
+	withValue := Project(map[string]any{"security_group_id": "sg-1"}, mapping, transforms)
+	arr, ok := withValue["security_group_ids"].([]any)
+	if !ok || len(arr) != 1 || arr[0] != "sg-1" {
+		t.Errorf("valeur scalaire mal enveloppée en liste : %#v", withValue["security_group_ids"])
+	}
+
+	// Chemin `a||b` : présent dès qu'une alternative l'est.
+	coalesce := map[string]string{"tags": "labels||tags"}
+	kv := map[string]any{"tags": "kv"}
+	if out := Project(map[string]any{"tags": map[string]any{}}, coalesce, kv); len(out) != 1 {
+		t.Errorf("chemin coalescé : la clé présente doit être projetée, got %+v", out)
+	}
+	if out := Project(map[string]any{"autre": 1}, coalesce, kv); len(out) != 0 {
+		t.Errorf("chemin coalescé : aucune alternative présente, rien ne doit être projeté, got %+v", out)
+	}
+}
+
 func TestValidateTransform(t *testing.T) {
 	// Connus : bare, préfixés, chaînage, table de remplacement.
 	for _, ok := range []any{


### PR DESCRIPTION
Trouvé en rejouant contre le binaire les **quinze stacks Terraform de tiers** recensées dans `feint` (`examples/stacks/surveyed.md`). Reproducteur d'origine : `Rookain-Kiwi/kiwinet-infra-cloud`.

## Le défaut

Une instance Scaleway dont le groupe de sécurité est créé **par le même plan** — la configuration la plus ordinaire qui soit — était rapportée `CRITICAL CLD-CMP-1 : VM sans groupe de sécurité`. Le `server.tf` référence pourtant bien son SG.

## La chaîne causale

1. au stade plan, `security_group_id` est *unknown after apply*, donc **absent** de `planned_values` ;
2. `providers/scaleway.yaml` mappe `security_group_ids` avec `transforms: {security_group_ids: list}` ;
3. dans `internal/collect/engine.go`, la garde nil **exempte délibérément** `list` et `kv`, parce qu'un transform de collection doit préserver « présent mais vide » : des tags déclarés et vides sont une information réelle ;
4. appliquée à une clé **absente**, cette même règle fabrique `[]` ;
5. la garde de capacité de la règle (`"security_group_ids" in object.keys(vm.attributes)`) est alors satisfaite, et le finding part.

La garde existe précisément pour empêcher ce cas. On lui présentait une valeur qui *avait l'air* collectée.

## Le correctif

Séparer les deux situations : un transform de collection ne s'applique que si la clé source **existe** réellement. `lookup` ne savait pas les distinguer (nil dans les deux cas), d'où `sourcePresent`/`pathExists`, qui répondent la présence plutôt que la valeur, chemins `a||b` compris.

Le chemin **live** en bénéficie aussi : une API qui omet une clé produisait le même `[]` fabriqué.

## Mesures

- la fixture Terraform du dépôt rend **10 findings avant et après** : aucune détection perdue ;
- le cas nominal passe de `CRITICAL` à `not-evaluated`, avec sa raison affichée ;
- `go test ./... -race` vert, **247/247** tests Rego.

## L'arbitrage, dit franchement

Sur un plan, une instance réellement dépourvue de SG est **indistinguable** d'une instance dont le SG n'est pas encore connu : dans les deux cas la clé est absente. Pépin ne peut donc pas trancher, et répond désormais « non évalué » au lieu de deviner.

Un faux positif `critical` sur le cas nominal coûte plus cher qu'un contrôle non évalué : il apprend à ignorer l'outil. Restaurer la détection demanderait de lire `configuration.root_module.resources[].expressions`, qui porte les **références** même non résolues — un travail distinct, à traiter à part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
