### PR TITLE
fix(action): give the attestation check the token it needs

### DIFF
--- a/.github/actions/pepin-scan/action.yml
+++ b/.github/actions/pepin-scan/action.yml
@@ -122,6 +122,14 @@ runs:
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
+        # `gh attestation verify` calls the GitHub API and refuses to run in a
+        # workflow without a token. Without this line the installer failed on
+        # EVERY consumer -- provenance unverified, installation refused -- which
+        # is the release job's own action-proof catching it. The action supplies
+        # the token itself rather than making it an input: the caller should not
+        # have to wire one up to install a binary, and `github.token` already
+        # carries the read access the attestation API needs on a public repo.
+        GH_TOKEN: ${{ github.token }}
       # The PATH line lets later steps of the calling job run `pepin` (verify a
       # bundle, re-scan). What lands on the PATH is RUNNER_TEMP, a value the
       # runner owns, holding a binary whose checksum was verified one line

--- a/.github/workflows/entrypoints.yml
+++ b/.github/workflows/entrypoints.yml
@@ -224,3 +224,40 @@ jobs:
           run_case 2 env PROVIDER=scaleway INVENTORY=/absent.json FAIL_ON_NONCONFORMITY=false
           run_case 2 env PROVIDER=scaleway
           echo "les quatre chemins répondent le code documenté"
+
+  # Le chemin PUBLIC de l'action, celui qu'un consommateur emprunte : pas d'URL
+  # de base, pas de saut d'attestation, l'action appelée comme on l'appelle
+  # dehors. Les tests ci-dessus servent install.sh en boucle locale avec
+  # PEPIN_SKIP_ATTESTATION=1, donc ils n'exercent JAMAIS `gh attestation verify`
+  # ni ce dont il a besoin pour tourner.
+  #
+  # Cet angle mort a coûté deux releases : l'installateur refusait toute
+  # installation faute de GH_TOKEN, et seul le job d'après-publication l'a vu.
+  # Ici, le défaut apparaît sur la pull request qui l'introduit.
+  #
+  # Le job épingle une version DÉJÀ PUBLIÉE : il éprouve l'action du dépôt telle
+  # qu'elle est écrite maintenant, contre des artefacts qui existent réellement.
+  published-action:
+    name: The action's public path works as a consumer calls it
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: A compliant inventory passes through the action itself
+        uses: ./.github/actions/pepin-scan
+        with:
+          version: '0.1.0'
+          provider: scaleway
+          inventory: examples/scaleway/inventory-ok.json
+          format: json
+


### PR DESCRIPTION
## Le défaut

Le job d'après-publication de v0.1.1 échoue, et v0.1.0 échouait déjà :

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
provenance non vérifiée pour pepin-linux-amd64 : installation refusée
```

La vérification de provenance ajoutée avant v0.1.0 appelle `gh attestation verify` sans token. `gh` refuse de tourner dans un workflow sans `GH_TOKEN`, donc l'installateur conclut à un binaire invérifiable et **refuse l'installation — chez tous les consommateurs, pour les deux releases publiées**.

## Le correctif

L'action fournit elle-même `github.token`, plutôt que d'en faire une entrée : personne ne devrait avoir à câbler un token pour installer un binaire, et le token par défaut porte déjà l'accès en lecture dont l'API d'attestation a besoin sur un dépôt public.

## L'angle mort, qui est le vrai sujet

`entrypoints` sert `install.sh` en boucle locale avec `PEPIN_SKIP_ATTESTATION=1`. Le chemin **public** — pas d'URL de base, pas de saut, l'action appelée comme on l'appelle dehors — n'était donc jamais exercé avant le job d'après-publication. C'est-à-dire après que le tag existe, quand il est trop tard.

Un nouveau job appelle l'action du dépôt contre une version **déjà publiée**, sur chaque pull request. Ce défaut-ci apparaîtra désormais sur la PR qui l'introduit.

## À noter

v0.1.0 et v0.1.1 restent affectées : leur `action.yml` publié ne porte pas le token. La correction ne vaudra que pour les versions suivantes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)