### PR TITLE
docs: make documentation an explicit step of the canonical procedure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,18 @@ Les artefacts pilotent tout : `catalogue.yaml` (QUOI), `contrats/<provider>.yaml
    Passer l'entrée du catalogue en `statut: implemente`.
 6. **Valider.** `mise run validate` (codes↔règles↔SCSL gelé↔catalogue) **puis**
    `mise run test` + `mise run audit` au vert. Aucun commit si l'un échoue (§1, §7).
+7. **Documenter.** `mise run gen-docs`, et committer ce qu'il régénère : la matrice
+   de couverture et les sorties capturées sont GÉNÉRÉES depuis le binaire et le
+   référentiel, et `TestGeneratedDocsAreUpToDate` casse la CI si elles dérivent.
+   Puis relire ce que le changement rend FAUX ailleurs — `docs/known-limitations.md`
+   si un angle mort se comble, la page du provider concerné, `docs/coverage.md` —
+   dans les DEUX langues. Un changement qui déplace un verdict sur un tenant
+   inchangé, une surface analysable ou un code de sortie a sa ligne au CHANGELOG.
+
+   La documentation n'est pas une étape de suivi : une page qui décrit un produit
+   disparu est pire qu'une page absente, parce qu'elle inspire confiance. La
+   question qui tranche : *quelqu'un qui lit la documentation sans lire le code
+   serait-il induit en erreur par ce changement ?*
 
 Invariants vérifiés par `mise run validate` : tout contrôle actif a une règle ; tout
 code émis est catalogué ; tout `scsl` existe dans l'index **gelé** ; le catalogue

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -62,7 +62,28 @@ rapport anglais ne doit jamais basculer au français en milieu de phrase. Le
 français est la langue de référence du contenu normatif, l'anglais en est la
 traduction.
 
-## Commits
+## Documentation et commits
 
-Conventional Commits (`feat`/`fix`/`docs`/`refactor`/`test`/`chore`), sujet à
-l'impératif.
+Les docs du dépôt sont **bilingues** : l'anglais est primaire (`README.md`), le
+français en est la contrepartie (`README.fr.md`), reliés par un sélecteur de
+langue. Les commits suivent les Conventional Commits
+(`feat`/`fix`/`docs`/`refactor`/`test`/`chore`), sujet à l'impératif.
+
+**La documentation fait partie du changement, pas d'un suivi.** L'essentiel de
+`docs/` est généré depuis le binaire et le référentiel, et
+`TestGeneratedDocsAreUpToDate` casse la CI dès que cela dérive. Donc, avant
+d'ouvrir une pull request :
+
+- lancer `mise run gen-docs` et committer ce qu'il régénère ;
+- relire les pages que le changement rend **fausses**, pas seulement les pages
+  générées : `docs/known-limitations.md` quand un angle mort se comble, la page
+  du provider touché, `docs/coverage.md` ;
+- tenir les deux langues synchronisées ;
+- ajouter une ligne au CHANGELOG, dans les deux langues, dès que le changement
+  déplace un **verdict** sur un tenant inchangé, une surface analysable ou un
+  code de sortie.
+
+Une page qui décrit un produit disparu est pire qu'une page absente : elle
+inspire une confiance qu'elle ne peut pas tenir. La question qui tranche :
+*quelqu'un qui lit la documentation sans lire le code serait-il induit en erreur
+par ce changement ?*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,19 @@ Repository docs are **bilingual**: English is primary (`README.md`), French is t
 counterpart (`README.fr.md`), linked by a language switcher. Commits follow
 Conventional Commits (`feat`/`fix`/`docs`/`refactor`/`test`/`chore`), imperative
 subject.
+
+**Documentation is part of the change, not a follow-up.** Most of `docs/` is
+generated from the binary and the reference, and `TestGeneratedDocsAreUpToDate`
+fails the build when it drifts. So, before opening a pull request:
+
+- run `mise run gen-docs` and commit what it regenerates;
+- re-read the pages your change makes **wrong**, not only the generated ones:
+  `docs/known-limitations.md` when a blind spot closes, the provider page you
+  touched, `docs/coverage.md`;
+- keep both languages in step;
+- add a CHANGELOG line, in both languages, whenever the change moves a **verdict**
+  on an unchanged tenant, a parsable surface, or an exit code.
+
+A page describing a product that no longer exists is worse than a missing page:
+it earns trust it cannot honour. The question that settles it: *would someone
+reading the documentation without reading the code be misled by this change?*

--- a/docs/contributing/adding-a-control.fr.md
+++ b/docs/contributing/adding-a-control.fr.md
@@ -1,0 +1,390 @@
+> [🇬🇧 English](adding-a-control.md) · 🇫🇷 Français
+
+# Ajouter un contrôle, de bout en bout
+
+Ce guide suit un contrôle réel de ce dépôt, du risque à la pull request :
+**`database_service_not_open_to_internet`**, une base de données managée dont la liste
+d'IP autorisées admet un CIDR public. Chaque fichier cité ci-dessous existe ; rien ici
+n'est une esquisse.
+
+Avant toute chose, deux invariants décident de la forme du travail.
+
+**Un seul jeu de règles, commun à tous les fournisseurs.** Un contrôle s'écrit **une
+fois**, dans `internal/commonrules/rules/`, et il évalue le modèle *normalisé*. Ce qui
+change d'un cloud à l'autre, c'est la **source** (le collecteur, le mapping Terraform),
+jamais la règle. Si un contrôle semble exiger une logique propre à un fournisseur, c'est
+la normalisation qui manque, pas une seconde règle. Voir
+[l'architecture](../project/architecture.fr.md).
+
+**Tout ce qu'un humain lit est écrit deux fois.** Le français est la langue de référence
+du contenu normatif, l'anglais en est la traduction maintenue. Un contrôle porte
+`titre_en`, `description_en` et `remediation_en` ; une règle porte `labels.message_en`
+et `labels.remediation_en`. `mise run validate` refuse l'absence de l'un d'eux : un
+rapport anglais ne doit jamais retomber en français au milieu d'une phrase.
+
+Vous n'avez **pas** besoin d'un compte cloud pour suivre ce guide. Auditer un plan
+Terraform ne provisionne rien, et cela suffit à valider un mapping et une règle.
+
+---
+
+## 1. Identifier le risque
+
+Le formuler comme un fait de configuration observable, pas comme une intention. « La
+base est joignable depuis Internet » est observable ; « la base n'est pas sécurisée » ne
+l'est pas.
+
+Pour notre exemple : une base de données managée expose une ACL (une liste de CIDR
+autorisés). Si cette liste contient `0.0.0.0/0`, le service est joignable depuis
+Internet tout entier.
+
+## 2. Trouver la référence normative : l'index est gelé
+
+Chaque contrôle se rattache à une exigence SCSL **existante** du module de posture cloud
+(`CLD-*`). L'index est **gelé** : on s'y rattache, on n'en crée jamais.
+
+Les identifiants gelés sont listés dans
+[`referentiel/scsl-baseline.json`](../../referentiel/scsl-baseline.json) :
+
+```bash
+grep -o 'CLD-[A-Z]*-[0-9]*' referentiel/scsl-baseline.json | sort -u
+```
+
+Avec le framework SCSL cloné à côté de Pépin, le rapport complet est :
+
+```bash
+./pepin scsl                                            # index par défaut : ../framework-scsl/api/v1/exigences.json
+./pepin scsl --index /chemin/vers/api/v1/exigences.json
+```
+
+Notre exemple se rattache à `CLD-NET-1` (la source d'un service exposé est restreinte à
+un CIDR maîtrisé, jamais `0.0.0.0/0`).
+
+**Si aucune exigence gelée ne couvre le besoin, on s'arrête ici.** Le contrôle reste au
+[`referentiel/catalogue.yaml`](../../referentiel/catalogue.yaml) avec `statut: a_trier`,
+hors périmètre tant que SCSL n'a rien figé pour lui. Inventer une référence rendrait tout
+le rapport inopposable, c'est-à-dire la seule panne que ce projet ne peut pas se
+permettre.
+
+## 3. Vérifier l'applicabilité, fournisseur par fournisseur
+
+Pour chaque fournisseur que vous comptez activer, le champ natif doit être **vérifié
+dans le SDK ou la documentation officielle de l'API**, puis consigné dans
+`providers/<fournisseur>.yaml`. « Absent » est un constat lui aussi, et il se prouve en
+lisant le SDK, jamais en le supposant.
+
+Côté Scaleway, le contrat consigne le type comme vérifié et nomme d'où vient l'attribut :
+
+```yaml
+    managed_database:
+      etat: verifie
+      source: >
+        Terraform scaleway_rdb_acl (mapping validé par un plan réel : acl_rules[].ip
+        agrégés en ip_filter ; formes reprises de scaleway/dagster-scaleway et
+        Qovery/engine, ip=0.0.0.0/0). API live api/rdb/v1 ACLRule.IP à câbler en collecte.
+      mapping:
+        database_id: instance_id du RDB parent
+        ip_filter: '[acl_rules[].ip] (CIDR autorisés ; transform list)'
+```
+
+Trois états existent, et ils ne sont pas interchangeables : `verifie` (lu dans le SDK, et
+projeté), `a_verifier` (plausible, non lu : aucun « pass » ne sera affirmé), `absent` (le
+mécanisme n'existe pas, avec sa justification). L'état commande le « pass » :
+`internal/assess` refuse d'affirmer une conformité sur un type que le contrat n'a pas
+vérifié.
+
+## 4. Ajouter le contrôle au référentiel
+
+`referentiel/controles.yaml` est la source de vérité. Un contrôle est agnostique : son
+`code` suit `<service>_<resource>_<check>` avec un préfixe de service neutre
+(`network_`, `compute_`, `objectstorage_`, `blockstorage_`, `iam_`, `kubernetes_`,
+`loadbalancer_`, `governance_`). Aucun nom de fournisseur n'apparaît jamais dans un code.
+
+```yaml
+  - code: database_service_not_open_to_internet
+    famille: reseau
+    titre: Base de données managée joignable depuis Internet
+    titre_en: Managed database reachable from the internet
+    severite: high
+    description: >
+      La liste d'IP autorisées (ACL) d'une base de données managée admet un CIDR
+      public : le service de base de données est joignable depuis Internet.
+    description_en: >
+      The allowed IP list (ACL) of a managed database admits a public CIDR: the
+      database service is reachable from the internet.
+    remediation: >
+      Restreindre l'ACL de la base aux seuls CIDR applicatifs (réseau privé quand
+      disponible) ; retirer 0.0.0.0/0.
+    remediation_en: >
+      Restrict the database ACL to the application CIDRs only (a private network
+      where one is available); remove 0.0.0.0/0.
+    scsl: [CLD-NET-1]
+    frameworks:
+      secnumcloud_3_2: ["13.2"]
+      cis_controls_v8: ["4.4", "12.2"]
+      iso_27001_2022: ["A.8.20", "A.8.22"]
+    fournisseurs: [scaleway]
+```
+
+`fournisseurs` est l'interrupteur d'activation. Le laisser **vide** tant que le mapping
+n'a pas été validé sur un plan réel ou un scan réel : un contrôle déclaré pour un
+fournisseur qu'il ne sait pas mesurer est une promesse fausse, et la matrice de
+couverture le dira.
+
+## 5. Déterminer les attributs décisifs
+
+C'est l'étape qui sépare un contrôle honnête d'un faux vert, et elle est détaillée au
+[§ 6](#6-létape-quon-oublie--la-donnée-manquante).
+
+Une seule question à se poser : **si l'attribut que la règle lit n'a jamais été
+collecté, la règle reste-t-elle muette ?** Pour notre exemple, oui : pas d'`ip_filter`,
+pas d'écart. Le silence se lirait alors comme une conformité, ce qui est exactement
+faux : une base Scaleway est ouverte tant qu'aucune ACL n'est posée.
+
+L'attribut est donc déclaré dans la table `requiredAttr` de
+[`internal/assess/assess.go`](../../internal/assess/assess.go) :
+
+```go
+	// La base est ouverte tant qu'aucune ACL n'est posée (défaut d'API Scaleway) :
+	// sans ip_filter collecté, « conforme » est exactement l'inverse de la réalité.
+	"database_service_not_open_to_internet": {"ip_filter"},
+```
+
+Les contrôles **non** listés se jugent à la présence d'un écart : l'absence de mauvaise
+configuration y vaut réellement conformité. C'est une décision à prendre délibérément,
+contrôle par contrôle, pas un défaut dont on hérite.
+
+## 6. L'étape qu'on oublie : la donnée manquante
+
+Une règle qui ne se déclenche pas faute de donnée doit produire **`not-evaluated`**,
+jamais `pass`. Ce n'est pas une nuance, c'est la différence entre un audit et une
+réassurance. Un audit interne de ce dépôt a trouvé **quatorze** contrôles qui
+concluaient « conforme » sans avoir jamais lu l'attribut décisif. Un faux vert est
+invisible par construction, ce qui en fait le pire défaut possible pour un outil de
+posture.
+
+Deux mécanismes travaillent ensemble, et les deux sont nécessaires :
+
+1. **La garde de capacité, dans la règle.** La règle ne lit l'attribut que s'il est
+   présent : un attribut non collecté ne produit donc aucun faux positif.
+
+   ```rego
+   "ip_filter" in object.keys(r.attributes)
+   ```
+
+2. **Le verrou du « pass », dans `internal/assess`.** L'entrée `requiredAttr` transforme
+   le silence en `not-evaluated` quand aucune ressource du type visé ne portait
+   l'attribut. Sans elle, la garde achèterait un vert en silence.
+
+Un test tient les deux synchronisés : `TestRequiredAttrGuardsExist`
+(`internal/assess/requiredattr_test.go`) échoue si une entrée `requiredAttr` nomme un
+contrôle qu'aucune règle n'émet, ou un attribut que la règle ne lit jamais, autrement dit
+« un gate qui ne protège rien ».
+
+La table générée de tous les contrôles gatés, avec leur attribut décisif, est dans
+[le modèle d'assessment](../concepts/assessment-model.fr.md).
+
+## 7. Écrire la règle commune
+
+Un fichier, `internal/commonrules/rules/<code>.rego`, `package pepin.rules`,
+`import rego.v1`, et un `deny contains f if { … }`. L'en-tête cite la source ancrée ;
+`labels.provider` est tiré **de la ressource** via `provider_of(r)`, jamais codé en dur.
+
+```rego
+# database_service_not_open_to_internet
+#   Base de données managée dont la liste d'IP autorisées (ACL) admet un CIDR
+#   public : le service de base de données est joignable depuis Internet.
+# SCSL : CLD-NET-1 (source restreinte à un CIDR maîtrisé, jamais 0.0.0.0/0).
+# Contrat : type normalisé agnostique `managed_database` ; attribut ip_filter
+#   (liste de CIDR autorisés, DÉRIVÉ — Scaleway RDB ACLs / Exoscale DBaaS
+#   ip-filter). Absent ⇒ pas de finding (garde de capacité).
+package pepin.rules
+
+import rego.v1
+
+deny contains f if {
+	some r in resources_of_type("managed_database")
+	"ip_filter" in object.keys(r.attributes)
+	some cidr in cidr_list(object.get(r.attributes, "ip_filter", []))
+	is_public_cidr(cidr)
+	id := object.get(r.attributes, "database_id", r.id)
+	f := {
+		"code": "database_service_not_open_to_internet",
+		"severity": "high",
+		"subject": id,
+		"message": sprintf("Base de données managée « %s » : ACL autorisant un CIDR public (%s) — service exposé à Internet.", [id, cidr]),
+		"remediation": "Restreindre l'ACL de la base aux seuls CIDR applicatifs (réseau privé quand disponible) ; retirer 0.0.0.0/0.",
+		"labels": {
+			"provider": provider_of(r),
+			"category": "security",
+			"message_en": sprintf("Managed database \"%s\": ACL allowing a public CIDR (%s) — the service is exposed to the internet.", [id, cidr]),
+			"remediation_en": "Restrict the database ACL to the application CIDRs only (a private network where one is available); remove 0.0.0.0/0.",
+		},
+	}
+}
+```
+
+Deux détails faciles à rater :
+
+- **Accès défensif uniquement** (`object.get`, `object.keys`) : un inventaire est une
+  entrée non fiable, et une règle ne doit jamais paniquer sur un champ absent.
+- **La sévérité doit correspondre au référentiel.**
+  `TestRegoSeverityMatchesReferentiel` compare les deux et échoue sur un écart.
+
+Réutiliser les helpers partagés de `lib.rego` (`resources_of_type`, `provider_of`,
+`is_public_cidr`, `cidr_list`) plutôt que de les réécrire : un helper corrigé une fois
+est corrigé pour toutes les règles.
+
+## 8. Ajouter les fixtures
+
+Les fixtures sont des **réponses d'API ou de plan réalistes**, jamais des formes
+inventées. Deux miroirs comptent :
+
+- le non conforme, sous `examples/<fournisseur>/terraform/` (ou la fixture
+  d'inventaire), qui déclenche la règle ;
+- le conforme, sous `examples/<fournisseur>/terraform-fixed/` ou comme preuve de
+  remédiation dans `references/remediation/<fournisseur>/<code>/`, qui ne doit **pas** la
+  déclencher.
+
+Aucun secret ne va jamais dans une fixture : les identifiants viennent de
+l'environnement, et `mise run secrets` (gitleaks) scanne l'historique à la recherche des
+motifs de clés souveraines.
+
+## 9. Tester l'échec, le succès et l'absence
+
+Le fichier de test de la règle, `<code>_test.rego`, doit contenir les trois cas. Voici le
+vrai, sans coupe :
+
+```rego
+package pepin.rules
+
+import rego.v1
+
+_db(attrs) := {"resources": [{"provider": "scaleway", "type": "managed_database", "id": "db-1", "attributes": attrs}]}
+
+# ✗ ACL avec 0.0.0.0/0 → finding.
+test_db_open_to_all_denied if {
+	some f in deny with input as _db({"database_id": "db-1", "ip_filter": ["0.0.0.0/0"]})
+	f.code == "database_service_not_open_to_internet"
+}
+
+# ✗ ACL avec un /1 (moitié d'Internet) → finding (réutilise is_public_cidr).
+test_db_half_internet_denied if {
+	some f in deny with input as _db({"database_id": "db-1", "ip_filter": ["128.0.0.0/1"]})
+	f.code == "database_service_not_open_to_internet"
+}
+
+# ✓ ACL restreinte à un CIDR privé → aucun finding.
+test_db_restricted_ok if {
+	count({f | some f in deny; f.code == "database_service_not_open_to_internet"}) == 0 with input as _db({"database_id": "db-1", "ip_filter": ["10.0.0.0/16"]})
+}
+
+# ✓ ip_filter non collecté (garde de capacité) → pas de faux positif.
+test_db_uncollected_ok if {
+	count({f | some f in deny; f.code == "database_service_not_open_to_internet"}) == 0 with input as _db({"database_id": "db-1"})
+}
+```
+
+Le dernier test est celui qu'on saute. Il prouve que la garde existe ; c'est l'entrée
+`requiredAttr` de l'étape 5 qui transforme son silence en `not-evaluated` plutôt qu'en
+`pass`. Les deux sont nécessaires : le test seul laisserait un faux vert, la table seule
+laisserait un faux positif.
+
+```bash
+mise run test-rego     # opa test internal/commonrules/rules -v
+mise run test          # tests Go (-race) + tests Rego
+```
+
+Un test ne vaut que ce que vaut sa capacité à échouer. Casser la règle exprès (retirer la
+garde, inverser une comparaison) et vérifier que la suite passe au rouge. Une suite qui
+reste verte alors que son sujet est cassé ne mesure plus son sujet, elle mesure sa propre
+panne.
+
+## 10. Vérifier `not-applicable` et `not-evaluated` sur un scan réel
+
+Lancer le scan et lire les statuts, plutôt que de faire confiance aux tests unitaires :
+
+```bash
+./pepin scan scaleway --terraform examples/scaleway/terraform/plan.json --format assessment
+./pepin scan scaleway --terraform examples/scaleway/terraform-fixed/plan.json --format assessment
+```
+
+Ce qu'il faut vérifier, dans l'ordre :
+
+- le contrôle apparaît dans `results` (sinon, le code n'est pas au référentiel ou aucune
+  règle ne l'émet : `mise run validate` dit lequel des deux) ;
+- il est `fail` sur l'entrée non conforme, avec un `subject` qui nomme la ressource
+  fautive ;
+- il est `pass` sur l'entrée conforme, et `evidence.observed` dit **pourquoi** le « pass »
+  est affirmé ;
+- sur une entrée où l'attribut décisif est absent, il est `not-evaluated` **avec son
+  motif**, et non `pass`.
+
+Si un fournisseur n'a réellement pas ce mécanisme, ce n'est pas un trou de Pépin : le
+consigner en `non_applicable` dans `providers/<fournisseur>.yaml` **avec sa
+justification**, bilingue. Le scan rend alors `not-applicable` accompagné de ce motif, sur
+lequel un auditeur peut agir. Un N/A sans justification n'est pas opposable, et un test
+impose la justification bilingue.
+
+## 11. Documenter la remédiation
+
+Les champs `remediation` et `remediation_en` de l'étape 4 sont obligatoires et tenus par
+`TestEveryFindingCarriesRemediation`. La couche du dessus, une preuve **déployable** sous
+`references/remediation/<fournisseur>/<code>/`, est décrite dans
+[le guide de remédiation](../guides/remediation.fr.md). C'est la différence entre dire au
+lecteur quoi faire et lui montrer le montage qui le fait.
+
+## 12. Régénérer la documentation dérivée
+
+Le catalogue des contrôles, la matrice de couverture et toutes les sorties de commande
+montrées dans `docs/` sont **générées**. Ne jamais les éditer à la main :
+
+```bash
+mise run gen-docs
+```
+
+Votre contrôle a désormais ses deux pages sous `docs/controls/`, il apparaît dans
+`docs/coverage.fr.md` avec son statut par fournisseur et par source, et les chiffres
+bougent. `TestGeneratedDocsAreUpToDate` échoue sur toute documentation en retard : la
+régénération n'est pas facultative.
+
+---
+
+## Checklist avant la pull request
+
+- [ ] L'exigence SCSL (`CLD-*`) **existait déjà** dans l'index gelé ; aucune n'a été
+      inventée. Si aucune ne couvre le besoin, le contrôle est resté au `catalogue.yaml`.
+- [ ] Pour chaque fournisseur activé, le champ natif est consigné dans
+      `providers/<fournisseur>.yaml` avec `etat: verifie` et sa source.
+- [ ] Le contrôle est dans `referentiel/controles.yaml` avec un `code` agnostique, sa
+      sévérité, son `scsl`, ses correspondances de frameworks et ses `fournisseurs`.
+- [ ] Les six champs de prose sont remplis **dans les deux langues**
+      (`titre`/`titre_en`, `description`/`description_en`,
+      `remediation`/`remediation_en`).
+- [ ] Une règle dans `internal/commonrules/rules/`, `package pepin.rules`, avec
+      `labels.provider: provider_of(r)` et `labels.message_en` /
+      `labels.remediation_en`.
+- [ ] La sévérité de la règle correspond à celle du référentiel.
+- [ ] La règle porte sa **garde de capacité**, et l'attribut décisif est déclaré dans
+      `requiredAttr` dès que le silence achèterait un `pass`.
+- [ ] `<code>_test.rego` couvre l'**échec**, le **succès** et l'**attribut manquant**.
+- [ ] La suite a été éprouvée sur sa capacité à échouer : casser la règle la fait passer
+      au rouge.
+- [ ] Un scan réel montre `fail`, `pass` et `not-evaluated` là où chacun est attendu,
+      jamais un `pass` sur une donnée non collectée.
+- [ ] Tout `non_applicable` est justifié, en deux langues, dans le contrat du
+      fournisseur.
+- [ ] `mise run gen-docs` a été lancé et le résultat committé.
+- [ ] `mise run validate`, `mise run test` et `mise run audit` sont au vert.
+- [ ] Le commit suit Conventional Commits, en anglais, à l'impératif, sous 72 caractères.
+
+## Voir aussi
+
+- [Architecture](../project/architecture.fr.md) : pourquoi un seul jeu de règles, et ce
+  qui change d'un cloud à l'autre.
+- [Ajouter un fournisseur](adding-a-provider.fr.md) : l'autre moitié, la source.
+- [Catalogue des contrôles](../controls/index.fr.md) : à quoi ressemblera la page de
+  votre contrôle.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut
+  affirme.
+- [CONTRIBUTING.fr.md](../../CONTRIBUTING.fr.md) : les portes de qualité et les points
+  non négociables.

--- a/docs/contributing/adding-a-control.md
+++ b/docs/contributing/adding-a-control.md
@@ -1,0 +1,374 @@
+> 🇬🇧 English · [🇫🇷 Français](adding-a-control.fr.md)
+
+# Adding a control, end to end
+
+This guide follows one real control of this repository, from the risk to the pull
+request: **`database_service_not_open_to_internet`** — a managed database whose allowed
+IP list admits a public CIDR. Every file quoted below exists; nothing here is a sketch.
+
+Before anything else, two invariants decide how the work is shaped.
+
+**One rule set, common to every provider.** A control is written **once**, in
+`internal/commonrules/rules/`, and it evaluates the *normalized* model. What changes
+from one cloud to the next is the **source** (the collector, the Terraform mapping),
+never the rule. If a check seems to need provider-specific logic, the normalization is
+what is missing, not a second rule. See [the architecture](../project/architecture.md).
+
+**Everything a human reads is written twice.** French is the reference language of the
+normative content, English its maintained translation. A control carries `titre_en`,
+`description_en` and `remediation_en`; a rule carries `labels.message_en` and
+`labels.remediation_en`. `mise run validate` refuses any of these missing — an English
+report must never fall back to French mid-sentence.
+
+You do **not** need a cloud account to follow this guide. Auditing a Terraform plan
+provisions nothing, and it is enough to validate a mapping and a rule.
+
+---
+
+## 1. Identify the risk
+
+State it as an observable configuration fact, not as an intention. "The database is
+reachable from the internet" is observable; "the database is insecure" is not.
+
+For our example: a managed database exposes an ACL (a list of allowed CIDRs). If that
+list contains `0.0.0.0/0`, the service is reachable from the whole internet.
+
+## 2. Find the normative reference — the index is frozen
+
+Every control maps onto an **existing** SCSL requirement of the cloud posture module
+(`CLD-*`). The index is **frozen**: you map onto a requirement, you never create one.
+
+The frozen identifiers are listed in
+[`referentiel/scsl-baseline.json`](../../referentiel/scsl-baseline.json):
+
+```bash
+grep -o 'CLD-[A-Z]*-[0-9]*' referentiel/scsl-baseline.json | sort -u
+```
+
+With the SCSL framework checked out next to Pépin, the full report is:
+
+```bash
+./pepin scsl                                          # default index: ../framework-scsl/api/v1/exigences.json
+./pepin scsl --index /path/to/api/v1/exigences.json
+```
+
+Our example maps onto `CLD-NET-1` (the source of an exposed service is restricted to a
+controlled CIDR, never `0.0.0.0/0`).
+
+**If no frozen requirement covers the need, stop here.** The control stays in
+[`referentiel/catalogue.yaml`](../../referentiel/catalogue.yaml) with
+`statut: a_trier`, out of scope until SCSL freezes something for it. Inventing a
+reference would make the whole report unopposable, which is the one failure mode this
+project cannot afford.
+
+## 3. Check applicability, provider by provider
+
+For each provider you intend to activate, the native field must be **verified in the
+SDK or the official API documentation** and recorded in `providers/<provider>.yaml`.
+"Absent" is a finding too, and it is proven by reading the SDK, never assumed.
+
+For Scaleway, the contract records the type as verified and names where the attribute
+comes from:
+
+```yaml
+    managed_database:
+      etat: verifie
+      source: >
+        Terraform scaleway_rdb_acl (mapping validé par un plan réel : acl_rules[].ip
+        agrégés en ip_filter ; formes reprises de scaleway/dagster-scaleway et
+        Qovery/engine, ip=0.0.0.0/0). API live api/rdb/v1 ACLRule.IP à câbler en collecte.
+      mapping:
+        database_id: instance_id du RDB parent
+        ip_filter: '[acl_rules[].ip] (CIDR autorisés ; transform list)'
+```
+
+Three states exist, and they are not interchangeable: `verifie` (read in the SDK, and
+projected), `a_verifier` (plausible, unread — no `pass` will be asserted), `absent`
+(the mechanism does not exist, with its justification). The state gates the `pass`:
+`internal/assess` refuses to assert compliance on a type the contract has not verified.
+
+## 4. Add the control to the reference
+
+`referentiel/controles.yaml` is the source of truth. A control is agnostic: its `code`
+follows `<service>_<resource>_<check>` with a neutral service prefix (`network_`,
+`compute_`, `objectstorage_`, `blockstorage_`, `iam_`, `kubernetes_`, `loadbalancer_`,
+`governance_`). No provider name ever appears in a code.
+
+```yaml
+  - code: database_service_not_open_to_internet
+    famille: reseau
+    titre: Base de données managée joignable depuis Internet
+    titre_en: Managed database reachable from the internet
+    severite: high
+    description: >
+      La liste d'IP autorisées (ACL) d'une base de données managée admet un CIDR
+      public : le service de base de données est joignable depuis Internet.
+    description_en: >
+      The allowed IP list (ACL) of a managed database admits a public CIDR: the
+      database service is reachable from the internet.
+    remediation: >
+      Restreindre l'ACL de la base aux seuls CIDR applicatifs (réseau privé quand
+      disponible) ; retirer 0.0.0.0/0.
+    remediation_en: >
+      Restrict the database ACL to the application CIDRs only (a private network
+      where one is available); remove 0.0.0.0/0.
+    scsl: [CLD-NET-1]
+    frameworks:
+      secnumcloud_3_2: ["13.2"]
+      cis_controls_v8: ["4.4", "12.2"]
+      iso_27001_2022: ["A.8.20", "A.8.22"]
+    fournisseurs: [scaleway]
+```
+
+`fournisseurs` is the activation switch. Leave it **empty** until the mapping has been
+validated on a real plan or a real scan: a control declared for a provider it cannot
+actually measure is a false promise, and the coverage matrix will say so.
+
+## 5. Determine the deciding attributes
+
+This is the step that separates an honest control from a false green, and it is
+detailed in [§ 6](#6-the-step-everyone-forgets-missing-data).
+
+Ask one question: **if the attribute the rule reads was never collected, does the rule
+stay silent?** For our example, yes: no `ip_filter`, no finding. Silence would then be
+read as compliance, which is exactly wrong — a Scaleway database is open until an ACL
+is set.
+
+The attribute is therefore declared in the `requiredAttr` table of
+[`internal/assess/assess.go`](../../internal/assess/assess.go):
+
+```go
+	// La base est ouverte tant qu'aucune ACL n'est posée (défaut d'API Scaleway) :
+	// sans ip_filter collecté, « conforme » est exactement l'inverse de la réalité.
+	"database_service_not_open_to_internet": {"ip_filter"},
+```
+
+Controls **not** listed are judged on the presence of a deviation: the absence of a bad
+configuration genuinely means compliance. That is a decision to make deliberately, per
+control, not a default to inherit.
+
+## 6. The step everyone forgets: missing data
+
+A rule that does not fire for lack of data must produce **`not-evaluated`**, never
+`pass`. This is not a nuance; it is the difference between an audit and a reassurance.
+An internal audit of this repository found **fourteen** controls concluding "compliant"
+without ever having read the deciding attribute. A false green is invisible by
+construction, which makes it the worst possible defect for a posture tool.
+
+Two mechanisms work together, and both are needed:
+
+1. **The capability guard, in the rule.** The rule reads the attribute only if it is
+   present, so an uncollected attribute produces no false positive:
+
+   ```rego
+   "ip_filter" in object.keys(r.attributes)
+   ```
+
+2. **The `pass` lock, in `internal/assess`.** The `requiredAttr` entry turns the
+   silence into `not-evaluated` when no resource of the targeted type carried the
+   attribute. Without it, the guard would silently buy a green.
+
+A test keeps the two in sync: `TestRequiredAttrGuardsExist`
+(`internal/assess/requiredattr_test.go`) fails if a `requiredAttr` entry names a control
+no rule emits, or an attribute the rule never reads — "a gate that protects nothing".
+
+The generated table of every gated control, with its deciding attribute, is in
+[the assessment model](../concepts/assessment-model.md).
+
+## 7. Write the common rule
+
+One file, `internal/commonrules/rules/<code>.rego`, `package pepin.rules`,
+`import rego.v1`, and a `deny contains f if { … }`. The header cites the anchored
+source; `labels.provider` comes **from the resource** through `provider_of(r)`, never
+hardcoded.
+
+```rego
+# database_service_not_open_to_internet
+#   Base de données managée dont la liste d'IP autorisées (ACL) admet un CIDR
+#   public : le service de base de données est joignable depuis Internet.
+# SCSL : CLD-NET-1 (source restreinte à un CIDR maîtrisé, jamais 0.0.0.0/0).
+# Contrat : type normalisé agnostique `managed_database` ; attribut ip_filter
+#   (liste de CIDR autorisés, DÉRIVÉ — Scaleway RDB ACLs / Exoscale DBaaS
+#   ip-filter). Absent ⇒ pas de finding (garde de capacité).
+package pepin.rules
+
+import rego.v1
+
+deny contains f if {
+	some r in resources_of_type("managed_database")
+	"ip_filter" in object.keys(r.attributes)
+	some cidr in cidr_list(object.get(r.attributes, "ip_filter", []))
+	is_public_cidr(cidr)
+	id := object.get(r.attributes, "database_id", r.id)
+	f := {
+		"code": "database_service_not_open_to_internet",
+		"severity": "high",
+		"subject": id,
+		"message": sprintf("Base de données managée « %s » : ACL autorisant un CIDR public (%s) — service exposé à Internet.", [id, cidr]),
+		"remediation": "Restreindre l'ACL de la base aux seuls CIDR applicatifs (réseau privé quand disponible) ; retirer 0.0.0.0/0.",
+		"labels": {
+			"provider": provider_of(r),
+			"category": "security",
+			"message_en": sprintf("Managed database \"%s\": ACL allowing a public CIDR (%s) — the service is exposed to the internet.", [id, cidr]),
+			"remediation_en": "Restrict the database ACL to the application CIDRs only (a private network where one is available); remove 0.0.0.0/0.",
+		},
+	}
+}
+```
+
+Two details that are easy to get wrong:
+
+- **Defensive access only** (`object.get`, `object.keys`): an inventory is untrusted
+  input, and a rule must never crash on a missing field.
+- **The severity must match the reference.** `TestRegoSeverityMatchesReferentiel`
+  compares the two and fails on a divergence.
+
+Reuse the shared helpers of `lib.rego` (`resources_of_type`, `provider_of`,
+`is_public_cidr`, `cidr_list`) rather than re-implementing them: a helper fixed once is
+fixed for every rule.
+
+## 8. Add the fixtures
+
+Fixtures are **realistic API or plan responses**, never invented shapes. Two mirrors
+matter:
+
+- the non-compliant one, under `examples/<provider>/terraform/` (or the inventory
+  fixture), which makes the rule fire;
+- the compliant one, under `examples/<provider>/terraform-fixed/` or as a remediation
+  proof in `references/remediation/<provider>/<code>/`, which must **not** make it fire.
+
+No secret ever goes into a fixture: credentials come from the environment, and
+`mise run secrets` (gitleaks) scans the history for the sovereign key patterns.
+
+## 9. Test the failure, the pass and the absence
+
+The rule's test file, `<code>_test.rego`, must contain the three cases. This is the
+real one, unabridged:
+
+```rego
+package pepin.rules
+
+import rego.v1
+
+_db(attrs) := {"resources": [{"provider": "scaleway", "type": "managed_database", "id": "db-1", "attributes": attrs}]}
+
+# ✗ ACL avec 0.0.0.0/0 → finding.
+test_db_open_to_all_denied if {
+	some f in deny with input as _db({"database_id": "db-1", "ip_filter": ["0.0.0.0/0"]})
+	f.code == "database_service_not_open_to_internet"
+}
+
+# ✗ ACL avec un /1 (moitié d'Internet) → finding (réutilise is_public_cidr).
+test_db_half_internet_denied if {
+	some f in deny with input as _db({"database_id": "db-1", "ip_filter": ["128.0.0.0/1"]})
+	f.code == "database_service_not_open_to_internet"
+}
+
+# ✓ ACL restreinte à un CIDR privé → aucun finding.
+test_db_restricted_ok if {
+	count({f | some f in deny; f.code == "database_service_not_open_to_internet"}) == 0 with input as _db({"database_id": "db-1", "ip_filter": ["10.0.0.0/16"]})
+}
+
+# ✓ ip_filter non collecté (garde de capacité) → pas de faux positif.
+test_db_uncollected_ok if {
+	count({f | some f in deny; f.code == "database_service_not_open_to_internet"}) == 0 with input as _db({"database_id": "db-1"})
+}
+```
+
+The last test is the one people skip. It proves the guard exists; the `requiredAttr`
+entry of step 5 is what turns its silence into `not-evaluated` instead of `pass`. Both
+are needed: the test alone would leave a false green, the table alone would leave a
+false positive.
+
+```bash
+mise run test-rego     # opa test internal/commonrules/rules -v
+mise run test          # Go tests (-race) + Rego tests
+```
+
+A test is only worth what its ability to fail is worth. Break the rule on purpose (drop
+the guard, flip a comparison) and check the suite goes red. A suite that stays green
+while the subject is broken is measuring its own failure, not the code.
+
+## 10. Check `not-applicable` and `not-evaluated` on a real scan
+
+Run the scan and read the statuses, rather than trusting the unit tests:
+
+```bash
+./pepin scan scaleway --terraform examples/scaleway/terraform/plan.json --format assessment
+./pepin scan scaleway --terraform examples/scaleway/terraform-fixed/plan.json --format assessment
+```
+
+What to check, in order:
+
+- the control appears in `results` (if it does not, the code is not in the reference or
+  no rule emits it — `mise run validate` says which);
+- it is `fail` on the non-compliant input, with a `subject` naming the offending
+  resource;
+- it is `pass` on the compliant input, and `evidence.observed` says **why** the pass is
+  asserted;
+- on an input where the deciding attribute is absent, it is `not-evaluated` **with its
+  reason** — not `pass`.
+
+If a provider genuinely has no such mechanism, that is not a gap in Pépin: record it as
+`non_applicable` in `providers/<provider>.yaml` **with its justification**, bilingual.
+The scan then returns `not-applicable` with that reason, which an auditor can act on. An
+N/A without a justification is not opposable, and a test enforces the bilingual
+justification.
+
+## 11. Document the remediation
+
+The `remediation` and `remediation_en` fields of step 4 are mandatory and gated by
+`TestEveryFindingCarriesRemediation`. The layer above — a **deployable** proof under
+`references/remediation/<provider>/<code>/` — is described in
+[the remediation guide](../guides/remediation.md). It is the difference between telling
+the reader what to do and showing them the setup that does it.
+
+## 12. Regenerate the derived documentation
+
+The control catalogue, the coverage matrix and every command output shown in `docs/`
+are **generated**. Never edit them by hand:
+
+```bash
+mise run gen-docs
+```
+
+Your control now has its two pages under `docs/controls/`, it appears in
+`docs/coverage.md` with its status per provider and per source, and the figures move.
+`TestGeneratedDocsAreUpToDate` fails on any documentation that lags behind, so
+regenerating is not optional.
+
+---
+
+## Checklist before the pull request
+
+- [ ] The SCSL requirement (`CLD-*`) **already existed** in the frozen index; none was
+      invented. If none covers the need, the control stayed in `catalogue.yaml`.
+- [ ] For every activated provider, the native field is recorded in
+      `providers/<provider>.yaml` with `etat: verifie` and its source.
+- [ ] The control is in `referentiel/controles.yaml` with an agnostic `code`, its
+      severity, its `scsl`, its framework mappings and its `fournisseurs`.
+- [ ] The six prose fields are filled **in both languages** (`titre`/`titre_en`,
+      `description`/`description_en`, `remediation`/`remediation_en`).
+- [ ] One rule in `internal/commonrules/rules/`, `package pepin.rules`, with
+      `labels.provider: provider_of(r)` and `labels.message_en` /
+      `labels.remediation_en`.
+- [ ] The rule severity matches the reference.
+- [ ] The rule carries its **capability guard**, and the deciding attribute is declared
+      in `requiredAttr` when silence would otherwise buy a `pass`.
+- [ ] `<code>_test.rego` covers the **failure**, the **pass** and the **missing
+      attribute**.
+- [ ] The suite was checked for its ability to fail: breaking the rule turns it red.
+- [ ] A real scan shows `fail`, `pass` and `not-evaluated` where each is expected,
+      never a `pass` on uncollected data.
+- [ ] Any `non_applicable` is justified, bilingually, in the provider contract.
+- [ ] `mise run gen-docs` has been run and the result committed.
+- [ ] `mise run validate`, `mise run test` and `mise run audit` are green.
+- [ ] The commit follows Conventional Commits, imperative, under 72 characters.
+
+## See also
+
+- [Architecture](../project/architecture.md) — why one rule set, and what changes per cloud.
+- [Adding a provider](adding-a-provider.md) — the other half: the source.
+- [Control catalogue](../controls/index.md) — what your control's page will look like.
+- [The assessment model](../concepts/assessment-model.md) — what each status asserts.
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — the quality gates and the non-negotiables.

--- a/docs/contributing/adding-a-provider.fr.md
+++ b/docs/contributing/adding-a-provider.fr.md
@@ -1,0 +1,375 @@
+> [🇬🇧 English](adding-a-provider.md) · 🇫🇷 Français
+
+# Ajouter un fournisseur, de bout en bout
+
+Un fournisseur, dans Pépin, est **une source, pas un jeu de règles**. Toutes les règles
+de posture sont communes à tous les clouds et s'évaluent sur le modèle normalisé ; ce
+qu'un fournisseur apporte, c'est la projection de son API et de ses ressources Terraform
+vers ce modèle. Ajouter un cloud revient donc à écrire **un descripteur**,
+`providers/<nom>.yaml`, et **zéro règle**.
+
+Ce n'est pas un slogan, c'est le critère d'acceptation : si votre changement ajoute un
+fichier `.rego`, c'est la normalisation qui a manqué. Voir
+[l'architecture](../project/architecture.fr.md) pour la raison.
+
+Voici ce que le binaire connaît des fournisseurs enregistrés aujourd'hui :
+
+<!-- pepin:gen provider-list -->
+```text
+
+// pépin  providers enregistrés
+  exoscale  Exoscale (CH) — instances, security groups, block storage, SKS, SOS
+  kubernetes  Kubernetes (in-cluster) — RBAC, Pod Security Standards, NetworkPolicy
+  outscale  Outscale (3DS) — VM, BSU, OOS, EIM, security groups, OKS, LBU
+  scaleway  Scaleway — object storage, instances, IAM, security groups
+```
+<!-- /pepin:gen provider-list -->
+
+## La règle d'or : ne jamais inventer le modèle de ressources
+
+Le modèle que Pépin évalue **doit** refléter le contrat natif du fournisseur : champs
+réels, types réels, tags JSON réels, lus dans le SDK ou dans la documentation officielle
+de l'API. Un champ que vous n'avez pas vérifié ne s'emploie pas. Un champ que vous
+**dérivez** (calculé par le collecteur ou par le mapping) est marqué comme dérivé, avec
+sa formule.
+
+La raison n'est pas le purisme. Un CSPM qui lit un champ inventé n'échoue pas bruyamment :
+il rend « conforme » en silence, parce que l'attribut n'est tout simplement jamais là.
+C'est un faux vert, et un faux vert est invisible par construction.
+
+Deux habitudes rendent la chose praticable :
+
+- Mettre en cache les pages sur lesquelles vous vous appuyez : `mise run fetch-docs`
+  stocke la documentation officielle en Markdown sous `references/docs/<fournisseur>/`,
+  et une entrée de contrat cite alors un fichier plutôt qu'un souvenir.
+- Consigner les questions ouvertes dans
+  `references/questions-providers/<fournisseur>.yaml` au lieu de deviner. Une question
+  sans réponse vaut `a_verifier`, pas `verifie`.
+
+## Préférer ne rien provisionner
+
+Pépin sait auditer un **plan Terraform** (`terraform show -json`), ce qui suffit à
+valider un mapping et une règle **sans créer la moindre ressource** :
+
+```bash
+terraform plan -out tfplan && terraform show -json tfplan > plan.json
+./pepin scan <fournisseur> --terraform plan.json
+```
+
+Le scan live ne sert qu'à confirmer le **contrat d'API** (les champs que l'API rend
+réellement) quand le plan ne suffit pas. Et la règle est alors absolue : **toute
+ressource provisionnée pour un test doit être détruite** (`terraform destroy`, ou
+suppression via l'API ou la console). Tenir la liste de ce que vous créez, et confirmer
+la destruction avant de conclure. Le coût, la surface d'exposition et la dérive plaident
+dans le même sens.
+
+---
+
+## 1. Identité et portée
+
+```yaml
+name: acme                       # l'identifiant que prend la CLI : pepin scan acme
+description: "ACME (FR) — instances, security groups, stockage objet"
+scope: cloud                     # « cloud » (défaut) | « in-cluster » pour une autre portée
+region_key: region               # la clé logique alimentée par --region (Exoscale : « zone »)
+```
+
+`scope` n'est pas cosmétique : un fournisseur dont la portée n'est pas le plan de
+contrôle cloud (le fournisseur `kubernetes` audite l'intérieur d'un cluster) est tenu
+hors de la matrice de parité cloud, aucune des deux portées ne pouvant couvrir l'autre.
+
+## 2. Les faits de souveraineté
+
+Ces champs alimentent la ressource synthétique `governance_provider`, qu'évalue le
+contrôle `CLD-GVN-4`. Ce sont des **faits sourcés**, pas des impressions :
+
+```yaml
+souverainete:
+  eu_etabli: true                 # le siège du fournisseur est-il établi dans l'UE
+  juridiction: FR                 # pays du siège
+  controle_capitalistique: FR     # juridiction du contrôle ultime : FR | UE | extra_ue | a_verifier
+  secnumcloud: non                # qualifie | en_cours | non
+  exposition_extraterritoriale: false
+  sources: "les URL qui établissent la chaîne capitalistique"
+```
+
+Remonter la chaîne capitalistique jusqu'au bout. Le descripteur d'Exoscale en est
+l'exemple travaillé : société suisse, contrôle ultime hors UE, chaîne écrite et sourcée.
+
+## 3. Authentification et résolution des identifiants
+
+Le descripteur déclare comment une requête est signée et d'où viennent les identifiants.
+Trois sources, dans l'ordre : l'environnement, le fichier de configuration natif du
+fournisseur, puis les valeurs par défaut.
+
+```yaml
+auth:
+  type: header                   # header | sigv4 | exoscale-hmac
+  header: X-Auth-Token
+  value: "{secret_key}"
+credentials:
+  env:
+    access_key: ACME_ACCESS_KEY
+    secret_key: ACME_SECRET_KEY
+    region: ACME_REGION
+  file: { path: "~/.config/acme/config.yaml", format: scw }   # scw | osc | exoscale
+  defaults: { region: fr-par }
+```
+
+Lire le fichier de configuration natif compte plus qu'il n'y paraît : quelqu'un qui a
+déjà configuré la CLI du fournisseur s'attend à ce que Pépin fonctionne sans rien
+réexporter.
+
+**Aucun secret n'entre jamais dans le dépôt.** Les identifiants viennent de
+l'environnement ou de ce fichier ; `mise run secrets` (gitleaks) scanne l'historique à la
+recherche des motifs de clés souveraines.
+
+## 4. Projeter vers le modèle normalisé
+
+Les règles lisent des types normalisés (`compute_instance`, `security_group`,
+`security_group_rule`, `object_storage_bucket`, `managed_database`, `iam_policy`,
+`network`, `kubernetes_cluster`…) et des attributs normalisés. Votre travail consiste à
+y projeter le vocabulaire natif du fournisseur.
+
+Partir des types existants. Lire
+[`internal/commonrules/rules/`](../../internal/commonrules/rules) pour voir quels
+attributs les règles lisent réellement, et
+[le catalogue des contrôles](../controls/index.fr.md), où chaque page nomme le type lu et
+l'attribut dont dépend sa décision.
+
+Si votre fournisseur expose un mécanisme qu'aucun type normalisé ne couvre, c'est un
+changement de normalisation (un type, un attribut) suivi d'**une règle commune**, jamais
+d'une règle propre au fournisseur.
+
+## 5. Le mapping Terraform, ancré sur le schéma réel
+
+```yaml
+mapping_terraform:
+  resources:
+    - tf_type: acme_security_group_rule
+      type: security_group_rule
+      id: security_group_id
+      map:
+        security_group_id: security_group_id
+        direction: direction
+        protocol: protocol
+        port_from: from_port
+        port_to: to_port
+        cidrs: cidr_blocks
+      transforms:
+        protocol: lower
+        cidrs: list
+```
+
+C'est l'endroit où l'invention est attrapée automatiquement.
+`TestProviderMappingsMatchSchema` exécute `terraform providers schema -json` dans
+`examples/<nom>/terraform/` et vérifie que **chaque attribut source nommé par la spec
+existe dans le schéma réel du provider**. Un `tf_type` qui n'existe pas, ou un attribut
+qui n'existe pas, fait échouer le test. Quand Terraform ou le schéma sont indisponibles,
+le contrôle est ignoré plutôt que déclaré vert : lancez-le donc au moins une fois sur une
+machine qui a les deux.
+
+Les blocs imbriqués passent par `items` (le bloc répété est éclaté, `_parent.*` désignant
+le conteneur), et `for_each` exprime une liste parente qui alimente un appel par élément.
+
+## 6. La spec de collecte live
+
+Le même descripteur décrit l'API live, pilotée par le moteur de collecte commun
+(`internal/collect`) : aucun code Go pour une API REST/JSON.
+
+```yaml
+collecte:
+  base_url: https://api.{region}.acme.example/v1
+  resources:
+    - type: compute_instance
+      path: /instances
+      items: instances
+      id: vm_id
+      map:
+        vm_id: id
+        state: state
+        public_ip: public_ip
+        security_group_ids: security_groups
+```
+
+Les points qui décident de la fiabilité du résultat :
+
+- **La pagination.** Une liste tronquée en silence produit un rapport qui rate des
+  ressources. Le moteur implémente quatre styles (`page`, `token`, `offset-body`,
+  `token-body`) et refuse de tronquer sans le dire : il rend une erreur quand il atteint
+  sa borne de pages. Déclarer le style de votre API plutôt que d'accepter la première
+  page.
+- **Les jointures.** `for_each` couvre le « lister les parents, puis appeler le détail
+  par élément », qui est la façon d'atteindre les user-data, les clés par utilisateur ou
+  le détail par instance.
+- **La région est posée sur chaque ressource** par le moteur de collecte, ce qui rend la
+  localisation observable en live pour tout fournisseur qui collecte quoi que ce soit.
+
+Deux collecteurs sont du **code Go partagé**, pas de la spec : le stockage objet
+(compatible S3) et le Kubernetes managé. On les active en déclarant leur endpoint :
+
+```yaml
+s3:
+  endpoint: "https://s3.{region}.acme.example"
+  region: "{region}"
+  sse_kms: false        # true seulement si le fournisseur expose une clé client par bucket
+oks:
+  endpoint: "https://api.{region}.oks.acme.example"
+```
+
+## 7. Le contrat : ce qui est vérifié, ce qui ne l'est pas, ce qui n'existe pas
+
+Le contrat est la couche d'honnêteté, et c'est lui qui pilote l'assessment. Pour chaque
+type normalisé, l'un des trois états :
+
+```yaml
+contrat:
+  types:
+    security_group_rule:
+      etat: verifie          # lu dans le SDK/l'API et réellement projeté
+      source: "GET /security-groups — SecurityGroupRule.{direction,protocol,from_port}"
+      mapping:
+        protocol: Protocol (tcp|udp|icmp)
+    blockstorage_volume:
+      etat: a_verifier       # plausible, non lu : aucun « pass » ne sera jamais affirmé
+      source: "à confirmer dans le SDK"
+  non_applicable:
+    - control: loadbalancer_http_redirect_to_https
+      reason: "aucun mécanisme de redirection HTTP→HTTPS dans l'API des load balancers"
+      reason_en: "no HTTP→HTTPS redirection mechanism in the load balancer API"
+```
+
+Trois invariants sont tenus par des tests :
+
+- `TestContractVerifiedTypesAreCollected` : un type déclaré `verifie` **doit** être
+  collecté ou mappé. Sinon les règles qui le lisent sont mortes, chargées mais jamais
+  alimentées.
+- `TestEveryContractJustificationIsBilingual` : toute justification `non_applicable`
+  porte sa contrepartie anglaise, et la version anglaise ne porte aucun caractère
+  accentué. C'est ce motif qu'un auditeur lit en face d'un `not-applicable` ; un N/A sans
+  motif n'est pas opposable, et un N/A dont le motif bascule de langue ne l'est pas
+  davantage.
+- `TestProvidersValid` : identité, auth, identifiants et sources ne sont pas vides.
+
+`a_verifier` n'est pas un échec, c'est un état honnête : il met le `pass` hors d'atteinte
+et fait dire `partial` à la matrice de couverture, avec le motif. Déclarer `verifie` pour
+verdir une case est la seule chose qui ne doit jamais arriver.
+
+## 8. Les fixtures : ce qui est simulé, et ce qui est mesuré
+
+Les fixtures sont des réponses d'API et des plans **réalistes**, dans le vocabulaire
+natif du fournisseur :
+
+```
+examples/<nom>/terraform/         # un plan volontairement non conforme (plan.json)
+examples/<nom>/inventory.json     # un inventaire normalisé, pour un scan hors ligne
+```
+
+Soyez explicite sur les deux registres, car ils n'ont pas le même poids :
+
+- **Simulé** : une fixture committée prouve le *mapping* et la *règle*. Elle ne prouve
+  rien du comportement de l'API.
+- **Mesuré** : une exécution réelle (un plan produit depuis du vrai Terraform, ou un scan
+  live) prouve le *contrat*, c'est-à-dire que l'API rend bien ce champ, sous cette forme.
+
+Une entrée de contrat passe à `verifie` sur la foi du second, jamais du premier. Dites
+lequel des deux vous avez fait dans la pull request : la différence est toute la valeur
+de l'outil.
+
+## 9. Régions et zones
+
+`region_key` nomme la clé logique qu'alimente `--region`, parce que les fournisseurs ne
+s'accordent pas sur le mot : Exoscale raisonne en zones, d'autres en régions. Elle
+substitue `{region}` ou `{zone}` dans `base_url`, dans l'endpoint S3 et dans les chemins.
+Déclarez une valeur `defaults` raisonnable pour qu'un premier scan fonctionne sans
+cérémonie.
+
+## 10. Les permissions de moindre privilège
+
+Un scan Pépin est en **lecture seule**. La liste exacte des appels d'API que la collecte
+live effectue est dérivée de votre descripteur et publiée sur la page du fournisseur :
+c'est donc la liste des droits que doit porter une clé de lecture. Ne maintenez pas cette
+liste à la main, elle est générée.
+
+Pour donner sa page à votre fournisseur, l'ajouter à `documentedProviders` dans
+[`internal/docgen/providers.go`](../../internal/docgen/providers.go) et créer
+`docs/providers/<nom>.md` et `docs/providers/<nom>.fr.md` avec les régions générées
+(`provider-<nom>-identity`, `-credentials`, `-live`, `-terraform`, `-coverage`, `-na`,
+`-onesource`, `-scan`). Copier une page existante : tout ce qu'elle affirme de factuel y
+est injecté.
+
+## 11. Enregistrer, compiler, vérifier
+
+Les descripteurs sont **embarqués** dans le binaire (`embed.go`,
+`//go:embed all:providers`) : ajouter un cloud demande donc une recompilation, mais aucun
+code Go.
+
+```bash
+mise run build
+./pepin provider list
+./pepin scan <nom> --terraform examples/<nom>/terraform/plan.json
+```
+
+Puis les portes :
+
+```bash
+mise run validate   # référentiel ↔ règles ↔ index SCSL gelé ↔ catalogue ↔ bilinguisme
+mise run test       # tests Go (-race) + tests Rego + fraîcheur de la documentation
+mise run audit      # vet + lint + gosec + govulncheck + osv
+mise run gen-docs   # régénère la matrice, les pages de contrôles, la page du fournisseur
+```
+
+## 12. Valider sur un vrai compte, si vous en avez un
+
+Seulement si le scan live est la seule façon de confirmer le contrat :
+
+1. Scanner d'abord en **lecture seule**, sans rien provisionner. La plupart des questions
+   de contrat trouvent leur réponse dans ce qu'un tenant existant rend déjà.
+2. Si une ressource doit exister pour observer un champ, créer le strict minimum, dans un
+   projet isolé, et noter ce que vous avez créé.
+3. Observer, puis consigner le champ au contrat avec sa source.
+4. **Tout détruire**, et confirmer la destruction avant de conclure.
+
+Ne jamais laisser vivre une ressource de test. Et ne jamais annoncer une couverture
+qu'une exécution n'a pas montrée : un contrôle non validé reste `fournisseurs: []`,
+écrit, testé, activation gelée.
+
+---
+
+## Checklist de release du fournisseur
+
+- [ ] `providers/<nom>.yaml` existe, et **aucun** fichier `.rego` n'a été ajouté.
+- [ ] Identité, `scope` et `region_key` sont posés ; `pepin provider list` montre le
+      fournisseur.
+- [ ] Les faits de souveraineté sont remplis, avec la chaîne capitalistique **sourcée**.
+- [ ] L'auth et la résolution des identifiants fonctionnent depuis l'environnement **et**
+      depuis le fichier de configuration natif.
+- [ ] Chaque attribut mappé est ancré : lu dans le SDK ou la doc officielle, et cité (une
+      page de `references/docs/<nom>/`, ou la `source` du contrat).
+- [ ] Les attributs dérivés sont marqués comme dérivés, avec leur formule.
+- [ ] `TestProviderMappingsMatchSchema` a été lancé **sur une machine avec Terraform**, et
+      le mapping correspond au schéma réel du provider.
+- [ ] Tout type marqué `verifie` est réellement collecté ou mappé ; ce qui n'a pas été lu
+      reste `a_verifier`.
+- [ ] Tout `non_applicable` porte sa justification bilingue.
+- [ ] Les fixtures sont réalistes et **ne contiennent aucun secret**.
+- [ ] La pull request dit explicitement ce qui a été **simulé** et ce qui a été **mesuré**.
+- [ ] Toute ressource provisionnée pour un test a été **détruite**, et la destruction est
+      confirmée.
+- [ ] La page du fournisseur existe dans les deux langues, avec ses régions générées.
+- [ ] `mise run gen-docs` a été lancé et le résultat committé.
+- [ ] `mise run validate`, `mise run test` et `mise run audit` sont au vert.
+
+## Voir aussi
+
+- [Architecture](../project/architecture.fr.md) : c'est la source qui change, pas la
+  règle.
+- [Ajouter un contrôle](adding-a-control.fr.md) : l'autre moitié, la règle.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : ce que chaque
+  source peut montrer, et ce qu'elle ne peut pas.
+- [Matrice de couverture](../coverage.fr.md) : où votre fournisseur apparaîtra, et
+  pourquoi une case n'est pas verte.
+- Les descripteurs existants, qui sont la vraie référence :
+  [`providers/exoscale.yaml`](../../providers/exoscale.yaml),
+  [`providers/outscale.yaml`](../../providers/outscale.yaml),
+  [`providers/scaleway.yaml`](../../providers/scaleway.yaml).

--- a/docs/contributing/adding-a-provider.md
+++ b/docs/contributing/adding-a-provider.md
@@ -1,0 +1,360 @@
+> 🇬🇧 English · [🇫🇷 Français](adding-a-provider.fr.md)
+
+# Adding a provider, end to end
+
+A provider in Pépin is **a source, not a set of rules**. Every posture rule is common to
+every cloud and evaluates the normalized model; what a provider brings is the projection
+of its own API and of its Terraform resources onto that model. Adding a cloud therefore
+means writing **one descriptor**, `providers/<name>.yaml`, and **zero rules**.
+
+That is not a slogan, it is the acceptance criterion: if your change adds a `.rego` file,
+something went wrong in the normalization. See
+[the architecture](../project/architecture.md) for why.
+
+Here is what the binary knows about the providers registered today:
+
+<!-- pepin:gen provider-list -->
+```text
+
+// pepin  registered providers
+  exoscale  Exoscale (CH) — instances, security groups, block storage, SKS, SOS
+  kubernetes  Kubernetes (in-cluster) — RBAC, Pod Security Standards, NetworkPolicy
+  outscale  Outscale (3DS) — VM, BSU, OOS, EIM, security groups, OKS, LBU
+  scaleway  Scaleway — object storage, instances, IAM, security groups
+```
+<!-- /pepin:gen provider-list -->
+
+## The golden rule: never invent the resource model
+
+The model Pépin evaluates **must** reflect the provider's native contract: real fields,
+real types, real JSON tags, read in the SDK or in the official API documentation. A
+field you have not verified is not used. A field you **derive** (computed by the
+collector or the mapping) is marked as derived, with its formula.
+
+The reason is not purism. A CSPM that reads an invented field does not fail loudly: it
+silently returns "compliant", because the attribute is simply never there. That is a
+false green, and a false green is invisible by construction.
+
+Two habits make this practical:
+
+- Cache the pages you rely on: `mise run fetch-docs` stores the official documentation
+  as Markdown under `references/docs/<provider>/`, and a contract entry then cites a
+  file rather than a memory.
+- Record the open questions in `references/questions-providers/<provider>.yaml` instead
+  of guessing. An unanswered question is a `a_verifier` state, not a `verifie` one.
+
+## Prefer not provisioning anything
+
+Pépin can audit a **Terraform plan** (`terraform show -json`), which is enough to
+validate a mapping and a rule **without creating a single resource**:
+
+```bash
+terraform plan -out tfplan && terraform show -json tfplan > plan.json
+./pepin scan <provider> --terraform plan.json
+```
+
+A live scan is only needed to confirm the **API contract** (the fields the API really
+returns) when a plan cannot show it. And then the rule is absolute: **every resource
+provisioned for a test must be destroyed** (`terraform destroy`, or deletion through the
+API or the console). Keep the list of what you create, and confirm the teardown before
+you conclude. Cost, exposure surface and drift all argue the same way.
+
+---
+
+## 1. Identity and scope
+
+```yaml
+name: acme                       # the identifier the CLI takes: pepin scan acme
+description: "ACME (FR) — instances, security groups, object storage"
+scope: cloud                     # "cloud" (default) | "in-cluster" for a different scope
+region_key: region               # the logical key --region feeds (Exoscale uses "zone")
+```
+
+`scope` is not cosmetic: a provider whose scope is not a cloud control plane (the
+`kubernetes` provider audits the inside of a cluster) is kept out of the cloud parity
+matrix, because neither scope can cover the other.
+
+## 2. Sovereignty facts
+
+These fields feed the `governance_provider` synthetic resource, which control
+`CLD-GVN-4` evaluates. They are **facts with sources**, not impressions:
+
+```yaml
+souverainete:
+  eu_etabli: true                 # is the provider's registered office in the EU
+  juridiction: FR                 # country of the registered office
+  controle_capitalistique: FR     # jurisdiction of ultimate control: FR | UE | extra_ue | a_verifier
+  secnumcloud: non                # qualifie | en_cours | non
+  exposition_extraterritoriale: false
+  sources: "the URLs that establish the ownership chain"
+```
+
+Trace the ownership chain to the end. Exoscale's descriptor is the worked example: a
+Swiss company, ultimately controlled from outside the EU, with the chain written out and
+sourced.
+
+## 3. Authentication and credential resolution
+
+The descriptor declares how a request is signed and where credentials come from. Three
+sources, in order: the environment, the provider's native configuration file, then
+defaults.
+
+```yaml
+auth:
+  type: header                   # header | sigv4 | exoscale-hmac
+  header: X-Auth-Token
+  value: "{secret_key}"
+credentials:
+  env:
+    access_key: ACME_ACCESS_KEY
+    secret_key: ACME_SECRET_KEY
+    region: ACME_REGION
+  file: { path: "~/.config/acme/config.yaml", format: scw }   # scw | osc | exoscale
+  defaults: { region: fr-par }
+```
+
+Reading the native configuration file matters more than it looks: a user who already has
+the provider's own CLI configured expects Pépin to work without re-exporting anything.
+
+**No secret ever enters the repository.** Credentials come from the environment or from
+that file; `mise run secrets` (gitleaks) scans the history for sovereign key patterns.
+
+## 4. Map onto the normalized model
+
+The rules read normalized types (`compute_instance`, `security_group`,
+`security_group_rule`, `object_storage_bucket`, `managed_database`, `iam_policy`,
+`network`, `kubernetes_cluster`…) and normalized attributes. Your job is to project the
+provider's native vocabulary onto them.
+
+Start from the existing types. Read
+[`internal/commonrules/rules/`](../../internal/commonrules/rules) to see which
+attributes the rules actually read, and
+[the control catalogue](../controls/index.md), where each page names the type it reads
+and the attribute its decision depends on.
+
+If your provider exposes a mechanism no normalized type covers, that is a normalization
+change (a new type, a new attribute) followed by **one common rule** — never a
+provider-specific rule.
+
+## 5. The Terraform mapping, anchored on the real schema
+
+```yaml
+mapping_terraform:
+  resources:
+    - tf_type: acme_security_group_rule
+      type: security_group_rule
+      id: security_group_id
+      map:
+        security_group_id: security_group_id
+        direction: direction
+        protocol: protocol
+        port_from: from_port
+        port_to: to_port
+        cidrs: cidr_blocks
+      transforms:
+        protocol: lower
+        cidrs: list
+```
+
+This is the part where invention gets caught automatically.
+`TestProviderMappingsMatchSchema` runs `terraform providers schema -json` in
+`examples/<name>/terraform/` and checks that **every source attribute the spec names
+exists in the real provider schema**. A `tf_type` that does not exist, or an attribute
+that does not, fails the test. When Terraform or the schema is unavailable the check
+skips rather than passing silently — so run it at least once on a machine that has both.
+
+Nested blocks are supported through `items` (the repeated block is exploded, and
+`_parent.*` refers to the container), and `for_each` expresses a parent list feeding a
+per-item call.
+
+## 6. The live collection spec
+
+The same descriptor describes the live API, driven by the shared collection engine
+(`internal/collect`): no Go code for a REST/JSON API.
+
+```yaml
+collecte:
+  base_url: https://api.{region}.acme.example/v1
+  resources:
+    - type: compute_instance
+      path: /instances
+      items: instances
+      id: vm_id
+      map:
+        vm_id: id
+        state: state
+        public_ip: public_ip
+        security_group_ids: security_groups
+```
+
+Points that decide whether the result is trustworthy:
+
+- **Pagination.** A list that silently truncates produces a report that misses
+  resources. The engine implements four styles (`page`, `token`, `offset-body`,
+  `token-body`) and refuses to truncate quietly: it errors out when it hits its page
+  bound. Declare the style your API uses rather than accepting the first page.
+- **Joins.** `for_each` covers "list the parents, then call the detail endpoint per
+  item" — which is how user-data, per-user keys or per-instance details are reached.
+- **The region is posted on every resource** by the collection engine, which is what
+  makes localisation observable in live for any provider that collects anything.
+
+Two collectors are **shared Go code**, not spec: object storage (S3-compatible) and
+managed Kubernetes. You enable them by declaring their endpoint:
+
+```yaml
+s3:
+  endpoint: "https://s3.{region}.acme.example"
+  region: "{region}"
+  sse_kms: false        # true only if the provider exposes a customer key per bucket
+oks:
+  endpoint: "https://api.{region}.oks.acme.example"
+```
+
+## 7. The contract: what is verified, what is not, what does not exist
+
+The contract is the honesty layer, and it drives the assessment. For each normalized
+type, one of three states:
+
+```yaml
+contrat:
+  types:
+    security_group_rule:
+      etat: verifie          # read in the SDK/API and actually projected
+      source: "GET /security-groups — SecurityGroupRule.{direction,protocol,from_port}"
+      mapping:
+        protocol: Protocol (tcp|udp|icmp)
+    blockstorage_volume:
+      etat: a_verifier       # plausible, unread: no pass will ever be asserted
+      source: "to confirm in the SDK"
+  non_applicable:
+    - control: loadbalancer_http_redirect_to_https
+      reason: "aucun mécanisme de redirection HTTP→HTTPS dans l'API des load balancers"
+      reason_en: "no HTTP→HTTPS redirection mechanism in the load balancer API"
+```
+
+Three invariants are enforced by tests:
+
+- `TestContractVerifiedTypesAreCollected` — a type declared `verifie` **must** be
+  collected or mapped. Otherwise the rules that read it are dead: loaded, but never fed.
+- `TestEveryContractJustificationIsBilingual` — every `non_applicable` justification
+  carries its English counterpart, and the English one carries no accented characters.
+  An auditor reads that reason facing a `not-applicable`; an N/A without a reason is not
+  opposable, and one that flips language is not opposable either.
+- `TestProvidersValid` — identity, auth, credentials and sources are non-empty.
+
+`a_verifier` is not a failure, it is an honest state: it keeps `pass` out of reach and
+makes the coverage matrix say `partial` with the reason. Declaring `verifie` to make a
+cell green is the one thing that must never happen.
+
+## 8. Fixtures: what is mocked, and what is measured
+
+Fixtures are **realistic** API responses and plans, in the provider's native vocabulary:
+
+```
+examples/<name>/terraform/         # a deliberately non-compliant plan (plan.json)
+examples/<name>/inventory.json     # a normalized inventory, for an offline scan
+```
+
+Be explicit about the two registers, because they do not carry the same weight:
+
+- **Mocked** — a committed fixture proves the *mapping* and the *rule*. It proves
+  nothing about the API's behaviour.
+- **Measured** — a real run (a plan generated from real Terraform, or a live scan)
+  proves the *contract*: that the API really returns that field, with that shape.
+
+A contract entry moves to `verifie` on the strength of the second, never the first. Say
+which one you did in the pull request; the difference is the whole value of the tool.
+
+## 9. Regions and zones
+
+`region_key` names the logical key that `--region` feeds, because providers do not agree
+on the word: Exoscale reasons in zones, others in regions. It substitutes `{region}` or
+`{zone}` in `base_url`, in the S3 endpoint and in paths. Declare a sane `defaults` value
+so that a first scan works without ceremony.
+
+## 10. Least-privilege permissions
+
+A Pépin scan is **read-only**. The exact list of API calls the live collection makes is
+derived from your descriptor and published on the provider's page — which makes it the
+list of rights a read-only key must carry. Do not maintain that list by hand: it is
+generated.
+
+To give your provider its page, add it to `documentedProviders` in
+[`internal/docgen/providers.go`](../../internal/docgen/providers.go) and create
+`docs/providers/<name>.md` and `docs/providers/<name>.fr.md` with the generated regions
+(`provider-<name>-identity`, `-credentials`, `-live`, `-terraform`, `-coverage`, `-na`,
+`-onesource`, `-scan`). Copy an existing provider page: everything factual in it is
+injected.
+
+## 11. Register, build, and check
+
+Descriptors are **embedded** in the binary (`embed.go`, `//go:embed all:providers`), so
+adding a cloud requires a rebuild — but no Go code:
+
+```bash
+mise run build
+./pepin provider list
+./pepin scan <name> --terraform examples/<name>/terraform/plan.json
+```
+
+Then the gates:
+
+```bash
+mise run validate   # reference ↔ rules ↔ frozen SCSL index ↔ catalogue ↔ bilingualism
+mise run test       # Go tests (-race) + Rego tests + documentation freshness
+mise run audit      # vet + lint + gosec + govulncheck + osv
+mise run gen-docs   # regenerate the coverage matrix, the control pages, the provider page
+```
+
+## 12. Validating on a real account, if you have one
+
+Only if a live scan is the only way to confirm the contract:
+
+1. Scan **read-only** first, provisioning nothing. Most contract questions are answered
+   by what an existing tenant already returns.
+2. If a resource must exist to observe a field, create the strict minimum, in an
+   isolated project, and write down what you created.
+3. Observe, record the field in the contract with its source.
+4. **Destroy everything**, and confirm the teardown before concluding.
+
+Never leave a test resource alive. And never claim a coverage a run has not shown: an
+unvalidated control stays `fournisseurs: []` — written, tested, activation frozen.
+
+---
+
+## Provider release checklist
+
+- [ ] `providers/<name>.yaml` exists, and **no** `.rego` file was added.
+- [ ] Identity, `scope` and `region_key` are set; `pepin provider list` shows the
+      provider.
+- [ ] Sovereignty facts are filled, with the ownership chain **sourced**.
+- [ ] Auth and credential resolution work from the environment **and** from the native
+      configuration file.
+- [ ] Every mapped attribute is anchored: read in the SDK or in the official docs, and
+      cited (a page under `references/docs/<name>/`, or the contract's `source`).
+- [ ] Derived attributes are marked as derived, with their formula.
+- [ ] `TestProviderMappingsMatchSchema` was run **on a machine with Terraform**, and the
+      mapping matches the real provider schema.
+- [ ] Every type marked `verifie` is really collected or mapped; anything unread stays
+      `a_verifier`.
+- [ ] Every `non_applicable` carries its bilingual justification.
+- [ ] Fixtures are realistic, and **contain no secret**.
+- [ ] The pull request says explicitly what was **mocked** and what was **measured**.
+- [ ] Any resource provisioned for a test was **destroyed**, and the teardown is
+      confirmed.
+- [ ] The provider page exists in both languages, with its generated regions.
+- [ ] `mise run gen-docs` has been run and the result committed.
+- [ ] `mise run validate`, `mise run test` and `mise run audit` are green.
+
+## See also
+
+- [Architecture](../project/architecture.md) — the source changes, the rule does not.
+- [Adding a control](adding-a-control.md) — the other half: the rule.
+- [Terraform plan vs live scan](../concepts/terraform-vs-live.md) — what each source can
+  and cannot show.
+- [Coverage matrix](../coverage.md) — where your provider will appear, and why a cell is
+  not green.
+- Existing descriptors, which are the real reference:
+  [`providers/exoscale.yaml`](../../providers/exoscale.yaml),
+  [`providers/outscale.yaml`](../../providers/outscale.yaml),
+  [`providers/scaleway.yaml`](../../providers/scaleway.yaml).

--- a/docs/controls/blockstorage_snapshot_not_public.fr.md
+++ b/docs/controls/blockstorage_snapshot_not_public.fr.md
@@ -97,7 +97,7 @@ Retirer le partage public ; restreindre le partage aux comptes légitimes.
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -112,7 +112,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/blockstorage_snapshot_not_public.fr.md
+++ b/docs/controls/blockstorage_snapshot_not_public.fr.md
@@ -1,0 +1,118 @@
+> [🇬🇧 English](blockstorage_snapshot_not_public.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `blockstorage_snapshot_not_public`
+
+**Instantané ou image partagé publiquement**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `blockstorage_snapshot_not_public` |
+| Famille | `stockage` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-STO-2` |
+| Type de ressource lu | `blockstorage_snapshot` |
+| Attribut décisif | `global_permission` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Un instantané (snapshot) ou une image disque est partagé publiquement, exposant potentiellement des données ou des secrets.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-STO-2` |
+| `cis_controls_v8` | `3.3` |
+| `iso_27001_2022` | `A.5.15`, `A.8.3` |
+| `iso_27017` | `CLD.9.5.1` |
+| `secnumcloud_3_2` | `9.7`, `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ∅ | ∅ |
+| outscale | ✗ | ✅ |
+| scaleway | ∅ | ∅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| exoscale | terraform | ∅ `not-applicable` | Snapshots block-storage Exoscale non exportables/partageables (doc officielle) : le risque d'exposition publique est structurellement absent, conforme par construction (STO-2). |
+| exoscale | live | ∅ `not-applicable` | Snapshots block-storage Exoscale non exportables/partageables (doc officielle) : le risque d'exposition publique est structurellement absent, conforme par construction (STO-2). |
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « blockstorage_snapshot » |
+| scaleway | terraform | ∅ `not-applicable` | Les snapshots block Scaleway (api/block/v1) n'exposent aucun mécanisme de partage ou d'export public : le risque d'exposition publique est structurellement absent, conforme par construction (STO-2). |
+| scaleway | live | ∅ `not-applicable` | Les snapshots block Scaleway (api/block/v1) n'exposent aucun mécanisme de partage ou d'export public : le risque d'exposition publique est structurellement absent, conforme par construction (STO-2). |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | exoscale / terraform · exoscale / live · scaleway / terraform · scaleway / live |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `blockstorage_snapshot`
+- Attribut dont la décision dépend : `global_permission`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Retirer le partage public ; restreindre le partage aux comptes légitimes.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "blockstorage_snapshot_not_public"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/blockstorage_snapshot_not_public.md
+++ b/docs/controls/blockstorage_snapshot_not_public.md
@@ -1,0 +1,117 @@
+> 🇬🇧 English · [🇫🇷 Français](blockstorage_snapshot_not_public.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `blockstorage_snapshot_not_public`
+
+**Snapshot or image shared publicly**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `blockstorage_snapshot_not_public` |
+| Family | `stockage` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-STO-2` |
+| Resource type read | `blockstorage_snapshot` |
+| Deciding attribute | `global_permission` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+A snapshot or a disk image is shared publicly, potentially exposing data or secrets.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-STO-2` |
+| `cis_controls_v8` | `3.3` |
+| `iso_27001_2022` | `A.5.15`, `A.8.3` |
+| `iso_27017` | `CLD.9.5.1` |
+| `secnumcloud_3_2` | `9.7`, `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ∅ | ∅ |
+| outscale | ✗ | ✅ |
+| scaleway | ∅ | ∅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| exoscale | terraform | ∅ `not-applicable` | Exoscale block-storage snapshots cannot be exported or shared (official documentation): the risk of public exposure is structurally absent, compliant by construction (STO-2). |
+| exoscale | live | ∅ `not-applicable` | Exoscale block-storage snapshots cannot be exported or shared (official documentation): the risk of public exposure is structurally absent, compliant by construction (STO-2). |
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "blockstorage_snapshot" |
+| scaleway | terraform | ∅ `not-applicable` | Scaleway block snapshots (api/block/v1) expose no sharing or public export mechanism: the risk of public exposure is structurally absent, compliant by construction (STO-2). |
+| scaleway | live | ∅ `not-applicable` | Scaleway block snapshots (api/block/v1) expose no sharing or public export mechanism: the risk of public exposure is structurally absent, compliant by construction (STO-2). |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | exoscale / terraform · exoscale / live · scaleway / terraform · scaleway / live |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `blockstorage_snapshot`
+- Attribute the decision depends on: `global_permission`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Remove the public sharing; restrict sharing to legitimate accounts.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "blockstorage_snapshot_not_public"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/blockstorage_volume_encryption.fr.md
+++ b/docs/controls/blockstorage_volume_encryption.fr.md
@@ -1,0 +1,118 @@
+> [🇬🇧 English](blockstorage_volume_encryption.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `blockstorage_volume_encryption`
+
+**Chiffrement au repos désactivé**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `blockstorage_volume_encryption` |
+| Famille | `chiffrement` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-CHF-2` |
+| Type de ressource lu | `blockstorage_volume` |
+| Attribut décisif | `encrypted` |
+| État | actif |
+| Déclaré pour | `exoscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Un volume block storage n'a pas le chiffrement au repos activé. Le modèle diffère selon le fournisseur : chiffrement transparent toujours actif (Exoscale, conforme par construction), ou chiffrement côté invité à la charge du client et non exposé par l'API (Outscale, Scaleway : non applicable côté plateforme).
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-CHF-2` |
+| `iso_27001_2022` | `A.8.24` |
+| `secnumcloud_3_2` | `10.1` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ∅ | ∅ |
+| scaleway | ∅ | ∅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ∅ `not-applicable` | osc-sdk-go/v2 Volume n'expose aucun champ de chiffrement ; le chiffrement au repos est côté invité (EncFS/LUKS), responsabilité du client → non observable côté plateforme (CHF-2). |
+| outscale | live | ∅ `not-applicable` | osc-sdk-go/v2 Volume n'expose aucun champ de chiffrement ; le chiffrement au repos est côté invité (EncFS/LUKS), responsabilité du client → non observable côté plateforme (CHF-2). |
+| scaleway | terraform | ∅ `not-applicable` | Chiffrement au repos des volumes block côté invité (LUKS/Cryptsetup), responsabilité du client (responsabilité partagée) ; l'API block n'expose aucun champ de chiffrement → non observable côté plateforme (CHF-2). |
+| scaleway | live | ∅ `not-applicable` | Chiffrement au repos des volumes block côté invité (LUKS/Cryptsetup), responsabilité du client (responsabilité partagée) ; l'API block n'expose aucun champ de chiffrement → non observable côté plateforme (CHF-2). |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `blockstorage_volume`
+- Attribut dont la décision dépend : `encrypted`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Activer le chiffrement au repos du volume (transparent côté fournisseur, ou chiffrement client EncFS/LUKS selon le modèle de responsabilité partagée).
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "blockstorage_volume_encryption"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/blockstorage_volume_encryption.fr.md
+++ b/docs/controls/blockstorage_volume_encryption.fr.md
@@ -94,7 +94,7 @@ Activer le chiffrement au repos du volume (transparent côté fournisseur, ou ch
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -112,7 +112,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/blockstorage_volume_encryption.md
+++ b/docs/controls/blockstorage_volume_encryption.md
@@ -1,0 +1,117 @@
+> 🇬🇧 English · [🇫🇷 Français](blockstorage_volume_encryption.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `blockstorage_volume_encryption`
+
+**Encryption at rest disabled**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `blockstorage_volume_encryption` |
+| Family | `chiffrement` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-CHF-2` |
+| Resource type read | `blockstorage_volume` |
+| Deciding attribute | `encrypted` |
+| State | active |
+| Declared for | `exoscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+A block storage volume does not have encryption at rest enabled. The model differs from one provider to the next: transparent encryption always on (Exoscale, compliant by construction), or guest-side encryption left to the customer and not exposed by the API (Outscale, Scaleway: not applicable on the platform side).
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-CHF-2` |
+| `iso_27001_2022` | `A.8.24` |
+| `secnumcloud_3_2` | `10.1` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ∅ | ∅ |
+| scaleway | ∅ | ∅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ∅ `not-applicable` | osc-sdk-go/v2 Volume exposes no encryption field; encryption at rest is guest-side (EncFS/LUKS), a customer responsibility, hence unobservable on the platform side (CHF-2). |
+| outscale | live | ∅ `not-applicable` | osc-sdk-go/v2 Volume exposes no encryption field; encryption at rest is guest-side (EncFS/LUKS), a customer responsibility, hence unobservable on the platform side (CHF-2). |
+| scaleway | terraform | ∅ `not-applicable` | Encryption at rest of block volumes is guest-side (LUKS/Cryptsetup), a customer responsibility (shared responsibility model); the block API exposes no encryption field, hence unobservable on the platform side (CHF-2). |
+| scaleway | live | ∅ `not-applicable` | Encryption at rest of block volumes is guest-side (LUKS/Cryptsetup), a customer responsibility (shared responsibility model); the block API exposes no encryption field, hence unobservable on the platform side (CHF-2). |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `blockstorage_volume`
+- Attribute the decision depends on: `encrypted`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enable encryption at rest on the volume (transparent on the provider side, or client-side encryption with EncFS/LUKS, depending on the shared responsibility model).
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "blockstorage_volume_encryption"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/blockstorage_volume_snapshots_exist.fr.md
+++ b/docs/controls/blockstorage_volume_snapshots_exist.fr.md
@@ -1,0 +1,117 @@
+> [🇬🇧 English](blockstorage_volume_snapshots_exist.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `blockstorage_volume_snapshots_exist`
+
+**Absence de sauvegarde récente**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `blockstorage_volume_snapshots_exist` |
+| Famille | `stockage` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-STO-3` |
+| Type de ressource lu | `blockstorage_volume` |
+| Attribut décisif | `state` |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale` |
+| Preuves de remédiation | 0 / 2 |
+
+## Le risque
+
+Un volume de données en usage n'a pas d'instantané/sauvegarde récent : la restauration après incident n'est pas garantie.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-STO-3` |
+| `cis_controls_v8` | `11.2` |
+| `iso_27001_2022` | `A.8.13` |
+| `secnumcloud_3_2` | `12.5` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « blockstorage_volume » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `blockstorage_volume`
+- Attribut dont la décision dépend : `state`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Mettre en place une politique de sauvegarde régulière avec test de restauration ; chiffrer et appliquer une rétention documentée.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "blockstorage_volume_snapshots_exist"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/blockstorage_volume_snapshots_exist.fr.md
+++ b/docs/controls/blockstorage_volume_snapshots_exist.fr.md
@@ -93,7 +93,7 @@ Mettre en place une politique de sauvegarde régulière avec test de restauratio
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -111,7 +111,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/blockstorage_volume_snapshots_exist.md
+++ b/docs/controls/blockstorage_volume_snapshots_exist.md
@@ -1,0 +1,116 @@
+> 🇬🇧 English · [🇫🇷 Français](blockstorage_volume_snapshots_exist.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `blockstorage_volume_snapshots_exist`
+
+**No recent backup**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `blockstorage_volume_snapshots_exist` |
+| Family | `stockage` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-STO-3` |
+| Resource type read | `blockstorage_volume` |
+| Deciding attribute | `state` |
+| State | active |
+| Declared for | `exoscale`, `outscale` |
+| Remediation proofs | 0 / 2 |
+
+## The risk
+
+A data volume in use has no recent snapshot or backup: restoring after an incident is not guaranteed.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-STO-3` |
+| `cis_controls_v8` | `11.2` |
+| `iso_27001_2022` | `A.8.13` |
+| `secnumcloud_3_2` | `12.5` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "blockstorage_volume" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `blockstorage_volume`
+- Attribute the decision depends on: `state`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Set up a regular backup policy with restore testing; encrypt the backups and apply a documented retention.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "blockstorage_volume_snapshots_exist"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/compute_image_not_public.fr.md
+++ b/docs/controls/compute_image_not_public.fr.md
@@ -1,0 +1,115 @@
+> [🇬🇧 English](compute_image_not_public.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `compute_image_not_public`
+
+**Image machine partagée publiquement**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `compute_image_not_public` |
+| Famille | `stockage` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-STO-2` |
+| Type de ressource lu | `compute_image` |
+| Attribut décisif | `public` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Une image machine (OMI/template) est partagée publiquement : quiconque peut la lancer, exposant les données ou secrets embarqués dans l'image.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-STO-2` |
+| `cis_controls_v8` | `3.3` |
+| `iso_27001_2022` | `A.5.15`, `A.8.3` |
+| `iso_27017` | `CLD.9.5.1` |
+| `secnumcloud_3_2` | `9.7` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✅ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / terraform · outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / terraform · outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `compute_image`
+- Attribut dont la décision dépend : `public`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Retirer le partage public de l'image ; la réserver aux comptes légitimes.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan outscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "compute_image_not_public"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/compute_image_not_public.fr.md
+++ b/docs/controls/compute_image_not_public.fr.md
@@ -91,7 +91,7 @@ Retirer le partage public de l'image ; la réserver aux comptes légitimes.
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -109,7 +109,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/compute_image_not_public.md
+++ b/docs/controls/compute_image_not_public.md
@@ -1,0 +1,114 @@
+> 🇬🇧 English · [🇫🇷 Français](compute_image_not_public.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `compute_image_not_public`
+
+**Machine image shared publicly**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `compute_image_not_public` |
+| Family | `stockage` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-STO-2` |
+| Resource type read | `compute_image` |
+| Deciding attribute | `public` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+A machine image (OMI/template) is shared publicly: anyone can launch it, exposing the data or the secrets baked into the image.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-STO-2` |
+| `cis_controls_v8` | `3.3` |
+| `iso_27001_2022` | `A.5.15`, `A.8.3` |
+| `iso_27017` | `CLD.9.5.1` |
+| `secnumcloud_3_2` | `9.7` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✅ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / terraform · outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / terraform · outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `compute_image`
+- Attribute the decision depends on: `public`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Remove the image's public sharing; reserve it for legitimate accounts.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan outscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "compute_image_not_public"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/compute_instance_deletion_protection.fr.md
+++ b/docs/controls/compute_instance_deletion_protection.fr.md
@@ -89,7 +89,7 @@ Activer la protection contre la suppression sur les instances portant un service
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -111,7 +111,7 @@ Le tableau des motifs dit laquelle, et pourquoi.
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/compute_instance_deletion_protection.fr.md
+++ b/docs/controls/compute_instance_deletion_protection.fr.md
@@ -1,0 +1,117 @@
+> [🇬🇧 English](compute_instance_deletion_protection.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `compute_instance_deletion_protection`
+
+**Instance sans protection contre la suppression**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `compute_instance_deletion_protection` |
+| Famille | `compute` |
+| Sévérité | `medium` |
+| Exigence SCSL (index gelé) | `CLD-CMP-10` |
+| Type de ressource lu | `compute_instance` |
+| Attribut décisif | `deletion_protection` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Une instance de calcul n'a pas de protection contre la suppression : une commande accidentelle ou malveillante détruit le service et ses données locales, sans compromission préalable.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-CMP-10` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ◐ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ◐ `partial` | attribut décisif « deletion_protection » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / terraform · outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | outscale / terraform |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `compute_instance`
+- Attribut dont la décision dépend : `deletion_protection`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Activer la protection contre la suppression sur les instances portant un service en production.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan outscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "compute_instance_deletion_protection"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+**Une des deux sources ne sait pas lever le verrou du « pass »** pour ce contrôle :
+le fournisseur cité y produit bien le type visé, mais le scan y rendra `not-evaluated`.
+Le tableau des motifs dit laquelle, et pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/compute_instance_deletion_protection.md
+++ b/docs/controls/compute_instance_deletion_protection.md
@@ -1,0 +1,116 @@
+> 🇬🇧 English · [🇫🇷 Français](compute_instance_deletion_protection.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `compute_instance_deletion_protection`
+
+**Instance without deletion protection**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `compute_instance_deletion_protection` |
+| Family | `compute` |
+| Severity | `medium` |
+| SCSL requirement (frozen index) | `CLD-CMP-10` |
+| Resource type read | `compute_instance` |
+| Deciding attribute | `deletion_protection` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+A compute instance has no deletion protection: an accidental or malicious command destroys the service and its local data, with no prior compromise.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-CMP-10` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ◐ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ◐ `partial` | deciding attribute "deletion_protection" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / terraform · outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | outscale / terraform |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `compute_instance`
+- Attribute the decision depends on: `deletion_protection`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enable deletion protection on the instances carrying a production service.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan outscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "compute_instance_deletion_protection"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+**One of the two sources cannot lift the `pass` lock** for this control: the provider
+quoted does produce the targeted type there, but the scan will return `not-evaluated`.
+The reasons table says which one, and why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/compute_instance_has_security_group.fr.md
+++ b/docs/controls/compute_instance_has_security_group.fr.md
@@ -1,0 +1,117 @@
+> [🇬🇧 English](compute_instance_has_security_group.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `compute_instance_has_security_group`
+
+**Machine sans filtrage réseau**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `compute_instance_has_security_group` |
+| Famille | `compute` |
+| Sévérité | `critical` |
+| Exigence SCSL (index gelé) | `CLD-CMP-1` |
+| Type de ressource lu | `compute_instance` |
+| Attribut décisif | `security_group_ids` |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Une instance n'est associée à aucun groupe de sécurité : aucun filtrage réseau ne s'applique.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-CMP-1` |
+| `cis_controls_v8` | `4.4` |
+| `iso_27001_2022` | `A.8.20` |
+| `iso_27017` | `CLD.9.5.2` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `compute_instance`
+- Attribut dont la décision dépend : `security_group_ids`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Associer un groupe de sécurité restrictif (refus par défaut) à chaque instance.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "compute_instance_has_security_group"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/compute_instance_has_security_group.fr.md
+++ b/docs/controls/compute_instance_has_security_group.fr.md
@@ -93,7 +93,7 @@ Associer un groupe de sécurité restrictif (refus par défaut) à chaque instan
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -111,7 +111,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/compute_instance_has_security_group.md
+++ b/docs/controls/compute_instance_has_security_group.md
@@ -1,0 +1,116 @@
+> 🇬🇧 English · [🇫🇷 Français](compute_instance_has_security_group.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `compute_instance_has_security_group`
+
+**Instance without network filtering**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `compute_instance_has_security_group` |
+| Family | `compute` |
+| Severity | `critical` |
+| SCSL requirement (frozen index) | `CLD-CMP-1` |
+| Resource type read | `compute_instance` |
+| Deciding attribute | `security_group_ids` |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+An instance is not associated with any security group: no network filtering applies to it.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-CMP-1` |
+| `cis_controls_v8` | `4.4` |
+| `iso_27001_2022` | `A.8.20` |
+| `iso_27017` | `CLD.9.5.2` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `compute_instance`
+- Attribute the decision depends on: `security_group_ids`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Attach a restrictive security group (deny by default) to every instance.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "compute_instance_has_security_group"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/compute_instance_no_secrets_in_user_data.fr.md
+++ b/docs/controls/compute_instance_no_secrets_in_user_data.fr.md
@@ -1,0 +1,116 @@
+> [🇬🇧 English](compute_instance_no_secrets_in_user_data.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `compute_instance_no_secrets_in_user_data`
+
+**Secret en clair dans les données utilisateur (user-data)**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `compute_instance_no_secrets_in_user_data` |
+| Famille | `compute` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-CMP-9` |
+| Type de ressource lu | `compute_instance` |
+| Attribut décisif | `user_data` |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Les données utilisateur (user-data/cloud-init) contiennent un secret en clair : un SSRF ou un accès aux métadonnées peut l'exfiltrer.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-CMP-9` |
+| `secnumcloud_3_2` | `10.5` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ◐ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| scaleway | live | ◐ `partial` | attribut décisif « user_data » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | scaleway / live |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `compute_instance`
+- Attribut dont la décision dépend : `user_data`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Bannir les secrets des données utilisateur ; utiliser un coffre de secrets et l'injection au démarrage.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "compute_instance_no_secrets_in_user_data"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/compute_instance_no_secrets_in_user_data.fr.md
+++ b/docs/controls/compute_instance_no_secrets_in_user_data.fr.md
@@ -92,7 +92,7 @@ Bannir les secrets des données utilisateur ; utiliser un coffre de secrets et l
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -110,7 +110,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/compute_instance_no_secrets_in_user_data.md
+++ b/docs/controls/compute_instance_no_secrets_in_user_data.md
@@ -1,0 +1,115 @@
+> 🇬🇧 English · [🇫🇷 Français](compute_instance_no_secrets_in_user_data.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `compute_instance_no_secrets_in_user_data`
+
+**Cleartext secret in the user data (user-data)**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `compute_instance_no_secrets_in_user_data` |
+| Family | `compute` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-CMP-9` |
+| Resource type read | `compute_instance` |
+| Deciding attribute | `user_data` |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+The user data (user-data/cloud-init) contains a cleartext secret: an SSRF or any access to the metadata service can exfiltrate it.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-CMP-9` |
+| `secnumcloud_3_2` | `10.5` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ◐ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| scaleway | live | ◐ `partial` | deciding attribute "user_data" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | scaleway / live |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `compute_instance`
+- Attribute the decision depends on: `user_data`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Ban secrets from user data; use a secrets vault and inject them at boot.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "compute_instance_no_secrets_in_user_data"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/compute_instance_public_ip_with_open_securitygroup.fr.md
+++ b/docs/controls/compute_instance_public_ip_with_open_securitygroup.fr.md
@@ -1,0 +1,119 @@
+> [🇬🇧 English](compute_instance_public_ip_with_open_securitygroup.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `compute_instance_public_ip_with_open_securitygroup`
+
+**Machine exposée publiquement sans filtrage restrictif**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `compute_instance_public_ip_with_open_securitygroup` |
+| Famille | `reseau` |
+| Sévérité | `critical` |
+| Exigence SCSL (index gelé) | `CLD-NET-3` |
+| Type de ressource lu | `compute_instance` |
+| Attribut décisif | `public_ip` |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Une instance porte une IP publique et un groupe de sécurité ouvert à 0.0.0.0/0 : elle est directement atteignable depuis Internet.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-3` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `iso_27017` | `CLD.9.5.2` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ◐ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| scaleway | terraform | ◐ `partial` | attribut décisif « public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | scaleway / terraform |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `compute_instance`
+- Attribut dont la décision dépend : `public_ip`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Retirer l'IP publique si inutile ; restreindre le groupe de sécurité ; placer la machine derrière un répartiteur ou un VPN.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "compute_instance_public_ip_with_open_securitygroup"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/compute_instance_public_ip_with_open_securitygroup.fr.md
+++ b/docs/controls/compute_instance_public_ip_with_open_securitygroup.fr.md
@@ -95,7 +95,7 @@ Retirer l'IP publique si inutile ; restreindre le groupe de sécurité ; placer 
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -113,7 +113,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/compute_instance_public_ip_with_open_securitygroup.md
+++ b/docs/controls/compute_instance_public_ip_with_open_securitygroup.md
@@ -1,0 +1,118 @@
+> 🇬🇧 English · [🇫🇷 Français](compute_instance_public_ip_with_open_securitygroup.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `compute_instance_public_ip_with_open_securitygroup`
+
+**Instance publicly exposed without restrictive filtering**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `compute_instance_public_ip_with_open_securitygroup` |
+| Family | `reseau` |
+| Severity | `critical` |
+| SCSL requirement (frozen index) | `CLD-NET-3` |
+| Resource type read | `compute_instance` |
+| Deciding attribute | `public_ip` |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+An instance carries a public IP and a security group open to 0.0.0.0/0: it is directly reachable from the internet.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-3` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `iso_27017` | `CLD.9.5.2` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ◐ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| scaleway | terraform | ◐ `partial` | deciding attribute "public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | scaleway / terraform |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `compute_instance`
+- Attribute the decision depends on: `public_ip`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Remove the public IP if it is not needed; restrict the security group; place the instance behind a load balancer or a VPN.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "compute_instance_public_ip_with_open_securitygroup"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/database_backup_enabled.fr.md
+++ b/docs/controls/database_backup_enabled.fr.md
@@ -1,0 +1,113 @@
+> [🇬🇧 English](database_backup_enabled.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `database_backup_enabled`
+
+**Sauvegardes automatiques d'une base managée désactivées**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `database_backup_enabled` |
+| Famille | `stockage` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-STO-3` |
+| Type de ressource lu | `managed_database` |
+| Attribut décisif | `disable_backup` |
+| État | actif |
+| Déclaré pour | `scaleway` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Les sauvegardes automatiques d'une base de données managée sont désactivées : pas de restauration garantie après incident ou suppression.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-STO-3` |
+| `cis_controls_v8` | `11.2` |
+| `iso_27001_2022` | `A.8.13` |
+| `secnumcloud_3_2` | `12.5` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✅ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « managed_database » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | scaleway / terraform |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | scaleway / terraform |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `managed_database`
+- Attribut dont la décision dépend : `disable_backup`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Réactiver les sauvegardes automatiques et fixer une rétention adaptée au RPO.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan scaleway --terraform plan.json --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "database_backup_enabled"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/database_backup_enabled.fr.md
+++ b/docs/controls/database_backup_enabled.fr.md
@@ -92,7 +92,7 @@ Réactiver les sauvegardes automatiques et fixer une rétention adaptée au RPO.
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -107,7 +107,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/database_backup_enabled.md
+++ b/docs/controls/database_backup_enabled.md
@@ -1,0 +1,112 @@
+> 🇬🇧 English · [🇫🇷 Français](database_backup_enabled.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `database_backup_enabled`
+
+**Automatic backups disabled on a managed database**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `database_backup_enabled` |
+| Family | `stockage` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-STO-3` |
+| Resource type read | `managed_database` |
+| Deciding attribute | `disable_backup` |
+| State | active |
+| Declared for | `scaleway` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+Automatic backups of a managed database are disabled: there is no guaranteed restore after an incident or a deletion.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-STO-3` |
+| `cis_controls_v8` | `11.2` |
+| `iso_27001_2022` | `A.8.13` |
+| `secnumcloud_3_2` | `12.5` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✅ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| scaleway | live | ✗ `unsupported` | this source produces no resource of type "managed_database" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | scaleway / terraform |
+| `pass` | the deciding data was collected, and it is compliant | scaleway / terraform |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `managed_database`
+- Attribute the decision depends on: `disable_backup`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Re-enable automatic backups and set a retention that matches the RPO.
+
+| Provider | Deployable setup |
+|---|---|
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan scaleway --terraform plan.json --format assessment
+```
+
+In the `assessment` output, look for `"control": "database_backup_enabled"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/database_encryption_at_rest_enabled.fr.md
+++ b/docs/controls/database_encryption_at_rest_enabled.fr.md
@@ -1,0 +1,113 @@
+> [🇬🇧 English](database_encryption_at_rest_enabled.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `database_encryption_at_rest_enabled`
+
+**Base de données managée sans chiffrement au repos**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `database_encryption_at_rest_enabled` |
+| Famille | `chiffrement` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-CHF-2` |
+| Type de ressource lu | `managed_database` |
+| Attribut décisif | `encryption_at_rest` |
+| État | actif |
+| Déclaré pour | `scaleway` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Une base de données managée n'a pas le chiffrement au repos activé : en cas d'accès au support de stockage, les données sont lisibles en clair.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-CHF-2` |
+| `cis_controls_v8` | `3.11` |
+| `iso_27001_2022` | `A.8.24` |
+| `secnumcloud_3_2` | `10.1` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✅ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « managed_database » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | scaleway / terraform |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | scaleway / terraform |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `managed_database`
+- Attribut dont la décision dépend : `encryption_at_rest`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Activer le chiffrement au repos de l'instance (à la création ou par mise à niveau).
+
+| Fournisseur | Montage déployable |
+|---|---|
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan scaleway --terraform plan.json --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "database_encryption_at_rest_enabled"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/database_encryption_at_rest_enabled.fr.md
+++ b/docs/controls/database_encryption_at_rest_enabled.fr.md
@@ -92,7 +92,7 @@ Activer le chiffrement au repos de l'instance (à la création ou par mise à ni
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -107,7 +107,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/database_encryption_at_rest_enabled.md
+++ b/docs/controls/database_encryption_at_rest_enabled.md
@@ -1,0 +1,112 @@
+> 🇬🇧 English · [🇫🇷 Français](database_encryption_at_rest_enabled.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `database_encryption_at_rest_enabled`
+
+**Managed database without encryption at rest**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `database_encryption_at_rest_enabled` |
+| Family | `chiffrement` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-CHF-2` |
+| Resource type read | `managed_database` |
+| Deciding attribute | `encryption_at_rest` |
+| State | active |
+| Declared for | `scaleway` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+A managed database does not have encryption at rest enabled: should the storage media be accessed, the data is readable in cleartext.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-CHF-2` |
+| `cis_controls_v8` | `3.11` |
+| `iso_27001_2022` | `A.8.24` |
+| `secnumcloud_3_2` | `10.1` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✅ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| scaleway | live | ✗ `unsupported` | this source produces no resource of type "managed_database" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | scaleway / terraform |
+| `pass` | the deciding data was collected, and it is compliant | scaleway / terraform |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `managed_database`
+- Attribute the decision depends on: `encryption_at_rest`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enable encryption at rest on the instance (at creation time, or through an upgrade).
+
+| Provider | Deployable setup |
+|---|---|
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan scaleway --terraform plan.json --format assessment
+```
+
+In the `assessment` output, look for `"control": "database_encryption_at_rest_enabled"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/database_service_not_open_to_internet.fr.md
+++ b/docs/controls/database_service_not_open_to_internet.fr.md
@@ -1,0 +1,113 @@
+> [🇬🇧 English](database_service_not_open_to_internet.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `database_service_not_open_to_internet`
+
+**Base de données managée joignable depuis Internet**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `database_service_not_open_to_internet` |
+| Famille | `reseau` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-NET-1` |
+| Type de ressource lu | `managed_database` |
+| Attribut décisif | `ip_filter` |
+| État | actif |
+| Déclaré pour | `scaleway` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+La liste d'IP autorisées (ACL) d'une base de données managée admet un CIDR public : le service de base de données est joignable depuis Internet.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-1` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✅ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « managed_database » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | scaleway / terraform |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | scaleway / terraform |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `managed_database`
+- Attribut dont la décision dépend : `ip_filter`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Restreindre l'ACL de la base aux seuls CIDR applicatifs (réseau privé quand disponible) ; retirer 0.0.0.0/0.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan scaleway --terraform plan.json --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "database_service_not_open_to_internet"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/database_service_not_open_to_internet.fr.md
+++ b/docs/controls/database_service_not_open_to_internet.fr.md
@@ -92,7 +92,7 @@ Restreindre l'ACL de la base aux seuls CIDR applicatifs (réseau privé quand di
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -107,7 +107,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/database_service_not_open_to_internet.md
+++ b/docs/controls/database_service_not_open_to_internet.md
@@ -1,0 +1,112 @@
+> 🇬🇧 English · [🇫🇷 Français](database_service_not_open_to_internet.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `database_service_not_open_to_internet`
+
+**Managed database reachable from the internet**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `database_service_not_open_to_internet` |
+| Family | `reseau` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-NET-1` |
+| Resource type read | `managed_database` |
+| Deciding attribute | `ip_filter` |
+| State | active |
+| Declared for | `scaleway` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+The allowed IP list (ACL) of a managed database admits a public CIDR: the database service is reachable from the internet.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-1` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✅ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| scaleway | live | ✗ `unsupported` | this source produces no resource of type "managed_database" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | scaleway / terraform |
+| `pass` | the deciding data was collected, and it is compliant | scaleway / terraform |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `managed_database`
+- Attribute the decision depends on: `ip_filter`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Restrict the database ACL to the application CIDRs only (a private network where one is available); remove 0.0.0.0/0.
+
+| Provider | Deployable setup |
+|---|---|
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan scaleway --terraform plan.json --format assessment
+```
+
+In the `assessment` output, look for `"control": "database_service_not_open_to_internet"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/governance_provider_sovereignty.fr.md
+++ b/docs/controls/governance_provider_sovereignty.fr.md
@@ -89,7 +89,7 @@ Pour une exigence souveraine, retenir un fournisseur établi dans l'UE, au contr
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -107,7 +107,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/governance_provider_sovereignty.fr.md
+++ b/docs/controls/governance_provider_sovereignty.fr.md
@@ -1,0 +1,113 @@
+> [🇬🇧 English](governance_provider_sovereignty.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `governance_provider_sovereignty`
+
+**Souveraineté du fournisseur non établie**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `governance_provider_sovereignty` |
+| Famille | `gouvernance` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-GVN-4` |
+| Type de ressource lu | _aucun : contrôle transverse_ |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Le fournisseur cloud n'est pas établi dans l'Union européenne, ou son contrôle capitalistique extra-UE est déterminant, ou il est exposé à une loi extraterritoriale sans immunité reconnue (qualification SecNumCloud) : les données et le plan de contrôle sont susceptibles d'être soumis à une juridiction étrangère.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-GVN-4` |
+| `secnumcloud_3_2` | `19.2`, `19.6` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Contrôle transverse : il ne lit pas un type de ressource particulier.
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Pour une exigence souveraine, retenir un fournisseur établi dans l'UE, au contrôle capitalistique européen, idéalement qualifié SecNumCloud (immunité reconnue par l'ANSSI).
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "governance_provider_sovereignty"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/governance_provider_sovereignty.md
+++ b/docs/controls/governance_provider_sovereignty.md
@@ -1,0 +1,112 @@
+> 🇬🇧 English · [🇫🇷 Français](governance_provider_sovereignty.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `governance_provider_sovereignty`
+
+**Provider sovereignty not established**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `governance_provider_sovereignty` |
+| Family | `gouvernance` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-GVN-4` |
+| Resource type read | _none: cross-cutting control_ |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+The cloud provider is not established in the European Union, or its non-EU capital control is decisive, or it is exposed to an extraterritorial law without recognised immunity (SecNumCloud qualification): the data and the control plane may fall under a foreign jurisdiction.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-GVN-4` |
+| `secnumcloud_3_2` | `19.2`, `19.6` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Cross-cutting control: it does not read one particular resource type.
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+For a sovereignty requirement, pick a provider established in the EU, under European capital control, ideally SecNumCloud qualified (immunity recognised by the ANSSI).
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "governance_provider_sovereignty"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/governance_resource_region_in_eu.fr.md
+++ b/docs/controls/governance_resource_region_in_eu.fr.md
@@ -1,0 +1,116 @@
+> [🇬🇧 English](governance_resource_region_in_eu.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `governance_resource_region_in_eu`
+
+**Ressource hébergée hors Union européenne**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `governance_resource_region_in_eu` |
+| Famille | `gouvernance` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-GVN-3` |
+| Type de ressource lu | _aucun : contrôle transverse_ |
+| Attribut décisif | `region` |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Une ressource est hébergée hors de l'Union européenne : la localisation des données, du traitement et de l'administration doit rester dans l'UE (souveraineté). Deux niveaux : l'espace européen de confiance (EEE + Suisse), adéquat et sans loi extraterritoriale, est un écart mineur ; le reste (US, Asie…) est un écart majeur. L'exposition extraterritoriale relève de CLD-GVN-4.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-GVN-3` |
+| `secnumcloud_3_2` | `19.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ◐ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ◐ `partial` | attribut décisif « region » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | outscale / terraform |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Contrôle transverse : il ne lit pas un type de ressource particulier.
+- Attribut dont la décision dépend : `region`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Recréer ou migrer la ressource dans une région de l'Union européenne ; restreindre les régions autorisées au niveau de l'organisation.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "governance_resource_region_in_eu"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/governance_resource_region_in_eu.fr.md
+++ b/docs/controls/governance_resource_region_in_eu.fr.md
@@ -92,7 +92,7 @@ Recréer ou migrer la ressource dans une région de l'Union européenne ; restre
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -110,7 +110,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/governance_resource_region_in_eu.md
+++ b/docs/controls/governance_resource_region_in_eu.md
@@ -1,0 +1,115 @@
+> 🇬🇧 English · [🇫🇷 Français](governance_resource_region_in_eu.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `governance_resource_region_in_eu`
+
+**Resource hosted outside the European Union**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `governance_resource_region_in_eu` |
+| Family | `gouvernance` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-GVN-3` |
+| Resource type read | _none: cross-cutting control_ |
+| Deciding attribute | `region` |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+A resource is hosted outside the European Union: the location of the data, of the processing and of the administration must stay in the EU (sovereignty). Two levels: the European trusted area (EEA plus Switzerland), adequate and free of extraterritorial law, is a minor deviation; anything else (US, Asia…) is a major one. Extraterritorial exposure itself is covered by CLD-GVN-4.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-GVN-3` |
+| `secnumcloud_3_2` | `19.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ◐ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ◐ `partial` | deciding attribute "region" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | outscale / terraform |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Cross-cutting control: it does not read one particular resource type.
+- Attribute the decision depends on: `region`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Recreate or migrate the resource in a European Union region; restrict the allowed regions at the organisation level.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "governance_resource_region_in_eu"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/governance_resource_required_tags.fr.md
+++ b/docs/controls/governance_resource_required_tags.fr.md
@@ -1,0 +1,126 @@
+> [🇬🇧 English](governance_resource_required_tags.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `governance_resource_required_tags`
+
+**Inventaire et étiquetage incomplets**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `governance_resource_required_tags` |
+| Famille | `gouvernance` |
+| Sévérité | `medium` |
+| Exigence SCSL (index gelé) | `CLD-GVN-1` |
+| Type de ressource lu | _aucun : contrôle transverse_ |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Des ressources n'ont pas les étiquettes de gouvernance (propriétaire, projet, environnement) : l'inventaire et la responsabilité ne sont pas tenus.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-GVN-1` |
+| `cis_controls_v8` | `1.1` |
+| `iso_27001_2022` | `A.5.9`, `A.8.9` |
+| `secnumcloud_3_2` | `8.1` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ◐ | ◐ |
+| outscale | ◐ | ◐ |
+| scaleway | ◐ | ◐ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| exoscale | terraform | ◐ `partial` | aucun type de ressource visé et le contrôle ne lit pas le descripteur du fournisseur : le verrou du « pass » ne peut pas être levé, le scan rend « not-evaluated » tant qu'aucun écart n'est détecté |
+| exoscale | live | ◐ `partial` | aucun type de ressource visé et le contrôle ne lit pas le descripteur du fournisseur : le verrou du « pass » ne peut pas être levé, le scan rend « not-evaluated » tant qu'aucun écart n'est détecté |
+| outscale | terraform | ◐ `partial` | aucun type de ressource visé et le contrôle ne lit pas le descripteur du fournisseur : le verrou du « pass » ne peut pas être levé, le scan rend « not-evaluated » tant qu'aucun écart n'est détecté |
+| outscale | live | ◐ `partial` | aucun type de ressource visé et le contrôle ne lit pas le descripteur du fournisseur : le verrou du « pass » ne peut pas être levé, le scan rend « not-evaluated » tant qu'aucun écart n'est détecté |
+| scaleway | terraform | ◐ `partial` | aucun type de ressource visé et le contrôle ne lit pas le descripteur du fournisseur : le verrou du « pass » ne peut pas être levé, le scan rend « not-evaluated » tant qu'aucun écart n'est détecté |
+| scaleway | live | ◐ `partial` | aucun type de ressource visé et le contrôle ne lit pas le descripteur du fournisseur : le verrou du « pass » ne peut pas être levé, le scan rend « not-evaluated » tant qu'aucun écart n'est détecté |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | aucun |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Contrôle transverse : il ne lit pas un type de ressource particulier.
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Imposer des étiquettes obligatoires (propriétaire, projet, environnement) ; contrôler leur présence à la création.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "governance_resource_required_tags"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+**Une des deux sources ne sait pas lever le verrou du « pass »** pour ce contrôle :
+le fournisseur cité y produit bien le type visé, mais le scan y rendra `not-evaluated`.
+Le tableau des motifs dit laquelle, et pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/governance_resource_required_tags.fr.md
+++ b/docs/controls/governance_resource_required_tags.fr.md
@@ -98,7 +98,7 @@ Imposer des étiquettes obligatoires (propriétaire, projet, environnement) ; co
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -120,7 +120,7 @@ Le tableau des motifs dit laquelle, et pourquoi.
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/governance_resource_required_tags.md
+++ b/docs/controls/governance_resource_required_tags.md
@@ -1,0 +1,125 @@
+> 🇬🇧 English · [🇫🇷 Français](governance_resource_required_tags.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `governance_resource_required_tags`
+
+**Incomplete inventory and tagging**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `governance_resource_required_tags` |
+| Family | `gouvernance` |
+| Severity | `medium` |
+| SCSL requirement (frozen index) | `CLD-GVN-1` |
+| Resource type read | _none: cross-cutting control_ |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+Some resources do not carry the governance tags (owner, project, environment): the inventory and the accountability are not maintained.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-GVN-1` |
+| `cis_controls_v8` | `1.1` |
+| `iso_27001_2022` | `A.5.9`, `A.8.9` |
+| `secnumcloud_3_2` | `8.1` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ◐ | ◐ |
+| outscale | ◐ | ◐ |
+| scaleway | ◐ | ◐ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| exoscale | terraform | ◐ `partial` | no targeted resource type, and the control does not read the provider descriptor: the "pass" lock cannot be lifted, so the scan returns "not-evaluated" as long as no deviation is detected |
+| exoscale | live | ◐ `partial` | no targeted resource type, and the control does not read the provider descriptor: the "pass" lock cannot be lifted, so the scan returns "not-evaluated" as long as no deviation is detected |
+| outscale | terraform | ◐ `partial` | no targeted resource type, and the control does not read the provider descriptor: the "pass" lock cannot be lifted, so the scan returns "not-evaluated" as long as no deviation is detected |
+| outscale | live | ◐ `partial` | no targeted resource type, and the control does not read the provider descriptor: the "pass" lock cannot be lifted, so the scan returns "not-evaluated" as long as no deviation is detected |
+| scaleway | terraform | ◐ `partial` | no targeted resource type, and the control does not read the provider descriptor: the "pass" lock cannot be lifted, so the scan returns "not-evaluated" as long as no deviation is detected |
+| scaleway | live | ◐ `partial` | no targeted resource type, and the control does not read the provider descriptor: the "pass" lock cannot be lifted, so the scan returns "not-evaluated" as long as no deviation is detected |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | — |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Cross-cutting control: it does not read one particular resource type.
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enforce mandatory tags (owner, project, environment); check their presence at creation time.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "governance_resource_required_tags"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+**One of the two sources cannot lift the `pass` lock** for this control: the provider
+quoted does produce the targeted type there, but the scan will return `not-evaluated`.
+The reasons table says which one, and why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_accesskey_expiration_set.fr.md
+++ b/docs/controls/iam_accesskey_expiration_set.fr.md
@@ -91,7 +91,7 @@ Imposer une expiration et une rotation des clés ; préférer une identité cour
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -109,7 +109,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_accesskey_expiration_set.fr.md
+++ b/docs/controls/iam_accesskey_expiration_set.fr.md
@@ -1,0 +1,115 @@
+> [🇬🇧 English](iam_accesskey_expiration_set.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_accesskey_expiration_set`
+
+**Clé d'accès sans expiration ni rotation**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_accesskey_expiration_set` |
+| Famille | `iam` |
+| Sévérité | `critical` |
+| Exigence SCSL (index gelé) | `CLD-IAM-2` |
+| Type de ressource lu | `access_key` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 2 |
+
+## Le risque
+
+Une clé d'accès longue durée n'a pas de date d'expiration : une fuite reste exploitable indéfiniment.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-2` |
+| `iso_27001_2022` | `A.5.17`, `A.8.2` |
+| `secnumcloud_3_2` | `9.5`, `10.5` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « access_key » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `access_key`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Imposer une expiration et une rotation des clés ; préférer une identité courte (OIDC) aux secrets statiques.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan scaleway --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_accesskey_expiration_set"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_accesskey_expiration_set.md
+++ b/docs/controls/iam_accesskey_expiration_set.md
@@ -1,0 +1,114 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_accesskey_expiration_set.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_accesskey_expiration_set`
+
+**Access key without expiry or rotation**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_accesskey_expiration_set` |
+| Family | `iam` |
+| Severity | `critical` |
+| SCSL requirement (frozen index) | `CLD-IAM-2` |
+| Resource type read | `access_key` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `outscale`, `scaleway` |
+| Remediation proofs | 0 / 2 |
+
+## The risk
+
+A long-lived access key has no expiry date: a leak stays exploitable indefinitely.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-2` |
+| `iso_27001_2022` | `A.5.17`, `A.8.2` |
+| `secnumcloud_3_2` | `9.5`, `10.5` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "access_key" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `access_key`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enforce an expiry and a rotation for access keys; prefer a short-lived identity (OIDC) over static secrets.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan scaleway --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_accesskey_expiration_set"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_account_mfa_enforced.fr.md
+++ b/docs/controls/iam_account_mfa_enforced.fr.md
@@ -92,7 +92,7 @@ Activer l'exigence d'environnement de confiance (RequireTrustedEnv) pour imposer
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -107,7 +107,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_account_mfa_enforced.fr.md
+++ b/docs/controls/iam_account_mfa_enforced.fr.md
@@ -1,0 +1,113 @@
+> [🇬🇧 English](iam_account_mfa_enforced.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_account_mfa_enforced`
+
+**MFA non imposée au niveau du compte**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_account_mfa_enforced` |
+| Famille | `iam` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-IAM-3` |
+| Type de ressource lu | `api_access_policy` |
+| Attribut décisif | `require_trusted_env` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+La politique d'accès API du compte n'impose pas la MFA à l'ensemble des utilisateurs (environnement de confiance désactivé) : un mot de passe compromis suffit. Angle compte, complémentaire du MFA par utilisateur.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-3` |
+| `cis_controls_v8` | `6.5` |
+| `iso_27001_2022` | `A.5.17`, `A.8.5` |
+| `secnumcloud_3_2` | `9.5`, `9.6` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_policy » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `api_access_policy`
+- Attribut dont la décision dépend : `require_trusted_env`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Activer l'exigence d'environnement de confiance (RequireTrustedEnv) pour imposer la MFA (WebAuthn/OTP) à tous les utilisateurs du compte.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_account_mfa_enforced"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_account_mfa_enforced.md
+++ b/docs/controls/iam_account_mfa_enforced.md
@@ -1,0 +1,112 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_account_mfa_enforced.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_account_mfa_enforced`
+
+**MFA not enforced at the account level**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_account_mfa_enforced` |
+| Family | `iam` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-IAM-3` |
+| Resource type read | `api_access_policy` |
+| Deciding attribute | `require_trusted_env` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+The account's API access policy does not enforce MFA for all users (trusted environment disabled): a compromised password is enough. Account-level angle, complementary to per-user MFA.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-3` |
+| `cis_controls_v8` | `6.5` |
+| `iso_27001_2022` | `A.5.17`, `A.8.5` |
+| `secnumcloud_3_2` | `9.5`, `9.6` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_policy" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `api_access_policy`
+- Attribute the decision depends on: `require_trusted_env`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enable the trusted environment requirement (RequireTrustedEnv) to enforce MFA (WebAuthn/OTP) for every user of the account.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_account_mfa_enforced"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_apiaccesspolicy_max_key_expiration.fr.md
+++ b/docs/controls/iam_apiaccesspolicy_max_key_expiration.fr.md
@@ -91,7 +91,7 @@ Configurer une expiration maximale des clés d'accès (ex. 90 jours).
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -106,7 +106,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_apiaccesspolicy_max_key_expiration.fr.md
+++ b/docs/controls/iam_apiaccesspolicy_max_key_expiration.fr.md
@@ -1,0 +1,112 @@
+> [🇬🇧 English](iam_apiaccesspolicy_max_key_expiration.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_apiaccesspolicy_max_key_expiration`
+
+**Politique d'accès API sans expiration maximale des clés**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_apiaccesspolicy_max_key_expiration` |
+| Famille | `iam` |
+| Sévérité | `medium` |
+| Exigence SCSL (index gelé) | `CLD-IAM-2` |
+| Type de ressource lu | `api_access_policy` |
+| Attribut décisif | `max_access_key_expiration_seconds` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+La politique d'accès API du compte n'impose pas d'expiration maximale aux clés d'accès : rien ne force leur rotation.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-2` |
+| `iso_27001_2022` | `A.5.17` |
+| `secnumcloud_3_2` | `9.5`, `10.5` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_policy » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `api_access_policy`
+- Attribut dont la décision dépend : `max_access_key_expiration_seconds`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Configurer une expiration maximale des clés d'accès (ex. 90 jours).
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_apiaccesspolicy_max_key_expiration"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_apiaccesspolicy_max_key_expiration.md
+++ b/docs/controls/iam_apiaccesspolicy_max_key_expiration.md
@@ -1,0 +1,111 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_apiaccesspolicy_max_key_expiration.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_apiaccesspolicy_max_key_expiration`
+
+**API access policy without a maximum key expiry**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_apiaccesspolicy_max_key_expiration` |
+| Family | `iam` |
+| Severity | `medium` |
+| SCSL requirement (frozen index) | `CLD-IAM-2` |
+| Resource type read | `api_access_policy` |
+| Deciding attribute | `max_access_key_expiration_seconds` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+The account's API access policy sets no maximum expiry on access keys: nothing forces their rotation.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-2` |
+| `iso_27001_2022` | `A.5.17` |
+| `secnumcloud_3_2` | `9.5`, `10.5` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_policy" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `api_access_policy`
+- Attribute the decision depends on: `max_access_key_expiration_seconds`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Configure a maximum access key expiry (90 days, for instance).
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_apiaccesspolicy_max_key_expiration"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_apiaccessrule_defined.fr.md
+++ b/docs/controls/iam_apiaccessrule_defined.fr.md
@@ -91,7 +91,7 @@ Créer au moins une règle d'accès API restreignant les appels à des plages IP
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -106,7 +106,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_apiaccessrule_defined.fr.md
+++ b/docs/controls/iam_apiaccessrule_defined.fr.md
@@ -1,0 +1,112 @@
+> [🇬🇧 English](iam_apiaccessrule_defined.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_apiaccessrule_defined`
+
+**Aucune règle d'accès API définie**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_apiaccessrule_defined` |
+| Famille | `iam` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-IAM-4` |
+| Type de ressource lu | `api_access_summary` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Aucune règle d'accès API n'est définie : l'API du compte est joignable depuis n'importe où avec une clé d'accès valide.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-4` |
+| `cis_controls_v8` | `4.4` |
+| `iso_27001_2022` | `A.8.20` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_summary » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `api_access_summary`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Créer au moins une règle d'accès API restreignant les appels à des plages IP légitimes.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_apiaccessrule_defined"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_apiaccessrule_defined.md
+++ b/docs/controls/iam_apiaccessrule_defined.md
@@ -1,0 +1,111 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_apiaccessrule_defined.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_apiaccessrule_defined`
+
+**No API access rule defined**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_apiaccessrule_defined` |
+| Family | `iam` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-IAM-4` |
+| Resource type read | `api_access_summary` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+No API access rule is defined: the account's API is reachable from anywhere with a valid access key.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-4` |
+| `cis_controls_v8` | `4.4` |
+| `iso_27001_2022` | `A.8.20` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_summary" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `api_access_summary`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Create at least one API access rule restricting calls to legitimate IP ranges.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_apiaccessrule_defined"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_apiaccessrule_no_public_cidr.fr.md
+++ b/docs/controls/iam_apiaccessrule_no_public_cidr.fr.md
@@ -1,0 +1,113 @@
+> [🇬🇧 English](iam_apiaccessrule_no_public_cidr.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_apiaccessrule_no_public_cidr`
+
+**Règle d'accès API ouverte à un CIDR public**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_apiaccessrule_no_public_cidr` |
+| Famille | `iam` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-IAM-4` |
+| Type de ressource lu | `api_access_rule` |
+| Attribut décisif | `ip_ranges` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Une règle d'accès API autorise les appels depuis 0.0.0.0/0 ou ::/0 : une clé d'accès fuitée serait exploitable depuis n'importe où.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-4` |
+| `cis_controls_v8` | `4.4` |
+| `iso_27001_2022` | `A.8.20` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_rule » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `api_access_rule`
+- Attribut dont la décision dépend : `ip_ranges`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Restreindre les plages IP de la règle aux adresses légitimes ; supprimer toute règle ouverte à Internet.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_apiaccessrule_no_public_cidr"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_apiaccessrule_no_public_cidr.fr.md
+++ b/docs/controls/iam_apiaccessrule_no_public_cidr.fr.md
@@ -92,7 +92,7 @@ Restreindre les plages IP de la règle aux adresses légitimes ; supprimer toute
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -107,7 +107,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_apiaccessrule_no_public_cidr.md
+++ b/docs/controls/iam_apiaccessrule_no_public_cidr.md
@@ -1,0 +1,112 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_apiaccessrule_no_public_cidr.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_apiaccessrule_no_public_cidr`
+
+**API access rule open to a public CIDR**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_apiaccessrule_no_public_cidr` |
+| Family | `iam` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-IAM-4` |
+| Resource type read | `api_access_rule` |
+| Deciding attribute | `ip_ranges` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+An API access rule allows calls from 0.0.0.0/0 or ::/0: a leaked access key would be usable from anywhere.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-4` |
+| `cis_controls_v8` | `4.4` |
+| `iso_27001_2022` | `A.8.20` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_rule" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `api_access_rule`
+- Attribute the decision depends on: `ip_ranges`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Restrict the rule's IP ranges to legitimate addresses; remove any rule open to the internet.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_apiaccessrule_no_public_cidr"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_no_root_access_key.fr.md
+++ b/docs/controls/iam_no_root_access_key.fr.md
@@ -1,0 +1,123 @@
+> [🇬🇧 English](iam_no_root_access_key.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_no_root_access_key`
+
+**Clé d'accès rattachée au compte root**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_no_root_access_key` |
+| Famille | `iam` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-IAM-1` |
+| Type de ressource lu | `access_key` |
+| Attribut décisif | `root_owned` / `scope` |
+| État | actif |
+| Déclaré pour | `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 2 |
+
+## Le risque
+
+Une clé d'API/d'accès est rattachée au compte root de l'organisation, ce qui contourne les politiques IAM et le moindre privilège.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-1` |
+| `cis_controls_v8` | `5.4` |
+| `iso_27001_2022` | `A.5.15`, `A.5.18` |
+| `secnumcloud_3_2` | `9.3`, `9.6` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ◐ | ◐ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « access_key » |
+| scaleway | terraform | ◐ `partial` | attribut décisif « root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| scaleway | live | ◐ `partial` | attribut décisif « root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | scaleway / terraform · scaleway / live |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `access_key`
+- Attribut dont la décision dépend : `root_owned` / `scope`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Créer une identité/application dédiée à moindre privilège et révoquer la clé root.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan scaleway --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_no_root_access_key"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+**Une des deux sources ne sait pas lever le verrou du « pass »** pour ce contrôle :
+le fournisseur cité y produit bien le type visé, mais le scan y rendra `not-evaluated`.
+Le tableau des motifs dit laquelle, et pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_no_root_access_key.fr.md
+++ b/docs/controls/iam_no_root_access_key.fr.md
@@ -95,7 +95,7 @@ Créer une identité/application dédiée à moindre privilège et révoquer la 
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -117,7 +117,7 @@ Le tableau des motifs dit laquelle, et pourquoi.
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_no_root_access_key.md
+++ b/docs/controls/iam_no_root_access_key.md
@@ -1,0 +1,122 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_no_root_access_key.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_no_root_access_key`
+
+**Access key attached to the root account**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_no_root_access_key` |
+| Family | `iam` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-IAM-1` |
+| Resource type read | `access_key` |
+| Deciding attribute | `root_owned` / `scope` |
+| State | active |
+| Declared for | `outscale`, `scaleway` |
+| Remediation proofs | 0 / 2 |
+
+## The risk
+
+An API/access key is attached to the organisation's root account, which bypasses IAM policies and least privilege.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-1` |
+| `cis_controls_v8` | `5.4` |
+| `iso_27001_2022` | `A.5.15`, `A.5.18` |
+| `secnumcloud_3_2` | `9.3`, `9.6` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ◐ | ◐ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "access_key" |
+| scaleway | terraform | ◐ `partial` | deciding attribute "root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| scaleway | live | ◐ `partial` | deciding attribute "root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | scaleway / terraform · scaleway / live |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `access_key`
+- Attribute the decision depends on: `root_owned` / `scope`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Create a dedicated least-privilege identity or application, and revoke the root key.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan scaleway --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_no_root_access_key"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+**One of the two sources cannot lift the `pass` lock** for this control: the provider
+quoted does produce the targeted type there, but the scan will return `not-evaluated`.
+The reasons table says which one, and why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_policy_no_administrative_privileges.fr.md
+++ b/docs/controls/iam_policy_no_administrative_privileges.fr.md
@@ -1,0 +1,114 @@
+> [🇬🇧 English](iam_policy_no_administrative_privileges.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_policy_no_administrative_privileges`
+
+**Politique IAM à privilèges administratifs (action joker)**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_policy_no_administrative_privileges` |
+| Famille | `iam` |
+| Sévérité | `critical` |
+| Exigence SCSL (index gelé) | `CLD-IAM-1` |
+| Type de ressource lu | `iam_policy` |
+| Attribut décisif | `statements` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Une politique IAM accorde une action joker « * » (ou l'anti-pattern NotAction/NotResource), contournant le moindre privilège.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-1` |
+| `cis_controls_v8` | `6.7`, `6.8` |
+| `iso_27001_2022` | `A.5.15`, `A.5.18`, `A.8.2`, `A.8.3` |
+| `secnumcloud_3_2` | `9.1`, `9.3` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✅ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / terraform · outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / terraform · outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `iam_policy`
+- Attribut dont la décision dépend : `statements`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Restreindre la politique aux actions/ressources strictement nécessaires.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan outscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_policy_no_administrative_privileges"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_policy_no_administrative_privileges.fr.md
+++ b/docs/controls/iam_policy_no_administrative_privileges.fr.md
@@ -90,7 +90,7 @@ Restreindre la politique aux actions/ressources strictement nécessaires.
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -108,7 +108,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_policy_no_administrative_privileges.md
+++ b/docs/controls/iam_policy_no_administrative_privileges.md
@@ -1,0 +1,113 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_policy_no_administrative_privileges.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_policy_no_administrative_privileges`
+
+**IAM policy with administrative privileges (wildcard action)**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_policy_no_administrative_privileges` |
+| Family | `iam` |
+| Severity | `critical` |
+| SCSL requirement (frozen index) | `CLD-IAM-1` |
+| Resource type read | `iam_policy` |
+| Deciding attribute | `statements` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+An IAM policy grants a wildcard "*" action (or the NotAction/NotResource anti-pattern), bypassing least privilege.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-1` |
+| `cis_controls_v8` | `6.7`, `6.8` |
+| `iso_27001_2022` | `A.5.15`, `A.5.18`, `A.8.2`, `A.8.3` |
+| `secnumcloud_3_2` | `9.1`, `9.3` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✅ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / terraform · outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / terraform · outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `iam_policy`
+- Attribute the decision depends on: `statements`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Restrict the policy to the strictly necessary actions and resources.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan outscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_policy_no_administrative_privileges"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_policy_no_notaction_notresource.fr.md
+++ b/docs/controls/iam_policy_no_notaction_notresource.fr.md
@@ -1,0 +1,114 @@
+> [🇬🇧 English](iam_policy_no_notaction_notresource.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_policy_no_notaction_notresource`
+
+**Politique IAM avec NotAction/NotResource (anti-pattern)**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_policy_no_notaction_notresource` |
+| Famille | `iam` |
+| Sévérité | `critical` |
+| Exigence SCSL (index gelé) | `CLD-IAM-1` |
+| Type de ressource lu | `iam_policy` |
+| Attribut décisif | `statements` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Un Statement Allow emploie NotAction ou NotResource : ce pattern d'inversion autorise tout sauf une liste, ouvrant des permissions imprévues à chaque nouveau service/ressource.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-1` |
+| `cis_controls_v8` | `6.7`, `6.8` |
+| `iso_27001_2022` | `A.5.15`, `A.5.18` |
+| `secnumcloud_3_2` | `9.1`, `9.3` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✅ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / terraform · outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / terraform · outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `iam_policy`
+- Attribut dont la décision dépend : `statements`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Réécrire en liste d'autorisations explicite (Action/Resource). NotAction/NotResource n'est acceptable qu'avec Effect Deny.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan outscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_policy_no_notaction_notresource"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_policy_no_notaction_notresource.fr.md
+++ b/docs/controls/iam_policy_no_notaction_notresource.fr.md
@@ -90,7 +90,7 @@ Réécrire en liste d'autorisations explicite (Action/Resource). NotAction/NotRe
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -108,7 +108,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_policy_no_notaction_notresource.md
+++ b/docs/controls/iam_policy_no_notaction_notresource.md
@@ -1,0 +1,113 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_policy_no_notaction_notresource.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_policy_no_notaction_notresource`
+
+**IAM policy using NotAction/NotResource (anti-pattern)**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_policy_no_notaction_notresource` |
+| Family | `iam` |
+| Severity | `critical` |
+| SCSL requirement (frozen index) | `CLD-IAM-1` |
+| Resource type read | `iam_policy` |
+| Deciding attribute | `statements` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+An Allow statement uses NotAction or NotResource: this inversion pattern allows everything except a list, opening unforeseen permissions with every new service or resource.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-1` |
+| `cis_controls_v8` | `6.7`, `6.8` |
+| `iso_27001_2022` | `A.5.15`, `A.5.18` |
+| `secnumcloud_3_2` | `9.1`, `9.3` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✅ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / terraform · outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / terraform · outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `iam_policy`
+- Attribute the decision depends on: `statements`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Rewrite it as an explicit allow list (Action/Resource). NotAction/NotResource is only acceptable with an Effect Deny.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan outscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_policy_no_notaction_notresource"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_policy_no_privilege_escalation.fr.md
+++ b/docs/controls/iam_policy_no_privilege_escalation.fr.md
@@ -93,7 +93,7 @@ Retirer les actions de gestion d'identité des politiques d'usage courant ; les 
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -111,7 +111,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_policy_no_privilege_escalation.fr.md
+++ b/docs/controls/iam_policy_no_privilege_escalation.fr.md
@@ -1,0 +1,117 @@
+> [🇬🇧 English](iam_policy_no_privilege_escalation.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_policy_no_privilege_escalation`
+
+**Politique IAM permettant une élévation de privilèges**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_policy_no_privilege_escalation` |
+| Famille | `iam` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-IAM-12` |
+| Type de ressource lu | `iam_policy` |
+| Attribut décisif | `manages_iam` / `statements` |
+| État | actif |
+| Déclaré pour | `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 2 |
+
+## Le risque
+
+Une politique autorise des actions de gestion d'identité (attacher ou créer une politique, créer/réactiver une clé d'accès) qui permettent à un principal de s'octroyer lui-même des droits supplémentaires — chemin d'élévation de privilèges.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-12` |
+| `cis_controls_v8` | `6.8` |
+| `iso_27001_2022` | `A.5.15` |
+| `secnumcloud_3_2` | `9.1`, `9.3` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « iam_policy » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / terraform · outscale / live · scaleway / terraform |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / terraform · outscale / live · scaleway / terraform |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `iam_policy`
+- Attribut dont la décision dépend : `manages_iam` / `statements`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Retirer les actions de gestion d'identité des politiques d'usage courant ; les réserver à un rôle d'administration dédié, scopé aux ressources légitimes.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan outscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_policy_no_privilege_escalation"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_policy_no_privilege_escalation.md
+++ b/docs/controls/iam_policy_no_privilege_escalation.md
@@ -1,0 +1,116 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_policy_no_privilege_escalation.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_policy_no_privilege_escalation`
+
+**IAM policy allowing privilege escalation**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_policy_no_privilege_escalation` |
+| Family | `iam` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-IAM-12` |
+| Resource type read | `iam_policy` |
+| Deciding attribute | `manages_iam` / `statements` |
+| State | active |
+| Declared for | `outscale`, `scaleway` |
+| Remediation proofs | 0 / 2 |
+
+## The risk
+
+A policy allows identity management actions (attaching or creating a policy, creating or re-enabling an access key) that let a principal grant itself extra rights — a privilege escalation path.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-12` |
+| `cis_controls_v8` | `6.8` |
+| `iso_27001_2022` | `A.5.15` |
+| `secnumcloud_3_2` | `9.1`, `9.3` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| scaleway | live | ✗ `unsupported` | this source produces no resource of type "iam_policy" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / terraform · outscale / live · scaleway / terraform |
+| `pass` | the deciding data was collected, and it is compliant | outscale / terraform · outscale / live · scaleway / terraform |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `iam_policy`
+- Attribute the decision depends on: `manages_iam` / `statements`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Remove identity management actions from everyday policies; reserve them for a dedicated administration role, scoped to the legitimate resources.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan outscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_policy_no_privilege_escalation"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_policy_no_wildcard_resource.fr.md
+++ b/docs/controls/iam_policy_no_wildcard_resource.fr.md
@@ -90,7 +90,7 @@ Restreindre Resource aux identifiants (ORN) que la politique doit réellement co
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -108,7 +108,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_policy_no_wildcard_resource.fr.md
+++ b/docs/controls/iam_policy_no_wildcard_resource.fr.md
@@ -1,0 +1,114 @@
+> [🇬🇧 English](iam_policy_no_wildcard_resource.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_policy_no_wildcard_resource`
+
+**Politique IAM avec ressource joker**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_policy_no_wildcard_resource` |
+| Famille | `iam` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-IAM-1` |
+| Type de ressource lu | `iam_policy` |
+| Attribut décisif | `statements` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Un Statement Allow porte une ressource joker « * » : il s'applique à toutes les ressources du compte, au-delà du strict nécessaire.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-1` |
+| `cis_controls_v8` | `6.7`, `6.8` |
+| `iso_27001_2022` | `A.5.15`, `A.8.3` |
+| `secnumcloud_3_2` | `9.1`, `9.3` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✅ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / terraform · outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / terraform · outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `iam_policy`
+- Attribut dont la décision dépend : `statements`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Restreindre Resource aux identifiants (ORN) que la politique doit réellement couvrir.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan outscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_policy_no_wildcard_resource"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_policy_no_wildcard_resource.md
+++ b/docs/controls/iam_policy_no_wildcard_resource.md
@@ -1,0 +1,113 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_policy_no_wildcard_resource.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_policy_no_wildcard_resource`
+
+**IAM policy with a wildcard resource**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_policy_no_wildcard_resource` |
+| Family | `iam` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-IAM-1` |
+| Resource type read | `iam_policy` |
+| Deciding attribute | `statements` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+An Allow statement carries a wildcard "*" resource: it applies to every resource in the account, well beyond what is strictly needed.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-1` |
+| `cis_controls_v8` | `6.7`, `6.8` |
+| `iso_27001_2022` | `A.5.15`, `A.8.3` |
+| `secnumcloud_3_2` | `9.1`, `9.3` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✅ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / terraform · outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / terraform · outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `iam_policy`
+- Attribute the decision depends on: `statements`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Restrict Resource to the identifiers (ORN) the policy must actually cover.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan outscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_policy_no_wildcard_resource"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_role_key_lifetime_bounded.fr.md
+++ b/docs/controls/iam_role_key_lifetime_bounded.fr.md
@@ -89,7 +89,7 @@ Borner la durée de vie : définir un TTL de session maximal sur le rôle ou une
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -107,7 +107,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_role_key_lifetime_bounded.fr.md
+++ b/docs/controls/iam_role_key_lifetime_bounded.fr.md
@@ -1,0 +1,113 @@
+> [🇬🇧 English](iam_role_key_lifetime_bounded.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_role_key_lifetime_bounded`
+
+**Rôle IAM sans borne de durée de vie des accès**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_role_key_lifetime_bounded` |
+| Famille | `iam` |
+| Sévérité | `critical` |
+| Exigence SCSL (index gelé) | `CLD-IAM-2` |
+| Type de ressource lu | `iam_role` |
+| Attribut décisif | `max_session_ttl` / `policy_has_expiration` |
+| État | actif |
+| Déclaré pour | `exoscale` |
+| Preuves de remédiation | 1 / 1 |
+
+## Le risque
+
+La politique d'un rôle IAM ne borne pas la durée de vie des accès (ni TTL de session maximal, ni expiration dans la politique) : une clé assumant ce rôle conserve indéfiniment ses droits, contrairement au principe de secrets à durée limitée.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-2` |
+| `iso_27001_2022` | `A.5.17` |
+| `secnumcloud_3_2` | `9.5`, `10.5` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `iam_role`
+- Attribut dont la décision dépend : `max_session_ttl` / `policy_has_expiration`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Borner la durée de vie : définir un TTL de session maximal sur le rôle ou une condition d'expiration dans sa politique (au-delà d'une durée, les accès sont refusés).
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | [`references/remediation/exoscale/iam_role_key_lifetime_bounded`](../../references/remediation/exoscale/iam_role_key_lifetime_bounded) |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_role_key_lifetime_bounded"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_role_key_lifetime_bounded.md
+++ b/docs/controls/iam_role_key_lifetime_bounded.md
@@ -1,0 +1,112 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_role_key_lifetime_bounded.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_role_key_lifetime_bounded`
+
+**IAM role without a bounded credential lifetime**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_role_key_lifetime_bounded` |
+| Family | `iam` |
+| Severity | `critical` |
+| SCSL requirement (frozen index) | `CLD-IAM-2` |
+| Resource type read | `iam_role` |
+| Deciding attribute | `max_session_ttl` / `policy_has_expiration` |
+| State | active |
+| Declared for | `exoscale` |
+| Remediation proofs | 1 / 1 |
+
+## The risk
+
+An IAM role's policy does not bound the lifetime of credentials (no maximum session TTL, no expiry condition in the policy): a key assuming this role keeps its rights indefinitely, against the principle of time-limited secrets.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-2` |
+| `iso_27001_2022` | `A.5.17` |
+| `secnumcloud_3_2` | `9.5`, `10.5` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `iam_role`
+- Attribute the decision depends on: `max_session_ttl` / `policy_has_expiration`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Bound that lifetime: set a maximum session TTL on the role, or an expiry condition in its policy (past that duration, access is denied).
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | [`references/remediation/exoscale/iam_role_key_lifetime_bounded`](../../references/remediation/exoscale/iam_role_key_lifetime_bounded) |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_role_key_lifetime_bounded"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_role_no_admin_privileges.fr.md
+++ b/docs/controls/iam_role_no_admin_privileges.fr.md
@@ -90,7 +90,7 @@ Reposer la politique du rôle sur une stratégie de service « deny » par défa
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -108,7 +108,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_role_no_admin_privileges.fr.md
+++ b/docs/controls/iam_role_no_admin_privileges.fr.md
@@ -1,0 +1,114 @@
+> [🇬🇧 English](iam_role_no_admin_privileges.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_role_no_admin_privileges`
+
+**Rôle IAM aux privilèges excessifs**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_role_no_admin_privileges` |
+| Famille | `iam` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-IAM-1` |
+| Type de ressource lu | `iam_role` |
+| Attribut décisif | `admin_privileges` |
+| État | actif |
+| Déclaré pour | `exoscale` |
+| Preuves de remédiation | 1 / 1 |
+
+## Le risque
+
+La politique d'un rôle IAM autorise tout par défaut (stratégie de service « allow ») : sauf interdictions ciblées, une clé assumant ce rôle dispose de privilèges étendus, à l'encontre du moindre privilège.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-1` |
+| `cis_controls_v8` | `6.8` |
+| `iso_27001_2022` | `A.8.2` |
+| `secnumcloud_3_2` | `9.3` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `iam_role`
+- Attribut dont la décision dépend : `admin_privileges`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Reposer la politique du rôle sur une stratégie de service « deny » par défaut, puis n'autoriser explicitement que les opérations et ressources nécessaires.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | [`references/remediation/exoscale/iam_role_no_admin_privileges`](../../references/remediation/exoscale/iam_role_no_admin_privileges) |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_role_no_admin_privileges"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_role_no_admin_privileges.md
+++ b/docs/controls/iam_role_no_admin_privileges.md
@@ -1,0 +1,113 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_role_no_admin_privileges.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_role_no_admin_privileges`
+
+**IAM role with excessive privileges**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_role_no_admin_privileges` |
+| Family | `iam` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-IAM-1` |
+| Resource type read | `iam_role` |
+| Deciding attribute | `admin_privileges` |
+| State | active |
+| Declared for | `exoscale` |
+| Remediation proofs | 1 / 1 |
+
+## The risk
+
+An IAM role's policy allows everything by default ("allow" default service strategy): short of targeted denials, a key assuming this role holds broad privileges, against least privilege.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-1` |
+| `cis_controls_v8` | `6.8` |
+| `iso_27001_2022` | `A.8.2` |
+| `secnumcloud_3_2` | `9.3` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `iam_role`
+- Attribute the decision depends on: `admin_privileges`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Base the role's policy on a default "deny" service strategy, then explicitly allow only the required operations and resources.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | [`references/remediation/exoscale/iam_role_no_admin_privileges`](../../references/remediation/exoscale/iam_role_no_admin_privileges) |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_role_no_admin_privileges"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_role_source_ip_restricted.fr.md
+++ b/docs/controls/iam_role_source_ip_restricted.fr.md
@@ -1,0 +1,114 @@
+> [🇬🇧 English](iam_role_source_ip_restricted.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_role_source_ip_restricted`
+
+**Rôle IAM sans restriction d'IP source**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_role_source_ip_restricted` |
+| Famille | `iam` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-IAM-4` |
+| Type de ressource lu | `iam_role` |
+| Attribut décisif | `source_ip_restricted` |
+| État | actif |
+| Déclaré pour | `exoscale` |
+| Preuves de remédiation | 1 / 1 |
+
+## Le risque
+
+La politique d'un rôle IAM ne borne pas les IP sources autorisées : une clé assumant ce rôle est utilisable depuis n'importe quelle adresse, y compris en cas de fuite du secret.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-4` |
+| `cis_controls_v8` | `4.4` |
+| `iso_27001_2022` | `A.8.20` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `iam_role`
+- Attribut dont la décision dépend : `source_ip_restricted`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Ajouter à la politique du rôle une condition sur l'IP source (plages d'administration légitimes) afin de restreindre l'usage des accès.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | [`references/remediation/exoscale/iam_role_source_ip_restricted`](../../references/remediation/exoscale/iam_role_source_ip_restricted) |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_role_source_ip_restricted"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_role_source_ip_restricted.fr.md
+++ b/docs/controls/iam_role_source_ip_restricted.fr.md
@@ -90,7 +90,7 @@ Ajouter à la politique du rôle une condition sur l'IP source (plages d'adminis
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -108,7 +108,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_role_source_ip_restricted.md
+++ b/docs/controls/iam_role_source_ip_restricted.md
@@ -1,0 +1,113 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_role_source_ip_restricted.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_role_source_ip_restricted`
+
+**IAM role without a source IP restriction**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_role_source_ip_restricted` |
+| Family | `iam` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-IAM-4` |
+| Resource type read | `iam_role` |
+| Deciding attribute | `source_ip_restricted` |
+| State | active |
+| Declared for | `exoscale` |
+| Remediation proofs | 1 / 1 |
+
+## The risk
+
+An IAM role's policy does not bound the allowed source IPs: a key assuming this role is usable from any address, including after the secret leaks.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-4` |
+| `cis_controls_v8` | `4.4` |
+| `iso_27001_2022` | `A.8.20` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `iam_role`
+- Attribute the decision depends on: `source_ip_restricted`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Add a source IP condition to the role's policy (legitimate administration ranges) to restrict where the credentials can be used.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | [`references/remediation/exoscale/iam_role_source_ip_restricted`](../../references/remediation/exoscale/iam_role_source_ip_restricted) |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_role_source_ip_restricted"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/iam_user_mfa_enabled.fr.md
+++ b/docs/controls/iam_user_mfa_enabled.fr.md
@@ -1,0 +1,117 @@
+> [🇬🇧 English](iam_user_mfa_enabled.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_user_mfa_enabled`
+
+**MFA non activée sur un compte**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_user_mfa_enabled` |
+| Famille | `iam` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-IAM-3` |
+| Type de ressource lu | `iam_user` |
+| Attribut décisif | `mfa_enabled` |
+| État | actif |
+| Déclaré pour | `exoscale`, `scaleway` |
+| Preuves de remédiation | 0 / 2 |
+
+## Le risque
+
+Un compte utilisateur cloud n'a pas l'authentification multifacteur (MFA) activée : un mot de passe compromis suffit à accéder à la console ou à l'API.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-3` |
+| `cis_controls_v8` | `6.5` |
+| `iso_27001_2022` | `A.5.17`, `A.8.5` |
+| `secnumcloud_3_2` | `9.5`, `9.6` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✅ |
+| outscale | ∅ | ∅ |
+| scaleway | ✗ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| exoscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « iam_user » |
+| outscale | terraform | ∅ `not-applicable` | type de ressource « iam_user » absent de l'API outscale |
+| outscale | live | ∅ `not-applicable` | type de ressource « iam_user » absent de l'API outscale |
+| scaleway | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « iam_user » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / live · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / live · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | outscale / terraform · outscale / live |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `iam_user`
+- Attribut dont la décision dépend : `mfa_enabled`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Activer la MFA sur tous les comptes, en priorité les accès d'administration et la console ; l'imposer par politique au niveau de l'organisation.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_user_mfa_enabled"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/iam_user_mfa_enabled.fr.md
+++ b/docs/controls/iam_user_mfa_enabled.fr.md
@@ -96,7 +96,7 @@ Activer la MFA sur tous les comptes, en priorité les accès d'administration et
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -111,7 +111,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_user_mfa_enabled.md
+++ b/docs/controls/iam_user_mfa_enabled.md
@@ -1,0 +1,116 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_user_mfa_enabled.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_user_mfa_enabled`
+
+**MFA not enabled on an account**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_user_mfa_enabled` |
+| Family | `iam` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-IAM-3` |
+| Resource type read | `iam_user` |
+| Deciding attribute | `mfa_enabled` |
+| State | active |
+| Declared for | `exoscale`, `scaleway` |
+| Remediation proofs | 0 / 2 |
+
+## The risk
+
+A cloud user account does not have multi-factor authentication (MFA) enabled: a compromised password is enough to reach the console or the API.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-3` |
+| `cis_controls_v8` | `6.5` |
+| `iso_27001_2022` | `A.5.17`, `A.8.5` |
+| `secnumcloud_3_2` | `9.5`, `9.6` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✅ |
+| outscale | ∅ | ∅ |
+| scaleway | ✗ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| exoscale | terraform | ✗ `unsupported` | this source produces no resource of type "iam_user" |
+| outscale | terraform | ∅ `not-applicable` | resource type "iam_user" absent from the outscale API |
+| outscale | live | ∅ `not-applicable` | resource type "iam_user" absent from the outscale API |
+| scaleway | terraform | ✗ `unsupported` | this source produces no resource of type "iam_user" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / live · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / live · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | outscale / terraform · outscale / live |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `iam_user`
+- Attribute the decision depends on: `mfa_enabled`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enable MFA on every account, starting with administrative and console access; enforce it by policy at the organisation level.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_user_mfa_enabled"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/index.fr.md
+++ b/docs/controls/index.fr.md
@@ -10,7 +10,7 @@ Aucune métadonnée n'est recopiée ici : ajouter un contrôle, changer une sév
 retirer un fournisseur réécrit ces pages, et la CI refuse une documentation en retard.
 
 Ce catalogue dit ce que Pépin **peut conclure**, pas le résultat d'un scan. Pour la
-vue d'ensemble par fournisseur et par source, voir la [matrice de couverture](../coverage.md).
+vue d'ensemble par fournisseur et par source, voir la [matrice de couverture](../coverage.fr.md).
 
 ## Chiffres
 

--- a/docs/controls/index.fr.md
+++ b/docs/controls/index.fr.md
@@ -1,0 +1,141 @@
+> [🇬🇧 English](index.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# Catalogue des contrôles
+
+Un contrôle par page, calculé depuis `referentiel/controles.yaml` (la source de vérité),
+les descripteurs `providers/*.yaml` et le verrou du « pass » de `internal/assess`.
+Aucune métadonnée n'est recopiée ici : ajouter un contrôle, changer une sévérité ou
+retirer un fournisseur réécrit ces pages, et la CI refuse une documentation en retard.
+
+Ce catalogue dit ce que Pépin **peut conclure**, pas le résultat d'un scan. Pour la
+vue d'ensemble par fournisseur et par source, voir la [matrice de couverture](../coverage.md).
+
+## Chiffres
+
+| Chiffre | Nombre |
+|---|---:|
+| Contrôles au référentiel | 57 |
+| Contrôles actifs | 56 |
+| Contrôles dormants | 1 |
+| `critical` | 10 |
+| `high` | 32 |
+| `medium` | 13 |
+| `low` | 2 |
+| Preuves de remédiation déployables | 4 / 95 |
+
+## Comment lire ce catalogue
+
+- **Contrôle actif** : déclaré pour au moins un fournisseur (`fournisseurs:` non vide).
+  Un scan de ce fournisseur peut lui donner un statut.
+- **Contrôle dormant** : écrit et testé, déclaré pour aucun fournisseur. Il n'est jamais
+  évalué, et il ne compte dans aucune couverture. La liste complète est en bas de page.
+- **Preuves de remédiation** : les montages déployables présents sous
+  [`references/remediation/`](../../references/remediation/README.md). Le compte est
+  celui des couples (contrôle, fournisseur) déclarés, et il est aujourd'hui partiel :
+  la remédiation *textuelle*, elle, est portée par chaque écart émis.
+- Les contrôles encore au triage, non retenus dans le référentiel actif, vivent au
+  [catalogue de triage](../../referentiel/catalogue.yaml).
+
+## `iam`
+
+| Contrôle | Sévérité | SCSL | Actif pour | Preuves |
+|---|---|---|---|---|
+| [`iam_accesskey_expiration_set`](iam_accesskey_expiration_set.fr.md) Clé d'accès sans expiration ni rotation | critical | `CLD-IAM-2` | `outscale`, `scaleway` | 0 / 2 |
+| [`iam_account_mfa_enforced`](iam_account_mfa_enforced.fr.md) MFA non imposée au niveau du compte | high | `CLD-IAM-3` | `outscale` | 0 / 1 |
+| [`iam_apiaccesspolicy_max_key_expiration`](iam_apiaccesspolicy_max_key_expiration.fr.md) Politique d'accès API sans expiration maximale des clés | medium | `CLD-IAM-2` | `outscale` | 0 / 1 |
+| [`iam_apiaccessrule_defined`](iam_apiaccessrule_defined.fr.md) Aucune règle d'accès API définie | high | `CLD-IAM-4` | `outscale` | 0 / 1 |
+| [`iam_apiaccessrule_no_public_cidr`](iam_apiaccessrule_no_public_cidr.fr.md) Règle d'accès API ouverte à un CIDR public | high | `CLD-IAM-4` | `outscale` | 0 / 1 |
+| [`iam_no_root_access_key`](iam_no_root_access_key.fr.md) Clé d'accès rattachée au compte root | high | `CLD-IAM-1` | `outscale`, `scaleway` | 0 / 2 |
+| [`iam_policy_no_administrative_privileges`](iam_policy_no_administrative_privileges.fr.md) Politique IAM à privilèges administratifs (action joker) | critical | `CLD-IAM-1` | `outscale` | 0 / 1 |
+| [`iam_policy_no_notaction_notresource`](iam_policy_no_notaction_notresource.fr.md) Politique IAM avec NotAction/NotResource (anti-pattern) | critical | `CLD-IAM-1` | `outscale` | 0 / 1 |
+| [`iam_policy_no_privilege_escalation`](iam_policy_no_privilege_escalation.fr.md) Politique IAM permettant une élévation de privilèges | high | `CLD-IAM-12` | `outscale`, `scaleway` | 0 / 2 |
+| [`iam_policy_no_wildcard_resource`](iam_policy_no_wildcard_resource.fr.md) Politique IAM avec ressource joker | high | `CLD-IAM-1` | `outscale` | 0 / 1 |
+| [`iam_role_key_lifetime_bounded`](iam_role_key_lifetime_bounded.fr.md) Rôle IAM sans borne de durée de vie des accès | critical | `CLD-IAM-2` | `exoscale` | 1 / 1 |
+| [`iam_role_no_admin_privileges`](iam_role_no_admin_privileges.fr.md) Rôle IAM aux privilèges excessifs | high | `CLD-IAM-1` | `exoscale` | 1 / 1 |
+| [`iam_role_source_ip_restricted`](iam_role_source_ip_restricted.fr.md) Rôle IAM sans restriction d'IP source | high | `CLD-IAM-4` | `exoscale` | 1 / 1 |
+| [`iam_user_mfa_enabled`](iam_user_mfa_enabled.fr.md) MFA non activée sur un compte | high | `CLD-IAM-3` | `exoscale`, `scaleway` | 0 / 2 |
+
+## `reseau`
+
+| Contrôle | Sévérité | SCSL | Actif pour | Preuves |
+|---|---|---|---|---|
+| [`compute_instance_public_ip_with_open_securitygroup`](compute_instance_public_ip_with_open_securitygroup.fr.md) Machine exposée publiquement sans filtrage restrictif | critical | `CLD-NET-3` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`database_service_not_open_to_internet`](database_service_not_open_to_internet.fr.md) Base de données managée joignable depuis Internet | high | `CLD-NET-1` | `scaleway` | 0 / 1 |
+| [`k8s_namespace_network_policy_defined`](k8s_namespace_network_policy_defined.fr.md) Namespace sans NetworkPolicy (réseau plat) | high | `CLD-K8S-6` | `kubernetes` | 0 / 1 |
+| [`network_documented`](network_documented.fr.md) Réseau non documenté (cartographie non tenue) | low | `CLD-NET-5` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_flow_matrix_documented`](network_flow_matrix_documented.fr.md) Flux entrant sans justification dans la matrice des flux | medium | `CLD-NET-5` | `exoscale` | 0 / 1 |
+| [`network_peering_cross_organization`](network_peering_cross_organization.fr.md) Appairage réseau vers un autre système d'information | high | `CLD-NET-7` | `outscale` | 0 / 1 |
+| [`network_securitygroup_allow_ingress_from_internet_to_all_ports`](network_securitygroup_allow_ingress_from_internet_to_all_ports.fr.md) Tout le trafic entrant autorisé depuis Internet (any/any) | critical | `CLD-NET-2` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports`](network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.fr.md) Port sensible (base de données, annuaire…) ouvert à Internet | high | `CLD-NET-1` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports`](network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports.fr.md) Service UDP sensible (amplification, non authentifié) ouvert à Internet | high | `CLD-NET-1` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_securitygroup_allow_ingress_from_internet_to_tcp_port_22`](network_securitygroup_allow_ingress_from_internet_to_tcp_port_22.fr.md) SSH (port 22) ouvert à Internet | high | `CLD-NET-1`, `CLD-IAM-6`, `CLD-NET-6` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389`](network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.fr.md) RDP (port 3389) ouvert à Internet | high | `CLD-NET-1`, `CLD-IAM-6`, `CLD-NET-6` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_securitygroup_default_deny`](network_securitygroup_default_deny.fr.md) Politique entrante par défaut d'un groupe de sécurité en « accept » | high | `CLD-NET-2` | `scaleway` | 0 / 1 |
+| [`network_securitygroup_default_restrict_traffic`](network_securitygroup_default_restrict_traffic.fr.md) Security group « default » non restrictif | high | `CLD-NET-4` | `outscale` | 0 / 1 |
+| [`network_securitygroup_unrestricted_egress`](network_securitygroup_unrestricted_egress.fr.md) Filtrage sortant non restreint | medium | `CLD-NET-4` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_subnet_no_public_ip_by_default`](network_subnet_no_public_ip_by_default.fr.md) Sous-réseau attribuant une IP publique par défaut | medium | `CLD-NET-3` | `outscale` | 0 / 1 |
+
+## `compute`
+
+| Contrôle | Sévérité | SCSL | Actif pour | Preuves |
+|---|---|---|---|---|
+| [`compute_instance_deletion_protection`](compute_instance_deletion_protection.fr.md) Instance sans protection contre la suppression | medium | `CLD-CMP-10` | `outscale` | 0 / 1 |
+| [`compute_instance_has_security_group`](compute_instance_has_security_group.fr.md) Machine sans filtrage réseau | critical | `CLD-CMP-1` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`compute_instance_no_secrets_in_user_data`](compute_instance_no_secrets_in_user_data.fr.md) Secret en clair dans les données utilisateur (user-data) | high | `CLD-CMP-9` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`k8s_namespace_pod_security_enforced`](k8s_namespace_pod_security_enforced.fr.md) Pod Security Standards non imposés sur un namespace | high | `CLD-K8S-5` | `kubernetes` | 0 / 1 |
+| [`k8s_rbac_no_cluster_admin_binding`](k8s_rbac_no_cluster_admin_binding.fr.md) cluster-admin accordé au-delà du binding natif | critical | `CLD-K8S-4` | `kubernetes` | 0 / 1 |
+| [`kubernetes_cluster_auto_upgrade_enabled`](kubernetes_cluster_auto_upgrade_enabled.fr.md) Mises à jour automatiques du cluster Kubernetes désactivées | medium | `CLD-K8S-3` | `exoscale`, `outscale` | 0 / 2 |
+| [`kubernetes_cluster_control_plane_highly_available`](kubernetes_cluster_control_plane_highly_available.fr.md) Plan de contrôle Kubernetes non hautement disponible | high | `CLD-K8S-2` | `exoscale`, `outscale` | 0 / 2 |
+| [`kubernetes_cluster_deletion_protection`](kubernetes_cluster_deletion_protection.fr.md) Cluster Kubernetes sans protection contre la suppression | medium | `CLD-K8S-3` | `outscale` | 0 / 1 |
+| [`kubernetes_cluster_not_publicly_accessible`](kubernetes_cluster_not_publicly_accessible.fr.md) API server Kubernetes exposé à Internet | critical | `CLD-K8S-1` | `outscale` | 0 / 1 |
+
+## `stockage`
+
+| Contrôle | Sévérité | SCSL | Actif pour | Preuves |
+|---|---|---|---|---|
+| [`blockstorage_snapshot_not_public`](blockstorage_snapshot_not_public.fr.md) Instantané ou image partagé publiquement | high | `CLD-STO-2` | `outscale` | 0 / 1 |
+| [`blockstorage_volume_snapshots_exist`](blockstorage_volume_snapshots_exist.fr.md) Absence de sauvegarde récente | high | `CLD-STO-3` | `exoscale`, `outscale` | 0 / 2 |
+| [`compute_image_not_public`](compute_image_not_public.fr.md) Image machine partagée publiquement | high | `CLD-STO-2` | `outscale` | 0 / 1 |
+| [`database_backup_enabled`](database_backup_enabled.fr.md) Sauvegardes automatiques d'une base managée désactivées | high | `CLD-STO-3` | `scaleway` | 0 / 1 |
+| [`objectstorage_bucket_object_lock_enabled`](objectstorage_bucket_object_lock_enabled.fr.md) Object Lock (immutabilité) désactivé sur le stockage objet | low | `CLD-STO-8` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`objectstorage_bucket_public_access`](objectstorage_bucket_public_access.fr.md) Stockage objet exposé publiquement | critical | `CLD-STO-1` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`objectstorage_bucket_versioning_enabled`](objectstorage_bucket_versioning_enabled.fr.md) Versioning du stockage objet désactivé | medium | `CLD-STO-4` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+
+## `chiffrement`
+
+| Contrôle | Sévérité | SCSL | Actif pour | Preuves |
+|---|---|---|---|---|
+| [`blockstorage_volume_encryption`](blockstorage_volume_encryption.fr.md) Chiffrement au repos désactivé | high | `CLD-CHF-2` | `exoscale` | 0 / 1 |
+| [`database_encryption_at_rest_enabled`](database_encryption_at_rest_enabled.fr.md) Base de données managée sans chiffrement au repos | high | `CLD-CHF-2` | `scaleway` | 0 / 1 |
+| [`k8s_secrets_external_manager`](k8s_secrets_external_manager.fr.md) Secrets Kubernetes sans coffre externe | high | `CLD-K8S-10` | `kubernetes` | 0 / 1 |
+| [`loadbalancer_http_redirect_to_https`](loadbalancer_http_redirect_to_https.fr.md) Listener HTTP sans redirection HTTPS | medium | `CLD-CHF-1` | _dormant_ | aucun |
+| [`loadbalancer_ssl_listeners`](loadbalancer_ssl_listeners.fr.md) Chiffrement en transit absent | high | `CLD-CHF-1` | `outscale` | 0 / 1 |
+| [`objectstorage_bucket_default_encryption`](objectstorage_bucket_default_encryption.fr.md) Bucket sans chiffrement par défaut au repos | high | `CLD-CHF-2` | `outscale` | 0 / 1 |
+| [`objectstorage_bucket_kms_encryption`](objectstorage_bucket_kms_encryption.fr.md) Clé de chiffrement gérée par le client absente (BYOK) sur un bucket sensible | medium | `CLD-CHF-4` | `scaleway` | 0 / 1 |
+
+## `journalisation`
+
+| Contrôle | Sévérité | SCSL | Actif pour | Preuves |
+|---|---|---|---|---|
+| [`kubernetes_cluster_audit_logging_enabled`](kubernetes_cluster_audit_logging_enabled.fr.md) Journalisation d'audit du cluster Kubernetes désactivée | medium | `CLD-LOG-1` | `exoscale` | 1 / 1 |
+| [`loadbalancer_logging_enabled`](loadbalancer_logging_enabled.fr.md) Journalisation des accès désactivée | medium | `CLD-LOG-1` | `outscale` | 0 / 1 |
+
+## `gouvernance`
+
+| Contrôle | Sévérité | SCSL | Actif pour | Preuves |
+|---|---|---|---|---|
+| [`governance_provider_sovereignty`](governance_provider_sovereignty.fr.md) Souveraineté du fournisseur non établie | high | `CLD-GVN-4` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`governance_resource_region_in_eu`](governance_resource_region_in_eu.fr.md) Ressource hébergée hors Union européenne | high | `CLD-GVN-3` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`governance_resource_required_tags`](governance_resource_required_tags.fr.md) Inventaire et étiquetage incomplets | medium | `CLD-GVN-1` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+
+## Contrôles dormants
+
+Ces contrôles existent au référentiel mais ne sont déclarés pour aucun fournisseur :
+aucun scan ne les évalue aujourd'hui. Ils apparaissent ici pour que le catalogue ne se
+lise pas comme une couverture.
+
+| Contrôle | Sévérité | Famille |
+|---|---|---|
+| [`loadbalancer_http_redirect_to_https`](loadbalancer_http_redirect_to_https.fr.md) Listener HTTP sans redirection HTTPS | medium | `chiffrement` |

--- a/docs/controls/index.md
+++ b/docs/controls/index.md
@@ -1,0 +1,140 @@
+> 🇬🇧 English · [🇫🇷 Français](index.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# Control catalogue
+
+One page per control, computed from `referentiel/controles.yaml` (the source of truth),
+the `providers/*.yaml` descriptors and the `pass` lock in `internal/assess`.
+No metadata is copied here: adding a control, changing a severity or removing a provider
+rewrites these pages, and CI rejects documentation that lags behind.
+
+This catalogue states what Pépin **can conclude**, not the result of any scan. For the
+overview per provider and per source, see the [coverage matrix](../coverage.md).
+
+## Figures
+
+| Figure | Count |
+|---|---:|
+| Controls in the reference | 57 |
+| Active controls | 56 |
+| Dormant controls | 1 |
+| `critical` | 10 |
+| `high` | 32 |
+| `medium` | 13 |
+| `low` | 2 |
+| Deployable remediation proofs | 4 / 95 |
+
+## How to read this catalogue
+
+- **Active control**: declared for at least one provider (non-empty `fournisseurs:`).
+  A scan of that provider can give it a status.
+- **Dormant control**: written and tested, declared for no provider. It is never evaluated,
+  and it counts towards no coverage. The full list is at the bottom of this page.
+- **Remediation proofs**: the deployable setups present under
+  [`references/remediation/`](../../references/remediation/README.md). The count is over
+  declared (control, provider) pairs, and it is partial today: the *textual* remediation,
+  on the other hand, is carried by every deviation reported.
+- Controls still being triaged, not retained in the active reference, live in the
+  [triage catalogue](../../referentiel/catalogue.yaml).
+
+## `iam`
+
+| Control | Severity | SCSL | Active for | Proofs |
+|---|---|---|---|---|
+| [`iam_accesskey_expiration_set`](iam_accesskey_expiration_set.md) Access key without expiry or rotation | critical | `CLD-IAM-2` | `outscale`, `scaleway` | 0 / 2 |
+| [`iam_account_mfa_enforced`](iam_account_mfa_enforced.md) MFA not enforced at the account level | high | `CLD-IAM-3` | `outscale` | 0 / 1 |
+| [`iam_apiaccesspolicy_max_key_expiration`](iam_apiaccesspolicy_max_key_expiration.md) API access policy without a maximum key expiry | medium | `CLD-IAM-2` | `outscale` | 0 / 1 |
+| [`iam_apiaccessrule_defined`](iam_apiaccessrule_defined.md) No API access rule defined | high | `CLD-IAM-4` | `outscale` | 0 / 1 |
+| [`iam_apiaccessrule_no_public_cidr`](iam_apiaccessrule_no_public_cidr.md) API access rule open to a public CIDR | high | `CLD-IAM-4` | `outscale` | 0 / 1 |
+| [`iam_no_root_access_key`](iam_no_root_access_key.md) Access key attached to the root account | high | `CLD-IAM-1` | `outscale`, `scaleway` | 0 / 2 |
+| [`iam_policy_no_administrative_privileges`](iam_policy_no_administrative_privileges.md) IAM policy with administrative privileges (wildcard action) | critical | `CLD-IAM-1` | `outscale` | 0 / 1 |
+| [`iam_policy_no_notaction_notresource`](iam_policy_no_notaction_notresource.md) IAM policy using NotAction/NotResource (anti-pattern) | critical | `CLD-IAM-1` | `outscale` | 0 / 1 |
+| [`iam_policy_no_privilege_escalation`](iam_policy_no_privilege_escalation.md) IAM policy allowing privilege escalation | high | `CLD-IAM-12` | `outscale`, `scaleway` | 0 / 2 |
+| [`iam_policy_no_wildcard_resource`](iam_policy_no_wildcard_resource.md) IAM policy with a wildcard resource | high | `CLD-IAM-1` | `outscale` | 0 / 1 |
+| [`iam_role_key_lifetime_bounded`](iam_role_key_lifetime_bounded.md) IAM role without a bounded credential lifetime | critical | `CLD-IAM-2` | `exoscale` | 1 / 1 |
+| [`iam_role_no_admin_privileges`](iam_role_no_admin_privileges.md) IAM role with excessive privileges | high | `CLD-IAM-1` | `exoscale` | 1 / 1 |
+| [`iam_role_source_ip_restricted`](iam_role_source_ip_restricted.md) IAM role without a source IP restriction | high | `CLD-IAM-4` | `exoscale` | 1 / 1 |
+| [`iam_user_mfa_enabled`](iam_user_mfa_enabled.md) MFA not enabled on an account | high | `CLD-IAM-3` | `exoscale`, `scaleway` | 0 / 2 |
+
+## `reseau`
+
+| Control | Severity | SCSL | Active for | Proofs |
+|---|---|---|---|---|
+| [`compute_instance_public_ip_with_open_securitygroup`](compute_instance_public_ip_with_open_securitygroup.md) Instance publicly exposed without restrictive filtering | critical | `CLD-NET-3` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`database_service_not_open_to_internet`](database_service_not_open_to_internet.md) Managed database reachable from the internet | high | `CLD-NET-1` | `scaleway` | 0 / 1 |
+| [`k8s_namespace_network_policy_defined`](k8s_namespace_network_policy_defined.md) Namespace without a NetworkPolicy (flat network) | high | `CLD-K8S-6` | `kubernetes` | 0 / 1 |
+| [`network_documented`](network_documented.md) Undocumented network (mapping not maintained) | low | `CLD-NET-5` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_flow_matrix_documented`](network_flow_matrix_documented.md) Inbound flow without a justification in the flow matrix | medium | `CLD-NET-5` | `exoscale` | 0 / 1 |
+| [`network_peering_cross_organization`](network_peering_cross_organization.md) Network peering towards another information system | high | `CLD-NET-7` | `outscale` | 0 / 1 |
+| [`network_securitygroup_allow_ingress_from_internet_to_all_ports`](network_securitygroup_allow_ingress_from_internet_to_all_ports.md) All inbound traffic allowed from the internet (any/any) | critical | `CLD-NET-2` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports`](network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.md) Sensitive port (database, directory…) open to the internet | high | `CLD-NET-1` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports`](network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports.md) Sensitive UDP service (amplification, unauthenticated) open to the internet | high | `CLD-NET-1` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_securitygroup_allow_ingress_from_internet_to_tcp_port_22`](network_securitygroup_allow_ingress_from_internet_to_tcp_port_22.md) SSH (port 22) open to the internet | high | `CLD-NET-1`, `CLD-IAM-6`, `CLD-NET-6` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389`](network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.md) RDP (port 3389) open to the internet | high | `CLD-NET-1`, `CLD-IAM-6`, `CLD-NET-6` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_securitygroup_default_deny`](network_securitygroup_default_deny.md) Security group inbound default policy set to "accept" | high | `CLD-NET-2` | `scaleway` | 0 / 1 |
+| [`network_securitygroup_default_restrict_traffic`](network_securitygroup_default_restrict_traffic.md) The "default" security group is not restrictive | high | `CLD-NET-4` | `outscale` | 0 / 1 |
+| [`network_securitygroup_unrestricted_egress`](network_securitygroup_unrestricted_egress.md) Unrestricted outbound filtering | medium | `CLD-NET-4` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`network_subnet_no_public_ip_by_default`](network_subnet_no_public_ip_by_default.md) Subnet assigning a public IP by default | medium | `CLD-NET-3` | `outscale` | 0 / 1 |
+
+## `compute`
+
+| Control | Severity | SCSL | Active for | Proofs |
+|---|---|---|---|---|
+| [`compute_instance_deletion_protection`](compute_instance_deletion_protection.md) Instance without deletion protection | medium | `CLD-CMP-10` | `outscale` | 0 / 1 |
+| [`compute_instance_has_security_group`](compute_instance_has_security_group.md) Instance without network filtering | critical | `CLD-CMP-1` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`compute_instance_no_secrets_in_user_data`](compute_instance_no_secrets_in_user_data.md) Cleartext secret in the user data (user-data) | high | `CLD-CMP-9` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`k8s_namespace_pod_security_enforced`](k8s_namespace_pod_security_enforced.md) Pod Security Standards not enforced on a namespace | high | `CLD-K8S-5` | `kubernetes` | 0 / 1 |
+| [`k8s_rbac_no_cluster_admin_binding`](k8s_rbac_no_cluster_admin_binding.md) cluster-admin granted beyond the native binding | critical | `CLD-K8S-4` | `kubernetes` | 0 / 1 |
+| [`kubernetes_cluster_auto_upgrade_enabled`](kubernetes_cluster_auto_upgrade_enabled.md) Automatic Kubernetes cluster upgrades disabled | medium | `CLD-K8S-3` | `exoscale`, `outscale` | 0 / 2 |
+| [`kubernetes_cluster_control_plane_highly_available`](kubernetes_cluster_control_plane_highly_available.md) Kubernetes control plane not highly available | high | `CLD-K8S-2` | `exoscale`, `outscale` | 0 / 2 |
+| [`kubernetes_cluster_deletion_protection`](kubernetes_cluster_deletion_protection.md) Kubernetes cluster without deletion protection | medium | `CLD-K8S-3` | `outscale` | 0 / 1 |
+| [`kubernetes_cluster_not_publicly_accessible`](kubernetes_cluster_not_publicly_accessible.md) Kubernetes API server exposed to the internet | critical | `CLD-K8S-1` | `outscale` | 0 / 1 |
+
+## `stockage`
+
+| Control | Severity | SCSL | Active for | Proofs |
+|---|---|---|---|---|
+| [`blockstorage_snapshot_not_public`](blockstorage_snapshot_not_public.md) Snapshot or image shared publicly | high | `CLD-STO-2` | `outscale` | 0 / 1 |
+| [`blockstorage_volume_snapshots_exist`](blockstorage_volume_snapshots_exist.md) No recent backup | high | `CLD-STO-3` | `exoscale`, `outscale` | 0 / 2 |
+| [`compute_image_not_public`](compute_image_not_public.md) Machine image shared publicly | high | `CLD-STO-2` | `outscale` | 0 / 1 |
+| [`database_backup_enabled`](database_backup_enabled.md) Automatic backups disabled on a managed database | high | `CLD-STO-3` | `scaleway` | 0 / 1 |
+| [`objectstorage_bucket_object_lock_enabled`](objectstorage_bucket_object_lock_enabled.md) Object Lock (immutability) disabled on object storage | low | `CLD-STO-8` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`objectstorage_bucket_public_access`](objectstorage_bucket_public_access.md) Object storage publicly exposed | critical | `CLD-STO-1` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`objectstorage_bucket_versioning_enabled`](objectstorage_bucket_versioning_enabled.md) Object storage versioning disabled | medium | `CLD-STO-4` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+
+## `chiffrement`
+
+| Control | Severity | SCSL | Active for | Proofs |
+|---|---|---|---|---|
+| [`blockstorage_volume_encryption`](blockstorage_volume_encryption.md) Encryption at rest disabled | high | `CLD-CHF-2` | `exoscale` | 0 / 1 |
+| [`database_encryption_at_rest_enabled`](database_encryption_at_rest_enabled.md) Managed database without encryption at rest | high | `CLD-CHF-2` | `scaleway` | 0 / 1 |
+| [`k8s_secrets_external_manager`](k8s_secrets_external_manager.md) Kubernetes secrets without an external vault | high | `CLD-K8S-10` | `kubernetes` | 0 / 1 |
+| [`loadbalancer_http_redirect_to_https`](loadbalancer_http_redirect_to_https.md) HTTP listener without an HTTPS redirect | medium | `CLD-CHF-1` | _dormant_ | — |
+| [`loadbalancer_ssl_listeners`](loadbalancer_ssl_listeners.md) No encryption in transit | high | `CLD-CHF-1` | `outscale` | 0 / 1 |
+| [`objectstorage_bucket_default_encryption`](objectstorage_bucket_default_encryption.md) Bucket without default encryption at rest | high | `CLD-CHF-2` | `outscale` | 0 / 1 |
+| [`objectstorage_bucket_kms_encryption`](objectstorage_bucket_kms_encryption.md) No customer-managed encryption key (BYOK) on a sensitive bucket | medium | `CLD-CHF-4` | `scaleway` | 0 / 1 |
+
+## `journalisation`
+
+| Control | Severity | SCSL | Active for | Proofs |
+|---|---|---|---|---|
+| [`kubernetes_cluster_audit_logging_enabled`](kubernetes_cluster_audit_logging_enabled.md) Kubernetes cluster audit logging disabled | medium | `CLD-LOG-1` | `exoscale` | 1 / 1 |
+| [`loadbalancer_logging_enabled`](loadbalancer_logging_enabled.md) Access logging disabled | medium | `CLD-LOG-1` | `outscale` | 0 / 1 |
+
+## `gouvernance`
+
+| Control | Severity | SCSL | Active for | Proofs |
+|---|---|---|---|---|
+| [`governance_provider_sovereignty`](governance_provider_sovereignty.md) Provider sovereignty not established | high | `CLD-GVN-4` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`governance_resource_region_in_eu`](governance_resource_region_in_eu.md) Resource hosted outside the European Union | high | `CLD-GVN-3` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+| [`governance_resource_required_tags`](governance_resource_required_tags.md) Incomplete inventory and tagging | medium | `CLD-GVN-1` | `exoscale`, `outscale`, `scaleway` | 0 / 3 |
+
+## Dormant controls
+
+These controls exist in the reference but are declared for no provider: no scan evaluates
+them today. They appear here so that the catalogue is not read as coverage.
+
+| Control | Severity | Family |
+|---|---|---|
+| [`loadbalancer_http_redirect_to_https`](loadbalancer_http_redirect_to_https.md) HTTP listener without an HTTPS redirect | medium | `chiffrement` |

--- a/docs/controls/k8s_namespace_network_policy_defined.fr.md
+++ b/docs/controls/k8s_namespace_network_policy_defined.fr.md
@@ -91,7 +91,7 @@ Définir une NetworkPolicy de refus par défaut (ingress et egress) dans le name
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -106,7 +106,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/k8s_namespace_network_policy_defined.fr.md
+++ b/docs/controls/k8s_namespace_network_policy_defined.fr.md
@@ -1,0 +1,112 @@
+> [🇬🇧 English](k8s_namespace_network_policy_defined.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `k8s_namespace_network_policy_defined`
+
+**Namespace sans NetworkPolicy (réseau plat)**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `k8s_namespace_network_policy_defined` |
+| Famille | `reseau` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-K8S-6` |
+| Type de ressource lu | `k8s_namespace` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `kubernetes` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Aucune NetworkPolicy n'existe dans un namespace applicatif : tout pod peut joindre tout autre pod du cluster, sans cloisonnement — un pod compromis se déplace latéralement sans obstacle.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-K8S-6` |
+| `cis_controls_v8` | `12.2` |
+| `iso_27001_2022` | `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✅ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| kubernetes | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « k8s_namespace » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | kubernetes / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | kubernetes / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `k8s_namespace`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/kubernetes.yaml`](../../providers/kubernetes.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Définir une NetworkPolicy de refus par défaut (ingress et egress) dans le namespace, puis autoriser explicitement les flux légitimes.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| kubernetes | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan kubernetes --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "k8s_namespace_network_policy_defined"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/k8s_namespace_network_policy_defined.md
+++ b/docs/controls/k8s_namespace_network_policy_defined.md
@@ -1,0 +1,111 @@
+> 🇬🇧 English · [🇫🇷 Français](k8s_namespace_network_policy_defined.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `k8s_namespace_network_policy_defined`
+
+**Namespace without a NetworkPolicy (flat network)**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `k8s_namespace_network_policy_defined` |
+| Family | `reseau` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-K8S-6` |
+| Resource type read | `k8s_namespace` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `kubernetes` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+No NetworkPolicy exists in an application namespace: every pod can reach every other pod of the cluster, with no segregation — a compromised pod moves laterally without obstacle.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-K8S-6` |
+| `cis_controls_v8` | `12.2` |
+| `iso_27001_2022` | `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✅ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| kubernetes | terraform | ✗ `unsupported` | this source produces no resource of type "k8s_namespace" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | kubernetes / live |
+| `pass` | the deciding data was collected, and it is compliant | kubernetes / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `k8s_namespace`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/kubernetes.yaml`](../../providers/kubernetes.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Define a default-deny NetworkPolicy (ingress and egress) in the namespace, then explicitly allow the legitimate flows.
+
+| Provider | Deployable setup |
+|---|---|
+| kubernetes | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan kubernetes --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "k8s_namespace_network_policy_defined"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/k8s_namespace_pod_security_enforced.fr.md
+++ b/docs/controls/k8s_namespace_pod_security_enforced.fr.md
@@ -90,7 +90,7 @@ Poser le label pod-security.kubernetes.io/enforce (baseline ou restricted) sur l
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -105,7 +105,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/k8s_namespace_pod_security_enforced.fr.md
+++ b/docs/controls/k8s_namespace_pod_security_enforced.fr.md
@@ -1,0 +1,111 @@
+> [🇬🇧 English](k8s_namespace_pod_security_enforced.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `k8s_namespace_pod_security_enforced`
+
+**Pod Security Standards non imposés sur un namespace**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `k8s_namespace_pod_security_enforced` |
+| Famille | `compute` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-K8S-5` |
+| Type de ressource lu | `k8s_namespace` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `kubernetes` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Un namespace applicatif n'a pas de label pod-security.kubernetes.io/enforce : aucun garde-fou n'empêche d'y déployer un pod privilégié (accès à l'hôte, élévation de privilèges).
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-K8S-5` |
+| `iso_27001_2022` | `A.8.9` |
+| `secnumcloud_3_2` | `9.1` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✅ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| kubernetes | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « k8s_namespace » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | kubernetes / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | kubernetes / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `k8s_namespace`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/kubernetes.yaml`](../../providers/kubernetes.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Poser le label pod-security.kubernetes.io/enforce (baseline ou restricted) sur le namespace.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| kubernetes | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan kubernetes --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "k8s_namespace_pod_security_enforced"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/k8s_namespace_pod_security_enforced.md
+++ b/docs/controls/k8s_namespace_pod_security_enforced.md
@@ -1,0 +1,110 @@
+> 🇬🇧 English · [🇫🇷 Français](k8s_namespace_pod_security_enforced.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `k8s_namespace_pod_security_enforced`
+
+**Pod Security Standards not enforced on a namespace**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `k8s_namespace_pod_security_enforced` |
+| Family | `compute` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-K8S-5` |
+| Resource type read | `k8s_namespace` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `kubernetes` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+An application namespace carries no pod-security.kubernetes.io/enforce label: nothing prevents deploying a privileged pod there (host access, privilege escalation).
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-K8S-5` |
+| `iso_27001_2022` | `A.8.9` |
+| `secnumcloud_3_2` | `9.1` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✅ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| kubernetes | terraform | ✗ `unsupported` | this source produces no resource of type "k8s_namespace" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | kubernetes / live |
+| `pass` | the deciding data was collected, and it is compliant | kubernetes / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `k8s_namespace`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/kubernetes.yaml`](../../providers/kubernetes.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Set the pod-security.kubernetes.io/enforce label (baseline or restricted) on the namespace.
+
+| Provider | Deployable setup |
+|---|---|
+| kubernetes | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan kubernetes --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "k8s_namespace_pod_security_enforced"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/k8s_rbac_no_cluster_admin_binding.fr.md
+++ b/docs/controls/k8s_rbac_no_cluster_admin_binding.fr.md
@@ -1,0 +1,112 @@
+> [🇬🇧 English](k8s_rbac_no_cluster_admin_binding.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `k8s_rbac_no_cluster_admin_binding`
+
+**cluster-admin accordé au-delà du binding natif**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `k8s_rbac_no_cluster_admin_binding` |
+| Famille | `compute` |
+| Sévérité | `critical` |
+| Exigence SCSL (index gelé) | `CLD-K8S-4` |
+| Type de ressource lu | `k8s_cluster_role_binding` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `kubernetes` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Un ClusterRoleBinding accorde le rôle cluster-admin à un sujet autre que le groupe natif system:masters : ce sujet dispose des pleins pouvoirs sur le cluster, au-delà du moindre privilège.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-K8S-4` |
+| `cis_controls_v8` | `6.8` |
+| `iso_27001_2022` | `A.5.15`, `A.8.2` |
+| `secnumcloud_3_2` | `9.1`, `9.3` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✅ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| kubernetes | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « k8s_cluster_role_binding » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | kubernetes / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | kubernetes / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `k8s_cluster_role_binding`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/kubernetes.yaml`](../../providers/kubernetes.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Retirer cluster-admin de ce sujet et lui accorder un Role/ClusterRole restreint au strict nécessaire.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| kubernetes | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan kubernetes --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "k8s_rbac_no_cluster_admin_binding"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/k8s_rbac_no_cluster_admin_binding.fr.md
+++ b/docs/controls/k8s_rbac_no_cluster_admin_binding.fr.md
@@ -91,7 +91,7 @@ Retirer cluster-admin de ce sujet et lui accorder un Role/ClusterRole restreint 
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -106,7 +106,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/k8s_rbac_no_cluster_admin_binding.md
+++ b/docs/controls/k8s_rbac_no_cluster_admin_binding.md
@@ -1,0 +1,111 @@
+> 🇬🇧 English · [🇫🇷 Français](k8s_rbac_no_cluster_admin_binding.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `k8s_rbac_no_cluster_admin_binding`
+
+**cluster-admin granted beyond the native binding**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `k8s_rbac_no_cluster_admin_binding` |
+| Family | `compute` |
+| Severity | `critical` |
+| SCSL requirement (frozen index) | `CLD-K8S-4` |
+| Resource type read | `k8s_cluster_role_binding` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `kubernetes` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+A ClusterRoleBinding grants the cluster-admin role to a subject other than the native system:masters group: that subject holds full power over the cluster, beyond least privilege.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-K8S-4` |
+| `cis_controls_v8` | `6.8` |
+| `iso_27001_2022` | `A.5.15`, `A.8.2` |
+| `secnumcloud_3_2` | `9.1`, `9.3` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✅ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| kubernetes | terraform | ✗ `unsupported` | this source produces no resource of type "k8s_cluster_role_binding" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | kubernetes / live |
+| `pass` | the deciding data was collected, and it is compliant | kubernetes / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `k8s_cluster_role_binding`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/kubernetes.yaml`](../../providers/kubernetes.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Remove cluster-admin from this subject and grant it a Role/ClusterRole restricted to what it strictly needs.
+
+| Provider | Deployable setup |
+|---|---|
+| kubernetes | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan kubernetes --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "k8s_rbac_no_cluster_admin_binding"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/k8s_secrets_external_manager.fr.md
+++ b/docs/controls/k8s_secrets_external_manager.fr.md
@@ -90,7 +90,7 @@ Déployer un gestionnaire de secrets externes (External Secrets Operator ou Secr
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -105,7 +105,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/k8s_secrets_external_manager.fr.md
+++ b/docs/controls/k8s_secrets_external_manager.fr.md
@@ -1,0 +1,111 @@
+> [🇬🇧 English](k8s_secrets_external_manager.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `k8s_secrets_external_manager`
+
+**Secrets Kubernetes sans coffre externe**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `k8s_secrets_external_manager` |
+| Famille | `chiffrement` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-K8S-10` |
+| Type de ressource lu | `k8s_crd` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `kubernetes` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Aucun gestionnaire de secrets externes n'est déployé dans le cluster : les secrets reposent sur le stockage natif de Kubernetes (encodés en base64 dans etcd), sans coffre, sans rotation et exposés à quiconque peut les lire.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-K8S-10` |
+| `iso_27001_2022` | `A.8.24` |
+| `secnumcloud_3_2` | `10.5` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✅ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| kubernetes | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « k8s_crd » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | kubernetes / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | kubernetes / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `k8s_crd`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/kubernetes.yaml`](../../providers/kubernetes.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Déployer un gestionnaire de secrets externes (External Secrets Operator ou Secrets Store CSI) et monter les secrets depuis le coffre ; ne jamais placer de secret en clair dans un manifest ou une variable d'environnement.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| kubernetes | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan kubernetes --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "k8s_secrets_external_manager"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/k8s_secrets_external_manager.md
+++ b/docs/controls/k8s_secrets_external_manager.md
@@ -1,0 +1,110 @@
+> 🇬🇧 English · [🇫🇷 Français](k8s_secrets_external_manager.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `k8s_secrets_external_manager`
+
+**Kubernetes secrets without an external vault**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `k8s_secrets_external_manager` |
+| Family | `chiffrement` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-K8S-10` |
+| Resource type read | `k8s_crd` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `kubernetes` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+No external secrets manager is deployed in the cluster: secrets rely on Kubernetes' native storage (base64-encoded in etcd), with no vault, no rotation, and readable by anyone allowed to read them.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-K8S-10` |
+| `iso_27001_2022` | `A.8.24` |
+| `secnumcloud_3_2` | `10.5` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✅ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| kubernetes | terraform | ✗ `unsupported` | this source produces no resource of type "k8s_crd" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | kubernetes / live |
+| `pass` | the deciding data was collected, and it is compliant | kubernetes / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `k8s_crd`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/kubernetes.yaml`](../../providers/kubernetes.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Deploy an external secrets manager (External Secrets Operator or Secrets Store CSI) and mount secrets from the vault; never put a cleartext secret in a manifest or in an environment variable.
+
+| Provider | Deployable setup |
+|---|---|
+| kubernetes | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan kubernetes --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "k8s_secrets_external_manager"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/kubernetes_cluster_audit_logging_enabled.fr.md
+++ b/docs/controls/kubernetes_cluster_audit_logging_enabled.fr.md
@@ -89,7 +89,7 @@ Configurer l'audit Kubernetes du cluster (endpoint de collecte) ; centraliser et
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -107,7 +107,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/kubernetes_cluster_audit_logging_enabled.fr.md
+++ b/docs/controls/kubernetes_cluster_audit_logging_enabled.fr.md
@@ -1,0 +1,113 @@
+> [🇬🇧 English](kubernetes_cluster_audit_logging_enabled.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `kubernetes_cluster_audit_logging_enabled`
+
+**Journalisation d'audit du cluster Kubernetes désactivée**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `kubernetes_cluster_audit_logging_enabled` |
+| Famille | `journalisation` |
+| Sévérité | `medium` |
+| Exigence SCSL (index gelé) | `CLD-LOG-1` |
+| Type de ressource lu | `kubernetes_cluster` |
+| Attribut décisif | `audit_enabled` |
+| État | actif |
+| Déclaré pour | `exoscale` |
+| Preuves de remédiation | 1 / 1 |
+
+## Le risque
+
+L'audit Kubernetes du cluster managé n'est pas configuré (aucun endpoint d'audit) : les événements de sécurité du plan de contrôle ne sont pas collectés et un incident ne pourrait pas être investigué.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-LOG-1` |
+| `iso_27001_2022` | `A.8.15`, `A.8.16` |
+| `secnumcloud_3_2` | `12.6` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `kubernetes_cluster`
+- Attribut dont la décision dépend : `audit_enabled`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Configurer l'audit Kubernetes du cluster (endpoint de collecte) ; centraliser et conserver les journaux selon une politique de rétention.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | [`references/remediation/exoscale/kubernetes_cluster_audit_logging_enabled`](../../references/remediation/exoscale/kubernetes_cluster_audit_logging_enabled) |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "kubernetes_cluster_audit_logging_enabled"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/kubernetes_cluster_audit_logging_enabled.md
+++ b/docs/controls/kubernetes_cluster_audit_logging_enabled.md
@@ -1,0 +1,112 @@
+> 🇬🇧 English · [🇫🇷 Français](kubernetes_cluster_audit_logging_enabled.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `kubernetes_cluster_audit_logging_enabled`
+
+**Kubernetes cluster audit logging disabled**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `kubernetes_cluster_audit_logging_enabled` |
+| Family | `journalisation` |
+| Severity | `medium` |
+| SCSL requirement (frozen index) | `CLD-LOG-1` |
+| Resource type read | `kubernetes_cluster` |
+| Deciding attribute | `audit_enabled` |
+| State | active |
+| Declared for | `exoscale` |
+| Remediation proofs | 1 / 1 |
+
+## The risk
+
+Kubernetes auditing is not configured on the managed cluster (no audit endpoint): the control plane's security events are not collected, and an incident could not be investigated.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-LOG-1` |
+| `iso_27001_2022` | `A.8.15`, `A.8.16` |
+| `secnumcloud_3_2` | `12.6` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `kubernetes_cluster`
+- Attribute the decision depends on: `audit_enabled`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Configure the cluster's Kubernetes audit (collection endpoint); centralise the logs and keep them according to a retention policy.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | [`references/remediation/exoscale/kubernetes_cluster_audit_logging_enabled`](../../references/remediation/exoscale/kubernetes_cluster_audit_logging_enabled) |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "kubernetes_cluster_audit_logging_enabled"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/kubernetes_cluster_auto_upgrade_enabled.fr.md
+++ b/docs/controls/kubernetes_cluster_auto_upgrade_enabled.fr.md
@@ -92,7 +92,7 @@ Activer la maintenance / mise à jour automatique du cluster.
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -110,7 +110,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/kubernetes_cluster_auto_upgrade_enabled.fr.md
+++ b/docs/controls/kubernetes_cluster_auto_upgrade_enabled.fr.md
@@ -1,0 +1,116 @@
+> [🇬🇧 English](kubernetes_cluster_auto_upgrade_enabled.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `kubernetes_cluster_auto_upgrade_enabled`
+
+**Mises à jour automatiques du cluster Kubernetes désactivées**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `kubernetes_cluster_auto_upgrade_enabled` |
+| Famille | `compute` |
+| Sévérité | `medium` |
+| Exigence SCSL (index gelé) | `CLD-K8S-3` |
+| Type de ressource lu | `kubernetes_cluster` |
+| Attribut décisif | `auto_upgrade` |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale` |
+| Preuves de remédiation | 0 / 2 |
+
+## Le risque
+
+Les mises à jour / patches automatiques du cluster managé sont désactivés : les correctifs de sécurité ne sont pas appliqués en temps voulu.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-K8S-3` |
+| `cis_controls_v8` | `7.4` |
+| `secnumcloud_3_2` | `12.11` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « kubernetes_cluster » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `kubernetes_cluster`
+- Attribut dont la décision dépend : `auto_upgrade`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Activer la maintenance / mise à jour automatique du cluster.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "kubernetes_cluster_auto_upgrade_enabled"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/kubernetes_cluster_auto_upgrade_enabled.md
+++ b/docs/controls/kubernetes_cluster_auto_upgrade_enabled.md
@@ -1,0 +1,115 @@
+> 🇬🇧 English · [🇫🇷 Français](kubernetes_cluster_auto_upgrade_enabled.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `kubernetes_cluster_auto_upgrade_enabled`
+
+**Automatic Kubernetes cluster upgrades disabled**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `kubernetes_cluster_auto_upgrade_enabled` |
+| Family | `compute` |
+| Severity | `medium` |
+| SCSL requirement (frozen index) | `CLD-K8S-3` |
+| Resource type read | `kubernetes_cluster` |
+| Deciding attribute | `auto_upgrade` |
+| State | active |
+| Declared for | `exoscale`, `outscale` |
+| Remediation proofs | 0 / 2 |
+
+## The risk
+
+Automatic upgrades and patches of the managed cluster are disabled: security fixes are not applied in time.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-K8S-3` |
+| `cis_controls_v8` | `7.4` |
+| `secnumcloud_3_2` | `12.11` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "kubernetes_cluster" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `kubernetes_cluster`
+- Attribute the decision depends on: `auto_upgrade`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enable automatic maintenance and upgrades on the cluster.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "kubernetes_cluster_auto_upgrade_enabled"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/kubernetes_cluster_control_plane_highly_available.fr.md
+++ b/docs/controls/kubernetes_cluster_control_plane_highly_available.fr.md
@@ -92,7 +92,7 @@ Activer un plan de contrôle multi-AZ / multi-master sur le cluster managé.
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -110,7 +110,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/kubernetes_cluster_control_plane_highly_available.fr.md
+++ b/docs/controls/kubernetes_cluster_control_plane_highly_available.fr.md
@@ -1,0 +1,116 @@
+> [🇬🇧 English](kubernetes_cluster_control_plane_highly_available.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `kubernetes_cluster_control_plane_highly_available`
+
+**Plan de contrôle Kubernetes non hautement disponible**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `kubernetes_cluster_control_plane_highly_available` |
+| Famille | `compute` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-K8S-2` |
+| Type de ressource lu | `kubernetes_cluster` |
+| Attribut décisif | `control_plane_multi_az` |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale` |
+| Preuves de remédiation | 0 / 2 |
+
+## Le risque
+
+Le plan de contrôle du cluster managé n'est pas réparti sur plusieurs zones (mono-master / mono-AZ) : la perte d'une zone interrompt le plan de contrôle.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-K8S-2` |
+| `iso_27001_2022` | `A.8.14` |
+| `secnumcloud_3_2` | `17.4` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « kubernetes_cluster » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `kubernetes_cluster`
+- Attribut dont la décision dépend : `control_plane_multi_az`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Activer un plan de contrôle multi-AZ / multi-master sur le cluster managé.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "kubernetes_cluster_control_plane_highly_available"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/kubernetes_cluster_control_plane_highly_available.md
+++ b/docs/controls/kubernetes_cluster_control_plane_highly_available.md
@@ -1,0 +1,115 @@
+> 🇬🇧 English · [🇫🇷 Français](kubernetes_cluster_control_plane_highly_available.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `kubernetes_cluster_control_plane_highly_available`
+
+**Kubernetes control plane not highly available**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `kubernetes_cluster_control_plane_highly_available` |
+| Family | `compute` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-K8S-2` |
+| Resource type read | `kubernetes_cluster` |
+| Deciding attribute | `control_plane_multi_az` |
+| State | active |
+| Declared for | `exoscale`, `outscale` |
+| Remediation proofs | 0 / 2 |
+
+## The risk
+
+The managed cluster's control plane is not spread across several zones (single master / single AZ): losing one zone interrupts the control plane.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-K8S-2` |
+| `iso_27001_2022` | `A.8.14` |
+| `secnumcloud_3_2` | `17.4` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "kubernetes_cluster" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `kubernetes_cluster`
+- Attribute the decision depends on: `control_plane_multi_az`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enable a multi-AZ / multi-master control plane on the managed cluster.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "kubernetes_cluster_control_plane_highly_available"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/kubernetes_cluster_deletion_protection.fr.md
+++ b/docs/controls/kubernetes_cluster_deletion_protection.fr.md
@@ -1,0 +1,110 @@
+> [🇬🇧 English](kubernetes_cluster_deletion_protection.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `kubernetes_cluster_deletion_protection`
+
+**Cluster Kubernetes sans protection contre la suppression**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `kubernetes_cluster_deletion_protection` |
+| Famille | `compute` |
+| Sévérité | `medium` |
+| Exigence SCSL (index gelé) | `CLD-K8S-3` |
+| Type de ressource lu | `kubernetes_cluster` |
+| Attribut décisif | `deletion_protection` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Le cluster managé n'a pas de protection contre la suppression : une action accidentelle ou malveillante peut détruire le cluster.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-K8S-3` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « kubernetes_cluster » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `kubernetes_cluster`
+- Attribut dont la décision dépend : `deletion_protection`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Activer la protection contre la suppression sur le cluster.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "kubernetes_cluster_deletion_protection"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/kubernetes_cluster_deletion_protection.fr.md
+++ b/docs/controls/kubernetes_cluster_deletion_protection.fr.md
@@ -89,7 +89,7 @@ Activer la protection contre la suppression sur le cluster.
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -104,7 +104,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/kubernetes_cluster_deletion_protection.md
+++ b/docs/controls/kubernetes_cluster_deletion_protection.md
@@ -1,0 +1,109 @@
+> 🇬🇧 English · [🇫🇷 Français](kubernetes_cluster_deletion_protection.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `kubernetes_cluster_deletion_protection`
+
+**Kubernetes cluster without deletion protection**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `kubernetes_cluster_deletion_protection` |
+| Family | `compute` |
+| Severity | `medium` |
+| SCSL requirement (frozen index) | `CLD-K8S-3` |
+| Resource type read | `kubernetes_cluster` |
+| Deciding attribute | `deletion_protection` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+The managed cluster has no deletion protection: an accidental or malicious action can destroy the cluster.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-K8S-3` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "kubernetes_cluster" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `kubernetes_cluster`
+- Attribute the decision depends on: `deletion_protection`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enable deletion protection on the cluster.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "kubernetes_cluster_deletion_protection"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/kubernetes_cluster_not_publicly_accessible.fr.md
+++ b/docs/controls/kubernetes_cluster_not_publicly_accessible.fr.md
@@ -92,7 +92,7 @@ Restreindre la liste d'autorisation de l'API server aux CIDR d'administration ; 
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -107,7 +107,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/kubernetes_cluster_not_publicly_accessible.fr.md
+++ b/docs/controls/kubernetes_cluster_not_publicly_accessible.fr.md
@@ -1,0 +1,113 @@
+> [🇬🇧 English](kubernetes_cluster_not_publicly_accessible.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `kubernetes_cluster_not_publicly_accessible`
+
+**API server Kubernetes exposé à Internet**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `kubernetes_cluster_not_publicly_accessible` |
+| Famille | `compute` |
+| Sévérité | `critical` |
+| Exigence SCSL (index gelé) | `CLD-K8S-1` |
+| Type de ressource lu | `kubernetes_cluster` |
+| Attribut décisif | `admin_whitelist` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Le serveur d'API du cluster managé est joignable depuis 0.0.0.0/0 (liste d'autorisation ouverte), exposant le plan de contrôle.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-K8S-1` |
+| `cis_controls_v8` | `4.4`, `13.4` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « kubernetes_cluster » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `kubernetes_cluster`
+- Attribut dont la décision dépend : `admin_whitelist`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Restreindre la liste d'autorisation de l'API server aux CIDR d'administration ; activer un accès privé.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "kubernetes_cluster_not_publicly_accessible"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/kubernetes_cluster_not_publicly_accessible.md
+++ b/docs/controls/kubernetes_cluster_not_publicly_accessible.md
@@ -1,0 +1,112 @@
+> 🇬🇧 English · [🇫🇷 Français](kubernetes_cluster_not_publicly_accessible.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `kubernetes_cluster_not_publicly_accessible`
+
+**Kubernetes API server exposed to the internet**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `kubernetes_cluster_not_publicly_accessible` |
+| Family | `compute` |
+| Severity | `critical` |
+| SCSL requirement (frozen index) | `CLD-K8S-1` |
+| Resource type read | `kubernetes_cluster` |
+| Deciding attribute | `admin_whitelist` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+The managed cluster's API server is reachable from 0.0.0.0/0 (open allow list), exposing the control plane.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-K8S-1` |
+| `cis_controls_v8` | `4.4`, `13.4` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "kubernetes_cluster" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `kubernetes_cluster`
+- Attribute the decision depends on: `admin_whitelist`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Restrict the API server allow list to administration CIDRs; enable private access.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "kubernetes_cluster_not_publicly_accessible"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/loadbalancer_http_redirect_to_https.fr.md
+++ b/docs/controls/loadbalancer_http_redirect_to_https.fr.md
@@ -92,7 +92,7 @@ _Contrôle dormant : aucun fournisseur déclaré, donc aucune preuve attendue._
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -101,7 +101,7 @@ peut faire disparaître l'écart, il ne peut pas **démontrer** la conformité. 
 des motifs ci-dessus dit ce qui manque.
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/loadbalancer_http_redirect_to_https.fr.md
+++ b/docs/controls/loadbalancer_http_redirect_to_https.fr.md
@@ -1,0 +1,107 @@
+> [🇬🇧 English](loadbalancer_http_redirect_to_https.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `loadbalancer_http_redirect_to_https`
+
+**Listener HTTP sans redirection HTTPS**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `loadbalancer_http_redirect_to_https` |
+| Famille | `chiffrement` |
+| Sévérité | `medium` |
+| Exigence SCSL (index gelé) | `CLD-CHF-1` |
+| Type de ressource lu | `load_balancer` |
+| Attribut décisif | `redirect_to_https` |
+| État | dormant (déclaré pour aucun fournisseur) |
+| Déclaré pour | aucun |
+| Preuves de remédiation | 0 / 0 |
+
+## Le risque
+
+Un répartiteur de charge expose un listener HTTP (port 80) : sans redirection vers HTTPS, le trafic peut transiter en clair.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-CHF-1` |
+| `cis_controls_v8` | `3.10` |
+| `iso_27001_2022` | `A.8.24` |
+| `secnumcloud_3_2` | `10.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ∅ | ∅ |
+| outscale | ∅ | ∅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| exoscale | terraform | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
+| exoscale | live | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
+| outscale | terraform | ∅ `not-applicable` | Le LBU Outscale ne peut pas rediriger : `ListenerRule.Action` est documenté « always forward » au contrat OAPI (aucune action de redirection), et aucun attribut de redirection n'existe sur `Listener`. Le mécanisme est inexistant → contrôle non applicable (CHF-1). |
+| outscale | live | ∅ `not-applicable` | Le LBU Outscale ne peut pas rediriger : `ListenerRule.Action` est documenté « always forward » au contrat OAPI (aucune action de redirection), et aucun attribut de redirection n'existe sur `Listener`. Le mécanisme est inexistant → contrôle non applicable (CHF-1). |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | aucun |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | aucun |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `load_balancer`
+- Attribut dont la décision dépend : `redirect_to_https`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Mettre en place une redirection 301 du listener HTTP:80 vers HTTPS.
+
+_Contrôle dormant : aucun fournisseur déclaré, donc aucune preuve attendue._
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+Aucune source ne sait aujourd'hui conclure `pass` sur ce contrôle : un scan
+peut faire disparaître l'écart, il ne peut pas **démontrer** la conformité. Le tableau
+des motifs ci-dessus dit ce qui manque.
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/loadbalancer_http_redirect_to_https.md
+++ b/docs/controls/loadbalancer_http_redirect_to_https.md
@@ -1,0 +1,106 @@
+> 🇬🇧 English · [🇫🇷 Français](loadbalancer_http_redirect_to_https.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `loadbalancer_http_redirect_to_https`
+
+**HTTP listener without an HTTPS redirect**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `loadbalancer_http_redirect_to_https` |
+| Family | `chiffrement` |
+| Severity | `medium` |
+| SCSL requirement (frozen index) | `CLD-CHF-1` |
+| Resource type read | `load_balancer` |
+| Deciding attribute | `redirect_to_https` |
+| State | dormant (declared for no provider) |
+| Declared for | — |
+| Remediation proofs | 0 / 0 |
+
+## The risk
+
+A load balancer exposes an HTTP listener (port 80): without a redirect to HTTPS, traffic can travel in cleartext.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-CHF-1` |
+| `cis_controls_v8` | `3.10` |
+| `iso_27001_2022` | `A.8.24` |
+| `secnumcloud_3_2` | `10.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ∅ | ∅ |
+| outscale | ∅ | ∅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| exoscale | terraform | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
+| exoscale | live | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
+| outscale | terraform | ∅ `not-applicable` | The Outscale LBU cannot redirect: `ListenerRule.Action` is documented as "always forward" in the OAPI contract (no redirect action), and no redirect attribute exists on `Listener`. The mechanism does not exist, so the control is not applicable (CHF-1). |
+| outscale | live | ∅ `not-applicable` | The Outscale LBU cannot redirect: `ListenerRule.Action` is documented as "always forward" in the OAPI contract (no redirect action), and no redirect attribute exists on `Listener`. The mechanism does not exist, so the control is not applicable (CHF-1). |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | — |
+| `pass` | the deciding data was collected, and it is compliant | — |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `load_balancer`
+- Attribute the decision depends on: `redirect_to_https`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Set up a 301 redirect from the HTTP:80 listener to HTTPS.
+
+_Dormant control: no provider declared, so no proof expected._
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+No source can conclude `pass` on this control today: a scan can make the deviation
+disappear, it cannot **demonstrate** compliance. The reasons table above says what is
+missing.
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/loadbalancer_logging_enabled.fr.md
+++ b/docs/controls/loadbalancer_logging_enabled.fr.md
@@ -92,7 +92,7 @@ Activer la journalisation (piste d'audit, journaux d'accès) ; centraliser et co
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -107,7 +107,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/loadbalancer_logging_enabled.fr.md
+++ b/docs/controls/loadbalancer_logging_enabled.fr.md
@@ -1,0 +1,113 @@
+> [🇬🇧 English](loadbalancer_logging_enabled.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `loadbalancer_logging_enabled`
+
+**Journalisation des accès désactivée**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `loadbalancer_logging_enabled` |
+| Famille | `journalisation` |
+| Sévérité | `medium` |
+| Exigence SCSL (index gelé) | `CLD-LOG-1` |
+| Type de ressource lu | `load_balancer` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+La piste d'audit / les journaux d'accès aux services exposés ne sont pas activés : un incident ne pourrait pas être investigué.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-LOG-1` |
+| `iso_27001_2022` | `A.8.15`, `A.8.16` |
+| `secnumcloud_3_2` | `12.6` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ∅ | ∅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| exoscale | terraform | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
+| exoscale | live | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « load_balancer » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | exoscale / terraform · exoscale / live |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `load_balancer`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Activer la journalisation (piste d'audit, journaux d'accès) ; centraliser et conserver selon une politique de rétention.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "loadbalancer_logging_enabled"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/loadbalancer_logging_enabled.md
+++ b/docs/controls/loadbalancer_logging_enabled.md
@@ -1,0 +1,112 @@
+> 🇬🇧 English · [🇫🇷 Français](loadbalancer_logging_enabled.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `loadbalancer_logging_enabled`
+
+**Access logging disabled**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `loadbalancer_logging_enabled` |
+| Family | `journalisation` |
+| Severity | `medium` |
+| SCSL requirement (frozen index) | `CLD-LOG-1` |
+| Resource type read | `load_balancer` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+The audit trail and the access logs of the exposed services are not enabled: an incident could not be investigated.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-LOG-1` |
+| `iso_27001_2022` | `A.8.15`, `A.8.16` |
+| `secnumcloud_3_2` | `12.6` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ∅ | ∅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| exoscale | terraform | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
+| exoscale | live | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "load_balancer" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | exoscale / terraform · exoscale / live |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `load_balancer`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enable logging (audit trail, access logs); centralise the logs and keep them according to a retention policy.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "loadbalancer_logging_enabled"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/loadbalancer_ssl_listeners.fr.md
+++ b/docs/controls/loadbalancer_ssl_listeners.fr.md
@@ -1,0 +1,115 @@
+> [🇬🇧 English](loadbalancer_ssl_listeners.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `loadbalancer_ssl_listeners`
+
+**Chiffrement en transit absent**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `loadbalancer_ssl_listeners` |
+| Famille | `chiffrement` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-CHF-1` |
+| Type de ressource lu | `load_balancer` |
+| Attribut décisif | `load_balancer_type` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Un répartiteur de charge exposé n'impose pas de listener TLS/HTTPS : le trafic transite en clair.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-CHF-1` |
+| `cis_controls_v8` | `3.10`, `16.11` |
+| `iso_27001_2022` | `A.8.24`, `A.8.21` |
+| `secnumcloud_3_2` | `10.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ∅ | ∅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| exoscale | terraform | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
+| exoscale | live | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « load_balancer » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | exoscale / terraform · exoscale / live |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `load_balancer`
+- Attribut dont la décision dépend : `load_balancer_type`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Configurer un listener HTTPS/SSL (TLS ≥ 1.2) ; rediriger le trafic en clair vers HTTPS.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "loadbalancer_ssl_listeners"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/loadbalancer_ssl_listeners.fr.md
+++ b/docs/controls/loadbalancer_ssl_listeners.fr.md
@@ -94,7 +94,7 @@ Configurer un listener HTTPS/SSL (TLS ≥ 1.2) ; rediriger le trafic en clair ve
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -109,7 +109,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/loadbalancer_ssl_listeners.md
+++ b/docs/controls/loadbalancer_ssl_listeners.md
@@ -1,0 +1,114 @@
+> 🇬🇧 English · [🇫🇷 Français](loadbalancer_ssl_listeners.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `loadbalancer_ssl_listeners`
+
+**No encryption in transit**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `loadbalancer_ssl_listeners` |
+| Family | `chiffrement` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-CHF-1` |
+| Resource type read | `load_balancer` |
+| Deciding attribute | `load_balancer_type` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+An exposed load balancer does not enforce a TLS/HTTPS listener: traffic travels in cleartext.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-CHF-1` |
+| `cis_controls_v8` | `3.10`, `16.11` |
+| `iso_27001_2022` | `A.8.24`, `A.8.21` |
+| `secnumcloud_3_2` | `10.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ∅ | ∅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| exoscale | terraform | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
+| exoscale | live | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "load_balancer" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | exoscale / terraform · exoscale / live |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `load_balancer`
+- Attribute the decision depends on: `load_balancer_type`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Configure an HTTPS/SSL listener (TLS 1.2 or above); redirect cleartext traffic to HTTPS.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "loadbalancer_ssl_listeners"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/network_documented.fr.md
+++ b/docs/controls/network_documented.fr.md
@@ -1,0 +1,117 @@
+> [🇬🇧 English](network_documented.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `network_documented`
+
+**Réseau non documenté (cartographie non tenue)**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `network_documented` |
+| Famille | `reseau` |
+| Sévérité | `low` |
+| Exigence SCSL (index gelé) | `CLD-NET-5` |
+| Type de ressource lu | `network` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Un réseau (VPC / Net / réseau privé) n'a pas de nom ou d'étiquettes de gouvernance : la cartographie réseau (inventaire, propriétaire, projet) n'est pas tenue à jour, ce qui nuit à la revue et à la réponse aux incidents.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-5` |
+| `iso_27001_2022` | `A.5.9` |
+| `secnumcloud_3_2` | `13.1` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ◐ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| scaleway | terraform | ◐ `partial` | contrat du fournisseur : le type « network » n'est pas déclaré `verifie` (état : a_verifier) |
+| scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « network » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | scaleway / terraform |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `network`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Nommer et étiqueter chaque réseau (propriétaire, projet, environnement) ; tenir à jour la cartographie réseau et la réviser périodiquement.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "network_documented"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/network_documented.fr.md
+++ b/docs/controls/network_documented.fr.md
@@ -93,7 +93,7 @@ Nommer et étiqueter chaque réseau (propriétaire, projet, environnement) ; ten
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -111,7 +111,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/network_documented.md
+++ b/docs/controls/network_documented.md
@@ -1,0 +1,116 @@
+> 🇬🇧 English · [🇫🇷 Français](network_documented.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `network_documented`
+
+**Undocumented network (mapping not maintained)**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `network_documented` |
+| Family | `reseau` |
+| Severity | `low` |
+| SCSL requirement (frozen index) | `CLD-NET-5` |
+| Resource type read | `network` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+A network (VPC / Net / private network) has no name and no governance tags: the network mapping (inventory, owner, project) is not kept up to date, which hurts review and incident response.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-5` |
+| `iso_27001_2022` | `A.5.9` |
+| `secnumcloud_3_2` | `13.1` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ◐ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| scaleway | terraform | ◐ `partial` | provider contract: type "network" is not declared `verifie` (state: a_verifier) |
+| scaleway | live | ✗ `unsupported` | this source produces no resource of type "network" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | scaleway / terraform |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `network`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Name and tag every network (owner, project, environment); keep the network mapping up to date and review it periodically.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "network_documented"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/network_flow_matrix_documented.fr.md
+++ b/docs/controls/network_flow_matrix_documented.fr.md
@@ -1,0 +1,113 @@
+> [🇬🇧 English](network_flow_matrix_documented.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `network_flow_matrix_documented`
+
+**Flux entrant sans justification dans la matrice des flux**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `network_flow_matrix_documented` |
+| Famille | `reseau` |
+| Sévérité | `medium` |
+| Exigence SCSL (index gelé) | `CLD-NET-5` |
+| Type de ressource lu | `security_group_rule` |
+| Attribut décisif | `description` |
+| État | actif |
+| Déclaré pour | `exoscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Une règle de flux entrant n'a pas de justification (description) : la matrice des flux autorisés (services, protocoles, ports + justification) n'est pas tenue, ce qui empêche la revue et l'imputabilité des ouvertures réseau.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-5` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.1`, `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `security_group_rule`
+- Attribut dont la décision dépend : `description`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Documenter chaque règle de security group (service desservi, raison) via sa description ; tenir à jour la matrice des flux et la réviser périodiquement.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "network_flow_matrix_documented"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/network_flow_matrix_documented.fr.md
+++ b/docs/controls/network_flow_matrix_documented.fr.md
@@ -89,7 +89,7 @@ Documenter chaque règle de security group (service desservi, raison) via sa des
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -107,7 +107,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/network_flow_matrix_documented.md
+++ b/docs/controls/network_flow_matrix_documented.md
@@ -1,0 +1,112 @@
+> 🇬🇧 English · [🇫🇷 Français](network_flow_matrix_documented.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `network_flow_matrix_documented`
+
+**Inbound flow without a justification in the flow matrix**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `network_flow_matrix_documented` |
+| Family | `reseau` |
+| Severity | `medium` |
+| SCSL requirement (frozen index) | `CLD-NET-5` |
+| Resource type read | `security_group_rule` |
+| Deciding attribute | `description` |
+| State | active |
+| Declared for | `exoscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+An inbound flow rule carries no justification (description): the matrix of allowed flows (services, protocols, ports and justification) is not maintained, which prevents any review of, and accountability for, network openings.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-5` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.1`, `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✗ | ✗ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `security_group_rule`
+- Attribute the decision depends on: `description`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Document every security group rule (service served, reason) in its description; keep the flow matrix up to date and review it periodically.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "network_flow_matrix_documented"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/network_peering_cross_organization.fr.md
+++ b/docs/controls/network_peering_cross_organization.fr.md
@@ -91,7 +91,7 @@ Limiter les appairages aux réseaux du même SI ; pour un partenaire, justifier 
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -106,7 +106,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/network_peering_cross_organization.fr.md
+++ b/docs/controls/network_peering_cross_organization.fr.md
@@ -1,0 +1,112 @@
+> [🇬🇧 English](network_peering_cross_organization.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `network_peering_cross_organization`
+
+**Appairage réseau vers un autre système d'information**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `network_peering_cross_organization` |
+| Famille | `reseau` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-NET-7` |
+| Type de ressource lu | `network_peering` |
+| Attribut décisif | `accepter_account` / `source_account` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Un appairage réseau (peering) relie deux comptes/organisations différents : les flux internes sont ouverts vers un autre système d'information, à l'encontre du cloisonnement, sauf justification et restriction des routes.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-7` |
+| `iso_27001_2022` | `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « network_peering » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `network_peering`
+- Attribut dont la décision dépend : `accepter_account` / `source_account`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Limiter les appairages aux réseaux du même SI ; pour un partenaire, justifier l'appairage et restreindre les routes/flux échangés (matrice de flux).
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "network_peering_cross_organization"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/network_peering_cross_organization.md
+++ b/docs/controls/network_peering_cross_organization.md
@@ -1,0 +1,111 @@
+> 🇬🇧 English · [🇫🇷 Français](network_peering_cross_organization.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `network_peering_cross_organization`
+
+**Network peering towards another information system**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `network_peering_cross_organization` |
+| Family | `reseau` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-NET-7` |
+| Resource type read | `network_peering` |
+| Deciding attribute | `accepter_account` / `source_account` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+A network peering links two different accounts or organisations: internal flows are opened towards another information system, against segregation, unless it is justified and the routes are restricted.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-7` |
+| `iso_27001_2022` | `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "network_peering" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `network_peering`
+- Attribute the decision depends on: `accepter_account` / `source_account`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Limit peerings to networks of the same information system; for a partner, justify the peering and restrict the routes and flows exchanged (flow matrix).
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "network_peering_cross_organization"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_all_ports.fr.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_all_ports.fr.md
@@ -1,0 +1,115 @@
+> [🇬🇧 English](network_securitygroup_allow_ingress_from_internet_to_all_ports.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `network_securitygroup_allow_ingress_from_internet_to_all_ports`
+
+**Tout le trafic entrant autorisé depuis Internet (any/any)**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `network_securitygroup_allow_ingress_from_internet_to_all_ports` |
+| Famille | `reseau` |
+| Sévérité | `critical` |
+| Exigence SCSL (index gelé) | `CLD-NET-2` |
+| Type de ressource lu | `security_group_rule` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Une règle autorise l'ensemble des ports/protocoles depuis 0.0.0.0/0 — exposition maximale.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-2` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `security_group_rule`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Remplacer la règle par des autorisations explicites, port par port, restreintes aux sources légitimes.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "network_securitygroup_allow_ingress_from_internet_to_all_ports"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_all_ports.fr.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_all_ports.fr.md
@@ -91,7 +91,7 @@ Remplacer la règle par des autorisations explicites, port par port, restreintes
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -109,7 +109,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_all_ports.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_all_ports.md
@@ -1,0 +1,114 @@
+> 🇬🇧 English · [🇫🇷 Français](network_securitygroup_allow_ingress_from_internet_to_all_ports.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `network_securitygroup_allow_ingress_from_internet_to_all_ports`
+
+**All inbound traffic allowed from the internet (any/any)**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `network_securitygroup_allow_ingress_from_internet_to_all_ports` |
+| Family | `reseau` |
+| Severity | `critical` |
+| SCSL requirement (frozen index) | `CLD-NET-2` |
+| Resource type read | `security_group_rule` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+A rule allows every port and every protocol from 0.0.0.0/0 — maximum exposure.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-2` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `security_group_rule`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Replace the rule with explicit port-by-port allowances, restricted to legitimate sources.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "network_securitygroup_allow_ingress_from_internet_to_all_ports"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.fr.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.fr.md
@@ -91,7 +91,7 @@ Restreindre la source à un CIDR d'administration / d'application ; ne jamais ex
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -109,7 +109,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.fr.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.fr.md
@@ -1,0 +1,115 @@
+> [🇬🇧 English](network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports`
+
+**Port sensible (base de données, annuaire…) ouvert à Internet**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports` |
+| Famille | `reseau` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-NET-1` |
+| Type de ressource lu | `security_group_rule` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Une règle de filtrage accepte depuis 0.0.0.0/0 ou ::/0 un port sensible (PostgreSQL, MySQL, Redis, MongoDB, Elasticsearch, MS-SQL, RDP…), exposant un service critique à tout Internet.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-1` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `security_group_rule`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Restreindre la source à un CIDR d'administration / d'application ; ne jamais exposer une base de données ou un annuaire directement sur Internet.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.md
@@ -1,0 +1,114 @@
+> 🇬🇧 English · [🇫🇷 Français](network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports`
+
+**Sensitive port (database, directory…) open to the internet**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports` |
+| Family | `reseau` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-NET-1` |
+| Resource type read | `security_group_rule` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+A filtering rule accepts a sensitive port from 0.0.0.0/0 or ::/0 (PostgreSQL, MySQL, Redis, MongoDB, Elasticsearch, MS-SQL, RDP…), exposing a critical service to the whole internet.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-1` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `security_group_rule`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Restrict the source to an administration or application CIDR; never expose a database or a directory service directly on the internet.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports.fr.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports.fr.md
@@ -1,0 +1,115 @@
+> [🇬🇧 English](network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports`
+
+**Service UDP sensible (amplification, non authentifié) ouvert à Internet**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports` |
+| Famille | `reseau` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-NET-1` |
+| Type de ressource lu | `security_group_rule` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Une règle de filtrage accepte depuis 0.0.0.0/0 ou ::/0 un service UDP sensible (DNS, NTP, SNMP, memcached, NFS, LDAP/CLDAP…), vecteur classique d'amplification DDoS et souvent non authentifié.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-1` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `security_group_rule`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Restreindre la source à un CIDR légitime ; ne jamais exposer un service UDP d'amplification ou non authentifié directement sur Internet.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports.fr.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports.fr.md
@@ -91,7 +91,7 @@ Restreindre la source à un CIDR légitime ; ne jamais exposer un service UDP d'
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -109,7 +109,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports.md
@@ -1,0 +1,114 @@
+> 🇬🇧 English · [🇫🇷 Français](network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports`
+
+**Sensitive UDP service (amplification, unauthenticated) open to the internet**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports` |
+| Family | `reseau` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-NET-1` |
+| Resource type read | `security_group_rule` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+A filtering rule accepts a sensitive UDP service from 0.0.0.0/0 or ::/0 (DNS, NTP, SNMP, memcached, NFS, LDAP/CLDAP…), a classic DDoS amplification vector and often unauthenticated.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-1` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `security_group_rule`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Restrict the source to a legitimate CIDR; never expose an amplification or unauthenticated UDP service directly on the internet.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_tcp_port_22.fr.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_tcp_port_22.fr.md
@@ -1,0 +1,115 @@
+> [🇬🇧 English](network_securitygroup_allow_ingress_from_internet_to_tcp_port_22.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `network_securitygroup_allow_ingress_from_internet_to_tcp_port_22`
+
+**SSH (port 22) ouvert à Internet**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `network_securitygroup_allow_ingress_from_internet_to_tcp_port_22` |
+| Famille | `reseau` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-NET-1`, `CLD-IAM-6`, `CLD-NET-6` |
+| Type de ressource lu | `security_group_rule` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Une règle de filtrage accepte le port 22 (SSH) depuis 0.0.0.0/0 ou ::/0, exposant l'administration à tout Internet.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-1`, `CLD-IAM-6`, `CLD-NET-6` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `security_group_rule`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Restreindre la source à un CIDR d'administration ; passer par un bastion ou un VPN.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "network_securitygroup_allow_ingress_from_internet_to_tcp_port_22"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_tcp_port_22.fr.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_tcp_port_22.fr.md
@@ -91,7 +91,7 @@ Restreindre la source à un CIDR d'administration ; passer par un bastion ou un 
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -109,7 +109,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_tcp_port_22.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_tcp_port_22.md
@@ -1,0 +1,114 @@
+> 🇬🇧 English · [🇫🇷 Français](network_securitygroup_allow_ingress_from_internet_to_tcp_port_22.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `network_securitygroup_allow_ingress_from_internet_to_tcp_port_22`
+
+**SSH (port 22) open to the internet**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `network_securitygroup_allow_ingress_from_internet_to_tcp_port_22` |
+| Family | `reseau` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-NET-1`, `CLD-IAM-6`, `CLD-NET-6` |
+| Resource type read | `security_group_rule` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+A filtering rule accepts port 22 (SSH) from 0.0.0.0/0 or ::/0, exposing administration to the whole internet.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-1`, `CLD-IAM-6`, `CLD-NET-6` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `security_group_rule`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Restrict the source to an administration CIDR; go through a bastion or a VPN.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "network_securitygroup_allow_ingress_from_internet_to_tcp_port_22"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.fr.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.fr.md
@@ -1,0 +1,115 @@
+> [🇬🇧 English](network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389`
+
+**RDP (port 3389) ouvert à Internet**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389` |
+| Famille | `reseau` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-NET-1`, `CLD-IAM-6`, `CLD-NET-6` |
+| Type de ressource lu | `security_group_rule` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Une règle de filtrage accepte le port 3389 (RDP) depuis 0.0.0.0/0 ou ::/0, exposant l'administration Windows à tout Internet.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-1`, `CLD-IAM-6`, `CLD-NET-6` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `security_group_rule`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Restreindre la source à un CIDR d'administration ; passer par un bastion ou un VPN.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.fr.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.fr.md
@@ -91,7 +91,7 @@ Restreindre la source à un CIDR d'administration ; passer par un bastion ou un 
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -109,7 +109,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.md
+++ b/docs/controls/network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.md
@@ -1,0 +1,114 @@
+> 🇬🇧 English · [🇫🇷 Français](network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389`
+
+**RDP (port 3389) open to the internet**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389` |
+| Family | `reseau` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-NET-1`, `CLD-IAM-6`, `CLD-NET-6` |
+| Resource type read | `security_group_rule` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+A filtering rule accepts port 3389 (RDP) from 0.0.0.0/0 or ::/0, exposing Windows administration to the whole internet.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-1`, `CLD-IAM-6`, `CLD-NET-6` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `security_group_rule`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Restrict the source to an administration CIDR; go through a bastion or a VPN.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/network_securitygroup_default_deny.fr.md
+++ b/docs/controls/network_securitygroup_default_deny.fr.md
@@ -92,7 +92,7 @@ Basculer la politique entrante par défaut sur « drop » et n'ouvrir que les fl
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -107,7 +107,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_default_deny.fr.md
+++ b/docs/controls/network_securitygroup_default_deny.fr.md
@@ -1,0 +1,113 @@
+> [🇬🇧 English](network_securitygroup_default_deny.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `network_securitygroup_default_deny`
+
+**Politique entrante par défaut d'un groupe de sécurité en « accept »**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `network_securitygroup_default_deny` |
+| Famille | `reseau` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-NET-2` |
+| Type de ressource lu | `security_group` |
+| Attribut décisif | `inbound_default_policy` |
+| État | actif |
+| Déclaré pour | `scaleway` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+La politique par défaut en entrée d'un groupe de sécurité est « accept » : tout trafic non explicitement filtré est admis (any/any implicite), quel que soit le jeu de règles explicites.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-2` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✅ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « security_group » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | scaleway / terraform |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | scaleway / terraform |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `security_group`
+- Attribut dont la décision dépend : `inbound_default_policy`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Basculer la politique entrante par défaut sur « drop » et n'ouvrir que les flux légitimes par des règles explicites.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan scaleway --terraform plan.json --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "network_securitygroup_default_deny"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_default_deny.md
+++ b/docs/controls/network_securitygroup_default_deny.md
@@ -1,0 +1,112 @@
+> 🇬🇧 English · [🇫🇷 Français](network_securitygroup_default_deny.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `network_securitygroup_default_deny`
+
+**Security group inbound default policy set to "accept"**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `network_securitygroup_default_deny` |
+| Family | `reseau` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-NET-2` |
+| Resource type read | `security_group` |
+| Deciding attribute | `inbound_default_policy` |
+| State | active |
+| Declared for | `scaleway` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+A security group's default inbound policy is "accept": any traffic not explicitly filtered is admitted (implicit any/any), whatever the explicit rule set says.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-2` |
+| `cis_controls_v8` | `4.4`, `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✗ |
+| scaleway | ✅ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| scaleway | live | ✗ `unsupported` | this source produces no resource of type "security_group" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | scaleway / terraform |
+| `pass` | the deciding data was collected, and it is compliant | scaleway / terraform |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `security_group`
+- Attribute the decision depends on: `inbound_default_policy`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Switch the default inbound policy to "drop" and open only the legitimate flows through explicit rules.
+
+| Provider | Deployable setup |
+|---|---|
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan scaleway --terraform plan.json --format assessment
+```
+
+In the `assessment` output, look for `"control": "network_securitygroup_default_deny"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/network_securitygroup_default_restrict_traffic.fr.md
+++ b/docs/controls/network_securitygroup_default_restrict_traffic.fr.md
@@ -1,0 +1,120 @@
+> [🇬🇧 English](network_securitygroup_default_restrict_traffic.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `network_securitygroup_default_restrict_traffic`
+
+**Security group « default » non restrictif**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `network_securitygroup_default_restrict_traffic` |
+| Famille | `reseau` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-NET-4` |
+| Type de ressource lu | `security_group_rule` |
+| Attribut décisif | `security_group_name` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Le security group « default » est attaché d'office à toute ressource créée sans groupe explicite : la moindre règle entrante qu'il porte s'applique alors silencieusement, sans décision de l'exploitant.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-4` |
+| `cis_controls_v8` | `4.4` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ◐ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ◐ `partial` | attribut décisif « security_group_name » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / terraform · outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | outscale / terraform |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `security_group_rule`
+- Attribut dont la décision dépend : `security_group_name`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Vider le security group « default » de toutes ses règles et attacher explicitement un groupe dédié et restrictif à chaque ressource.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan outscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "network_securitygroup_default_restrict_traffic"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+**Une des deux sources ne sait pas lever le verrou du « pass »** pour ce contrôle :
+le fournisseur cité y produit bien le type visé, mais le scan y rendra `not-evaluated`.
+Le tableau des motifs dit laquelle, et pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_default_restrict_traffic.fr.md
+++ b/docs/controls/network_securitygroup_default_restrict_traffic.fr.md
@@ -92,7 +92,7 @@ Vider le security group « default » de toutes ses règles et attacher explicit
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -114,7 +114,7 @@ Le tableau des motifs dit laquelle, et pourquoi.
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_default_restrict_traffic.md
+++ b/docs/controls/network_securitygroup_default_restrict_traffic.md
@@ -1,0 +1,119 @@
+> 🇬🇧 English · [🇫🇷 Français](network_securitygroup_default_restrict_traffic.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `network_securitygroup_default_restrict_traffic`
+
+**The "default" security group is not restrictive**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `network_securitygroup_default_restrict_traffic` |
+| Family | `reseau` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-NET-4` |
+| Resource type read | `security_group_rule` |
+| Deciding attribute | `security_group_name` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+The "default" security group is attached automatically to every resource created without an explicit group: any inbound rule it carries then applies silently, without an operator decision.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-4` |
+| `cis_controls_v8` | `4.4` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ◐ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ◐ `partial` | deciding attribute "security_group_name" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / terraform · outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | outscale / terraform |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `security_group_rule`
+- Attribute the decision depends on: `security_group_name`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Empty the "default" security group of all its rules, and explicitly attach a dedicated, restrictive group to every resource.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan outscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "network_securitygroup_default_restrict_traffic"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+**One of the two sources cannot lift the `pass` lock** for this control: the provider
+quoted does produce the targeted type there, but the scan will return `not-evaluated`.
+The reasons table says which one, and why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/network_securitygroup_unrestricted_egress.fr.md
+++ b/docs/controls/network_securitygroup_unrestricted_egress.fr.md
@@ -91,7 +91,7 @@ Restreindre les règles de sortie aux destinations et ports légitimes.
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -109,7 +109,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_unrestricted_egress.fr.md
+++ b/docs/controls/network_securitygroup_unrestricted_egress.fr.md
@@ -1,0 +1,115 @@
+> [🇬🇧 English](network_securitygroup_unrestricted_egress.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `network_securitygroup_unrestricted_egress`
+
+**Filtrage sortant non restreint**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `network_securitygroup_unrestricted_egress` |
+| Famille | `reseau` |
+| Sévérité | `medium` |
+| Exigence SCSL (index gelé) | `CLD-NET-4` |
+| Type de ressource lu | `security_group_rule` |
+| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Un groupe de sécurité autorise tout le trafic sortant vers 0.0.0.0/0 sans restriction, facilitant l'exfiltration de données et les rappels C2.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-4` |
+| `cis_controls_v8` | `4.4` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `security_group_rule`
+- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Restreindre les règles de sortie aux destinations et ports légitimes.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "network_securitygroup_unrestricted_egress"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/network_securitygroup_unrestricted_egress.md
+++ b/docs/controls/network_securitygroup_unrestricted_egress.md
@@ -1,0 +1,114 @@
+> 🇬🇧 English · [🇫🇷 Français](network_securitygroup_unrestricted_egress.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `network_securitygroup_unrestricted_egress`
+
+**Unrestricted outbound filtering**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `network_securitygroup_unrestricted_egress` |
+| Family | `reseau` |
+| Severity | `medium` |
+| SCSL requirement (frozen index) | `CLD-NET-4` |
+| Resource type read | `security_group_rule` |
+| Deciding attribute | _none: judged on the presence of a deviation_ |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+A security group allows all outbound traffic to 0.0.0.0/0 without restriction, easing data exfiltration and C2 callbacks.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-4` |
+| `cis_controls_v8` | `4.4` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✅ | ✅ |
+| outscale | ✅ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `security_group_rule`
+- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Restrict the egress rules to legitimate destinations and ports.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan exoscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "network_securitygroup_unrestricted_egress"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/network_subnet_no_public_ip_by_default.fr.md
+++ b/docs/controls/network_subnet_no_public_ip_by_default.fr.md
@@ -1,0 +1,114 @@
+> [🇬🇧 English](network_subnet_no_public_ip_by_default.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `network_subnet_no_public_ip_by_default`
+
+**Sous-réseau attribuant une IP publique par défaut**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `network_subnet_no_public_ip_by_default` |
+| Famille | `reseau` |
+| Sévérité | `medium` |
+| Exigence SCSL (index gelé) | `CLD-NET-3` |
+| Type de ressource lu | `subnet` |
+| Attribut décisif | `map_public_ip_on_launch` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Un sous-réseau attribue automatiquement une IP publique à toute interface créée : les machines sont exposées à Internet par défaut, sans décision explicite.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-NET-3` |
+| `cis_controls_v8` | `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✅ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+_Aucune : toutes les cases déclarées sont pleinement observables._
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / terraform · outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / terraform · outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `subnet`
+- Attribut dont la décision dépend : `map_public_ip_on_launch`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Désactiver l'attribution automatique d'IP publique du sous-réseau ; n'attribuer une IP publique qu'aux interfaces qui le nécessitent.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan outscale --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "network_subnet_no_public_ip_by_default"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/network_subnet_no_public_ip_by_default.fr.md
+++ b/docs/controls/network_subnet_no_public_ip_by_default.fr.md
@@ -90,7 +90,7 @@ Désactiver l'attribution automatique d'IP publique du sous-réseau ; n'attribue
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -108,7 +108,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/network_subnet_no_public_ip_by_default.md
+++ b/docs/controls/network_subnet_no_public_ip_by_default.md
@@ -1,0 +1,113 @@
+> 🇬🇧 English · [🇫🇷 Français](network_subnet_no_public_ip_by_default.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `network_subnet_no_public_ip_by_default`
+
+**Subnet assigning a public IP by default**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `network_subnet_no_public_ip_by_default` |
+| Family | `reseau` |
+| Severity | `medium` |
+| SCSL requirement (frozen index) | `CLD-NET-3` |
+| Resource type read | `subnet` |
+| Deciding attribute | `map_public_ip_on_launch` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+A subnet automatically assigns a public IP to every interface created in it: machines are exposed to the internet by default, with no explicit decision.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-NET-3` |
+| `cis_controls_v8` | `12.2` |
+| `iso_27001_2022` | `A.8.20`, `A.8.22` |
+| `secnumcloud_3_2` | `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✅ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+_None: every declared cell is fully observable._
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / terraform · outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / terraform · outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `subnet`
+- Attribute the decision depends on: `map_public_ip_on_launch`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Disable the subnet's automatic public IP assignment; assign a public IP only to the interfaces that need one.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan outscale --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "network_subnet_no_public_ip_by_default"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/objectstorage_bucket_default_encryption.fr.md
+++ b/docs/controls/objectstorage_bucket_default_encryption.fr.md
@@ -1,0 +1,112 @@
+> [🇬🇧 English](objectstorage_bucket_default_encryption.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `objectstorage_bucket_default_encryption`
+
+**Bucket sans chiffrement par défaut au repos**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `objectstorage_bucket_default_encryption` |
+| Famille | `chiffrement` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-CHF-2` |
+| Type de ressource lu | `object_storage_bucket` |
+| Attribut décisif | `default_encryption_enabled` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Un bucket de stockage objet n'a pas de chiffrement par défaut : les objets y sont écrits en clair côté fournisseur. Le chiffrement au repos est opt-in par bucket chez plusieurs fournisseurs souverains — son absence est un écart réel.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-CHF-2` |
+| `iso_27001_2022` | `A.8.24` |
+| `secnumcloud_3_2` | `10.1` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « object_storage_bucket » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `object_storage_bucket`
+- Attribut dont la décision dépend : `default_encryption_enabled`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Activer le chiffrement par défaut du bucket (SSE) et vérifier que les objets déjà déposés sont ré-écrits chiffrés.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "objectstorage_bucket_default_encryption"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/objectstorage_bucket_default_encryption.fr.md
+++ b/docs/controls/objectstorage_bucket_default_encryption.fr.md
@@ -91,7 +91,7 @@ Activer le chiffrement par défaut du bucket (SSE) et vérifier que les objets d
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -106,7 +106,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/objectstorage_bucket_default_encryption.md
+++ b/docs/controls/objectstorage_bucket_default_encryption.md
@@ -1,0 +1,111 @@
+> 🇬🇧 English · [🇫🇷 Français](objectstorage_bucket_default_encryption.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `objectstorage_bucket_default_encryption`
+
+**Bucket without default encryption at rest**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `objectstorage_bucket_default_encryption` |
+| Family | `chiffrement` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-CHF-2` |
+| Resource type read | `object_storage_bucket` |
+| Deciding attribute | `default_encryption_enabled` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+An object storage bucket has no default encryption: objects are written in cleartext on the provider side. Encryption at rest is opt-in per bucket at several sovereign providers — its absence is a real deviation.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-CHF-2` |
+| `iso_27001_2022` | `A.8.24` |
+| `secnumcloud_3_2` | `10.1` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "object_storage_bucket" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `object_storage_bucket`
+- Attribute the decision depends on: `default_encryption_enabled`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enable the bucket's default encryption (SSE) and check that the objects already stored are rewritten encrypted.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "objectstorage_bucket_default_encryption"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/objectstorage_bucket_kms_encryption.fr.md
+++ b/docs/controls/objectstorage_bucket_kms_encryption.fr.md
@@ -95,7 +95,7 @@ Créer une clé dans le gestionnaire de clés du fournisseur (Key Manager) et l'
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -117,7 +117,7 @@ Le tableau des motifs dit laquelle, et pourquoi.
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/objectstorage_bucket_kms_encryption.fr.md
+++ b/docs/controls/objectstorage_bucket_kms_encryption.fr.md
@@ -1,0 +1,123 @@
+> [🇬🇧 English](objectstorage_bucket_kms_encryption.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `objectstorage_bucket_kms_encryption`
+
+**Clé de chiffrement gérée par le client absente (BYOK) sur un bucket sensible**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `objectstorage_bucket_kms_encryption` |
+| Famille | `chiffrement` |
+| Sévérité | `medium` |
+| Exigence SCSL (index gelé) | `CLD-CHF-4` |
+| Type de ressource lu | `object_storage_bucket` |
+| Attribut décisif | `sse_kms_enabled` |
+| État | actif |
+| Déclaré pour | `scaleway` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Un bucket de stockage objet portant des données classées sensibles n'utilise pas de clé de chiffrement gérée par le client (SSE-KMS / BYOK) : ses données restent sous le contrôle exclusif du fournisseur. Observable seulement là où l'API expose le chiffrement par défaut du bucket (Scaleway, via Key Manager) ; non applicable chez les fournisseurs sans clé client au niveau objet.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-CHF-4` |
+| `iso_27001_2022` | `A.8.24` |
+| `secnumcloud_3_2` | `10.1`, `10.5` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ∅ | ∅ |
+| outscale | ∅ | ∅ |
+| scaleway | ◐ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| exoscale | terraform | ∅ `not-applicable` | SOS chiffre au repos par défaut (SSE-SOS, clés gérées par Exoscale, type SSE-S3) mais n'expose pas de BYOK/KMS géré par le client au niveau bucket (SSE-C reste par-objet, non observable) → le contrôle BYOK-au-bucket est sans objet (CHF-4). |
+| exoscale | live | ∅ `not-applicable` | SOS chiffre au repos par défaut (SSE-SOS, clés gérées par Exoscale, type SSE-S3) mais n'expose pas de BYOK/KMS géré par le client au niveau bucket (SSE-C reste par-objet, non observable) → le contrôle BYOK-au-bucket est sans objet (CHF-4). |
+| outscale | terraform | ∅ `not-applicable` | OOS chiffre côté serveur en AES256 avec une clé FOURNISSEUR ; il n'existe ni service KMS ni clé maître gérée par le client, donc pas de BYOK à auditer au niveau bucket (CHF-4). NB : l'activation du SSE elle-même est opt-in et observable — elle relève d'un contrôle distinct, pas de ce N/A. |
+| outscale | live | ∅ `not-applicable` | OOS chiffre côté serveur en AES256 avec une clé FOURNISSEUR ; il n'existe ni service KMS ni clé maître gérée par le client, donc pas de BYOK à auditer au niveau bucket (CHF-4). NB : l'activation du SSE elle-même est opt-in et observable — elle relève d'un contrôle distinct, pas de ce N/A. |
+| scaleway | terraform | ◐ `partial` | attribut décisif « sse_kms_enabled » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | scaleway / terraform |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `object_storage_bucket`
+- Attribut dont la décision dépend : `sse_kms_enabled`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Créer une clé dans le gestionnaire de clés du fournisseur (Key Manager) et l'associer au bucket comme clé de chiffrement par défaut (SSE-KMS).
+
+| Fournisseur | Montage déployable |
+|---|---|
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan scaleway --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan scaleway --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "objectstorage_bucket_kms_encryption"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+**Une des deux sources ne sait pas lever le verrou du « pass »** pour ce contrôle :
+le fournisseur cité y produit bien le type visé, mais le scan y rendra `not-evaluated`.
+Le tableau des motifs dit laquelle, et pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/objectstorage_bucket_kms_encryption.md
+++ b/docs/controls/objectstorage_bucket_kms_encryption.md
@@ -1,0 +1,122 @@
+> 🇬🇧 English · [🇫🇷 Français](objectstorage_bucket_kms_encryption.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `objectstorage_bucket_kms_encryption`
+
+**No customer-managed encryption key (BYOK) on a sensitive bucket**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `objectstorage_bucket_kms_encryption` |
+| Family | `chiffrement` |
+| Severity | `medium` |
+| SCSL requirement (frozen index) | `CLD-CHF-4` |
+| Resource type read | `object_storage_bucket` |
+| Deciding attribute | `sse_kms_enabled` |
+| State | active |
+| Declared for | `scaleway` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+An object storage bucket holding data classified as sensitive does not use a customer-managed encryption key (SSE-KMS / BYOK): its data stays under the provider's exclusive control. Observable only where the API exposes the bucket's default encryption (Scaleway, through Key Manager); not applicable at providers without a customer key at the object level.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-CHF-4` |
+| `iso_27001_2022` | `A.8.24` |
+| `secnumcloud_3_2` | `10.1`, `10.5` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ∅ | ∅ |
+| outscale | ∅ | ∅ |
+| scaleway | ◐ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| exoscale | terraform | ∅ `not-applicable` | SOS encrypts at rest by default (SSE-SOS, keys managed by Exoscale, SSE-S3 style) but exposes no customer-managed BYOK/KMS key at the bucket level (SSE-C stays per-object and unobservable), so the BYOK-at-bucket control is moot (CHF-4). |
+| exoscale | live | ∅ `not-applicable` | SOS encrypts at rest by default (SSE-SOS, keys managed by Exoscale, SSE-S3 style) but exposes no customer-managed BYOK/KMS key at the bucket level (SSE-C stays per-object and unobservable), so the BYOK-at-bucket control is moot (CHF-4). |
+| outscale | terraform | ∅ `not-applicable` | OOS encrypts server-side in AES256 with a PROVIDER key; there is neither a KMS service nor a customer-managed master key, so there is no BYOK to audit at the bucket level (CHF-4). Note: enabling SSE itself is opt-in and observable, which is a separate control, not this N/A. |
+| outscale | live | ∅ `not-applicable` | OOS encrypts server-side in AES256 with a PROVIDER key; there is neither a KMS service nor a customer-managed master key, so there is no BYOK to audit at the bucket level (CHF-4). Note: enabling SSE itself is opt-in and observable, which is a separate control, not this N/A. |
+| scaleway | terraform | ◐ `partial` | deciding attribute "sse_kms_enabled" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | scaleway / terraform |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `object_storage_bucket`
+- Attribute the decision depends on: `sse_kms_enabled`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Create a key in the provider's key manager (Key Manager) and attach it to the bucket as its default encryption key (SSE-KMS).
+
+| Provider | Deployable setup |
+|---|---|
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan scaleway --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan scaleway --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "objectstorage_bucket_kms_encryption"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+**One of the two sources cannot lift the `pass` lock** for this control: the provider
+quoted does produce the targeted type there, but the scan will return `not-evaluated`.
+The reasons table says which one, and why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/objectstorage_bucket_object_lock_enabled.fr.md
+++ b/docs/controls/objectstorage_bucket_object_lock_enabled.fr.md
@@ -1,0 +1,119 @@
+> [🇬🇧 English](objectstorage_bucket_object_lock_enabled.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `objectstorage_bucket_object_lock_enabled`
+
+**Object Lock (immutabilité) désactivé sur le stockage objet**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `objectstorage_bucket_object_lock_enabled` |
+| Famille | `stockage` |
+| Sévérité | `low` |
+| Exigence SCSL (index gelé) | `CLD-STO-8` |
+| Type de ressource lu | `object_storage_bucket` |
+| Attribut décisif | `object_lock_enabled` |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Un bucket de stockage objet n'a pas l'Object Lock (WORM) activé : ses objets peuvent être supprimés ou écrasés (accidentellement ou par un rançongiciel), sans garantie d'immutabilité. Recommandé pour les buckets de sauvegarde et les objets critiques.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-STO-8` |
+| `cis_controls_v8` | `11.1` |
+| `iso_27001_2022` | `A.8.13` |
+| `secnumcloud_3_2` | `12.5` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| exoscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « object_storage_bucket » |
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « object_storage_bucket » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / live · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / live · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `object_storage_bucket`
+- Attribut dont la décision dépend : `object_lock_enabled`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Activer l'Object Lock (mode conformité ou gouvernance) sur les buckets de sauvegarde et d'objets critiques, avec une période de rétention adaptée.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan scaleway --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "objectstorage_bucket_object_lock_enabled"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/objectstorage_bucket_object_lock_enabled.fr.md
+++ b/docs/controls/objectstorage_bucket_object_lock_enabled.fr.md
@@ -95,7 +95,7 @@ Activer l'Object Lock (mode conformité ou gouvernance) sur les buckets de sauve
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -113,7 +113,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/objectstorage_bucket_object_lock_enabled.md
+++ b/docs/controls/objectstorage_bucket_object_lock_enabled.md
@@ -1,0 +1,118 @@
+> 🇬🇧 English · [🇫🇷 Français](objectstorage_bucket_object_lock_enabled.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `objectstorage_bucket_object_lock_enabled`
+
+**Object Lock (immutability) disabled on object storage**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `objectstorage_bucket_object_lock_enabled` |
+| Family | `stockage` |
+| Severity | `low` |
+| SCSL requirement (frozen index) | `CLD-STO-8` |
+| Resource type read | `object_storage_bucket` |
+| Deciding attribute | `object_lock_enabled` |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+An object storage bucket does not have Object Lock (WORM) enabled: its objects can be deleted or overwritten (accidentally or by ransomware), with no immutability guarantee. Recommended for backup buckets and critical objects.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-STO-8` |
+| `cis_controls_v8` | `11.1` |
+| `iso_27001_2022` | `A.8.13` |
+| `secnumcloud_3_2` | `12.5` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| exoscale | terraform | ✗ `unsupported` | this source produces no resource of type "object_storage_bucket" |
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "object_storage_bucket" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / live · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / live · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `object_storage_bucket`
+- Attribute the decision depends on: `object_lock_enabled`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enable Object Lock (compliance or governance mode) on backup buckets and critical objects, with a suitable retention period.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan scaleway --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "objectstorage_bucket_object_lock_enabled"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/objectstorage_bucket_public_access.fr.md
+++ b/docs/controls/objectstorage_bucket_public_access.fr.md
@@ -96,7 +96,7 @@ Retirer l'accès public de l'ACL/la politique ; servir le contenu via des URLs s
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -114,7 +114,7 @@ correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourq
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/objectstorage_bucket_public_access.fr.md
+++ b/docs/controls/objectstorage_bucket_public_access.fr.md
@@ -1,0 +1,120 @@
+> [🇬🇧 English](objectstorage_bucket_public_access.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `objectstorage_bucket_public_access`
+
+**Stockage objet exposé publiquement**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `objectstorage_bucket_public_access` |
+| Famille | `stockage` |
+| Sévérité | `critical` |
+| Exigence SCSL (index gelé) | `CLD-STO-1` |
+| Type de ressource lu | `object_storage_bucket` |
+| Attribut décisif | `acl` / `acl_grants` / `public_via_acl` |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Un bucket de stockage objet est accessible publiquement (ACL au groupe AllUsers, ACL « canned » public-read/-write, ou politique publique).
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-STO-1` |
+| `cis_controls_v8` | `3.3` |
+| `iso_27001_2022` | `A.5.15`, `A.8.3` |
+| `iso_27017` | `CLD.9.5.1` |
+| `secnumcloud_3_2` | `9.7`, `13.2` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| exoscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « object_storage_bucket » |
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « object_storage_bucket » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / live · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / live · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `object_storage_bucket`
+- Attribut dont la décision dépend : `acl` / `acl_grants` / `public_via_acl`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Retirer l'accès public de l'ACL/la politique ; servir le contenu via des URLs signées si un accès externe est requis.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan scaleway --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "objectstorage_bucket_public_access"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/objectstorage_bucket_public_access.md
+++ b/docs/controls/objectstorage_bucket_public_access.md
@@ -1,0 +1,119 @@
+> 🇬🇧 English · [🇫🇷 Français](objectstorage_bucket_public_access.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `objectstorage_bucket_public_access`
+
+**Object storage publicly exposed**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `objectstorage_bucket_public_access` |
+| Family | `stockage` |
+| Severity | `critical` |
+| SCSL requirement (frozen index) | `CLD-STO-1` |
+| Resource type read | `object_storage_bucket` |
+| Deciding attribute | `acl` / `acl_grants` / `public_via_acl` |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+An object storage bucket is publicly accessible (ACL granting the AllUsers group, a public-read/public-write canned ACL, or a public policy).
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-STO-1` |
+| `cis_controls_v8` | `3.3` |
+| `iso_27001_2022` | `A.5.15`, `A.8.3` |
+| `iso_27017` | `CLD.9.5.1` |
+| `secnumcloud_3_2` | `9.7`, `13.2` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✅ |
+| outscale | ✗ | ✅ |
+| scaleway | ✅ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| exoscale | terraform | ✗ `unsupported` | this source produces no resource of type "object_storage_bucket" |
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "object_storage_bucket" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / live · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / live · outscale / live · scaleway / terraform · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `object_storage_bucket`
+- Attribute the decision depends on: `acl` / `acl_grants` / `public_via_acl`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Remove public access from the ACL and from the policy; serve the content through signed URLs if external access is required.
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan scaleway --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "objectstorage_bucket_public_access"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/objectstorage_bucket_versioning_enabled.fr.md
+++ b/docs/controls/objectstorage_bucket_versioning_enabled.fr.md
@@ -96,7 +96,7 @@ Activer le versioning sur les buckets de données critiques (PutBucketVersioning
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir
-[le guide de remédiation](../guides/remediation.md).
+[le guide de remédiation](../guides/remediation.fr.md).
 
 ## Comment vérifier la correction
 
@@ -118,7 +118,7 @@ Le tableau des motifs dit laquelle, et pourquoi.
 
 ## Voir aussi
 
-- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
-- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
-- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
-- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/objectstorage_bucket_versioning_enabled.fr.md
+++ b/docs/controls/objectstorage_bucket_versioning_enabled.fr.md
@@ -1,0 +1,124 @@
+> [🇬🇧 English](objectstorage_bucket_versioning_enabled.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `objectstorage_bucket_versioning_enabled`
+
+**Versioning du stockage objet désactivé**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `objectstorage_bucket_versioning_enabled` |
+| Famille | `stockage` |
+| Sévérité | `medium` |
+| Exigence SCSL (index gelé) | `CLD-STO-4` |
+| Type de ressource lu | `object_storage_bucket` |
+| Attribut décisif | `versioning` |
+| État | actif |
+| Déclaré pour | `exoscale`, `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 3 |
+
+## Le risque
+
+Un bucket de stockage objet n'a pas le versioning activé : une suppression ou un écrasement (accidentel ou malveillant, ex. rançongiciel) est irréversible.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-STO-4` |
+| `cis_controls_v8` | `11.1` |
+| `iso_27001_2022` | `A.8.13` |
+| `secnumcloud_3_2` | `12.5` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✅ |
+| outscale | ✗ | ✅ |
+| scaleway | ◐ | ✅ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| exoscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « object_storage_bucket » |
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « object_storage_bucket » |
+| scaleway | terraform | ◐ `partial` | attribut décisif « versioning » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | exoscale / live · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / live · outscale / live · scaleway / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | scaleway / terraform |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `object_storage_bucket`
+- Attribut dont la décision dépend : `versioning`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Activer le versioning sur les buckets de données critiques (PutBucketVersioning).
+
+| Fournisseur | Montage déployable |
+|---|---|
+| exoscale | _aucune preuve déposée à ce jour_ |
+| outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan scaleway --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan exoscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "objectstorage_bucket_versioning_enabled"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+**Une des deux sources ne sait pas lever le verrou du « pass »** pour ce contrôle :
+le fournisseur cité y produit bien le type visé, mais le scan y rendra `not-evaluated`.
+Le tableau des motifs dit laquelle, et pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.

--- a/docs/controls/objectstorage_bucket_versioning_enabled.md
+++ b/docs/controls/objectstorage_bucket_versioning_enabled.md
@@ -1,0 +1,123 @@
+> 🇬🇧 English · [🇫🇷 Français](objectstorage_bucket_versioning_enabled.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `objectstorage_bucket_versioning_enabled`
+
+**Object storage versioning disabled**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `objectstorage_bucket_versioning_enabled` |
+| Family | `stockage` |
+| Severity | `medium` |
+| SCSL requirement (frozen index) | `CLD-STO-4` |
+| Resource type read | `object_storage_bucket` |
+| Deciding attribute | `versioning` |
+| State | active |
+| Declared for | `exoscale`, `outscale`, `scaleway` |
+| Remediation proofs | 0 / 3 |
+
+## The risk
+
+An object storage bucket does not have versioning enabled: a deletion or an overwrite (accidental or malicious, ransomware for instance) is irreversible.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-STO-4` |
+| `cis_controls_v8` | `11.1` |
+| `iso_27001_2022` | `A.8.13` |
+| `secnumcloud_3_2` | `12.5` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✅ |
+| outscale | ✗ | ✅ |
+| scaleway | ◐ | ✅ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| exoscale | terraform | ✗ `unsupported` | this source produces no resource of type "object_storage_bucket" |
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "object_storage_bucket" |
+| scaleway | terraform | ◐ `partial` | deciding attribute "versioning" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | exoscale / live · outscale / live · scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / live · outscale / live · scaleway / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | scaleway / terraform |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `object_storage_bucket`
+- Attribute the decision depends on: `versioning`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Enable versioning on the buckets holding critical data (PutBucketVersioning).
+
+| Provider | Deployable setup |
+|---|---|
+| exoscale | _no proof filed yet_ |
+| outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan scaleway --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan exoscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "objectstorage_bucket_versioning_enabled"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+**One of the two sources cannot lift the `pass` lock** for this control: the provider
+quoted does produce the targeted type there, but the scan will return `not-evaluated`.
+The reasons table says which one, and why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/guides/remediation.fr.md
+++ b/docs/guides/remediation.fr.md
@@ -1,0 +1,272 @@
+> [🇬🇧 English](remediation.md) · 🇫🇷 Français
+
+# Corriger ce que Pépin trouve
+
+Un scanner qui se contente de nommer les problèmes déplace le travail, il ne le réduit
+pas. Cette page décrit comment Pépin passe de *détecter* à *agir* : ce que chaque écart
+porte déjà, ce à quoi une remédiation doit répondre, comment la correction est
+**vérifiée** plutôt que supposée, et jusqu'où vont exactement les preuves déployables
+aujourd'hui.
+
+## Chaque écart porte déjà sa remédiation
+
+Un écart n'est jamais émis sans la phrase qui dit quoi en faire. Ce n'est pas une
+habitude éditoriale, c'est une porte : `TestEveryFindingCarriesRemediation`
+(`referentiel/validate_test.go`, exécuté par `mise run validate`) refuse toute règle
+dont la `remediation` manque, et exige au passage ses contreparties anglaises
+(`labels.message_en`, `labels.remediation_en`). Un rapport anglais ne doit jamais
+retomber en français au milieu d'une phrase.
+
+Le référentiel suit la même règle : chaque contrôle porte `remediation` et
+`remediation_en` dans `referentiel/controles.yaml`. C'est ce texte que le rapport
+imprime, et que chaque [page de contrôle](../controls/index.fr.md) cite.
+
+La remédiation **textuelle** est donc un problème résolu, et couvert par un test. Ce qui
+suit porte sur la couche du dessus : la *preuve déployable*.
+
+## Les quatre questions auxquelles une remédiation doit répondre
+
+| Question | Où vit la réponse |
+|---|---|
+| **Pourquoi c'est un risque** | la description du contrôle, tirée du référentiel |
+| **Comment enquêter** | le type de ressource normalisé lu, et l'attribut dont la décision dépend |
+| **Comment corriger** | le texte de remédiation du référentiel, plus le montage déployable quand il existe |
+| **Comment vérifier** | la commande `pepin scan` exacte, et le statut qui doit changer |
+
+Chaque page de contrôle répond aux quatre, et rien n'y est écrit à la main : les pages
+sont générées depuis le référentiel, les descripteurs de fournisseurs et le verrou du
+« pass ». Le point d'entrée est le
+[catalogue des contrôles](../controls/index.fr.md).
+
+## La boucle, mesurée
+
+Une remédiation non vérifiée est une affirmation. Pépin ferme la boucle avec la commande
+qui a trouvé le problème, sur la même nature d'entrée. Les deux extraits ci-dessous sont
+**capturés par exécution réelle** sur les plans d'exemple du dépôt : celui qui est
+volontairement mal configuré, puis le même module corrigé.
+
+Avant, sur `examples/scaleway/terraform/plan.json` :
+
+<!-- pepin:gen remediation-before -->
+```json
+{
+  "control": "objectstorage_bucket_public_access",
+  "evidence": {
+    "observed": "Bucket « scaleway_object_bucket_acl.backups » accessible publiquement (ACL publique).",
+    "proves": [
+      "",
+      "",
+      ""
+    ],
+    "source": "terraform-plan"
+  },
+  "labels": {
+    "category": "security",
+    "provider": "scaleway"
+  },
+  "references": [
+    {
+      "framework": "scsl",
+      "id": "CLD-STO-1"
+    },
+    {
+      "framework": "cis-v8",
+      "id": "3.3"
+    },
+    {
+      "framework": "iso-27001",
+      "id": "A.5.15"
+    },
+    {
+      "framework": "iso-27001",
+      "id": "A.8.3"
+    },
+    {
+      "framework": "iso-27017",
+      "id": "CLD.9.5.1"
+    },
+    {
+      "framework": "secnumcloud-3.2",
+      "id": "9.7"
+    },
+    {
+      "framework": "secnumcloud-3.2",
+      "id": "13.2"
+    }
+  ],
+  "remediation": "Rendre le bucket privé (ACL private, retrait du grant AllUsers, suppression de la policy publique) ; servir via des URLs pré-signées si nécessaire.",
+  "severity": "critical",
+  "status": "fail",
+  "subject": "scaleway_object_bucket_acl.backups",
+  "title": "Stockage objet exposé publiquement"
+}
+```
+<!-- /pepin:gen remediation-before -->
+
+Après, sur `examples/scaleway/terraform-fixed/plan.json` :
+
+<!-- pepin:gen remediation-after -->
+```json
+{
+  "control": "objectstorage_bucket_public_access",
+  "evidence": {
+    "observed": "aucune non-conformité détectée sur les ressources de type « object_storage_bucket » collectées (contrat vérifié)",
+    "proves": [
+      "",
+      "",
+      ""
+    ],
+    "source": "terraform-plan"
+  },
+  "references": [
+    {
+      "framework": "scsl",
+      "id": "CLD-STO-1"
+    },
+    {
+      "framework": "cis-v8",
+      "id": "3.3"
+    },
+    {
+      "framework": "iso-27001",
+      "id": "A.5.15"
+    },
+    {
+      "framework": "iso-27001",
+      "id": "A.8.3"
+    },
+    {
+      "framework": "iso-27017",
+      "id": "CLD.9.5.1"
+    },
+    {
+      "framework": "secnumcloud-3.2",
+      "id": "9.7"
+    },
+    {
+      "framework": "secnumcloud-3.2",
+      "id": "13.2"
+    }
+  ],
+  "severity": "critical",
+  "status": "pass",
+  "subject": "scaleway",
+  "title": "Stockage objet exposé publiquement"
+}
+```
+<!-- /pepin:gen remediation-after -->
+
+Trois choses ont changé, et les trois comptent :
+
+- `status` est passé de `fail` à `pass`.
+- `subject` est passé de la ressource fautive au périmètre du fournisseur : il n'y a
+  plus de ressource à nommer.
+- `evidence.observed` dit **pourquoi** le « pass » est affirmé, et nomme le verrou
+  franchi : le contrat est vérifié, donc l'absence d'écart vaut conformité mesurée, et
+  non absence de mesure.
+
+Ce dernier point est toute la différence entre une correction et un angle mort. Si le
+statut était passé de `fail` à `not-evaluated`, rien n'aurait été démontré : l'écart
+aurait simplement cessé d'être visible. Voir
+[le modèle d'assessment](../concepts/assessment-model.fr.md) pour ce que chaque statut
+affirme, et [les codes de sortie](../reference/exit-codes.fr.md) pour ce qu'un pipeline
+en lit.
+
+## Ce qu'est une preuve déployable
+
+Une preuve de remédiation est un **module Terraform autonome et conforme** : il se
+déploie tel quel, dans le vocabulaire natif du fournisseur, et un scan de ce montage ne
+déclenche pas la règle. C'est le miroir des fixtures non conformes de
+`examples/<fournisseur>/terraform/`.
+
+```
+references/remediation/<fournisseur>/<code>/      # module Terraform autonome (préféré)
+references/remediation/<fournisseur>/<code>.md    # note ancrée sur la doc officielle, si Terraform n'est pas pertinent
+```
+
+Quatre règles, aucune cosmétique :
+
+1. **Un dossier par règle.** Terraform fusionne tous les `.tf` d'un même dossier :
+   plusieurs preuves au même endroit deviendraient indéployables et inauditables
+   séparément. Un montage qui satisfait des règles voisines est dupliqué, chaque copie
+   cadrée sur sa règle.
+2. **Déployable, et vérifié comme tel.** `terraform init -backend=false` puis
+   `terraform validate` doivent passer : configuration complète, variables déclarées,
+   champs réels du schéma. Un extrait inapplicable est du pseudo-code, et du pseudo-code
+   présenté comme une configuration est exactement ce que ce dépôt refuse.
+3. **Un en-tête obligatoire** nommant le `code`, l'exigence SCSL, le fournisseur,
+   **pourquoi le montage est conforme**, et la **source ancrée** (une page de
+   `references/docs/<fournisseur>/`, ou le contrat de `providers/<fournisseur>.yaml`).
+4. **Aucun secret.** Les identifiants viennent de l'environnement ou de variables,
+   jamais du fichier.
+
+La convention complète vit dans
+[`references/remediation/README.md`](../../references/remediation/README.md).
+
+## La couverture d'aujourd'hui, et elle est partielle
+
+Le compte ci-dessous est calculé depuis le dépôt au moment de la génération, sur les
+couples (contrôle, fournisseur) que le référentiel déclare réellement :
+
+<!-- pepin:gen remediation-coverage -->
+| Fournisseur | Preuves de remédiation |
+|---|---:|
+| exoscale | 4 / 26 |
+| kubernetes | 0 / 4 |
+| outscale | 0 / 40 |
+| scaleway | 0 / 25 |
+| **Total** | **4 / 95** |
+<!-- /pepin:gen remediation-coverage -->
+
+Ce tableau compte des **preuves déployables**, pas des remédiations. La remédiation
+textuelle est à 100 % et tenue par un test ; les preuves sont un chantier, et l'honnête
+est de le dire plutôt que d'arrondir.
+
+Pour reproduire le chiffre, et obtenir la liste des manquantes par fournisseur :
+
+```bash
+mise run check-remediation                     # tous les fournisseurs
+python3 scripts/check-remediation.py exoscale  # un seul
+```
+
+## Pourquoi cette porte n'est pas branchée dans `validate`
+
+`mise run check-remediation` est volontairement **découplé** de `mise run validate`. Une
+porte rouge en permanence est une porte qu'on apprend à ignorer, et une porte de qualité
+qu'on contourne par habitude est pire que pas de porte : elle enseigne le contournement.
+
+La condition de rebranchement est écrite là où on la verra, dans `mise.toml` à côté de
+la tâche : **un fournisseur à 100 %**, branché en `depends = [..., "check-remediation"]`,
+puis les autres au fil de l'eau. En attendant, le chiffre est publié (ci-dessus, et sur
+chaque page de contrôle) plutôt qu'imposé.
+
+## Déposer une preuve
+
+1. Ancrer le montage d'abord : le champ, son type et ses valeurs acceptées viennent du
+   SDK ou de la documentation officielle du fournisseur, jamais de mémoire. Mettre la
+   page en cache sous `references/docs/<fournisseur>/` (`mise run fetch-docs`) et la
+   citer.
+2. Écrire `references/remediation/<fournisseur>/<code>/main.tf` avec l'en-tête
+   obligatoire.
+3. Vérifier qu'il se déploie : `terraform init -backend=false && terraform validate`
+   dans ce dossier.
+4. Vérifier qu'il est **conforme** : en produire un plan et le scanner, la règle ne doit
+   pas se déclencher.
+
+   ```bash
+   terraform plan -out tfplan && terraform show -json tfplan > plan.json
+   ./pepin scan <fournisseur> --terraform plan.json --format assessment
+   ```
+
+5. Régénérer la documentation dérivée : `mise run gen-docs`. La page du contrôle lie
+   désormais votre preuve, et les chiffres de couverture bougent.
+6. `mise run validate` et `mise run test` restent au vert.
+
+## Voir aussi
+
+- [Catalogue des contrôles](../controls/index.fr.md) : les quatre questions, contrôle
+  par contrôle.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce qu'un `pass` affirme.
+- [Limites connues](../known-limitations.fr.md) : les angles morts, nommés.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout
+  en bout.

--- a/docs/guides/remediation.md
+++ b/docs/guides/remediation.md
@@ -1,0 +1,264 @@
+> 🇬🇧 English · [🇫🇷 Français](remediation.fr.md)
+
+# Remediating what Pépin finds
+
+A scanner that only names problems moves the work, it does not reduce it. This page
+describes how Pépin goes from *detecting* to *acting*: what every deviation already
+carries, what a remediation must answer, how the fix is **verified** rather than
+assumed, and exactly how far the deployable proofs go today.
+
+## Every deviation already carries its remediation
+
+A finding is never emitted without the sentence that says what to do about it. That is
+not an editorial habit, it is a gate: `TestEveryFindingCarriesRemediation`
+(`referentiel/validate_test.go`, run by `mise run validate`) rejects any rule whose
+`remediation` is missing, and it demands the English counterparts
+(`labels.message_en`, `labels.remediation_en`) at the same time. An English report must
+never fall back to French mid-sentence.
+
+The same applies to the reference: every control carries `remediation` and
+`remediation_en` in `referentiel/controles.yaml`. That text is what the report prints,
+and what each [control page](../controls/index.md) quotes.
+
+So the **textual** remediation is a solved problem, and it is covered by a test. What
+follows is about the layer above: the *deployable proof*.
+
+## The four questions a remediation must answer
+
+| Question | Where the answer lives |
+|---|---|
+| **Why it matters** | the control's description, from the reference |
+| **How to investigate** | the normalized resource type read, and the attribute the decision depends on |
+| **How to remediate** | the reference's remediation text, plus a deployable setup when one is filed |
+| **How to verify** | the exact `pepin scan` command, and the status that must change |
+
+Every control page answers the four, and none of it is hand-written: the pages are
+generated from the reference, the provider descriptors and the `pass` lock. Start from
+the [control catalogue](../controls/index.md).
+
+## The loop, measured
+
+A remediation that is not verified is a claim. Pépin closes the loop with the same
+command that found the problem, on the same kind of input. The two extracts below are
+**captured from real runs** of the repository's own example plans: the deliberately
+misconfigured one, then the same module fixed.
+
+Before, on `examples/scaleway/terraform/plan.json`:
+
+<!-- pepin:gen remediation-before -->
+```json
+{
+  "control": "objectstorage_bucket_public_access",
+  "evidence": {
+    "observed": "Bucket \"scaleway_object_bucket_acl.backups\" is publicly accessible (public ACL).",
+    "proves": [
+      "",
+      "",
+      ""
+    ],
+    "source": "terraform-plan"
+  },
+  "labels": {
+    "category": "security",
+    "provider": "scaleway"
+  },
+  "references": [
+    {
+      "framework": "scsl",
+      "id": "CLD-STO-1"
+    },
+    {
+      "framework": "cis-v8",
+      "id": "3.3"
+    },
+    {
+      "framework": "iso-27001",
+      "id": "A.5.15"
+    },
+    {
+      "framework": "iso-27001",
+      "id": "A.8.3"
+    },
+    {
+      "framework": "iso-27017",
+      "id": "CLD.9.5.1"
+    },
+    {
+      "framework": "secnumcloud-3.2",
+      "id": "9.7"
+    },
+    {
+      "framework": "secnumcloud-3.2",
+      "id": "13.2"
+    }
+  ],
+  "remediation": "Make the bucket private (private ACL, remove the AllUsers grant, delete the public policy); serve through pre-signed URLs if needed.",
+  "severity": "critical",
+  "status": "fail",
+  "subject": "scaleway_object_bucket_acl.backups",
+  "title": "Object storage publicly exposed"
+}
+```
+<!-- /pepin:gen remediation-before -->
+
+After, on `examples/scaleway/terraform-fixed/plan.json`:
+
+<!-- pepin:gen remediation-after -->
+```json
+{
+  "control": "objectstorage_bucket_public_access",
+  "evidence": {
+    "observed": "no deviation detected on the collected resources of type \"object_storage_bucket\" (contract verified)",
+    "proves": [
+      "",
+      "",
+      ""
+    ],
+    "source": "terraform-plan"
+  },
+  "references": [
+    {
+      "framework": "scsl",
+      "id": "CLD-STO-1"
+    },
+    {
+      "framework": "cis-v8",
+      "id": "3.3"
+    },
+    {
+      "framework": "iso-27001",
+      "id": "A.5.15"
+    },
+    {
+      "framework": "iso-27001",
+      "id": "A.8.3"
+    },
+    {
+      "framework": "iso-27017",
+      "id": "CLD.9.5.1"
+    },
+    {
+      "framework": "secnumcloud-3.2",
+      "id": "9.7"
+    },
+    {
+      "framework": "secnumcloud-3.2",
+      "id": "13.2"
+    }
+  ],
+  "severity": "critical",
+  "status": "pass",
+  "subject": "scaleway",
+  "title": "Object storage publicly exposed"
+}
+```
+<!-- /pepin:gen remediation-after -->
+
+Three things changed, and all three matter:
+
+- `status` went from `fail` to `pass`.
+- `subject` went from the offending resource to the provider scope: there is no longer
+  a resource to name.
+- `evidence.observed` states **why** the pass is asserted, and names the lock it went
+  through: the contract is verified, so the absence of a deviation is a measured
+  compliance rather than an absence of measurement.
+
+That last point is the whole difference between a fix and a blind spot. If the status
+had gone from `fail` to `not-evaluated`, nothing would have been demonstrated: the
+deviation would merely have stopped being visible. See
+[the assessment model](../concepts/assessment-model.md) for what each status asserts,
+and [exit codes](../reference/exit-codes.md) for what a pipeline reads from it.
+
+## What a deployable proof is
+
+A proof of remediation is a **self-contained Terraform module that is compliant**: it
+deploys as is, in the provider's native vocabulary, and scanning it does not trigger the
+rule. It is the mirror image of the non-compliant fixtures in
+`examples/<provider>/terraform/`.
+
+```
+references/remediation/<provider>/<code>/      # self-contained Terraform module (preferred)
+references/remediation/<provider>/<code>.md    # note anchored on the official docs, when Terraform is not relevant
+```
+
+Four rules, none of them cosmetic:
+
+1. **One directory per rule.** Terraform merges every `.tf` of a directory, so several
+   proofs in one directory could not be deployed or audited separately. A single setup
+   satisfying neighbouring rules is duplicated, each copy scoped to its own rule.
+2. **Deployable, verified as such.** `terraform init -backend=false` then
+   `terraform validate` must pass: complete configuration, declared variables, real
+   schema fields. A snippet that cannot be applied is pseudo-code, and pseudo-code
+   presented as a configuration is exactly what this repository refuses.
+3. **A mandatory header** naming the `code`, the SCSL requirement, the provider, **why
+   the setup is compliant**, and the **anchored source** (a page under
+   `references/docs/<provider>/`, or the contract in `providers/<provider>.yaml`).
+4. **No secret.** Credentials come from the environment or from variables, never from
+   the file.
+
+The full convention lives in
+[`references/remediation/README.md`](../../references/remediation/README.md).
+
+## Coverage today, and it is partial
+
+The count below is computed from the repository at generation time, over the (control,
+provider) pairs the reference actually declares:
+
+<!-- pepin:gen remediation-coverage -->
+| Provider | Remediation proofs |
+|---|---:|
+| exoscale | 4 / 26 |
+| kubernetes | 0 / 4 |
+| outscale | 0 / 40 |
+| scaleway | 0 / 25 |
+| **Total** | **4 / 95** |
+<!-- /pepin:gen remediation-coverage -->
+
+Read that table for what it is: it counts **deployable proofs**, not remediations. The
+textual remediation is at 100 % and gated by a test; the proofs are a work in progress,
+and the honest thing is to say so rather than to round it up.
+
+To reproduce the number, and to get the missing list per provider:
+
+```bash
+mise run check-remediation                     # every provider
+python3 scripts/check-remediation.py exoscale  # one provider
+```
+
+## Why that gate is not wired into `validate`
+
+`mise run check-remediation` is deliberately **decoupled** from `mise run validate`. A
+gate that is red permanently is a gate people learn to ignore, and a quality gate that
+is routinely bypassed is worse than no gate: it teaches the habit of overriding it.
+
+The rebranch condition is written where it will be seen, in `mise.toml` next to the
+task: **one provider at 100 %**, wired in as `depends = [..., "check-remediation"]`,
+then the others as they land. Until then the count is published (above, and on every
+control page) rather than enforced.
+
+## Filing a proof
+
+1. Anchor the setup first: the field, its type and its accepted values come from the
+   provider's SDK or official documentation, never from memory. Cache the page under
+   `references/docs/<provider>/` (`mise run fetch-docs`) and cite it.
+2. Write `references/remediation/<provider>/<code>/main.tf` with the mandatory header.
+3. Check it deploys: `terraform init -backend=false && terraform validate` in that
+   directory.
+4. Check it is **compliant**: generate a plan from it and scan it, the rule must not
+   fire.
+
+   ```bash
+   terraform plan -out tfplan && terraform show -json tfplan > plan.json
+   ./pepin scan <provider> --terraform plan.json --format assessment
+   ```
+
+5. Regenerate the derived documentation: `mise run gen-docs`. The control page now
+   links your proof, and the coverage figures move.
+6. `mise run validate` and `mise run test` stay green.
+
+## See also
+
+- [Control catalogue](../controls/index.md) — the four questions, answered per control.
+- [The assessment model](../concepts/assessment-model.md) — what `pass` actually asserts.
+- [Known limitations](../known-limitations.md) — the blind spots, named.
+- [Adding a control](../contributing/adding-a-control.md) — the end-to-end procedure.

--- a/docs/project/architecture.fr.md
+++ b/docs/project/architecture.fr.md
@@ -1,0 +1,233 @@
+> [🇬🇧 English](architecture.md) · 🇫🇷 Français
+
+# Architecture
+
+Pépin lit la configuration d'un tenant cloud, l'évalue contre un référentiel commun de
+contrôles, et produit un résultat **opposable** : un statut typé par contrôle, ses
+références normatives exactes, et un bundle de preuve scellé. Cette page explique
+comment, et surtout **pourquoi les pièces sont découpées à cet endroit-là**.
+
+## Le pipeline
+
+```mermaid
+flowchart LR
+  subgraph SRC["Sources : une par cloud"]
+    TF["Plan Terraform<br/>(terraform show -json)"]
+    API["API du fournisseur<br/>(collecte live)"]
+  end
+  subgraph COL["Projection"]
+    DESC["providers/&lt;nom&gt;.yaml<br/>descripteur"]
+    ENG["internal/collect · internal/tfmap<br/>internal/objectstorage · internal/oks"]
+  end
+  MOD["Modèle normalisé<br/>internal/model — resources[]"]
+  RULES["internal/commonrules/rules/*.rego<br/>UN seul jeu de règles commun"]
+  FIND["findings<br/>scankit/finding"]
+  REF["referentiel/<br/>controles.yaml + SCSL"]
+  ASSESS["internal/assess<br/>statuts · verrous · provenance"]
+  OUT["terminal · json · sarif<br/>assessment · OSCAL · bundle scellé"]
+
+  TF --> DESC
+  API --> DESC
+  DESC --> ENG --> MOD --> RULES --> FIND --> ASSESS --> OUT
+  REF --> ASSESS
+  DESC -. contrat .-> ASSESS
+```
+
+En une phrase : **la source change d'un cloud à l'autre ; tout ce qui est en aval du
+modèle normalisé ne change pas.**
+
+## Le choix : un seul jeu de règles, commun à tous les fournisseurs
+
+Toutes les règles de posture vivent dans `internal/commonrules/rules/`, s'écrivent une
+fois, et s'évaluent sur le modèle normalisé. **Aucune règle n'appartient à un
+fournisseur.** Une règle lit `input.resources[]`, des types et des attributs agnostiques,
+et étiquette son écart avec le fournisseur *tiré de la ressource* (`provider_of(r)`),
+jamais codé en dur.
+
+L'alternative évidente serait un jeu de règles par cloud. Il vaut la peine de dire ce
+qu'elle coûte, parce que le choix n'est pas esthétique :
+
+- **N fois la surface pour le même contrôle.** « Un security group ouvert à `0.0.0.0/0`
+  sur le port 22 » devient trois règles à maintenir d'accord. Elles dérivent, et la
+  dérive est silencieuse : rien n'échoue, les trois clouds cessent simplement d'être
+  jugés à la même aune.
+- **Des rapports incomparables.** Une posture multi-cloud n'a de sens que si un contrôle
+  veut dire la *même chose* partout. Avec des règles par fournisseur, un `pass` sur le
+  cloud A et un `pass` sur le cloud B sont deux affirmations différentes qui portent le
+  même mot.
+- **Une correction qui atterrit une fois au lieu de N.** Un faux positif corrigé dans la
+  règle commune est corrigé partout. Dans l'autre montage, il est corrigé là où
+  quelqu'un a pensé à regarder.
+- **Le mapping normatif perd son sens.** Un contrôle se rattache à une exigence SCSL. Si
+  trois règles l'implémentent différemment, laquelle l'exigence couvre-t-elle ?
+
+Un nouveau contrôle n'est donc jamais « une règle pour le cloud X ». C'est :
+**normaliser la donnée dans le descripteur, puis écrire une règle commune.** Si un
+contrôle semble exiger une logique propre à un fournisseur, c'est le signal qu'il manque
+une normalisation, un type, un attribut ou une dérivation, pas une seconde règle.
+
+Le corollaire est le critère d'acceptation d'un nouveau cloud : **un descripteur, zéro
+règle.** Voir [ajouter un fournisseur](../contributing/adding-a-provider.fr.md).
+
+## Ce qui change d'un cloud à l'autre : la source
+
+Un fournisseur est un descripteur `providers/<nom>.yaml`. Il porte tout ce qui est
+spécifique : identité et faits de souveraineté, authentification, résolution des
+identifiants, **spec de collecte live**, **mapping Terraform** et **contrat d'API**. Deux
+sources, décrites dans le même fichier :
+
+| Source | Ce qu'elle montre | Ce qu'elle ne peut pas montrer |
+|---|---|---|
+| **Plan Terraform** | l'état *planifié*, avant apply, sans aucun compte | tout ce qui est « known after apply », et tout ce qui n'est pas dans le code |
+| **Collecte live** | la configuration *effective*, dérive comprise | tout ce que les identifiants ne peuvent pas lire |
+
+Les deux ne sont pas interchangeables, et Pépin ne fait jamais semblant du contraire : la
+source est consignée dans l'assessment (`run.source`), et la matrice de couverture est
+calculée par source. [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md)
+détaille les vraies divergences.
+
+L'essentiel de la projection est déclaratif. Deux collecteurs sont du code **Go**
+partagé plutôt que de la spec, parce que leur protocole n'est pas « un endpoint REST qui
+rend du JSON » : le stockage objet (compatible S3, `internal/objectstorage`) et le
+Kubernetes managé (`internal/oks`). Ils s'activent en déclarant un endpoint dans le
+descripteur.
+
+## Le modèle normalisé
+
+Tout ce qui est en aval voit la même forme, et seulement celle-ci :
+
+```go
+type Resource struct {
+	Provider   string         `json:"provider"`
+	Type       string         `json:"type"`
+	ID         string         `json:"id"`
+	Name       string         `json:"name"`
+	Region     string         `json:"region,omitempty"`
+	Attributes map[string]any `json:"attributes"`
+}
+```
+
+`Type` est un type agnostique (`compute_instance`, `security_group_rule`,
+`object_storage_bucket`, `managed_database`, `iam_policy`, `kubernetes_cluster`…), et les
+clés d'attributs le sont aussi. Le vocabulaire natif du fournisseur s'arrête au
+descripteur : il survit dans la prose qu'un rapport imprime (Net, BSU, Kapsule, EIM),
+jamais dans l'évaluation.
+
+Une règle ne se déclenche que si des ressources du type qu'elle lit existent. Un
+fournisseur qui n'a pas ce type ne la déclenche tout simplement pas, et c'est pourquoi un
+jeu de règles commun ne produit aucun faux positif sur un cloud dépourvu du mécanisme.
+
+## Les trois verrous contre le faux vert
+
+Un outil de posture échoue dans deux directions, et elles ne sont pas symétriques. Un
+faux positif est bruyant, donc il se corrige. Un **faux vert est invisible par
+construction**, et c'est contre lui que cette architecture est taillée. Trois verrous
+séparent « aucun écart » de `pass` :
+
+1. **La garde de capacité, dans la règle.** La règle ne lit un attribut que s'il est
+   présent : une donnée non collectée ne produit jamais de faux positif.
+2. **Le verrou du contrat, dans `internal/assess`.** Un `pass` n'est affirmé que si le
+   contrat du fournisseur déclare le type `verifie`, c'est-à-dire lu dans le SDK et
+   réellement projeté. Sinon le résultat est `not-evaluated`, avec son motif.
+3. **Le verrou `requiredAttr`.** Pour les contrôles dont le silence se lirait comme une
+   conformité, l'attribut décisif est déclaré dans `internal/assess`. Si aucune ressource
+   du type visé ne le portait, le contrôle est `not-evaluated` plutôt que `pass`.
+
+Les mêmes fonctions servent le scan et la documentation : `assess.Verified` est appelée
+par `cmd/scan.go` **et** par le générateur de couverture, si bien qu'une page de
+couverture ne peut pas décrire un verrou différent de celui qui est appliqué.
+[Le modèle d'assessment](../concepts/assessment-model.fr.md) dit ce que chaque statut
+affirme.
+
+## Ce qui vient de `scankit`, et ce qui reste dans Pépin
+
+Le moteur, le modèle de finding, le rendu et le scoring ne sont **pas** propres à Pépin :
+ils sont partagés avec son outil frère via
+[`github.com/stephrobert/scankit`](https://github.com/stephrobert/scankit), épinglé par
+version dans `go.mod`.
+
+| Vient de `scankit` | Reste dans Pépin |
+|---|---|
+| `engine` : évaluation OPA (`engine.Evaluate`) | les règles `.rego` elles-mêmes |
+| `finding.Finding` : le modèle de finding, avec ses `labels` | les collecteurs et `providers/*.yaml` |
+| `report` : rendus terminal, JSON, SARIF, OSCAL | `referentiel/` : le référentiel de contrôles et les mappings SCSL |
+| `scoring` : comptes par sévérité | `internal/assess` : statuts, verrous, provenance, bundle scellé |
+| `assessment` : les types de l'assessment | la marque, le verdict, la CLI, la couche bilingue |
+
+La règle est simple : **toute évolution du moteur, du rendu ou du scoring se fait dans
+`scankit`**, pour que les deux outils en profitent ; Pépin ne garde aucun moteur local.
+C'est aussi pourquoi la sortie terminal est identique à celle de son frère.
+
+## Le trajet d'une ressource, de bout en bout
+
+Prenons un plan Terraform contenant un `scaleway_object_bucket_acl` avec une ACL
+publique :
+
+1. **Analyse.** `internal/tfparse` lit `terraform show -json` et en tire les ressources
+   planifiées.
+2. **Projection.** La section `mapping_terraform` de `providers/scaleway.yaml` transforme
+   `scaleway_object_bucket_acl` en un `object_storage_bucket` normalisé portant
+   l'attribut `acl`. Rien de propre au fournisseur ne survit à cette étape.
+3. **Évaluation.** `engine.Evaluate` passe toutes les règles communes sur
+   `input.resources[]`. `objectstorage_bucket_public_access` se déclenche et émet un
+   écart avec son `code`, sa `severity`, son `subject`, son message français et son
+   `labels.message_en`, plus `labels.provider` tiré de la ressource.
+4. **Enrichissement.** L'écart est joint à `referentiel/controles.yaml` : exigence SCSL
+   exacte, correspondances SecNumCloud / CIS / ISO, lien de documentation.
+5. **Assessment.** `assess.Build` transforme les écarts en un statut typé par contrôle,
+   en appliquant les trois verrous ci-dessus, et enveloppe le tout dans une provenance
+   d'exécution (version de l'outil, empreinte du jeu de règles, cible, horodatage,
+   source, périmètre).
+6. **Rendu.** `scankit/report` imprime le rapport terminal, ou du JSON, du SARIF, de
+   l'OSCAL ; le verdict et le code de sortie suivent le scoring. `--seal` écrit le bundle
+   de preuve horodaté que `pepin verify` recontrôle.
+
+Le guide de remédiation montre les étapes 5 et 6
+[avant et après](../guides/remediation.fr.md) une correction, capturées par exécution
+réelle.
+
+## Les sources de vérité
+
+Rien, dans ce projet, n'est vrai à deux endroits à la fois. Quand deux artefacts se
+contredisent, ce tableau dit lequel l'emporte.
+
+| Question | Source de vérité |
+|---|---|
+| Quels contrôles existent, leur sévérité et leurs correspondances normatives | `referentiel/controles.yaml` |
+| Quelles exigences SCSL existent | l'index SCSL **gelé** (`framework-scsl`), reflété dans `referentiel/scsl-baseline.json` |
+| Ce qu'un fournisseur collecte, mappe et a vérifié | `providers/<nom>.yaml` |
+| Ce qui rend un `pass` affirmable | `internal/assess` (`Verified`, `requiredAttr`) |
+| Ce que l'outil détecte | `internal/commonrules/rules/*.rego` |
+| Ce que la documentation affirme de la couverture | calculé par `internal/docgen`, jamais écrit à la main |
+
+Cette dernière ligne est un choix d'architecture elle aussi : la matrice de couverture,
+le catalogue des contrôles et toutes les sorties de commande montrées dans `docs/` sont
+**générés**, et `TestGeneratedDocsAreUpToDate` régénère puis compare en CI. Une page de
+documentation n'est pas une source, c'est le rendu d'un calcul. Un CSPM qui ment sur ce
+qu'il mesure est pire qu'un CSPM sans documentation.
+
+## Bilingue par construction
+
+Pépin résout une langue au démarrage, `--lang` → `PEPIN_LANG` → `LC_ALL` → `LANG` →
+repli `en`, et tout ce qu'un humain lit suit : rapport, verdict, aide, erreurs, ainsi que
+la prose contenue dans `json`, `sarif`, `oscal` et `assessment`. Ce qui ne change jamais
+avec la langue : les codes, les identifiants de contrôle, les sévérités, les statuts, les
+sujets et les codes de sortie. C'est là-dessus qu'un pipeline se branche.
+
+Le français est la langue de référence du contenu normatif ; l'anglais en est la
+traduction maintenue. `mise run validate` refuse un contrôle, une règle ou une
+justification de contrat à qui il manque sa contrepartie : un rapport anglais ne doit
+jamais retomber en français au milieu d'une phrase.
+
+## Voir aussi
+
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : le côté règle, de bout
+  en bout.
+- [Ajouter un fournisseur](../contributing/adding-a-provider.fr.md) : le côté source, de
+  bout en bout.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut
+  affirme.
+- [Matrice de couverture](../coverage.fr.md) : ce qui est mesurable, par fournisseur et
+  par source.
+- [Périmètre et non-objectifs](../concepts/scope.fr.md) : ce qu'un rapport Pépin n'est
+  pas.

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -1,0 +1,221 @@
+> 🇬🇧 English · [🇫🇷 Français](architecture.fr.md)
+
+# Architecture
+
+Pépin reads the configuration of a cloud tenant, evaluates it against a common control
+reference, and produces an **opposable** result: a typed status per control, its exact
+normative references, and a sealed evidence bundle. This page explains how, and — more
+usefully — **why the pieces are cut where they are**.
+
+## The pipeline
+
+```mermaid
+flowchart LR
+  subgraph SRC["Sources — one per cloud"]
+    TF["Terraform plan<br/>(terraform show -json)"]
+    API["Provider API<br/>(live collection)"]
+  end
+  subgraph COL["Projection"]
+    DESC["providers/&lt;name&gt;.yaml<br/>descriptor"]
+    ENG["internal/collect · internal/tfmap<br/>internal/objectstorage · internal/oks"]
+  end
+  MOD["Normalized model<br/>internal/model — resources[]"]
+  RULES["internal/commonrules/rules/*.rego<br/>ONE common rule set"]
+  FIND["findings<br/>scankit/finding"]
+  REF["referentiel/<br/>controles.yaml + SCSL"]
+  ASSESS["internal/assess<br/>statuses · locks · provenance"]
+  OUT["terminal · json · sarif<br/>assessment · OSCAL · sealed bundle"]
+
+  TF --> DESC
+  API --> DESC
+  DESC --> ENG --> MOD --> RULES --> FIND --> ASSESS --> OUT
+  REF --> ASSESS
+  DESC -. contract .-> ASSESS
+```
+
+Read it in one sentence: **the source changes from one cloud to the next; everything
+downstream of the normalized model does not.**
+
+## The decision: one rule set, common to every provider
+
+Every posture rule lives in `internal/commonrules/rules/`, is written once, and
+evaluates the normalized model. **No rule belongs to a provider.** A rule reads
+`input.resources[]` — agnostic types, agnostic attributes — and labels its finding with
+the provider *taken from the resource* (`provider_of(r)`), never hardcoded.
+
+The obvious alternative is one rule set per cloud. It is worth spelling out what that
+costs, because the choice is not aesthetic:
+
+- **N times the surface for the same check.** "A security group open to `0.0.0.0/0` on
+  port 22" becomes three rules that must be kept in agreement. They drift, and the drift
+  is silent: nothing fails, the three clouds simply stop being judged by the same
+  standard.
+- **Reports that cannot be compared.** A multi-cloud posture is only meaningful if a
+  control means the *same thing* everywhere. With per-provider rules, `pass` on cloud A
+  and `pass` on cloud B are two different claims wearing the same word.
+- **A fix that lands once instead of N times.** A false positive corrected in the common
+  rule is corrected everywhere. In the other design it is corrected where someone
+  remembered to look.
+- **The normative mapping stops making sense.** A control maps onto an SCSL requirement.
+  If three rules implement it differently, which one does the requirement cover?
+
+So a new check is never "a rule for cloud X". It is: **normalize the data in the
+descriptor, then write one common rule.** If a check seems to require provider-specific
+logic, that is the signal that the normalization is missing — a type, an attribute, a
+derivation — not that a second rule is needed.
+
+The corollary is the acceptance criterion for a new cloud: **one descriptor, zero
+rules.** See [adding a provider](../contributing/adding-a-provider.md).
+
+## What changes per cloud: the source
+
+A provider is a `providers/<name>.yaml` descriptor. It carries everything that is
+specific: identity and sovereignty facts, authentication, credential resolution, the
+**live collection spec**, the **Terraform mapping**, and the **API contract**. Two
+sources, described in the same file:
+
+| Source | What it shows | What it cannot show |
+|---|---|---|
+| **Terraform plan** | the *planned* state, before apply, with no account needed | anything "known after apply", and anything not in the code |
+| **Live collection** | the *effective* configuration, drift included | anything the credentials cannot read |
+
+The two are not interchangeable, and Pépin never pretends they are: the source is
+recorded in the assessment (`run.source`), and the coverage matrix is computed per
+source. [Terraform plan vs live scan](../concepts/terraform-vs-live.md) goes into the
+real divergences.
+
+Most of the projection is declarative. Two collectors are shared **Go** code rather than
+spec, because their protocol is not "a REST endpoint returning JSON": object storage
+(S3-compatible, `internal/objectstorage`) and managed Kubernetes (`internal/oks`). They
+are enabled by declaring an endpoint in the descriptor.
+
+## The normalized model
+
+Everything downstream sees the same shape, and only this shape:
+
+```go
+type Resource struct {
+	Provider   string         `json:"provider"`
+	Type       string         `json:"type"`
+	ID         string         `json:"id"`
+	Name       string         `json:"name"`
+	Region     string         `json:"region,omitempty"`
+	Attributes map[string]any `json:"attributes"`
+}
+```
+
+`Type` is an agnostic type (`compute_instance`, `security_group_rule`,
+`object_storage_bucket`, `managed_database`, `iam_policy`, `kubernetes_cluster`…), and
+the attribute keys are agnostic too. The provider's native vocabulary stops at the
+descriptor: it survives in the prose a report prints (Net, BSU, Kapsule, EIM), never in
+the evaluation.
+
+A rule only fires if resources of the type it reads exist. A provider that has no such
+type simply does not trigger it — which is why a common rule set produces no false
+positives on a cloud that lacks the mechanism.
+
+## The three locks against a false green
+
+A posture tool fails in two directions, and they are not symmetrical. A false positive
+is noisy and gets fixed. A **false green is invisible by construction**, and it is the
+one this architecture is shaped against. Three locks sit between "no finding" and
+`pass`:
+
+1. **The capability guard, in the rule.** The rule reads an attribute only if it is
+   present, so uncollected data never produces a false positive.
+2. **The contract lock, in `internal/assess`.** A `pass` is asserted only if the
+   provider contract declares the type `verifie` — read in the SDK and really projected.
+   Otherwise the result is `not-evaluated`, with its reason.
+3. **The `requiredAttr` lock.** For controls whose silence would otherwise read as
+   compliance, the deciding attribute is declared in `internal/assess`. If no resource
+   of the targeted type carried it, the control is `not-evaluated` rather than `pass`.
+
+The same functions serve the scan and the documentation: `assess.Verified` is called by
+`cmd/scan.go` **and** by the coverage generator, so a coverage page cannot describe a
+lock different from the one applied. [The assessment
+model](../concepts/assessment-model.md) states what each status asserts.
+
+## What comes from `scankit`, and what stays in Pépin
+
+The engine, the finding model, the rendering and the scoring are **not** Pépin-specific:
+they are shared with its sibling tool through
+[`github.com/stephrobert/scankit`](https://github.com/stephrobert/scankit), pinned by
+version in `go.mod`.
+
+| Comes from `scankit` | Stays in Pépin |
+|---|---|
+| `engine` — OPA evaluation (`engine.Evaluate`) | the `.rego` rules themselves |
+| `finding.Finding` — the finding model, with its `labels` | the collectors and `providers/*.yaml` |
+| `report` — terminal, JSON, SARIF, OSCAL rendering | `referentiel/` — the control reference and SCSL mappings |
+| `scoring` — severity counts | `internal/assess` — statuses, locks, provenance, sealed bundle |
+| `assessment` — the assessment types | the brand, the verdict, the CLI, the bilingual layer |
+
+The rule is: **any engine, rendering or scoring change happens in `scankit`**, so both
+tools benefit; Pépin keeps no local engine. That is also why the terminal output is
+identical to its sibling's.
+
+## The journey of one resource, end to end
+
+Take a Terraform plan containing a `scaleway_object_bucket_acl` with a public ACL:
+
+1. **Parse.** `internal/tfparse` reads `terraform show -json` and yields the planned
+   resources.
+2. **Project.** The `mapping_terraform` section of `providers/scaleway.yaml` turns
+   `scaleway_object_bucket_acl` into a normalized `object_storage_bucket` carrying the
+   `acl` attribute. Nothing provider-specific survives past this step.
+3. **Evaluate.** `engine.Evaluate` runs every common rule over
+   `input.resources[]`. `objectstorage_bucket_public_access` fires, and emits a finding
+   with its `code`, `severity`, `subject`, its French message and its
+   `labels.message_en`, plus `labels.provider` taken from the resource.
+4. **Enrich.** The finding is joined to `referentiel/controles.yaml`: exact SCSL
+   requirement, SecNumCloud / CIS / ISO mappings, documentation link.
+5. **Assess.** `assess.Build` turns findings into a typed status per control, applying
+   the three locks above, and wraps everything in a run provenance envelope (tool
+   version, ruleset digest, target, timestamp, source, scope).
+6. **Render.** `scankit/report` prints the terminal report, or JSON, SARIF, OSCAL; the
+   verdict and the exit code follow the scoring. `--seal` writes the timestamped
+   evidence bundle that `pepin verify` re-checks.
+
+The remediation guide shows steps 5 and 6 [before and
+after](../guides/remediation.md#the-loop-measured) a fix, captured from real runs.
+
+## Sources of truth
+
+Nothing in this project is true in two places at once. When two artefacts disagree, this
+table says which one wins.
+
+| Question | Source of truth |
+|---|---|
+| Which controls exist, their severity and their normative mappings | `referentiel/controles.yaml` |
+| Which SCSL requirements exist | the **frozen** SCSL index (`framework-scsl`), mirrored in `referentiel/scsl-baseline.json` |
+| What a provider collects, maps, and has verified | `providers/<name>.yaml` |
+| What makes a `pass` assertable | `internal/assess` (`Verified`, `requiredAttr`) |
+| What the tool detects | `internal/commonrules/rules/*.rego` |
+| What the documentation claims about coverage | computed by `internal/docgen`, never written by hand |
+
+That last line is a design choice too: the coverage matrix, the control catalogue and
+every command output shown in `docs/` are **generated**, and
+`TestGeneratedDocsAreUpToDate` regenerates and compares in CI. A documentation page is
+not a source; it is the rendering of a computation. A CSPM that lies about what it
+measures is worse than one with no documentation.
+
+## Bilingual by construction
+
+Pépin resolves one language at startup — `--lang` → `PEPIN_LANG` → `LC_ALL` → `LANG` →
+fallback `en` — and everything a human reads follows: report, verdict, help, errors, and
+the prose inside `json`, `sarif`, `oscal` and `assessment`. What never changes with the
+language: codes, check identifiers, severities, statuses, subjects and exit codes. A
+pipeline keys on those.
+
+French is the reference language of the normative content; English is its maintained
+translation. `mise run validate` refuses a control, a rule or a contract justification
+that is missing its counterpart: an English report must never fall back to French
+mid-sentence.
+
+## See also
+
+- [Adding a control](../contributing/adding-a-control.md) — the rule side, end to end.
+- [Adding a provider](../contributing/adding-a-provider.md) — the source side, end to end.
+- [The assessment model](../concepts/assessment-model.md) — what each status asserts.
+- [Coverage matrix](../coverage.md) — what is measurable, per provider and per source.
+- [Scope and non-goals](../concepts/scope.md) — what a Pépin report is not.

--- a/internal/docgen/blocks.go
+++ b/internal/docgen/blocks.go
@@ -42,6 +42,12 @@ const (
 }`
 )
 
+// remediationWitness : le contrôle que le guide de remédiation suit d'un scan à l'autre. Il
+// est CRITIQUE, actif chez les trois fournisseurs, et l'exemple corrigé du dépôt le fait
+// passer de `fail` à `pass` — c'est-à-dire qu'il démontre la boucle complète plutôt que la
+// simple disparition d'un écart.
+const remediationWitness = "objectstorage_bucket_public_access"
+
 // Chemins des fixtures du dépôt utilisées par les captures.
 const (
 	planVulnerable = "examples/scaleway/terraform/plan.json"
@@ -53,14 +59,17 @@ const (
 // captures rassemble toutes les exécutions réelles de `pepin` dont la documentation montre la
 // sortie. Aucune autre source n'est admise dans une page.
 type captures struct {
-	vulnerable  Capture
-	fixed       Capture
-	assessment  Capture // --format assessment sur le plan non conforme
-	missingFile Capture
-	empty       Capture
-	tagless     Capture
-	taglessStr  Capture
-	providers   Capture
+	vulnerable Capture
+	fixed      Capture
+	assessment Capture // --format assessment sur le plan non conforme
+	// assessmentFixed : le MÊME scan sur le plan corrigé. C'est l'avant/après d'une
+	// remédiation, mesuré et non raconté : le même contrôle y passe de `fail` à `pass`.
+	assessmentFixed Capture
+	missingFile     Capture
+	empty           Capture
+	tagless         Capture
+	taglessStr      Capture
+	providers       Capture
 
 	// Référence CLI : une aide par verbe, dans la langue de la page. Les captures y sont
 	// tenues par POINTEUR : une valeur de carte n'est pas adressable, et la neutralisation
@@ -92,7 +101,7 @@ type captures struct {
 // liste énumérée à la main y oublierait une capture au premier ajout, et la page concernée
 // divergerait à chaque build sans qu'aucun comportement n'ait bougé.
 func (c *captures) all() []*Capture {
-	out := []*Capture{&c.vulnerable, &c.fixed, &c.assessment, &c.missingFile, &c.empty,
+	out := []*Capture{&c.vulnerable, &c.fixed, &c.assessment, &c.assessmentFixed, &c.missingFile, &c.empty,
 		&c.tagless, &c.taglessStr, &c.providers, &c.jsonReport, &c.sarif, &c.oscal,
 		&c.driftLive, &c.outscalePlanJSON,
 		&c.bundle.seal, &c.bundle.verify, &c.bundle.reDerive, &c.bundle.tampered,
@@ -138,6 +147,7 @@ func captureAll(root, bin, lang string) (captures, error) {
 		{&c.vulnerable, []string{"scan", "scaleway", "--terraform", planVulnerable}, nil},
 		{&c.fixed, []string{"scan", "scaleway", "--terraform", planFixed}, nil},
 		{&c.assessment, []string{"scan", "scaleway", "--terraform", planVulnerable, "--format", "assessment"}, nil},
+		{&c.assessmentFixed, []string{"scan", "scaleway", "--terraform", planFixed, "--format", "assessment"}, nil},
 		{&c.missingFile, []string{"scan", "scaleway", planMissing}, nil},
 		{&c.empty, []string{"scan", "scaleway", emptyPath}, []string{"scan", "scaleway", "empty-inventory.json"}},
 		{&c.tagless, []string{"scan", "scaleway", taglessPath}, []string{"scan", "scaleway", "tagless-inventory.json"}},
@@ -362,6 +372,8 @@ func buildBlocks(lang string, m Matrix, c captures, rem []RemediationCoverage) m
 		"single-source":             singleSourceTable(t, m),
 		"not-applicable-list":       notApplicableTable(t, m),
 		"remediation-coverage":      remediationTable(t, rem),
+		"remediation-before":        assessmentControl(driftText(lang), c.assessment, remediationWitness),
+		"remediation-after":         assessmentControl(driftText(lang), c.assessmentFixed, remediationWitness),
 		"coverage-totals":           m.countsTable(coverageText(lang)),
 		"control-counts":            controlCountsTable(t, m),
 	}

--- a/internal/docgen/controls.go
+++ b/internal/docgen/controls.go
@@ -1,0 +1,526 @@
+package docgen
+
+// Le catalogue des contrôles, DÉRIVÉ du référentiel.
+//
+// Une page par contrôle et un index, calculés depuis `referentiel/controles.yaml` (code,
+// famille, sévérité, prose bilingue, mappings normatifs, fournisseurs déclarés), les
+// descripteurs `providers/*.yaml` (ce que chaque source sait produire), le verrou du « pass »
+// de `internal/assess` et les preuves de remédiation présentes sous `references/remediation/`.
+//
+// Rien n'y est recopié à la main : ajouter un contrôle, changer une sévérité, retirer un
+// fournisseur ou déposer une preuve de remédiation change ces pages, et
+// TestGeneratedDocsAreUpToDate refuse une documentation qui ne suivrait pas.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	yaml "go.yaml.in/yaml/v3"
+
+	"github.com/stephrobert/pepin/internal/i18n"
+	"github.com/stephrobert/pepin/referentiel"
+)
+
+// controlsDir est le dossier des pages de contrôles, relatif à la racine du dépôt. Il est
+// ENTIÈREMENT généré : Write y supprime ce que le générateur ne produit plus, sans quoi le
+// retrait d'un contrôle laisserait une page orpheline qu'aucun test ne verrait.
+const controlsDir = "docs/controls"
+
+// familyOrder rend les familles du référentiel DANS LEUR ORDRE DE DÉCLARATION. L'ordre porte
+// une intention éditoriale (IAM d'abord, gouvernance en dernier) qu'un tri alphabétique
+// détruirait. La liste est lue dans le référentiel embarqué : la page ne peut pas connaître
+// une famille que le référentiel ignore.
+func familyOrder() ([]string, error) {
+	var doc struct {
+		Familles []struct {
+			Code string `yaml:"code"`
+		} `yaml:"familles"`
+	}
+	if err := yaml.Unmarshal(referentiel.Raw(), &doc); err != nil {
+		return nil, fmt.Errorf("lecture des familles du référentiel : %w", err)
+	}
+	if len(doc.Familles) == 0 {
+		return nil, fmt.Errorf("aucune famille lue dans le référentiel : le catalogue serait vide")
+	}
+	out := make([]string, 0, len(doc.Familles))
+	for _, f := range doc.Familles {
+		out = append(out, f.Code)
+	}
+	return out, nil
+}
+
+// controlPages rend l'index et la page de chaque contrôle, pour une langue.
+func controlPages(lang string, m Matrix, proofs map[string]map[string]string, families []string) map[string]string {
+	t := controlText(lang)
+	out := map[string]string{controlsDir + "/" + pageName("index", lang): m.controlIndex(t, lang, proofs, families)}
+	for _, r := range m.Rows {
+		out[controlsDir+"/"+pageName(r.Code, lang)] = m.controlPage(t, lang, r, proofs)
+	}
+	return out
+}
+
+// pageName rend le nom de fichier d'une page dans une langue : l'anglais est primaire, le
+// français porte le suffixe `.fr`.
+func pageName(base, lang string) string {
+	if lang == "fr" {
+		return base + ".fr.md"
+	}
+	return base + ".md"
+}
+
+// switcher rend le sélecteur de langue en tête de page, vers la contrepartie de MÊME nom.
+func switcher(base, lang string) string {
+	if lang == "fr" {
+		return "> [🇬🇧 English](" + base + ".md) · 🇫🇷 Français\n\n"
+	}
+	return "> 🇬🇧 English · [🇫🇷 Français](" + base + ".fr.md)\n\n"
+}
+
+// providersOf rend tous les fournisseurs de la matrice, cloud puis autre portée.
+func (m Matrix) providersOf() []string {
+	return append(append([]string{}, m.CloudProviders...), m.OtherProviders...)
+}
+
+// controlIndex rend docs/controls/index.md : la liste complète, par famille, avec ce qui
+// permet de trier au premier coup d'œil — sévérité, exigence SCSL gelée, fournisseurs actifs,
+// et présence d'une preuve de remédiation déployable.
+func (m Matrix) controlIndex(t controlStrings, lang string, proofs map[string]map[string]string, families []string) string {
+	var b strings.Builder
+	b.WriteString(switcher("index", lang))
+	b.WriteString(generatedBanner(lang, "mise run gen-docs"))
+	b.WriteString("\n# " + t.indexTitle + "\n\n")
+	b.WriteString(t.indexIntro + "\n\n")
+
+	b.WriteString("## " + t.figuresTitle + "\n\n")
+	b.WriteString(m.indexFigures(t, proofs))
+
+	b.WriteString("\n## " + t.readingTitle + "\n\n")
+	b.WriteString(t.readingBody + "\n")
+
+	byFamily := map[string][]Row{}
+	for _, r := range m.Rows {
+		byFamily[r.Family] = append(byFamily[r.Family], r)
+	}
+	// Une famille présente au référentiel mais absente de l'en-tête `familles:` ne doit pas
+	// disparaître silencieusement du catalogue : elle est rendue après les autres.
+	seen := map[string]bool{}
+	order := append([]string{}, families...)
+	for _, f := range order {
+		seen[f] = true
+	}
+	extra := make([]string, 0)
+	for f := range byFamily {
+		if !seen[f] {
+			extra = append(extra, f)
+		}
+	}
+	sort.Strings(extra)
+	order = append(order, extra...)
+
+	for _, fam := range order {
+		rows := byFamily[fam]
+		if len(rows) == 0 {
+			continue
+		}
+		_, _ = fmt.Fprintf(&b, "\n## `%s`\n\n", fam)
+		b.WriteString("| " + t.colControl + " | " + t.colSeverity + " | SCSL | " +
+			t.colActiveFor + " | " + t.colProofs + " |\n|---|---|---|---|---|\n")
+		for _, r := range rows {
+			active := m.declaredProviders(r)
+			state := strings.Join(codeList(active), ", ")
+			if len(active) == 0 {
+				state = "_" + t.dormant + "_"
+			}
+			_, _ = fmt.Fprintf(&b, "| [`%s`](%s) %s | %s | %s | %s | %s |\n",
+				r.Code, pageName(r.Code, lang), r.Title, r.Severity,
+				strings.Join(codeList(r.SCSL), ", "), state, proofCount(t, proofs, active, r.Code))
+		}
+	}
+
+	b.WriteString("\n## " + t.dormantTitle + "\n\n")
+	b.WriteString(t.dormantIntro + "\n\n")
+	b.WriteString(m.dormantTable(t, lang))
+	return b.String()
+}
+
+// indexFigures donne les chiffres du catalogue : contrôles, contrôles actifs, dormants,
+// répartition par sévérité, preuves de remédiation. Ce sont les chiffres qu'on cite, donc
+// exactement ceux qu'on ne veut pas maintenir à la main.
+func (m Matrix) indexFigures(t controlStrings, proofs map[string]map[string]string) string {
+	bySeverity := map[string]int{}
+	active, dormant := 0, 0
+	pairs, proven := 0, 0
+	for _, r := range m.Rows {
+		bySeverity[r.Severity]++
+		declared := m.declaredProviders(r)
+		if len(declared) == 0 {
+			dormant++
+		} else {
+			active++
+		}
+		for _, p := range declared {
+			pairs++
+			if proofs[p][r.Code] != "" {
+				proven++
+			}
+		}
+	}
+	var b strings.Builder
+	b.WriteString("| " + t.colFigure + " | " + t.colCount + " |\n|---|---:|\n")
+	_, _ = fmt.Fprintf(&b, "| %s | %d |\n", t.figTotal, len(m.Rows))
+	_, _ = fmt.Fprintf(&b, "| %s | %d |\n", t.figActive, active)
+	_, _ = fmt.Fprintf(&b, "| %s | %d |\n", t.figDormant, dormant)
+	for _, s := range []string{"critical", "high", "medium", "low"} {
+		_, _ = fmt.Fprintf(&b, "| `%s` | %d |\n", s, bySeverity[s])
+	}
+	_, _ = fmt.Fprintf(&b, "| %s | %d / %d |\n", t.figProofs, proven, pairs)
+	return b.String()
+}
+
+// dormantTable liste les contrôles écrits mais déclarés pour AUCUN fournisseur. Les laisser
+// se fondre dans la masse ferait lire le catalogue comme une couverture.
+func (m Matrix) dormantTable(t controlStrings, lang string) string {
+	var b strings.Builder
+	b.WriteString("| " + t.colControl + " | " + t.colSeverity + " | " + t.colFamily + " |\n|---|---|---|\n")
+	rows := 0
+	for _, r := range m.Rows {
+		if len(m.declaredProviders(r)) > 0 {
+			continue
+		}
+		_, _ = fmt.Fprintf(&b, "| [`%s`](%s) %s | %s | `%s` |\n",
+			r.Code, pageName(r.Code, lang), r.Title, r.Severity, r.Family)
+		rows++
+	}
+	if rows == 0 {
+		return t.noDormant + "\n"
+	}
+	return b.String()
+}
+
+// controlPage rend docs/controls/<code>.md : tout ce que le dépôt sait d'un contrôle, sans
+// qu'un lecteur ait à ouvrir le référentiel, les descripteurs et le code du verrou.
+func (m Matrix) controlPage(t controlStrings, lang string, r Row, proofs map[string]map[string]string) string {
+	ctl, ok := referentiel.Lookup(r.Code)
+	var b strings.Builder
+	b.WriteString(switcher(r.Code, lang))
+	b.WriteString(generatedBanner(lang, "mise run gen-docs"))
+	b.WriteString("\n# `" + r.Code + "`\n\n")
+	b.WriteString("**" + r.Title + "**\n\n")
+	b.WriteString("[" + t.backToIndex + "](" + pageName("index", lang) + ")\n\n")
+
+	b.WriteString(m.identityTable(t, r, proofs))
+
+	b.WriteString("\n## " + t.whyTitle + "\n\n")
+	if ok {
+		b.WriteString(paragraph(ctl.DescriptionIn(i18n.Lang(lang))) + "\n")
+	}
+	b.WriteString("\n" + t.whyNote + "\n")
+
+	b.WriteString("\n## " + t.mappingTitle + "\n\n")
+	b.WriteString(t.mappingIntro + "\n\n")
+	b.WriteString(mappingTable(t, r, ctl))
+
+	b.WriteString("\n## " + t.whereTitle + "\n\n")
+	b.WriteString(t.whereIntro + "\n\n")
+	b.WriteString(m.whereTable(t, r))
+	b.WriteString("\n" + t.reasonsIntro + "\n\n")
+	b.WriteString(m.whyNotTable(t, r))
+
+	b.WriteString("\n## " + t.concludeTitle + "\n\n")
+	b.WriteString(m.concludeTable(t, r))
+
+	b.WriteString("\n## " + t.investigateTitle + "\n\n")
+	b.WriteString(m.investigateBody(t, r))
+
+	b.WriteString("\n## " + t.remediateTitle + "\n\n")
+	if ok {
+		b.WriteString(paragraph(ctl.RemediationIn(i18n.Lang(lang))) + "\n\n")
+	}
+	b.WriteString(m.proofTable(t, r, proofs))
+	b.WriteString("\n" + t.proofNote + "\n")
+
+	b.WriteString("\n## " + t.verifyTitle + "\n\n")
+	b.WriteString(m.verifyBody(t, r))
+
+	b.WriteString("\n## " + t.seeAlsoTitle + "\n\n")
+	b.WriteString(t.seeAlso + "\n")
+	return b.String()
+}
+
+// identityTable rend la carte d'identité du contrôle : ce qu'il est, ce qu'il lit, et ce dont
+// sa décision dépend.
+func (m Matrix) identityTable(t controlStrings, r Row, proofs map[string]map[string]string) string {
+	declared := m.declaredProviders(r)
+	typ := "_" + t.noType + "_"
+	if r.Type != "" {
+		typ = "`" + r.Type + "`"
+	}
+	attrs := "_" + t.noAttr + "_"
+	if len(r.RequiredAttrs) > 0 {
+		attrs = strings.Join(codeList(r.RequiredAttrs), " / ")
+	}
+	state := t.stateActive
+	if len(declared) == 0 {
+		state = t.stateDormant
+	}
+	proven := 0
+	for _, p := range declared {
+		if proofs[p][r.Code] != "" {
+			proven++
+		}
+	}
+	var b strings.Builder
+	b.WriteString("| " + t.colField + " | " + t.colValue + " |\n|---|---|\n")
+	_, _ = fmt.Fprintf(&b, "| %s | `%s` |\n", t.rowCode, r.Code)
+	_, _ = fmt.Fprintf(&b, "| %s | `%s` |\n", t.rowFamily, r.Family)
+	_, _ = fmt.Fprintf(&b, "| %s | `%s` |\n", t.rowSeverity, r.Severity)
+	_, _ = fmt.Fprintf(&b, "| %s | %s |\n", t.rowSCSL, orNone(t, strings.Join(codeList(r.SCSL), ", ")))
+	_, _ = fmt.Fprintf(&b, "| %s | %s |\n", t.rowType, typ)
+	_, _ = fmt.Fprintf(&b, "| %s | %s |\n", t.rowAttrs, attrs)
+	_, _ = fmt.Fprintf(&b, "| %s | %s |\n", t.rowState, state)
+	_, _ = fmt.Fprintf(&b, "| %s | %s |\n", t.rowDeclared, orNone(t, strings.Join(codeList(declared), ", ")))
+	_, _ = fmt.Fprintf(&b, "| %s | %d / %d |\n", t.rowProofs, proven, len(declared))
+	return b.String()
+}
+
+// mappingTable rend les correspondances normatives EXACTES du référentiel : l'exigence SCSL
+// gelée d'abord, puis les frameworks. Aucune n'est reformulée ici.
+func mappingTable(t controlStrings, r Row, ctl referentiel.Control) string {
+	var b strings.Builder
+	b.WriteString("| " + t.colFramework + " | " + t.colRefs + " |\n|---|---|\n")
+	if len(r.SCSL) > 0 {
+		_, _ = fmt.Fprintf(&b, "| `scsl` | %s |\n", strings.Join(codeList(r.SCSL), ", "))
+	}
+	names := make([]string, 0, len(ctl.Frameworks))
+	for fw := range ctl.Frameworks {
+		names = append(names, fw)
+	}
+	sort.Strings(names)
+	for _, fw := range names {
+		ids := ctl.Frameworks[fw]
+		if len(ids) == 0 {
+			continue
+		}
+		_, _ = fmt.Fprintf(&b, "| `%s` | %s |\n", fw, strings.Join(codeList(ids), ", "))
+	}
+	return b.String()
+}
+
+// whereTable rend la couverture du contrôle, fournisseur par fournisseur et source par source.
+func (m Matrix) whereTable(t controlStrings, r Row) string {
+	var b strings.Builder
+	b.WriteString("| " + t.colProvider + " | " + t.colTerraform + " | " + t.colLive + " |\n|---|:-:|:-:|\n")
+	for _, p := range m.CloudProviders {
+		_, _ = fmt.Fprintf(&b, "| %s | %s | %s |\n", p,
+			mark(r.Cells[p][SourceTerraform].Status), mark(r.Cells[p][SourceLive].Status))
+	}
+	for _, p := range m.OtherProviders {
+		_, _ = fmt.Fprintf(&b, "| %s | %s | %s |\n", p, t.noSource, mark(r.Cells[p][SourceLive].Status))
+	}
+	return b.String()
+}
+
+// whyNotTable détaille chaque case qui n'est pas ✅ alors que le contrôle est déclaré pour ce
+// fournisseur. Même règle que la matrice de couverture : un statut sans motif n'est pas
+// opposable, et un « non déclaré » n'apprend rien de plus que le tableau ci-dessus.
+func (m Matrix) whyNotTable(t controlStrings, r Row) string {
+	var b strings.Builder
+	b.WriteString("| " + t.colProvider + " | " + t.colSource + " | " + t.colStatus + " | " + t.colReason + " |\n|---|---|---|---|\n")
+	rows := 0
+	for _, p := range m.providersOf() {
+		for _, src := range []Source{SourceTerraform, SourceLive} {
+			c := r.Cells[p][src]
+			if c.Status == Supported || c.Undeclared {
+				continue
+			}
+			_, _ = fmt.Fprintf(&b, "| %s | %s | %s `%s` | %s |\n", p, src, mark(c.Status), c.Status, oneLine(c.Reason))
+			rows++
+		}
+	}
+	if rows == 0 {
+		return t.noReason + "\n"
+	}
+	return b.String()
+}
+
+// concludeTable dit, statut par statut, OÙ ce contrôle peut réellement l'atteindre. C'est la
+// question qu'un auditeur pose : « ce vert, il vaut pour quelle source ? ».
+func (m Matrix) concludeTable(t controlStrings, r Row) string {
+	var pass, fail, ne, na []string
+	for _, p := range m.providersOf() {
+		for _, src := range []Source{SourceTerraform, SourceLive} {
+			c := r.Cells[p][src]
+			label := p + " / " + string(src)
+			switch c.Status {
+			case Supported:
+				pass = append(pass, label)
+				fail = append(fail, label)
+			case Partial:
+				fail = append(fail, label)
+				ne = append(ne, label)
+			case NotApplicable:
+				na = append(na, label)
+			case Unsupported:
+			}
+		}
+	}
+	var b strings.Builder
+	b.WriteString("| " + t.colStatus + " | " + t.colMeans + " | " + t.colWhere + " |\n|---|---|---|\n")
+	_, _ = fmt.Fprintf(&b, "| `fail` | %s | %s |\n", t.meansFail, orNone(t, strings.Join(fail, " · ")))
+	_, _ = fmt.Fprintf(&b, "| `pass` | %s | %s |\n", t.meansPass, orNone(t, strings.Join(pass, " · ")))
+	_, _ = fmt.Fprintf(&b, "| `not-applicable` | %s | %s |\n", t.meansNA, orNone(t, strings.Join(na, " · ")))
+	_, _ = fmt.Fprintf(&b, "| `not-evaluated` | %s | %s |\n", t.meansNE, orNone(t, strings.Join(ne, " · ")))
+	b.WriteString("\n" + t.concludeNote + "\n")
+	return b.String()
+}
+
+// investigateBody dit quoi regarder côté fournisseur : le type normalisé lu, les attributs
+// dont la décision dépend, et les descripteurs où leur projection se lit.
+func (m Matrix) investigateBody(t controlStrings, r Row) string {
+	var b strings.Builder
+	if r.Type == "" {
+		b.WriteString("- " + t.investNoType + "\n")
+	} else {
+		b.WriteString("- " + t.investType + " `" + r.Type + "`\n")
+	}
+	if len(r.RequiredAttrs) > 0 {
+		b.WriteString("- " + t.investAttrs + " " + strings.Join(codeList(r.RequiredAttrs), " / ") + "\n")
+		b.WriteString("- " + t.investGuard + "\n")
+	} else {
+		b.WriteString("- " + t.investNoAttrs + "\n")
+	}
+	declared := m.declaredProviders(r)
+	if len(declared) > 0 {
+		b.WriteString("- " + t.investDescriptors + " ")
+		links := make([]string, 0, len(declared))
+		for _, p := range declared {
+			links = append(links, "[`providers/"+p+".yaml`](../../providers/"+p+".yaml)")
+		}
+		b.WriteString(strings.Join(links, " · ") + "\n")
+	}
+	b.WriteString("- " + t.investRule + "\n")
+	return b.String()
+}
+
+// proofTable rend, par fournisseur déclaré, la preuve de remédiation DÉPLOYABLE présente au
+// dépôt — ou son absence. L'absence est dite, elle n'est pas masquée : c'est le chantier que
+// `mise run check-remediation` suit.
+func (m Matrix) proofTable(t controlStrings, r Row, proofs map[string]map[string]string) string {
+	declared := m.declaredProviders(r)
+	if len(declared) == 0 {
+		return t.proofDormant + "\n"
+	}
+	var b strings.Builder
+	b.WriteString("| " + t.colProvider + " | " + t.colProof + " |\n|---|---|\n")
+	for _, p := range declared {
+		path := proofs[p][r.Code]
+		if path == "" {
+			_, _ = fmt.Fprintf(&b, "| %s | _%s_ |\n", p, t.proofMissing)
+			continue
+		}
+		_, _ = fmt.Fprintf(&b, "| %s | [`%s`](../../%s) |\n", p, path, path)
+	}
+	return b.String()
+}
+
+// verifyBody rend la commande qui confirme la correction. Le fournisseur cité n'est pas
+// choisi au hasard : c'est un de ceux dont CETTE source sait conclure, sinon la commande
+// montrée rendrait `not-evaluated` sur un tenant parfaitement corrigé. Quand aucune source ne
+// sait lever le verrou du « pass », la page le dit au lieu de proposer une vérification qui
+// ne vérifie rien.
+func (m Matrix) verifyBody(t controlStrings, r Row) string {
+	tf, tfExact := m.witness(r, SourceTerraform)
+	live, liveExact := m.witness(r, SourceLive)
+	if tf == "" && live == "" {
+		return t.verifyNone
+	}
+	var cmds []string
+	if tf != "" {
+		cmds = append(cmds, "# "+t.verifyTF, "./pepin scan "+tf+" --terraform plan.json --format assessment")
+	}
+	if live != "" {
+		if len(cmds) > 0 {
+			cmds = append(cmds, "")
+		}
+		cmds = append(cmds, "# "+t.verifyLive, "./pepin scan "+live+" --live --format assessment")
+	}
+	var b strings.Builder
+	b.WriteString(Fence("bash", strings.Join(cmds, "\n")) + "\n\n")
+	b.WriteString(fmt.Sprintf(t.verifyBodyFmt, r.Code) + "\n")
+	if !tfExact || !liveExact {
+		b.WriteString("\n" + t.verifyPartial + "\n")
+	}
+	return b.String()
+}
+
+// witness rend un fournisseur témoin pour une source : de préférence un qui sait conclure
+// (`supported`), à défaut un qui produit le type sans pouvoir lever le verrou (`partial`). Le
+// second retour dit si le témoin est du premier genre.
+func (m Matrix) witness(r Row, src Source) (string, bool) {
+	fallback := ""
+	for _, p := range m.declaredProviders(r) {
+		switch r.Cells[p][src].Status {
+		case Supported:
+			return p, true
+		case Partial:
+			if fallback == "" {
+				fallback = p
+			}
+		case NotApplicable, Unsupported:
+		}
+	}
+	return fallback, fallback == ""
+}
+
+// declaredProviders rend les fournisseurs pour lesquels le contrôle est DÉCLARÉ au référentiel
+// (`fournisseurs:`), dans l'ordre de la matrice. La liste vient du référentiel et non des cases :
+// une non-applicabilité justifiée est rendue AVANT la porte de déclaration, donc lire les cases
+// comptait comme déclarés des couples que le référentiel ignore.
+func (m Matrix) declaredProviders(r Row) []string {
+	var out []string
+	for _, p := range m.providersOf() {
+		if contains(r.Declared, p) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// proofCount rend « n / m » : les preuves de remédiation présentes sur les couples déclarés.
+func proofCount(t controlStrings, proofs map[string]map[string]string, declared []string, code string) string {
+	if len(declared) == 0 {
+		return t.none
+	}
+	n := 0
+	for _, p := range declared {
+		if proofs[p][code] != "" {
+			n++
+		}
+	}
+	return fmt.Sprintf("%d / %d", n, len(declared))
+}
+
+// codeList met chaque valeur en code Markdown, pour qu'un identifiant ne se lise pas comme de
+// la prose.
+func codeList(vals []string) []string {
+	out := make([]string, 0, len(vals))
+	for _, v := range vals {
+		out = append(out, "`"+v+"`")
+	}
+	return out
+}
+
+// orNone rend un marqueur explicite plutôt qu'une cellule vide : une cellule vide se lit
+// comme un oubli de rendu, pas comme une absence constatée.
+func orNone(t controlStrings, s string) string {
+	if strings.TrimSpace(s) == "" {
+		return t.none
+	}
+	return s
+}
+
+// paragraph aplatit la prose du référentiel (pliée par le YAML) en un paragraphe.
+func paragraph(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/internal/docgen/controls_strings.go
+++ b/internal/docgen/controls_strings.go
@@ -1,0 +1,255 @@
+package docgen
+
+// Les libellés des pages du catalogue des contrôles, dans une langue.
+//
+// Seuls les EN-TÊTES et les intitulés de situation vivent ici. Le contenu (titres de
+// contrôles, descriptions, remédiations, motifs de non-couverture) vient toujours du
+// référentiel et des contrats de fournisseurs, qui sont eux-mêmes bilingues : les deux
+// versions d'une page disent donc exactement la même chose.
+type controlStrings struct {
+	indexTitle, indexIntro                     string
+	figuresTitle, readingTitle, readingBody    string
+	dormantTitle, dormantIntro, noDormant      string
+	dormant, none                              string
+	colControl, colSeverity, colActiveFor      string
+	colProofs, colFamily, colFigure, colCount  string
+	figTotal, figActive, figDormant, figProofs string
+
+	backToIndex                                string
+	colField, colValue                         string
+	rowCode, rowFamily, rowSeverity, rowSCSL   string
+	rowType, rowAttrs, rowState, rowDeclared   string
+	rowProofs, noType, noAttr                  string
+	stateActive, stateDormant                  string
+	whyTitle, whyNote                          string
+	mappingTitle, mappingIntro                 string
+	colFramework, colRefs                      string
+	whereTitle, whereIntro, reasonsIntro       string
+	colProvider, colTerraform, colLive         string
+	colSource, colStatus, colReason, noReason  string
+	concludeTitle, colMeans, colWhere          string
+	meansFail, meansPass, meansNA, meansNE     string
+	concludeNote                               string
+	investigateTitle, investType, investNoType string
+	investAttrs, investNoAttrs, investGuard    string
+	investDescriptors, investRule              string
+	remediateTitle, colProof, proofMissing     string
+	proofDormant, proofNote                    string
+	verifyTitle, verifyTF, verifyLive          string
+	verifyBodyFmt, verifyNone, verifyPartial   string
+	noSource                                   string
+	seeAlsoTitle, seeAlso                      string
+}
+
+func controlText(lang string) controlStrings {
+	if lang == "fr" {
+		return controlStrings{
+			indexTitle: "Catalogue des contrôles",
+			indexIntro: "Un contrôle par page, calculé depuis `referentiel/controles.yaml` (la source de vérité),\n" +
+				"les descripteurs `providers/*.yaml` et le verrou du « pass » de `internal/assess`.\n" +
+				"Aucune métadonnée n'est recopiée ici : ajouter un contrôle, changer une sévérité ou\n" +
+				"retirer un fournisseur réécrit ces pages, et la CI refuse une documentation en retard.\n\n" +
+				"Ce catalogue dit ce que Pépin **peut conclure**, pas le résultat d'un scan. Pour la\n" +
+				"vue d'ensemble par fournisseur et par source, voir la [matrice de couverture](../coverage.md).",
+			figuresTitle: "Chiffres",
+			readingTitle: "Comment lire ce catalogue",
+			readingBody: "- **Contrôle actif** : déclaré pour au moins un fournisseur (`fournisseurs:` non vide).\n" +
+				"  Un scan de ce fournisseur peut lui donner un statut.\n" +
+				"- **Contrôle dormant** : écrit et testé, déclaré pour aucun fournisseur. Il n'est jamais\n" +
+				"  évalué, et il ne compte dans aucune couverture. La liste complète est en bas de page.\n" +
+				"- **Preuves de remédiation** : les montages déployables présents sous\n" +
+				"  [`references/remediation/`](../../references/remediation/README.md). Le compte est\n" +
+				"  celui des couples (contrôle, fournisseur) déclarés, et il est aujourd'hui partiel :\n" +
+				"  la remédiation *textuelle*, elle, est portée par chaque écart émis.\n" +
+				"- Les contrôles encore au triage, non retenus dans le référentiel actif, vivent au\n" +
+				"  [catalogue de triage](../../referentiel/catalogue.yaml).",
+			dormantTitle: "Contrôles dormants",
+			dormantIntro: "Ces contrôles existent au référentiel mais ne sont déclarés pour aucun fournisseur :\n" +
+				"aucun scan ne les évalue aujourd'hui. Ils apparaissent ici pour que le catalogue ne se\n" +
+				"lise pas comme une couverture.",
+			noDormant:  "_Aucun : tout contrôle du référentiel est déclaré pour au moins un fournisseur._",
+			dormant:    "dormant",
+			none:       "aucun",
+			colControl: "Contrôle", colSeverity: "Sévérité", colActiveFor: "Actif pour",
+			colProofs: "Preuves", colFamily: "Famille", colFigure: "Chiffre", colCount: "Nombre",
+			figTotal: "Contrôles au référentiel", figActive: "Contrôles actifs",
+			figDormant: "Contrôles dormants", figProofs: "Preuves de remédiation déployables",
+
+			backToIndex: "Retour au catalogue",
+			colField:    "Champ", colValue: "Valeur",
+			rowCode: "Code", rowFamily: "Famille", rowSeverity: "Sévérité",
+			rowSCSL: "Exigence SCSL (index gelé)", rowType: "Type de ressource lu",
+			rowAttrs: "Attribut décisif", rowState: "État", rowDeclared: "Déclaré pour",
+			rowProofs: "Preuves de remédiation",
+			noType:    "aucun : contrôle transverse", noAttr: "aucun : jugé à la présence d'un écart",
+			stateActive: "actif", stateDormant: "dormant (déclaré pour aucun fournisseur)",
+			whyTitle: "Le risque",
+			whyNote: "Cette description vient du référentiel : c'est le texte que le rapport cite, dans la\n" +
+				"langue du lecteur.",
+			mappingTitle: "Correspondances normatives",
+			mappingIntro: "Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :\n" +
+				"un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.\n" +
+				"Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de\n" +
+				"qualification.",
+			whereTitle: "Où Pépin sait le mesurer",
+			whereIntro: "Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur\n" +
+				"le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut\n" +
+				"pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non\n" +
+				"déclaré, ou type absent de cette source ».",
+			reasonsIntro: "Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,\n" +
+				"porte son motif :",
+			colProvider: "Fournisseur", colTerraform: "Plan Terraform", colLive: "Collecte live",
+			colFramework: "Cadre", colRefs: "Références",
+			colSource: "Source", colStatus: "Statut", colReason: "Motif",
+			noReason:      "_Aucune : toutes les cases déclarées sont pleinement observables._",
+			concludeTitle: "Ce que Pépin peut conclure",
+			colMeans:      "Ce que le statut affirme", colWhere: "Atteignable depuis",
+			meansFail: "un écart a été détecté sur une ressource réelle",
+			meansPass: "la donnée décisive a été collectée, et elle est conforme",
+			meansNA:   "le contrat du fournisseur déclare le contrôle non testable, avec sa justification",
+			meansNE:   "le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée",
+			concludeNote: "Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne\n" +
+				"contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».",
+			investigateTitle: "Comment enquêter",
+			investType:       "Type de ressource normalisé lu par la règle :",
+			investNoType:     "Contrôle transverse : il ne lit pas un type de ressource particulier.",
+			investAttrs:      "Attribut dont la décision dépend :",
+			investNoAttrs: "Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, " +
+				"l'absence de mauvaise configuration valant conformité.",
+			investGuard: "Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` " +
+				"et non `pass` (`internal/assess`, table `requiredAttr`).",
+			investDescriptors: "Ce que chaque source projette se lit dans le descripteur :",
+			investRule: "La règle qui émet ce code vit dans " +
+				"[`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** " +
+				"à tous les fournisseurs, seule la source change.",
+			remediateTitle: "Comment corriger",
+			colProof:       "Montage déployable",
+			proofMissing:   "aucune preuve déposée à ce jour",
+			proofDormant:   "_Contrôle dormant : aucun fournisseur déclaré, donc aucune preuve attendue._",
+			proofNote: "Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie\n" +
+				"tel quel, ou une note ancrée sur la documentation officielle. Voir\n" +
+				"[le guide de remédiation](../guides/remediation.md).",
+			verifyTitle: "Comment vérifier la correction",
+			verifyTF:    "depuis un plan Terraform : aucune ressource n'est créée",
+			verifyLive:  "depuis l'API du fournisseur : configuration effective",
+			verifyBodyFmt: "Dans la sortie `assessment`, chercher `\"control\": \"%s\"` : son `status` doit être\n" +
+				"`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la\n" +
+				"correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.",
+			verifyNone: "Aucune source ne sait aujourd'hui conclure `pass` sur ce contrôle : un scan\n" +
+				"peut faire disparaître l'écart, il ne peut pas **démontrer** la conformité. Le tableau\n" +
+				"des motifs ci-dessus dit ce qui manque.",
+			verifyPartial: "**Une des deux sources ne sait pas lever le verrou du « pass »** pour ce contrôle :\n" +
+				"le fournisseur cité y produit bien le type visé, mais le scan y rendra `not-evaluated`.\n" +
+				"Le tableau des motifs dit laquelle, et pourquoi.",
+			noSource:     "sans objet",
+			seeAlsoTitle: "Voir aussi",
+			seeAlso: "- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.\n" +
+				"- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.\n" +
+				"- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.\n" +
+				"- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.",
+		}
+	}
+	return controlStrings{
+		indexTitle: "Control catalogue",
+		indexIntro: "One page per control, computed from `referentiel/controles.yaml` (the source of truth),\n" +
+			"the `providers/*.yaml` descriptors and the `pass` lock in `internal/assess`.\n" +
+			"No metadata is copied here: adding a control, changing a severity or removing a provider\n" +
+			"rewrites these pages, and CI rejects documentation that lags behind.\n\n" +
+			"This catalogue states what Pépin **can conclude**, not the result of any scan. For the\n" +
+			"overview per provider and per source, see the [coverage matrix](../coverage.md).",
+		figuresTitle: "Figures",
+		readingTitle: "How to read this catalogue",
+		readingBody: "- **Active control**: declared for at least one provider (non-empty `fournisseurs:`).\n" +
+			"  A scan of that provider can give it a status.\n" +
+			"- **Dormant control**: written and tested, declared for no provider. It is never evaluated,\n" +
+			"  and it counts towards no coverage. The full list is at the bottom of this page.\n" +
+			"- **Remediation proofs**: the deployable setups present under\n" +
+			"  [`references/remediation/`](../../references/remediation/README.md). The count is over\n" +
+			"  declared (control, provider) pairs, and it is partial today: the *textual* remediation,\n" +
+			"  on the other hand, is carried by every deviation reported.\n" +
+			"- Controls still being triaged, not retained in the active reference, live in the\n" +
+			"  [triage catalogue](../../referentiel/catalogue.yaml).",
+		dormantTitle: "Dormant controls",
+		dormantIntro: "These controls exist in the reference but are declared for no provider: no scan evaluates\n" +
+			"them today. They appear here so that the catalogue is not read as coverage.",
+		noDormant:  "_None: every control in the reference is declared for at least one provider._",
+		dormant:    "dormant",
+		none:       "—",
+		colControl: "Control", colSeverity: "Severity", colActiveFor: "Active for",
+		colProofs: "Proofs", colFamily: "Family", colFigure: "Figure", colCount: "Count",
+		figTotal: "Controls in the reference", figActive: "Active controls",
+		figDormant: "Dormant controls", figProofs: "Deployable remediation proofs",
+
+		backToIndex: "Back to the catalogue",
+		colField:    "Field", colValue: "Value",
+		rowCode: "Code", rowFamily: "Family", rowSeverity: "Severity",
+		rowSCSL: "SCSL requirement (frozen index)", rowType: "Resource type read",
+		rowAttrs: "Deciding attribute", rowState: "State", rowDeclared: "Declared for",
+		rowProofs: "Remediation proofs",
+		noType:    "none: cross-cutting control", noAttr: "none: judged on the presence of a deviation",
+		stateActive: "active", stateDormant: "dormant (declared for no provider)",
+		whyTitle: "The risk",
+		whyNote: "This description comes from the reference: it is the text the report quotes, in the\n" +
+			"reader's language.",
+		mappingTitle: "Normative mappings",
+		mappingIntro: "Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:\n" +
+			"a control maps onto an existing requirement, never onto one created for it. These mappings\n" +
+			"are **indicative**: a Pépin report is not proof of qualification.",
+		whereTitle: "Where Pépin can measure it",
+		whereIntro: "A ✅ cell means the source produces the targeted type, the provider contract marks it\n" +
+			"`verifie`, and the deciding attribute is projected. ◐ means \"Pépin cannot decide from this\n" +
+			"source\", ∅ \"not testable, with justification\", ✗ \"not declared, or type absent from this\n" +
+			"source\".",
+		reasonsIntro: "Every cell that is not ✅ **while the control is declared for that provider** carries its\n" +
+			"reason:",
+		colProvider: "Provider", colTerraform: "Terraform plan", colLive: "Live collection",
+		colFramework: "Framework", colRefs: "References",
+		colSource: "Source", colStatus: "Status", colReason: "Reason",
+		noReason:      "_None: every declared cell is fully observable._",
+		concludeTitle: "What Pépin can conclude",
+		colMeans:      "What the status asserts", colWhere: "Reachable from",
+		meansFail: "a deviation was detected on a real resource",
+		meansPass: "the deciding data was collected, and it is compliant",
+		meansNA:   "the provider contract declares the control untestable, with its justification",
+		meansNE:   "the control is implemented, but the data it depends on was not confirmed",
+		concludeNote: "An observable control still returns `not-evaluated` on an inventory that contains no\n" +
+			"resource of the targeted type: \"nothing to look at\" is not \"compliant\".",
+		investigateTitle: "How to investigate",
+		investType:       "Normalized resource type the rule reads:",
+		investNoType:     "Cross-cutting control: it does not read one particular resource type.",
+		investAttrs:      "Attribute the decision depends on:",
+		investNoAttrs: "No attribute lock: the control is judged on the presence of a deviation, " +
+			"absence of a bad configuration counting as compliance.",
+		investGuard: "Without that attribute on a resource of the targeted type, the scan returns " +
+			"`not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).",
+		investDescriptors: "What each source projects is readable in the descriptor:",
+		investRule: "The rule that emits this code lives in " +
+			"[`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every " +
+			"provider, only the source changes.",
+		remediateTitle: "How to remediate",
+		colProof:       "Deployable setup",
+		proofMissing:   "no proof filed yet",
+		proofDormant:   "_Dormant control: no provider declared, so no proof expected._",
+		proofNote: "A remediation proof is a self-contained, **compliant** Terraform module that deploys as\n" +
+			"is, or a note anchored on the official documentation. See\n" +
+			"[the remediation guide](../guides/remediation.md).",
+		verifyTitle: "How to verify the fix",
+		verifyTF:    "from a Terraform plan: nothing is provisioned",
+		verifyLive:  "from the provider API: effective configuration",
+		verifyBodyFmt: "In the `assessment` output, look for `\"control\": \"%s\"`: its `status` must be `pass`.\n" +
+			"If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**\n" +
+			"demonstrated: the reasons table above says why.",
+		verifyNone: "No source can conclude `pass` on this control today: a scan can make the deviation\n" +
+			"disappear, it cannot **demonstrate** compliance. The reasons table above says what is\n" +
+			"missing.",
+		verifyPartial: "**One of the two sources cannot lift the `pass` lock** for this control: the provider\n" +
+			"quoted does produce the targeted type there, but the scan will return `not-evaluated`.\n" +
+			"The reasons table says which one, and why.",
+		noSource:     "n/a",
+		seeAlsoTitle: "See also",
+		seeAlso: "- [The assessment model](../concepts/assessment-model.md): what each status asserts.\n" +
+			"- [Coverage matrix](../coverage.md): the same information, across every control.\n" +
+			"- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.\n" +
+			"- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.",
+	}
+}

--- a/internal/docgen/controls_strings.go
+++ b/internal/docgen/controls_strings.go
@@ -50,7 +50,7 @@ func controlText(lang string) controlStrings {
 				"Aucune métadonnée n'est recopiée ici : ajouter un contrôle, changer une sévérité ou\n" +
 				"retirer un fournisseur réécrit ces pages, et la CI refuse une documentation en retard.\n\n" +
 				"Ce catalogue dit ce que Pépin **peut conclure**, pas le résultat d'un scan. Pour la\n" +
-				"vue d'ensemble par fournisseur et par source, voir la [matrice de couverture](../coverage.md).",
+				"vue d'ensemble par fournisseur et par source, voir la [matrice de couverture](../coverage.fr.md).",
 			figuresTitle: "Chiffres",
 			readingTitle: "Comment lire ce catalogue",
 			readingBody: "- **Contrôle actif** : déclaré pour au moins un fournisseur (`fournisseurs:` non vide).\n" +
@@ -128,7 +128,7 @@ func controlText(lang string) controlStrings {
 			proofDormant:   "_Contrôle dormant : aucun fournisseur déclaré, donc aucune preuve attendue._",
 			proofNote: "Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie\n" +
 				"tel quel, ou une note ancrée sur la documentation officielle. Voir\n" +
-				"[le guide de remédiation](../guides/remediation.md).",
+				"[le guide de remédiation](../guides/remediation.fr.md).",
 			verifyTitle: "Comment vérifier la correction",
 			verifyTF:    "depuis un plan Terraform : aucune ressource n'est créée",
 			verifyLive:  "depuis l'API du fournisseur : configuration effective",
@@ -143,10 +143,10 @@ func controlText(lang string) controlStrings {
 				"Le tableau des motifs dit laquelle, et pourquoi.",
 			noSource:     "sans objet",
 			seeAlsoTitle: "Voir aussi",
-			seeAlso: "- [Le modèle d'assessment](../concepts/assessment-model.md) : ce que chaque statut affirme.\n" +
-				"- [Matrice de couverture](../coverage.md) : la même information, tous contrôles confondus.\n" +
-				"- [Plan Terraform ou scan live](../concepts/terraform-vs-live.md) : choisir la source.\n" +
-				"- [Ajouter un contrôle](../contributing/adding-a-control.md) : la procédure de bout en bout.",
+			seeAlso: "- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.\n" +
+				"- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.\n" +
+				"- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.\n" +
+				"- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.",
 		}
 	}
 	return controlStrings{

--- a/internal/docgen/controls_test.go
+++ b/internal/docgen/controls_test.go
@@ -1,0 +1,144 @@
+package docgen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/pepin/referentiel"
+)
+
+// TestEveryControlHasItsTwoPages : le catalogue n'a pas de trou. Un contrôle sans page serait
+// invisible dans un dossier de 116 fichiers, et c'est exactement l'absence qui fait mentir une
+// documentation de couverture.
+func TestEveryControlHasItsTwoPages(t *testing.T) {
+	pages := generatedControlPages(t)
+	for code := range referentiel.All() {
+		for _, want := range []string{
+			controlsDir + "/" + code + ".md",
+			controlsDir + "/" + code + ".fr.md",
+		} {
+			if _, ok := pages[want]; !ok {
+				t.Errorf("%s : page absente du catalogue généré", want)
+			}
+		}
+	}
+	for _, want := range []string{controlsDir + "/index.md", controlsDir + "/index.fr.md"} {
+		if _, ok := pages[want]; !ok {
+			t.Errorf("%s : index absent", want)
+		}
+	}
+}
+
+// TestNoStaleControlPage : le dossier du catalogue est ENTIÈREMENT généré, donc ce qui s'y
+// trouve sans y être produit décrit un contrôle que le produit n'a plus. Le test de fraîcheur
+// compare le CONTENU de ce qu'il génère : sans ce contrôle-ci, une page orpheline survivrait
+// indéfiniment à la suppression de son contrôle.
+func TestNoStaleControlPage(t *testing.T) {
+	pages := generatedControlPages(t)
+	stale, err := stalePages(repoRoot, controlsDir, pages)
+	if err != nil {
+		t.Fatalf("lecture de %s : %v", controlsDir, err)
+	}
+	for _, p := range stale {
+		t.Errorf("%s : page orpheline (le générateur ne la produit plus) — lancer `mise run gen-docs`", p)
+	}
+}
+
+// TestTheStalePageCheckWouldCatchAnOrphan : le contrôle ci-dessus ne vaut que s'il SAIT
+// échouer. Une page inventée doit être signalée, sans quoi le test mesurerait sa propre panne.
+func TestTheStalePageCheckWouldCatchAnOrphan(t *testing.T) {
+	orphan := controlsDir + "/controle-qui-nexiste-plus.md"
+	full := filepath.Join(repoRoot, orphan)
+	if err := os.WriteFile(full, []byte("témoin\n"), 0o600); err != nil {
+		t.Fatalf("écriture du témoin : %v", err)
+	}
+	defer func() { _ = os.Remove(full) }()
+
+	stale, err := stalePages(repoRoot, controlsDir, generatedControlPages(t))
+	if err != nil {
+		t.Fatalf("lecture de %s : %v", controlsDir, err)
+	}
+	found := false
+	for _, p := range stale {
+		if p == orphan {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("la page témoin n'a pas été signalée comme orpheline : le contrôle ne discrimine plus rien")
+	}
+}
+
+// TestEveryLinkedRemediationProofExists : une page qui LIE une preuve affirme qu'elle existe.
+// La table des preuves est calculée par la même lecture que `mise run check-remediation` ; ce
+// test vérifie que le chemin rendu est bien celui d'un fichier ou d'un dossier du dépôt, et
+// non une construction plausible.
+func TestEveryLinkedRemediationProofExists(t *testing.T) {
+	proofs, err := RemediationProofs(repoRoot)
+	if err != nil {
+		t.Fatalf("preuves de remédiation : %v", err)
+	}
+	seen := 0
+	for provider, byCode := range proofs {
+		for code, rel := range byCode {
+			if _, serr := os.Stat(filepath.Join(repoRoot, rel)); serr != nil {
+				t.Errorf("%s / %s : preuve liée vers %q, introuvable (%v)", provider, code, rel, serr)
+			}
+			seen++
+		}
+	}
+	if seen == 0 {
+		t.Fatal("aucune preuve de remédiation lue : le test ne mesurerait plus rien")
+	}
+}
+
+// TestDormantControlsAreNamedAsSuch : un contrôle déclaré pour aucun fournisseur ne doit pas
+// se lire comme un contrôle couvert. La page le dit, et l'index le range à part.
+func TestDormantControlsAreNamedAsSuch(t *testing.T) {
+	pages := generatedControlPages(t)
+	dormant := 0
+	for code, ctl := range referentiel.All() {
+		if len(ctl.Fournisseurs) > 0 {
+			continue
+		}
+		dormant++
+		page := pages[controlsDir+"/"+code+".md"]
+		if !strings.Contains(page, "dormant") {
+			t.Errorf("%s : contrôle déclaré pour aucun fournisseur, mais sa page ne le dit pas", code)
+		}
+		if !strings.Contains(pages[controlsDir+"/index.md"], "["+"`"+code+"`") {
+			t.Errorf("%s : contrôle dormant absent de l'index", code)
+		}
+	}
+	if dormant == 0 {
+		t.Skip("aucun contrôle dormant au référentiel : rien à vérifier")
+	}
+}
+
+// generatedControlPages rend les pages du catalogue telles que le générateur les produit
+// aujourd'hui. Le binaire n'est pas requis : le catalogue est dérivé du référentiel et des
+// descripteurs, jamais d'une capture.
+func generatedControlPages(t *testing.T) map[string]string {
+	t.Helper()
+	proofs, err := RemediationProofs(repoRoot)
+	if err != nil {
+		t.Fatalf("preuves de remédiation : %v", err)
+	}
+	families, err := familyOrder()
+	if err != nil {
+		t.Fatalf("familles du référentiel : %v", err)
+	}
+	out := map[string]string{}
+	for _, lang := range []string{"fr", "en"} {
+		m, merr := BuildMatrix(repoRoot, lang)
+		if merr != nil {
+			t.Fatalf("matrice (%s) : %v", lang, merr)
+		}
+		for page, body := range controlPages(lang, m, proofs, families) {
+			out[page] = body
+		}
+	}
+	return out
+}

--- a/internal/docgen/coverage.go
+++ b/internal/docgen/coverage.go
@@ -70,6 +70,11 @@ type Row struct {
 	Severity string
 	Family   string
 	SCSL     []string
+	// Declared est la liste `fournisseurs:` du référentiel, telle quelle. Elle ne se déduit
+	// PAS des cases : une non-applicabilité justifiée est rendue avant la porte de
+	// déclaration, donc une case ∅ peut porter sur un fournisseur qui n'a jamais déclaré le
+	// contrôle. Compter les couples depuis les cases surestimait le périmètre.
+	Declared []string
 	// Cells est indexé par fournisseur puis par source.
 	Cells map[string]map[Source]Cell
 	// RequiredAttrs liste les attributs dont la présence conditionne un « pass » (table
@@ -168,6 +173,7 @@ func BuildMatrix(root, lang string) (Matrix, error) {
 			Severity:      ctl.Severite,
 			Family:        ctl.Famille,
 			SCSL:          ctl.Scsl,
+			Declared:      ctl.Fournisseurs,
 			Type:          genprovider.ControlType(code),
 			RequiredAttrs: required[code],
 			Cells:         map[string]map[Source]Cell{},

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -31,6 +31,8 @@ var injectedPages = []string{
 	"docs/reference/output-formats.fr.md",
 	"docs/concepts/terraform-vs-live.md",
 	"docs/concepts/terraform-vs-live.fr.md",
+	"docs/guides/remediation.md",
+	"docs/guides/remediation.fr.md",
 	"docs/guides/evidence-bundles.md",
 	"docs/guides/evidence-bundles.fr.md",
 	"docs/guides/github-actions.md",

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -31,6 +31,8 @@ var injectedPages = []string{
 	"docs/reference/output-formats.fr.md",
 	"docs/concepts/terraform-vs-live.md",
 	"docs/concepts/terraform-vs-live.fr.md",
+	"docs/contributing/adding-a-provider.md",
+	"docs/contributing/adding-a-provider.fr.md",
 	"docs/guides/remediation.md",
 	"docs/guides/remediation.fr.md",
 	"docs/guides/evidence-bundles.md",

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -51,6 +51,10 @@ var generatedPages = []string{
 	"docs/coverage.fr.md",
 }
 
+// fullyGeneratedDirs : les dossiers dont TOUT le contenu Markdown est produit par le
+// générateur. Ce qui s'y trouve sans y être produit est une orpheline, et se supprime.
+var fullyGeneratedDirs = []string{controlsDir}
+
 // blockRe repère une région générée :
 //
 //	<!-- pepin:gen id -->
@@ -67,6 +71,14 @@ var blockRe = regexp.MustCompile(`(?s)<!-- pepin:gen ([a-z0-9-]+) -->\n.*?<!-- /
 // pas de version « de vérification » qui pourrait diverger de la version « de production ».
 func Generate(root, bin string) (map[string]string, error) {
 	rem, err := RemediationCoverages(root)
+	if err != nil {
+		return nil, err
+	}
+	proofs, err := RemediationProofs(root)
+	if err != nil {
+		return nil, err
+	}
+	families, err := familyOrder()
 	if err != nil {
 		return nil, err
 	}
@@ -95,6 +107,14 @@ func Generate(root, bin string) (map[string]string, error) {
 	for _, page := range generatedPages {
 		lang := langOf(page)
 		out[page] = matrixByLang[lang].coveragePage(lang)
+	}
+	// Le catalogue des contrôles : une page par contrôle et par langue, plus son index.
+	// La liste des pages n'est pas énumérée ici — elle EST le référentiel, donc un contrôle
+	// ajouté produit sa page sans qu'on pense à l'inscrire quelque part.
+	for _, lang := range []string{"fr", "en"} {
+		for page, body := range controlPages(lang, matrixByLang[lang], proofs, families) {
+			out[page] = body
+		}
 	}
 	for _, page := range injectedPages {
 		lang := langOf(page)
@@ -139,7 +159,57 @@ func Write(root, bin string) ([]string, error) {
 		}
 		changed = append(changed, p)
 	}
-	return changed, nil
+	removed, err := prune(root, want)
+	if err != nil {
+		return nil, err
+	}
+	return append(changed, removed...), nil
+}
+
+// prune supprime, dans les dossiers ENTIÈREMENT générés, les pages que le générateur ne
+// produit plus. Sans cela, retirer un contrôle du référentiel laisserait sa page en place :
+// le test de fraîcheur compare le contenu de ce qu'il génère et ne verrait jamais l'orpheline,
+// c'est-à-dire une page qui décrit un contrôle que le produit n'a plus.
+func prune(root string, want map[string]string) ([]string, error) {
+	var removed []string
+	for _, dir := range fullyGeneratedDirs {
+		stale, err := stalePages(root, dir, want)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range stale {
+			if rerr := os.Remove(filepath.Join(root, p)); rerr != nil {
+				return nil, fmt.Errorf("suppression de %s : %w", p, rerr)
+			}
+			removed = append(removed, "(supprimé) "+p)
+		}
+	}
+	return removed, nil
+}
+
+// stalePages rend les pages présentes sur le disque dans un dossier entièrement généré que le
+// générateur ne produit pas. Exposé au test de fraîcheur, qui doit signaler l'orpheline plutôt
+// que de la corriger en silence.
+func stalePages(root, dir string, want map[string]string) ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(root, dir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("lecture de %s : %w", dir, err)
+	}
+	var stale []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		page := dir + "/" + e.Name()
+		if _, ok := want[page]; !ok {
+			stale = append(stale, page)
+		}
+	}
+	sort.Strings(stale)
+	return stale, nil
 }
 
 // inject remplace chaque région générée d'une page par son bloc. Un identifiant inconnu, ou

--- a/internal/docgen/remediation.go
+++ b/internal/docgen/remediation.go
@@ -62,6 +62,45 @@ func RemediationCoverages(root string) ([]RemediationCoverage, error) {
 	return out, nil
 }
 
+// RemediationProofs rend, par fournisseur puis par code, le chemin RELATIF À LA RACINE de la
+// preuve de remédiation déposée : le dossier du module Terraform, ou la note Markdown. Sert au
+// catalogue des contrôles, qui lie la preuve plutôt que d'affirmer qu'elle existe.
+func RemediationProofs(root string) (map[string]map[string]string, error) {
+	base := filepath.Join(root, "references", "remediation")
+	out := map[string]map[string]string{}
+	for code, ctl := range referentiel.All() {
+		for _, p := range ctl.Fournisseurs {
+			path, err := proofPath(base, p, code)
+			if err != nil {
+				return nil, err
+			}
+			if path == "" {
+				continue
+			}
+			if out[p] == nil {
+				out[p] = map[string]string{}
+			}
+			out[p][code] = path
+		}
+	}
+	return out, nil
+}
+
+// proofPath rend le chemin de la preuve, ou "" s'il n'y en a pas. Même règle d'existence que
+// hasProof : les deux s'appuient sur la MÊME lecture, sans quoi la page pourrait lier une
+// preuve que le compteur ignore.
+func proofPath(base, provider, code string) (string, error) {
+	rel := "references/remediation/" + provider + "/" + code
+	if _, err := os.Stat(filepath.Join(base, provider, code+".md")); err == nil {
+		return rel + ".md", nil
+	}
+	ok, err := hasProof(base, provider, code)
+	if err != nil || !ok {
+		return "", err
+	}
+	return rel, nil
+}
+
 // hasProof applique la règle de `check-remediation` : une note Markdown, ou un dossier
 // contenant au moins un `.tf`.
 func hasProof(base, provider, code string) (bool, error) {


### PR DESCRIPTION
La règle existait en pratique et nulle part par écrit : un changement passait, et la documentation suivait quand quelqu'un y pensait.

## Pourquoi les skills ne suffisaient pas

Les skills du projet (`nouvelle-regle`, `nouveau-provider`, `ancrage-contrat`, `osv-scan`, `verifier`) portent désormais chacun une section documentaire, adaptée à leur geste plutôt que copiée cinq fois.

Mais `.claude/` est **gitignoré**, délibérément : il contient des notes internes non publiées. Une règle qui n'existe que là atteint **une machine et aucun contributeur**. Elle est donc portée ici, où elle est versionnée.

## Ce qui est ajouté

- **`CLAUDE.md` §10** gagne une septième étape à la procédure canonique.
- **`CONTRIBUTING.md` et `CONTRIBUTING.fr.md`** disent la même chose, la section française devenant « Documentation et commits » pour rester symétrique de l'anglaise.

## Ce que la porte de non-dérive ne sait pas attraper

`TestGeneratedDocsAreUpToDate` rattrape l'oubli de `mise run gen-docs`, mais **après coup**, et seulement pour les pages générées. Ce qu'elle ne voit pas, c'est une page que le changement a rendue **fausse** : une limitation qui ne tient plus, une page provider dont la couverture a bougé, un déplacement de verdict que personne n'a consigné. D'où la relecture explicite demandée.

Le cadrage qui mérite de survivre : *une page qui décrit un produit disparu est pire qu'une page absente, parce qu'elle inspire une confiance qu'elle ne peut pas tenir.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)