### PR TITLE
docs: make documentation an explicit step of the canonical procedure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,18 @@ Les artefacts pilotent tout : `catalogue.yaml` (QUOI), `contrats/<provider>.yaml
    Passer l'entrée du catalogue en `statut: implemente`.
 6. **Valider.** `mise run validate` (codes↔règles↔SCSL gelé↔catalogue) **puis**
    `mise run test` + `mise run audit` au vert. Aucun commit si l'un échoue (§1, §7).
+7. **Documenter.** `mise run gen-docs`, et committer ce qu'il régénère : la matrice
+   de couverture et les sorties capturées sont GÉNÉRÉES depuis le binaire et le
+   référentiel, et `TestGeneratedDocsAreUpToDate` casse la CI si elles dérivent.
+   Puis relire ce que le changement rend FAUX ailleurs — `docs/known-limitations.md`
+   si un angle mort se comble, la page du provider concerné, `docs/coverage.md` —
+   dans les DEUX langues. Un changement qui déplace un verdict sur un tenant
+   inchangé, une surface analysable ou un code de sortie a sa ligne au CHANGELOG.
+
+   La documentation n'est pas une étape de suivi : une page qui décrit un produit
+   disparu est pire qu'une page absente, parce qu'elle inspire confiance. La
+   question qui tranche : *quelqu'un qui lit la documentation sans lire le code
+   serait-il induit en erreur par ce changement ?*
 
 Invariants vérifiés par `mise run validate` : tout contrôle actif a une règle ; tout
 code émis est catalogué ; tout `scsl` existe dans l'index **gelé** ; le catalogue

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -62,7 +62,28 @@ rapport anglais ne doit jamais basculer au français en milieu de phrase. Le
 français est la langue de référence du contenu normatif, l'anglais en est la
 traduction.
 
-## Commits
+## Documentation et commits
 
-Conventional Commits (`feat`/`fix`/`docs`/`refactor`/`test`/`chore`), sujet à
-l'impératif.
+Les docs du dépôt sont **bilingues** : l'anglais est primaire (`README.md`), le
+français en est la contrepartie (`README.fr.md`), reliés par un sélecteur de
+langue. Les commits suivent les Conventional Commits
+(`feat`/`fix`/`docs`/`refactor`/`test`/`chore`), sujet à l'impératif.
+
+**La documentation fait partie du changement, pas d'un suivi.** L'essentiel de
+`docs/` est généré depuis le binaire et le référentiel, et
+`TestGeneratedDocsAreUpToDate` casse la CI dès que cela dérive. Donc, avant
+d'ouvrir une pull request :
+
+- lancer `mise run gen-docs` et committer ce qu'il régénère ;
+- relire les pages que le changement rend **fausses**, pas seulement les pages
+  générées : `docs/known-limitations.md` quand un angle mort se comble, la page
+  du provider touché, `docs/coverage.md` ;
+- tenir les deux langues synchronisées ;
+- ajouter une ligne au CHANGELOG, dans les deux langues, dès que le changement
+  déplace un **verdict** sur un tenant inchangé, une surface analysable ou un
+  code de sortie.
+
+Une page qui décrit un produit disparu est pire qu'une page absente : elle
+inspire une confiance qu'elle ne peut pas tenir. La question qui tranche :
+*quelqu'un qui lit la documentation sans lire le code serait-il induit en erreur
+par ce changement ?*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,19 @@ Repository docs are **bilingual**: English is primary (`README.md`), French is t
 counterpart (`README.fr.md`), linked by a language switcher. Commits follow
 Conventional Commits (`feat`/`fix`/`docs`/`refactor`/`test`/`chore`), imperative
 subject.
+
+**Documentation is part of the change, not a follow-up.** Most of `docs/` is
+generated from the binary and the reference, and `TestGeneratedDocsAreUpToDate`
+fails the build when it drifts. So, before opening a pull request:
+
+- run `mise run gen-docs` and commit what it regenerates;
+- re-read the pages your change makes **wrong**, not only the generated ones:
+  `docs/known-limitations.md` when a blind spot closes, the provider page you
+  touched, `docs/coverage.md`;
+- keep both languages in step;
+- add a CHANGELOG line, in both languages, whenever the change moves a **verdict**
+  on an unchanged tenant, a parsable surface, or an exit code.
+
+A page describing a product that no longer exists is worse than a missing page:
+it earns trust it cannot honour. The question that settles it: *would someone
+reading the documentation without reading the code be misled by this change?*


### PR DESCRIPTION
La règle existait en pratique et nulle part par écrit : un changement passait, et la documentation suivait quand quelqu'un y pensait.

## Pourquoi les skills ne suffisaient pas

Les skills du projet (`nouvelle-regle`, `nouveau-provider`, `ancrage-contrat`, `osv-scan`, `verifier`) portent désormais chacun une section documentaire, adaptée à son geste plutôt que copiée cinq fois.

Mais `.claude/` est **gitignoré**, délibérément : il contient des notes internes non publiées. Une règle qui n'existe que là atteint **une machine et aucun contributeur**. Elle est donc portée ici, où elle est versionnée.

## Ce qui est ajouté

- **`CLAUDE.md` §10** gagne une septième étape à la procédure canonique.
- **`CONTRIBUTING.md` et `CONTRIBUTING.fr.md`** disent la même chose, la section française devenant « Documentation et commits » pour rester symétrique de l'anglaise.

## Ce que la porte de non-dérive ne sait pas attraper

`TestGeneratedDocsAreUpToDate` rattrape l'oubli de `mise run gen-docs`, mais **après coup**, et seulement pour les pages générées. Ce qu'elle ne voit pas, c'est une page que le changement a rendue **fausse** : une limitation qui ne tient plus, une page provider dont la couverture a bougé, un déplacement de verdict que personne n'a consigné. D'où la relecture explicite demandée.

Le cadrage qui mérite de survivre : *une page qui décrit un produit disparu est pire qu'une page absente, parce qu'elle inspire une confiance qu'elle ne peut pas tenir.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)