### PR TITLE
feat(trust): provenance, frozen inventory contract, and EXEMPTED status

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -24,6 +24,46 @@ l'une ni l'autre appartient au `git log`.
 
 ### Ajouté
 
+- **`exempted` : un cinquième statut d'assessment de premier rang, et des dérogations
+  datées.** `scan --exceptions <fichier.yaml>` lit une politique de dérogations
+  versionnée : `control`, `justification`, `expires_at`, `owner`, `approved_by`, les
+  cinq obligatoires et tous validés au chargement. Un `fail` couvert par une entrée
+  valide devient `exempted`, jamais `pass` : le finding reste dans `--format json`,
+  dans le SARIF et dans le décompte par sévérité, `summary.conforme` reste faux, et le
+  verdict annonce `NON CONFORME sous dérogation`. **Un nouveau code de sortie, `4`**,
+  signifie « tout écart critical/high restant est couvert par une dérogation datée et
+  attribuée » : non nul, donc rien ne passe en silence, et distinct, donc un pipeline
+  qui l'accepte doit écrire le chiffre. Une dérogation expirée cesse de s'appliquer et
+  le dit ; une dérogation qui nomme un contrôle ou un sujet inexistant est signalée
+  comme orpheline ; les deux font échouer une porte `--strict`. Le bundle scelle
+  `exemptions.json`, si bien que l'empreinte du dossier dépend de ce qu'il a écarté, et
+  `verify --re-derive` rejoue la politique scellée à l'instant scellé.
+  *Un statut et un code de sortie sont deux surfaces qu'un pipeline doit savoir lire.*
+
+- **Chaque attribut de l'inventaire normalisé porte sa provenance.** À côté
+  d'`attributes`, un index parallèle `provenance` dit, pour chaque attribut, d'où vient
+  la valeur : `api` avec la requête **réellement servie**, `terraform-plan` avec le type
+  de ressource du plan, ou `derived` pour un littéral de descripteur ou une valeur
+  calculée localement, et si la source portait vraiment le champ. C'est un index
+  parallèle et non une enveloppe autour de chaque valeur : les 59 règles Rego lisent
+  `attributes.<nom>` sans changer, donc aucun verdict ne peut bouger (mesuré sur neuf
+  fixtures × deux formats × deux langues : findings, statuts et codes de sortie
+  identiques). `--format assessment` expose désormais, pour chaque contrôle ayant un
+  attribut décisif, cet attribut et son attestation dans `evidence.attribute` /
+  `evidence.source`. Cela rend visible, sans la changer, la situation de deux contrôles
+  qui franchissent leur garde d'attribut grâce à une constante de descripteur plutôt
+  qu'à une mesure.
+
+- **L'inventaire normalisé est un contrat interne versionné.** `pepin-inventory/v1`,
+  gelé dans `cmd/testdata/frozen/inventory.json` avec son enveloppe, la forme de sa
+  ressource et le vocabulaire complet des types et attributs communs, dérivé des
+  descripteurs et des collecteurs. La version voyage avec chaque bundle de preuve
+  (`manifest.inventory_schema`), et une nouvelle page de référence dit ce qui est
+  garanti et ce qui ne l'est pas. **Format de bundle `/v2`** (le manifeste porte le
+  schéma d'inventaire et le résumé des dérogations), **surface CLI v3**
+  (`--exceptions`, code de sortie 4).
+
+
 - **Vague 3 de la documentation : le catalogue des contrôles est généré, et le
   projet s'explique.** Une page générée par contrôle sous `docs/controls/` (ce qu'il
   conclut, depuis quelle source, avec son motif quand il ne peut pas conclure), un

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,44 @@ belongs in `git log`.
 
 ### Added
 
+- **`exempted`: a fifth, first-class assessment status, and dated exemptions.**
+  `scan --exceptions <file.yaml>` reads a versioned exemption policy — `control`,
+  `justification`, `expires_at`, `owner`, `approved_by`, all five mandatory and all
+  validated at load time. A `fail` covered by a valid entry becomes `exempted`, never
+  `pass`: the finding stays in `--format json`, in the SARIF and in the severity
+  counts, `summary.conforme` stays false, and the verdict reads `NON-COMPLIANT under
+  waiver`. **A new exit code, `4`**, means "every remaining critical/high deviation is
+  covered by a dated, attributed exemption" — non-zero, so nothing passes in silence,
+  and distinct, so a pipeline that accepts it has to write the number down. An expired
+  exemption stops applying and says so; one naming a control or subject that does not
+  exist is reported as an orphan; both fail a `--strict` gate. The bundle seals
+  `exemptions.json`, so the dossier digest depends on what it set aside, and
+  `verify --re-derive` replays the sealed policy at the sealed instant.
+  *A status and an exit code are both surfaces a pipeline must know how to read.*
+
+- **Every attribute of the normalized inventory carries its provenance.** Beside
+  `attributes`, a parallel `provenance` index says, for each attribute, where the
+  value came from — `api` with the request **actually served**, `terraform-plan` with
+  the plan resource type, or `derived` for a descriptor literal or a locally computed
+  value — and whether the source really carried the field. It is a parallel index and
+  not a wrapper around each value: the 59 Rego rules read `attributes.<name>`
+  unchanged, so no verdict can move (measured on nine fixtures × two formats × two
+  languages: identical findings, statuses and exit codes). `--format assessment` now
+  exposes, for every control with a deciding attribute, that attribute and its
+  attestation in `evidence.attribute` / `evidence.source`. This makes visible, without
+  changing it, that two controls cross their attribute gate thanks to a descriptor
+  constant rather than a measurement.
+
+- **The normalized inventory is a versioned internal contract.**
+  `pepin-inventory/v1`, frozen in `cmd/testdata/frozen/inventory.json` with its
+  envelope, its resource shape and the full vocabulary of resource types and common
+  attributes derived from the descriptors and collectors. The version travels with
+  every evidence bundle (`manifest.inventory_schema`), and a new reference page states
+  what is guaranteed and what is not. **Bundle format `/v2`** (manifest carries the
+  inventory schema and the exemption summary), **CLI surface v3** (`--exceptions`,
+  exit code 4).
+
+
 - **Wave 3 of the documentation: the control catalogue is generated, and the
   project explains itself.** One generated page per control under `docs/controls/`
   (what it concludes, from which source, with which reason when it cannot), a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,11 @@ source du contrat dans l'en-tête de chaque règle.
 ## 6. Codes de sortie (portes de CI)
 
 `0` conforme · `1` non-conformité (≥ 1 finding critical/high) · `2` erreur
-technique. Ne pas changer cette sémantique sans mettre à jour README et tests.
+technique · `3` rien de mesuré (inventaire vide, ou écarts medium/low avec
+`--strict`) · `4` tout écart critical/high est couvert par une dérogation valide.
+`3` et `4` ne sont PAS des `0` : ni le vide ni la dérogation ne valent conformité.
+Ne pas changer cette sémantique sans mettre à jour README, `docs/reference/exit-codes.md`
+(généré) et les tests.
 
 ## 7. Commits & branches
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -108,7 +108,7 @@ d'un contrôle qui fait foi.
 - [Lire un scan](docs/getting-started/understanding-a-scan.fr.md) : un run réel, commenté
   ligne à ligne, jusqu'au code de sortie.
 - [Le modèle d'assessment](docs/concepts/assessment-model.fr.md) : ce que `pass`, `fail`,
-  `not-applicable` et `not-evaluated` affirment réellement.
+  `not-applicable`, `not-evaluated` et `exempted` affirment réellement.
 - [Matrice de couverture](docs/coverage.fr.md) : ce qui est mesurable, par fournisseur et par
   source. **Générée** depuis le référentiel et les descripteurs, vérifiée en CI.
 - [Catalogue des contrôles](docs/controls/index.fr.md) : une page générée par contrôle,
@@ -122,7 +122,8 @@ d'un contrôle qui fait foi.
   authentification, appels d'API, permissions minimales en lecture seule, couverture.
 - Référence : [CLI](docs/reference/cli.fr.md) ·
   [Codes de sortie](docs/reference/exit-codes.fr.md) ·
-  [Formats de sortie](docs/reference/output-formats.fr.md).
+  [Formats de sortie](docs/reference/output-formats.fr.md) ·
+  [Inventaire normalisé](docs/reference/inventory.fr.md).
 - Guides : [Remédiation](docs/guides/remediation.fr.md) ·
   [Le bundle de preuve](docs/guides/evidence-bundles.fr.md) ·
   [GitHub Actions](docs/guides/github-actions.fr.md) ·

--- a/README.fr.md
+++ b/README.fr.md
@@ -71,8 +71,9 @@ terraform plan -out tfplan && terraform show -json tfplan > plan.json
 
 Formats de sortie : `--format table|json|assessment|oscal|sarif`.
 Codes de sortie : `0` conforme · `1` non-conformité · `2` erreur · `3` rien de mesuré
-ou, avec `--strict`, écarts medium/low restants (exploitables en CI). Un scan qui n'a
-collecté aucune ressource ne rend jamais `0` : un résultat vide n'est pas un résultat conforme.
+ou, avec `--strict`, écarts medium/low restants · `4` tout écart critical/high est couvert
+par une dérogation valide (exploitables en CI). Un scan qui n'a collecté aucune ressource ne
+rend jamais `0` : un résultat vide n'est pas conforme, un résultat dérogé non plus.
 
 ## Langue
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ terraform plan -out tfplan && terraform show -json tfplan > plan.json
 
 Output formats: `--format table|json|assessment|oscal|sarif`.
 Exit codes: `0` compliant · `1` non-compliance · `2` error · `3` nothing measured
-or, with `--strict`, remaining medium/low gaps (CI-friendly). A scan that collected
-no resource never returns `0`: an empty result is not a compliant one.
+or, with `--strict`, remaining medium/low gaps · `4` every critical/high deviation is
+covered by a valid exemption (CI-friendly). A scan that collected no resource never
+returns `0`: an empty result is not a compliant one, and an exempted one is not either.
 
 ## Language
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ control is the one that governs.
 - [Understanding a scan](docs/getting-started/understanding-a-scan.md) — one real run,
   read line by line, down to the exit code.
 - [The assessment model](docs/concepts/assessment-model.md) — what `pass`, `fail`,
-  `not-applicable` and `not-evaluated` actually assert.
+  `not-applicable`, `not-evaluated` and `exempted` actually assert.
 - [Coverage matrix](docs/coverage.md) — what is measurable, per provider and per source.
   **Generated** from the reference and the provider descriptors, and verified in CI.
 - [Control catalogue](docs/controls/index.md) — one generated page per control: what it
@@ -121,7 +121,8 @@ control is the one that governs.
   [Exoscale](docs/providers/exoscale.md) — authentication, API calls, minimal
   read-only permissions, coverage.
 - Reference: [CLI](docs/reference/cli.md) · [Exit codes](docs/reference/exit-codes.md) ·
-  [Output formats](docs/reference/output-formats.md).
+  [Output formats](docs/reference/output-formats.md) ·
+  [Normalized inventory](docs/reference/inventory.md).
 - Guides: [Remediation](docs/guides/remediation.md) ·
   [Evidence bundles](docs/guides/evidence-bundles.md) ·
   [GitHub Actions](docs/guides/github-actions.md) · [GitLab CI](docs/guides/gitlab-ci.md).

--- a/cmd/exempt_test.go
+++ b/cmd/exempt_test.go
@@ -1,0 +1,321 @@
+package cmd
+
+// Les critères d'acceptation des dérogations, mesurés sur le PRODUIT : on compile
+// le binaire, on lui donne un fichier de dérogations, et on lit ce qu'il imprime et
+// ce qu'il rend comme code de sortie.
+//
+// L'invariant que ces tests existent pour tenir : **une dérogation écarte, elle ne
+// déclare jamais conforme**. Il est vérifié aux trois endroits où un faux vert
+// pourrait naître — le code de sortie, le décompte, et les formats analysables.
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// exemptFixture : le plan Terraform non conforme du dépôt. Ses écarts critical et
+// high sont exactement ce qu'une dérogation doit pouvoir couvrir.
+const exemptFixture = "examples/scaleway/terraform/plan.json"
+
+// Les deux seuls écarts critical/high du plan qu'il faut couvrir pour que la porte
+// bascule. Nommer les autres serait inutile : le contrôle bascule quand il ne reste
+// AUCUN écart critical/high ouvert.
+const allDeviations = `exceptions:
+  - control: objectstorage_bucket_public_access
+    justification: "Bucket de diffusion publique assumé, contenu non sensible"
+    expires_at: 2099-12-31
+    owner: platform-security
+    approved_by: security@example.org
+  - control: compute_instance_no_secrets_in_user_data
+    justification: "Jeton de bootstrap à rotation horaire, hors périmètre"
+    expires_at: 2099-12-31
+    owner: platform-security
+    approved_by: security@example.org
+  - control: database_backup_enabled
+    justification: "Base de recette, restaurée depuis la production"
+    expires_at: 2099-12-31
+    owner: data-platform
+    approved_by: security@example.org
+  - control: database_encryption_at_rest_enabled
+    justification: "Base de recette, aucune donnée réelle"
+    expires_at: 2099-12-31
+    owner: data-platform
+    approved_by: security@example.org
+  - control: database_service_not_open_to_internet
+    justification: "Accès depuis le runner de CI, ACL en cours de pose"
+    expires_at: 2099-12-31
+    owner: data-platform
+    approved_by: security@example.org
+  - control: iam_policy_no_privilege_escalation
+    justification: "Rôle de déploiement, revue trimestrielle"
+    expires_at: 2099-12-31
+    owner: platform-security
+    approved_by: security@example.org
+  - control: network_securitygroup_allow_ingress_from_internet_to_tcp_port_22
+    justification: "Bastion administré, accès restreint par IP source"
+    expires_at: 2099-12-31
+    owner: platform-security
+    approved_by: security@example.org
+  - control: network_securitygroup_default_deny
+    justification: "Groupe par défaut en cours de durcissement"
+    expires_at: 2099-12-31
+    owner: platform-security
+    approved_by: security@example.org
+`
+
+// writeExceptions écrit un fichier de dérogations jetable et rend son chemin
+// ABSOLU : le binaire tourne depuis la racine du dépôt.
+func writeExceptions(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "exceptions.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("écriture du fichier de dérogations : %v", err)
+	}
+	return path
+}
+
+// runScan exécute un scan et rend ses flux et son code de sortie.
+func runScan(t *testing.T, bin string, args ...string) (stdout, stderr string, code int) {
+	t.Helper()
+	cmd := exec.Command(bin, args...) // #nosec G204 -- binaire compilé par le test, arguments constants.
+	cmd.Dir = repoRoot
+	cmd.Env = []string{"NO_COLOR=1", "TERM=dumb", "PEPIN_LANG=en", "HOME=" + t.TempDir()}
+	var o, e strings.Builder
+	cmd.Stdout = &o
+	cmd.Stderr = &e
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if !asExitError(err, &ee) {
+			t.Fatalf("exécution de pepin %s : %v", strings.Join(args, " "), err)
+		}
+		code = ee.ExitCode()
+	}
+	return o.String(), e.String(), code
+}
+
+// TestAnExemptionNeverProducesAZeroExitCode : le point qui décide de tout. Une
+// dérogation ne rend pas la porte verte en silence ; elle la rend d'une couleur que
+// le pipeline doit avoir explicitement acceptée.
+func TestAnExemptionNeverProducesAZeroExitCode(t *testing.T) {
+	bin := buildPepin(t)
+	_, _, code := runScan(t, bin, "scan", "scaleway", "-t", exemptFixture,
+		"--exceptions", writeExceptions(t, allDeviations))
+
+	if code == 0 {
+		t.Fatal("un scan dont tous les écarts sont exemptés a rendu 0 — une exemption ne doit JAMAIS rendre vert en silence")
+	}
+	if code != exitDerogation {
+		t.Errorf("code de sortie %d, attendu %d (dérogation appliquée)", code, exitDerogation)
+	}
+}
+
+// TestAnUncoveredDeviationStillFailsTheGate : la dérogation ne couvre qu'un écart
+// sur plusieurs, la porte reste rouge au code de la non-conformité. Sinon une seule
+// exemption suffirait à masquer tout le reste.
+func TestAnUncoveredDeviationStillFailsTheGate(t *testing.T) {
+	bin := buildPepin(t)
+	partial := `exceptions:
+  - control: objectstorage_bucket_public_access
+    justification: "Bucket de diffusion publique assumé"
+    expires_at: 2099-12-31
+    owner: platform-security
+    approved_by: security@example.org
+`
+	_, _, code := runScan(t, bin, "scan", "scaleway", "-t", exemptFixture,
+		"--exceptions", writeExceptions(t, partial))
+	if code != exitNonConformite {
+		t.Errorf("code de sortie %d, attendu %d — des écarts non couverts subsistent", code, exitNonConformite)
+	}
+}
+
+// TestAnExpiredExemptionDoesNotOpenTheGate : la même dérogation, une date passée.
+// Elle ne s'applique plus, la porte reste celle de la non-conformité, et
+// l'expiration est dite à l'opérateur.
+func TestAnExpiredExemptionDoesNotOpenTheGate(t *testing.T) {
+	bin := buildPepin(t)
+	expired := strings.ReplaceAll(allDeviations, "2099-12-31", "2020-01-01")
+	_, stderr, code := runScan(t, bin, "scan", "scaleway", "-t", exemptFixture,
+		"--exceptions", writeExceptions(t, expired))
+	if code != exitNonConformite {
+		t.Errorf("code de sortie %d, attendu %d — une dérogation expirée n'écarte rien", code, exitNonConformite)
+	}
+	if !strings.Contains(stderr, "EXPIRED") {
+		t.Errorf("l'expiration n'est pas signalée sur stderr :\n%s", stderr)
+	}
+}
+
+// TestAnOrphanExemptionIsReportedByTheBinary : une exception oubliée après le
+// retrait d'un contrôle doit se voir, pas se taire.
+func TestAnOrphanExemptionIsReportedByTheBinary(t *testing.T) {
+	bin := buildPepin(t)
+	orphan := `exceptions:
+  - control: controle_supprime_il_y_a_deux_ans
+    justification: "Exception héritée d'une ancienne campagne"
+    expires_at: 2099-12-31
+    owner: platform-security
+    approved_by: security@example.org
+`
+	_, stderr, _ := runScan(t, bin, "scan", "scaleway", "-t", exemptFixture,
+		"--exceptions", writeExceptions(t, orphan))
+	if !strings.Contains(stderr, "ORPHAN") {
+		t.Errorf("la dérogation orpheline n'est pas signalée :\n%s", stderr)
+	}
+}
+
+// TestExemptedIsAFirstClassStatusInTheParsableFormats : `exempted` existe dans
+// l'assessment et dans `--format json`, et n'y est jamais compté conforme.
+func TestExemptedIsAFirstClassStatusInTheParsableFormats(t *testing.T) {
+	bin := buildPepin(t)
+	file := writeExceptions(t, allDeviations)
+
+	// --- assessment -------------------------------------------------------
+	stdout, _, _ := runScan(t, bin, "scan", "scaleway", "-t", exemptFixture, "-f", "assessment", "--exceptions", file)
+	var asmt struct {
+		Results []struct {
+			Control string `json:"control"`
+			Status  string `json:"status"`
+			Waiver  *struct {
+				Justification string `json:"justification"`
+				Until         string `json:"until"`
+			} `json:"waiver"`
+			Labels map[string]string `json:"labels"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &asmt); err != nil {
+		t.Fatalf("assessment illisible : %v", err)
+	}
+	exempted := 0
+	for _, r := range asmt.Results {
+		if r.Status != "exempted" {
+			continue
+		}
+		exempted++
+		if r.Waiver == nil || r.Waiver.Justification == "" || r.Waiver.Until == "" {
+			t.Errorf("%s : exempté sans justification ni échéance scellées", r.Control)
+		}
+		if r.Labels["exemption_owner"] == "" || r.Labels["exemption_approved_by"] == "" {
+			t.Errorf("%s : exempté sans responsable ni approbateur", r.Control)
+		}
+	}
+	if exempted == 0 {
+		t.Fatal("aucun résultat `exempted` dans l'assessment")
+	}
+
+	// --- json -------------------------------------------------------------
+	stdout, _, _ = runScan(t, bin, "scan", "scaleway", "-t", exemptFixture, "-f", "json", "--exceptions", file)
+	var report struct {
+		Findings []struct {
+			Code string `json:"code"`
+		} `json:"findings"`
+		Summary struct {
+			Conforme bool `json:"conforme"`
+		} `json:"summary"`
+		Exemptions *struct {
+			Records []struct {
+				Effect string `json:"effect"`
+			} `json:"records"`
+		} `json:"exemptions"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("rapport json illisible : %v", err)
+	}
+	if report.Exemptions == nil || len(report.Exemptions.Records) == 0 {
+		t.Fatal("`--format json` ne publie pas les dérogations : un pipeline qui accepte le code 4 ne peut pas savoir ce qu'il accepte")
+	}
+	if report.Summary.Conforme {
+		t.Error("le résumé se déclare conforme alors que des écarts sont exemptés — un exempté n'est PAS un conforme")
+	}
+	if len(report.Findings) == 0 {
+		t.Error("les écarts exemptés ont disparu de `findings` : une dérogation écarte de la PORTE, jamais du rapport")
+	}
+}
+
+// TestTheTerminalShowsTheExemptionsInPlainSight : une exemption discrète est une
+// exemption qu'on oublie de revoir.
+func TestTheTerminalShowsTheExemptionsInPlainSight(t *testing.T) {
+	bin := buildPepin(t)
+	stdout, _, _ := runScan(t, bin, "scan", "scaleway", "-t", exemptFixture,
+		"--exceptions", writeExceptions(t, allDeviations))
+
+	for _, want := range []string{
+		"EXEMPTIONS APPLIED", "NOT compliant",
+		"platform-security", "security@example.org", "2099-12-31",
+		"Bastion administré, accès restreint par IP source",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("le rendu terminal ne montre pas %q :\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "Verdict: compliant") {
+		t.Error("le verdict se dit conforme alors que des écarts sont exemptés")
+	}
+	if !strings.Contains(stdout, "NON-COMPLIANT under waiver") {
+		t.Errorf("le verdict ne qualifie pas la dérogation :\n%s", stdout)
+	}
+}
+
+// TestAnIncompleteExemptionFileStopsTheScan : les champs obligatoires sont validés
+// au chargement. Le scan s'arrête sur une erreur technique plutôt que de produire
+// un rapport qui tairait la moitié de ses exceptions.
+func TestAnIncompleteExemptionFileStopsTheScan(t *testing.T) {
+	bin := buildPepin(t)
+	incomplete := `exceptions:
+  - control: objectstorage_bucket_public_access
+    justification: "sans responsable ni date"
+`
+	_, stderr, code := runScan(t, bin, "scan", "scaleway", "-t", exemptFixture,
+		"--exceptions", writeExceptions(t, incomplete))
+	if code != exitErreur {
+		t.Errorf("code de sortie %d, attendu %d (erreur technique)", code, exitErreur)
+	}
+	for _, want := range []string{"expires_at", "owner", "approved_by"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("l'erreur ne nomme pas le champ manquant %q :\n%s", want, stderr)
+		}
+	}
+}
+
+// TestASealedBundleCarriesItsExemptions : un dossier qui tait ses exemptions n'est
+// pas opposable. Elles entrent au bundle, donc au checksums.txt que l'opérateur
+// signe — et la re-dérivation les rejoue, sinon un bundle fidèle serait déclaré
+// falsifié.
+func TestASealedBundleCarriesItsExemptions(t *testing.T) {
+	bin := buildPepin(t)
+	dir := t.TempDir()
+	runScan(t, bin, "scan", "scaleway", "-t", exemptFixture,
+		"--exceptions", writeExceptions(t, allDeviations), "--seal", dir)
+
+	raw, err := os.ReadFile(filepath.Join(dir, "exemptions.json")) // #nosec G304 -- dossier de test.
+	if err != nil {
+		t.Fatalf("exemptions.json absent du bundle : %v", err)
+	}
+	if !strings.Contains(string(raw), "security@example.org") {
+		t.Error("exemptions.json ne porte pas l'approbateur")
+	}
+	checksums, err := os.ReadFile(filepath.Join(dir, "checksums.txt")) // #nosec G304 -- dossier de test.
+	if err != nil {
+		t.Fatalf("checksums.txt : %v", err)
+	}
+	if !strings.Contains(string(checksums), "exemptions.json") {
+		t.Error("exemptions.json n'est pas dans checksums.txt : la dérogation ne serait pas scellée")
+	}
+	manifest, err := os.ReadFile(filepath.Join(dir, "manifest.json")) // #nosec G304 -- dossier de test.
+	if err != nil {
+		t.Fatalf("manifest.json : %v", err)
+	}
+	for _, want := range []string{`"exemptions"`, `"policy_digest"`, `"inventory_schema"`} {
+		if !strings.Contains(string(manifest), want) {
+			t.Errorf("le manifeste ne porte pas %s", want)
+		}
+	}
+	// La re-dérivation rejoue les dérogations scellées : un bundle fidèle ne doit
+	// pas être déclaré falsifié parce que le vérificateur n'a pas le fichier.
+	stdout, stderr, code := runScan(t, bin, "verify", dir, "--re-derive")
+	if code != 0 {
+		t.Errorf("re-dérivation d'un bundle avec dérogations : code %d\n%s\n%s", code, stdout, stderr)
+	}
+}

--- a/cmd/fournisseurs_test.go
+++ b/cmd/fournisseurs_test.go
@@ -2,11 +2,29 @@ package cmd
 
 import (
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/stephrobert/pepin/internal/genprovider"
 	"github.com/stephrobert/pepin/referentiel"
 )
+
+// registerOnce : provider.Register PANIQUE sur un doublon, donc le chargement des
+// descripteurs ne peut avoir lieu qu'une fois par binaire de test. Plusieurs tests
+// en ont besoin (la couverture déclarée, la surface gelée de l'inventaire) et
+// l'ordre d'exécution ne doit décider de rien : une surface gelée qui dépendrait de
+// qui a tourné en premier gèlerait tantôt une chose, tantôt une autre.
+var registerOnce sync.Once
+
+// ensureProvidersRegistered charge les descripteurs du dépôt, une seule fois.
+func ensureProvidersRegistered(t *testing.T) {
+	t.Helper()
+	var err error
+	registerOnce.Do(func() { err = genprovider.RegisterAll(os.DirFS(".."), "providers") })
+	if err != nil {
+		t.Fatalf("chargement des providers : %v", err)
+	}
+}
 
 // governanceMultiType : contrôles de gouvernance évalués via la ressource synthétique
 // governance_provider (ou multi-types), sans type de contrat unique à confronter.
@@ -22,9 +40,7 @@ var governanceMultiType = map[string]bool{
 // (l'inflation exacte que le projet dénonce). L'état verifie/a_verifier est ensuite
 // distingué à l'évaluation (assess : Pass vs NotEvaluated), pas ici.
 func TestFournisseursAreCollected(t *testing.T) {
-	if err := genprovider.RegisterAll(os.DirFS(".."), "providers"); err != nil {
-		t.Fatalf("chargement des providers : %v", err)
-	}
+	ensureProvidersRegistered(t)
 	for code, ctl := range referentiel.All() {
 		if governanceMultiType[code] {
 			continue

--- a/cmd/frozen_test.go
+++ b/cmd/frozen_test.go
@@ -203,6 +203,7 @@ func cliSurface() map[string]any {
 			"non_conformite": exitNonConformite,
 			"erreur":         exitErreur,
 			"strict":         exitStrict,
+			"derogation":     exitDerogation,
 		},
 	}
 }

--- a/cmd/frozen_test.go
+++ b/cmd/frozen_test.go
@@ -59,6 +59,8 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/stephrobert/pepin/internal/assess"
+	"github.com/stephrobert/pepin/internal/genprovider"
+	"github.com/stephrobert/pepin/internal/model"
 	"github.com/stephrobert/pepin/internal/scoring"
 	"github.com/stephrobert/scankit/assessment"
 	"github.com/stephrobert/scankit/finding"
@@ -160,6 +162,7 @@ func observedSurfaces(t *testing.T) []frozenSurface {
 		{name: "assessment", version: assess.AssessmentSurfaceVersion,
 			content: mustJSON(t, typeTree(reflect.TypeOf(assessment.Assessment{}), nil))},
 		{name: "bundle", version: bundleFormatVersion(t), content: mustJSON(t, bundleSurface(t))},
+		{name: "inventory", version: model.InventorySchemaVersion(), content: mustJSON(t, inventorySurface(t))},
 	}
 	if os.Getenv("PEPIN_UPDATE_FROZEN") != "" {
 		for _, s := range surfaces {
@@ -211,7 +214,7 @@ func bundleSurface(t *testing.T) map[string]any {
 	t.Helper()
 	dir := t.TempDir()
 	a := assessment.Assessment{Run: assessment.Run{Timestamp: "1970-01-01T00:00:00Z"}}
-	if _, err := assess.WriteBundle(dir, a, []byte("{}\n")); err != nil {
+	if _, err := assess.WriteBundle(dir, a, []byte("{}\n"), assess.BundleExtras{}); err != nil {
 		t.Fatalf("écriture du bundle témoin : %v", err)
 	}
 	raw, err := os.ReadFile(filepath.Join(dir, "manifest.json")) // #nosec G304 -- dossier de test.
@@ -226,11 +229,70 @@ func bundleSurface(t *testing.T) map[string]any {
 	for _, art := range m.Artifacts {
 		files[art.File] = art.Role
 	}
+	// Un second bundle, celui-là AVEC des dérogations : l'artefact qui les scelle
+	// est conditionnel, et une surface gelée sur le seul cas sans dérogation ne
+	// dirait rien du cas qui compte — celui où le dossier doit prouver ce qu'il a
+	// écarté.
+	for file, role := range bundleWithExemptions(t) {
+		files[file] = role
+	}
 	return map[string]any{
 		"format":   assess.BundleFormat,
 		"files":    files,
 		"manifest": typeTree(reflect.TypeOf(assess.Manifest{}), nil),
 	}
+}
+
+// inventorySurface gèle le CONTRAT de l'inventaire normalisé : la forme de
+// l'enveloppe et de la ressource (dérivée du type Go, donc du contrat lui-même) et
+// le VOCABULAIRE — chaque type de ressource et les attributs communs qu'il peut
+// porter, dérivés des descripteurs et des collecteurs.
+//
+// Geler le vocabulaire est délibéré, et son coût est assumé : ajouter un attribut
+// à un descripteur fera rougir ce test, et demandera l'incrément de
+// model.InventoryFormat plus sa ligne de CHANGELOG. C'est exactement le sens de
+// « l'inventaire cesse d'être un détail d'implémentation » : le nombre dit « la
+// forme a changé », et un consommateur qui lit `manifest.inventory_schema` sait
+// alors qu'il a quelque chose à relire.
+func inventorySurface(t *testing.T) map[string]any {
+	t.Helper()
+	// Les descripteurs sont chargés ICI, explicitement : le catalogue en dérive, et
+	// une surface gelée qui dépendrait de l'ordre d'exécution des tests gèlerait
+	// tantôt le vocabulaire complet, tantôt celui des seuls collecteurs Go.
+	ensureProvidersRegistered(t)
+	return map[string]any{
+		"format":   model.InventoryFormat,
+		"envelope": typeTree(reflect.TypeOf(model.Posture{}), nil),
+		"types":    genprovider.InventoryCatalogue(),
+	}
+}
+
+// bundleWithExemptions écrit un bundle portant une politique de dérogations et rend
+// ses fichiers avec leurs rôles.
+func bundleWithExemptions(t *testing.T) map[string]string {
+	t.Helper()
+	dir := t.TempDir()
+	a := assessment.Assessment{Run: assessment.Run{Timestamp: "1970-01-01T00:00:00Z"}}
+	extras := assess.BundleExtras{
+		Exemptions:       []byte("{}\n"),
+		ExemptionSummary: &assess.ExemptionSummary{PolicyDigest: "sha256:0", Applied: 1},
+	}
+	if _, err := assess.WriteBundle(dir, a, []byte("{}\n"), extras); err != nil {
+		t.Fatalf("écriture du bundle témoin avec dérogations : %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "manifest.json")) // #nosec G304 -- dossier de test.
+	if err != nil {
+		t.Fatalf("lecture du manifest témoin : %v", err)
+	}
+	var m assess.Manifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("manifest témoin invalide : %v", err)
+	}
+	out := map[string]string{}
+	for _, art := range m.Artifacts {
+		out[art.File] = art.Role
+	}
+	return out
 }
 
 // bundleFormatVersion extrait la version de surface du suffixe /vN de

--- a/cmd/i18n.go
+++ b/cmd/i18n.go
@@ -119,6 +119,9 @@ func localize() {
 	setUsage(scanCmd, "seal", tr(
 		"écrire un bundle de preuve opposable (assessment + OSCAL + manifest + checksums) dans ce dossier",
 		"write a defensible evidence bundle (assessment + OSCAL + manifest + checksums) into this directory"))
+	setUsage(scanCmd, "exceptions", tr(
+		"`fichier` YAML de dérogations (control, justification, expires_at, owner, approved_by) — un écart couvert passe au statut exempted, jamais conforme",
+		"exemptions YAML `file` (control, justification, expires_at, owner, approved_by) — a covered deviation becomes exempted, never compliant"))
 	setUsage(scanCmd, "strict", tr(
 		"porte CI stricte : code de sortie ≠ 0 si aucun contrôle n'est mesuré (hors gouvernance) ou s'il subsiste un écart medium/low",
 		"strict CI gate: non-zero exit code if no control is measured (governance aside) or if medium/low deviations remain"))

--- a/cmd/i18n.go
+++ b/cmd/i18n.go
@@ -120,7 +120,7 @@ func localize() {
 		"écrire un bundle de preuve opposable (assessment + OSCAL + manifest + checksums) dans ce dossier",
 		"write a defensible evidence bundle (assessment + OSCAL + manifest + checksums) into this directory"))
 	setUsage(scanCmd, "exceptions", tr(
-		"`fichier` YAML de dérogations (control, justification, expires_at, owner, approved_by) — un écart couvert passe au statut exempted, jamais conforme",
+		"`fichier` YAML de dérogations (control, justification, expires_at, owner, approved_by) : un écart couvert passe au statut exempted, jamais conforme",
 		"exemptions YAML `file` (control, justification, expires_at, owner, approved_by) — a covered deviation becomes exempted, never compliant"))
 	setUsage(scanCmd, "strict", tr(
 		"porte CI stricte : code de sortie ≠ 0 si aucun contrôle n'est mesuré (hors gouvernance) ou s'il subsiste un écart medium/low",

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -127,6 +127,9 @@ var scanCmd = &cobra.Command{
 		// normative references, and run provenance (tool/ruleset digests, target, timestamp).
 		rtypes := resourceTypesOf(input)
 		asmt := assess.Build(name, referentiel.All(), findings, rtypes, providerNAReasons(name), providerVerified(name), controlTypes(), attrsByTypeOf(input), buildRun(name, rtypes))
+		// La provenance des attributs décisifs, en PASSE POSTÉRIEURE : elle enrichit la
+		// preuve (d'où vient la donnée, a-t-elle été observée) et ne touche aucun statut.
+		asmt = assess.WithProvenance(asmt, assess.ProvenanceOf(input), controlTypes())
 
 		// Bundle de preuve horodaté et hashé (opposabilité : intégrité + non-répudiation).
 		if scanSeal != "" {

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -452,7 +452,7 @@ func renderExemptions(w io.Writer, rep exempt.Report) {
 		return
 	}
 	_, _ = fmt.Fprintf(w, "\n%s\n", exemptStyle.Render(tr(
-		"DÉROGATIONS APPLIQUÉES — écarts assumés, NON conformes",
+		"DÉROGATIONS APPLIQUÉES : écarts assumés, NON conformes",
 		"EXEMPTIONS APPLIED — accepted deviations, NOT compliant")))
 	for _, rec := range rep.Records {
 		if rec.Effect != exempt.EffectApplied {
@@ -501,7 +501,7 @@ func init() {
 	scanCmd.Flags().StringVar(&scanProfile, "profile", "", "profil d'identifiants pour la collecte live (ex. ~/.osc/config.json)")
 	scanCmd.Flags().StringVar(&scanS3Endpoint, "s3-endpoint", "", "endpoint S3 custom pour le stockage objet (collecte live ; ex. MinIO http://localhost:9000)")
 	scanCmd.Flags().StringVar(&scanSeal, "seal", "", "écrire un bundle de preuve opposable (assessment + OSCAL + manifest + checksums) dans ce dossier")
-	scanCmd.Flags().StringVar(&scanExceptions, "exceptions", "", "`fichier` YAML de dérogations (control, justification, expires_at, owner, approved_by) — un écart couvert passe au statut exempted, jamais conforme")
+	scanCmd.Flags().StringVar(&scanExceptions, "exceptions", "", "`fichier` YAML de dérogations (control, justification, expires_at, owner, approved_by) : un écart couvert passe au statut exempted, jamais conforme")
 	scanCmd.Flags().BoolVar(&scanStrict, "strict", false, "porte CI stricte : code de sortie ≠ 0 si aucun contrôle n'est mesuré (hors gouvernance) ou s'il subsiste un écart medium/low")
 	scanCmd.Flags().BoolVar(&scanRedact, "redact", false, "caviarder les valeurs sensibles (user-data, policies) de l'input.json du bundle — pour partage à un tiers ; INCOMPATIBLE avec verify --re-derive")
 	// --live et --terraform sont exclusifs : sinon loadInput privilégie le live et ignore le plan en silence.
@@ -986,12 +986,12 @@ func verdictHeadline(res scoring.Result, gate scoring.Result, asmt assessment.As
 			"Verdict: UNDETERMINED — no control measured on any resource (the "+scope+" is empty or was not collected)")
 	case !res.Conforme && gate.Conforme && exempted > 0:
 		return fmt.Sprintf(tr(
-			"Verdict : NON CONFORME sous dérogation — %d écart(s) critique/haut, tous couverts par une dérogation datée et attribuée",
+			"Verdict : NON CONFORME sous dérogation, %d écart(s) critique/haut tous couverts par une dérogation datée et attribuée",
 			"Verdict: NON-COMPLIANT under waiver — %d critical/high deviation(s), all covered by a dated, attributed exemption"),
 			res.Critical+res.High)
 	case !res.Conforme && exempted > 0:
 		return fmt.Sprintf(tr(
-			"Verdict : NON CONFORME — %d écart(s) critique/haut restant(s) hors dérogation, %d contrôle(s) exempté(s)",
+			"Verdict : NON CONFORME, %d écart(s) critique/haut restant(s) hors dérogation, %d contrôle(s) exempté(s)",
 			"Verdict: NON-COMPLIANT — %d critical/high deviation(s) left outside any exemption, %d exempted control(s)"),
 			gate.Critical+gate.High, exempted)
 	case !res.Conforme:

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"maps"
 	"os"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/stephrobert/pepin/internal/assess"
 	"github.com/stephrobert/pepin/internal/commonrules"
+	"github.com/stephrobert/pepin/internal/exempt"
 	"github.com/stephrobert/pepin/internal/genprovider"
 	"github.com/stephrobert/pepin/internal/i18n"
 	"github.com/stephrobert/pepin/internal/model"
@@ -44,6 +46,7 @@ var (
 	scanKubeconfig string
 	scanS3Endpoint string
 	scanSeal       string
+	scanExceptions string // fichier de dérogations (versionné, revu comme du code)
 	scanRedact     bool   // caviarder les valeurs sensibles de l'input.json embarqué
 	scanStrict     bool   // porte CI stricte : échec sur couverture nulle ou écart medium/low
 	scanTimestamp  string // instant d'évaluation (RFC3339 UTC), partagé input.evaluated_at + Run.Timestamp
@@ -62,6 +65,7 @@ var scanCmd = &cobra.Command{
 		if len(args) > 1 {
 			path = args[1]
 		}
+		scanTargetProvider = name
 		p, ok := provider.Get(name)
 		if !ok {
 			return fmt.Errorf(tr("provider inconnu : %q (voir `pepin providers`)",
@@ -73,6 +77,19 @@ var scanCmd = &cobra.Command{
 				"give a file (JSON export or Terraform plan), or use --live"))
 		}
 		scanTimestamp = time.Now().UTC().Format(time.RFC3339) // un seul instant, partagé input + run
+
+		// Les dérogations sont chargées et VALIDÉES avant toute collecte : un fichier
+		// incomplet arrête le scan ici, plutôt que de produire un rapport qui tairait la
+		// moitié de ses exceptions. Les champs obligatoires se vérifient au chargement,
+		// jamais au moment de l'appliquer.
+		var exPolicy exempt.Policy
+		if scanExceptions != "" {
+			pol, lerr := exempt.Load(scanExceptions)
+			if lerr != nil {
+				return lerr
+			}
+			exPolicy = pol
+		}
 
 		opts := scanReportOptions(name, scanSource(path))
 
@@ -130,6 +147,13 @@ var scanCmd = &cobra.Command{
 		// La provenance des attributs décisifs, en PASSE POSTÉRIEURE : elle enrichit la
 		// preuve (d'où vient la donnée, a-t-elle été observée) et ne touche aucun statut.
 		asmt = assess.WithProvenance(asmt, assess.ProvenanceOf(input), controlTypes())
+		// Les dérogations, en passe postérieure elles aussi : elles ne peuvent toucher
+		// qu'un `fail`, et ne produisent jamais un `pass`. L'instant de référence est
+		// celui du scan (pas l'horloge), pour qu'un bundle rejoué rende le même verdict.
+		asmt, exReport := exempt.Apply(asmt, exPolicy, evaluatedAt(), subjectsOf(input), knownControls())
+		for _, notice := range exReport.Notices() {
+			_, _ = fmt.Fprintln(os.Stderr, tr("pepin: ⚠ ", "pepin: ⚠ ")+notice)
+		}
 
 		// Bundle de preuve horodaté et hashé (opposabilité : intégrité + non-répudiation).
 		if scanSeal != "" {
@@ -146,7 +170,11 @@ var scanCmd = &cobra.Command{
 				return fmt.Errorf(tr("sérialisation de l'inventaire évalué : %w",
 					"serializing the evaluated inventory: %w"), merr)
 			}
-			cs, err := assess.WriteBundle(scanSeal, asmt, inputJSON)
+			extras, eerr := bundleExemptions(exReport)
+			if eerr != nil {
+				return eerr
+			}
+			cs, err := assess.WriteBundle(scanSeal, asmt, inputJSON, extras)
 			if err != nil {
 				return err
 			}
@@ -160,13 +188,18 @@ var scanCmd = &cobra.Command{
 				"pepin: evidence bundle written to %s — seal it with: cosign sign-blob %s\n"), scanSeal, cs)
 		}
 
+		// Le RAPPORT dit tout : aucun écart ne disparaît d'un format analysable parce
+		// qu'il est exempté. Seule la PORTE (le code de sortie) tient compte des
+		// dérogations, et elle le fait vers un code dédié, jamais vers 0.
+		open := openFindings(findings, exemptedKeys(asmt))
 		enrichFromReferentiel(findings)
 		res := scoring.Summarize(findings)
-		opts.SummaryHeadline = verdictHeadline(res, asmt, asmt.Run.Source)
+		gate := scoring.Summarize(open)
+		opts.SummaryHeadline = verdictHeadline(res, gate, asmt, exReport, asmt.Run.Source)
 
 		switch scanFormat {
 		case "json":
-			if err := renderJSON(findings, res); err != nil {
+			if err := renderJSON(findings, res, exReport); err != nil {
 				return err
 			}
 		case "assessment":
@@ -185,11 +218,12 @@ var scanCmd = &cobra.Command{
 			}
 		default:
 			_ = screport.Terminal(os.Stdout, opts, findings, scscoring.Summarize(findings)) // best-effort render
+			renderExemptions(os.Stdout, exReport)
 		}
 		// Portée prestataire/commanditaire : obligatoire pour l'opposabilité (un rapport pepin
 		// ne prouve pas une qualification, seulement la posture d'un tenant).
 		_, _ = fmt.Fprintf(os.Stderr, "\nⓘ %s\n", assess.ScopeDisclaimer())
-		if !res.Conforme {
+		if !gate.Conforme {
 			os.Exit(exitNonConformite)
 		}
 		// Couverture nulle : JAMAIS 0, et sans avoir à demander --strict. « Aucun finding »
@@ -200,9 +234,19 @@ var scanCmd = &cobra.Command{
 		if evaluatedNonGov(asmt) == 0 {
 			os.Exit(exitStrict)
 		}
+		// Une dérogation a écarté un écart : le scan ne peut PAS rendre 0. Un code
+		// dédié plutôt que 1 (le pipeline doit pouvoir distinguer « écart ouvert » de
+		// « écart assumé, daté et attribué ») et jamais 0 (une exemption ne rend pas
+		// vert en silence — c'est tout l'objet du statut exempted).
+		if exReport.Applied() {
+			os.Exit(exitDerogation)
+		}
 		// --strict : porte CI plus exigeante, qui refuse aussi les écarts medium/low
-		// (que le code de sortie normal ignore).
+		// (que le code de sortie normal ignore) et un fichier de dérogations périmé.
 		if scanStrict && res.Medium+res.Low > 0 {
+			os.Exit(exitStrict)
+		}
+		if scanStrict && exReport.Stale() {
 			os.Exit(exitStrict)
 		}
 		return nil
@@ -286,6 +330,150 @@ func redactInventory(input any) any {
 	return out
 }
 
+// evaluatedAt rend l'instant d'évaluation du scan. Les dérogations s'y ancrent
+// (et non à l'horloge) : une politique dont la date tombe pendant un scan ne doit
+// pas s'appliquer à la moitié des résultats, et un bundle rejoué doit rendre le
+// même verdict que le jour de son scellement.
+func evaluatedAt() time.Time {
+	t, err := time.Parse(time.RFC3339, scanTimestamp)
+	if err != nil {
+		return time.Now().UTC()
+	}
+	return t
+}
+
+// subjectsOf rend l'ensemble des sujets nommables de l'inventaire : identifiants ET
+// noms de ressources. Une dérogation écrite par un humain nomme ce qu'il connaît
+// (« vm-bastion »), pas nécessairement l'identifiant technique ; les deux formes
+// sont donc acceptées, et une dérogation qui ne correspond à NI l'un NI l'autre est
+// orpheline, donc signalée.
+func subjectsOf(input any) map[string]bool {
+	out := map[string]bool{}
+	m, ok := input.(map[string]any)
+	if !ok {
+		return out
+	}
+	add := func(vals ...string) {
+		for _, v := range vals {
+			if v != "" {
+				out[v] = true
+			}
+		}
+	}
+	switch rs := m["resources"].(type) {
+	case []model.Resource:
+		for _, r := range rs {
+			add(r.ID, r.Name)
+		}
+	case []any:
+		for _, it := range rs {
+			if rm, ok := it.(map[string]any); ok {
+				id, _ := rm["id"].(string)
+				name, _ := rm["name"].(string)
+				add(id, name)
+			}
+		}
+	}
+	// La cible elle-même est un sujet : les résultats non liés à une ressource
+	// précise (contrôles transverses) le portent.
+	add(targetID(scanTargetProvider))
+	return out
+}
+
+// scanTargetProvider retient le provider scanné, pour que subjectsOf compose le
+// même identifiant de cible que les résultats.
+var scanTargetProvider string
+
+// knownControls rend l'ensemble des codes de contrôle du référentiel. Une
+// dérogation qui vise autre chose est orpheline : le symptôme d'une exception
+// oubliée après le renommage ou le retrait d'un contrôle.
+func knownControls() map[string]bool {
+	out := map[string]bool{}
+	for code := range referentiel.All() {
+		out[code] = true
+	}
+	return out
+}
+
+// exemptedKeys rend les couples (contrôle, sujet) qu'une dérogation a écartés.
+func exemptedKeys(asmt assessment.Assessment) map[string]bool {
+	out := map[string]bool{}
+	for _, r := range asmt.Results {
+		if r.Status == exempt.StatusExempted {
+			out[r.Control+"\x00"+r.Subject] = true
+		}
+	}
+	return out
+}
+
+// openFindings rend les écarts NON couverts par une dérogation. Ils sont la base de
+// la porte de CI ; le rapport, lui, continue de tout montrer. Les findings sont
+// encore codés en agnostique ici (avant enrichFromReferentiel), comme l'assessment.
+func openFindings(findings []finding.Finding, exempted map[string]bool) []finding.Finding {
+	if len(exempted) == 0 {
+		return findings
+	}
+	out := make([]finding.Finding, 0, len(findings))
+	for _, f := range findings {
+		if exempted[f.Code+"\x00"+f.Subject] {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// bundleExemptions sérialise l'effet des dérogations pour le sceller au bundle.
+func bundleExemptions(rep exempt.Report) (assess.BundleExtras, error) {
+	if len(rep.Records) == 0 && len(rep.Exemptions) == 0 {
+		return assess.BundleExtras{}, nil
+	}
+	raw, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return assess.BundleExtras{}, fmt.Errorf(tr("sérialisation des dérogations : %w",
+			"serializing the exemptions: %w"), err)
+	}
+	return assess.BundleExtras{
+		Exemptions: raw,
+		ExemptionSummary: &assess.ExemptionSummary{
+			PolicyDigest: rep.PolicyDigest,
+			Applied:      rep.Count(exempt.EffectApplied),
+			Expired:      rep.Count(exempt.EffectExpired),
+			Orphan:       rep.Count(exempt.EffectOrphan),
+		},
+	}, nil
+}
+
+// renderExemptions affiche les dérogations APPLIQUÉES, en clair et en évidence.
+// Une exemption discrète est une exemption qu'on oublie de revoir : elle porte donc
+// son responsable, son approbateur et sa date, à côté de ce qu'elle écarte.
+func renderExemptions(w io.Writer, rep exempt.Report) {
+	if !rep.Applied() {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "\n%s\n", exemptStyle.Render(tr(
+		"DÉROGATIONS APPLIQUÉES — écarts assumés, NON conformes",
+		"EXEMPTIONS APPLIED — accepted deviations, NOT compliant")))
+	for _, rec := range rep.Records {
+		if rec.Effect != exempt.EffectApplied {
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "  · %s%s\n", rec.Control, subjectsLabel(rec.Subjects))
+		_, _ = fmt.Fprintf(w, "    %s\n", rec.Justification)
+		_, _ = fmt.Fprintf(w, "    %s\n", fmt.Sprintf(tr(
+			"jusqu'au %s · responsable %s · approuvé par %s",
+			"until %s · owner %s · approved by %s"), rec.ExpiresAt, rec.Owner, rec.ApprovedBy))
+	}
+}
+
+// subjectsLabel rend la liste des sujets écartés par une dérogation.
+func subjectsLabel(subjects []string) string {
+	if len(subjects) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(subjects, ", ") + ")"
+}
+
 // evaluatedNonGov compte les contrôles réellement mesurés (pass/fail) hors gouvernance.
 func evaluatedNonGov(asmt assessment.Assessment) int {
 	n := 0
@@ -313,6 +501,7 @@ func init() {
 	scanCmd.Flags().StringVar(&scanProfile, "profile", "", "profil d'identifiants pour la collecte live (ex. ~/.osc/config.json)")
 	scanCmd.Flags().StringVar(&scanS3Endpoint, "s3-endpoint", "", "endpoint S3 custom pour le stockage objet (collecte live ; ex. MinIO http://localhost:9000)")
 	scanCmd.Flags().StringVar(&scanSeal, "seal", "", "écrire un bundle de preuve opposable (assessment + OSCAL + manifest + checksums) dans ce dossier")
+	scanCmd.Flags().StringVar(&scanExceptions, "exceptions", "", "`fichier` YAML de dérogations (control, justification, expires_at, owner, approved_by) — un écart couvert passe au statut exempted, jamais conforme")
 	scanCmd.Flags().BoolVar(&scanStrict, "strict", false, "porte CI stricte : code de sortie ≠ 0 si aucun contrôle n'est mesuré (hors gouvernance) ou s'il subsiste un écart medium/low")
 	scanCmd.Flags().BoolVar(&scanRedact, "redact", false, "caviarder les valeurs sensibles (user-data, policies) de l'input.json du bundle — pour partage à un tiers ; INCOMPATIBLE avec verify --re-derive")
 	// --live et --terraform sont exclusifs : sinon loadInput privilégie le live et ignore le plan en silence.
@@ -756,7 +945,7 @@ func docURL(f finding.Finding) string {
 // un scan où RIEN n'a été évalué (collecte vide, gardes de capacité) ne doit jamais s'afficher
 // « CONFORME », et un verdict sur un plan Terraform est qualifié « périmètre déclaré » (état
 // planifié, pas configuration effective). Le code de sortie reste piloté par res.Conforme.
-func verdictHeadline(res scoring.Result, asmt assessment.Assessment, source string) string {
+func verdictHeadline(res scoring.Result, gate scoring.Result, asmt assessment.Assessment, ex exempt.Report, source string) string {
 	// `evaluated` ne compte QUE des contrôles mesurés sur des ressources collectées : les
 	// contrôles de gouvernance passent sur des faits AUTO-DÉCLARÉS (souveraineté) et ne doivent
 	// pas empêcher INDÉTERMINÉ sur un inventaire par ailleurs vide (sinon un tenant vidé de ses
@@ -781,11 +970,30 @@ func verdictHeadline(res scoring.Result, asmt assessment.Assessment, source stri
 		scope = tr("périmètre déclaré (plan Terraform, état planifié)",
 			"declared scope (Terraform plan, planned state)")
 	}
+	// Les écarts EXEMPTÉS ne rendent jamais un verdict conforme : ils le qualifient.
+	// « NON CONFORME sous dérogation » dit les deux choses vraies à la fois — l'écart
+	// existe, et quelqu'un l'a assumé — là où « conforme » n'en dirait aucune.
+	exempted := 0
+	for _, r := range asmt.Results {
+		if r.Status == exempt.StatusExempted {
+			exempted++
+		}
+	}
 	switch {
 	case evaluated == 0:
 		return tr(
 			"Verdict : INDÉTERMINÉ — aucun contrôle mesuré sur des ressources (le "+scope+" est vide ou non collecté)",
 			"Verdict: UNDETERMINED — no control measured on any resource (the "+scope+" is empty or was not collected)")
+	case !res.Conforme && gate.Conforme && exempted > 0:
+		return fmt.Sprintf(tr(
+			"Verdict : NON CONFORME sous dérogation — %d écart(s) critique/haut, tous couverts par une dérogation datée et attribuée",
+			"Verdict: NON-COMPLIANT under waiver — %d critical/high deviation(s), all covered by a dated, attributed exemption"),
+			res.Critical+res.High)
+	case !res.Conforme && exempted > 0:
+		return fmt.Sprintf(tr(
+			"Verdict : NON CONFORME — %d écart(s) critique/haut restant(s) hors dérogation, %d contrôle(s) exempté(s)",
+			"Verdict: NON-COMPLIANT — %d critical/high deviation(s) left outside any exemption, %d exempted control(s)"),
+			gate.Critical+gate.High, exempted)
 	case !res.Conforme:
 		return tr("Verdict : NON CONFORME", "Verdict: NON-COMPLIANT")
 	case res.Medium+res.Low > 0:
@@ -842,8 +1050,14 @@ func pepinBanner() []string {
 	return lines
 }
 
-func renderJSON(findings []finding.Finding, res scoring.Result) error {
+func renderJSON(findings []finding.Finding, res scoring.Result, ex exempt.Report) error {
 	out := map[string]any{"findings": findings, "summary": res}
+	// Les dérogations sont une SURFACE ANALYSABLE : un pipeline qui accepte le code
+	// de sortie des dérogations doit pouvoir lire lesquelles, par qui et jusqu'à
+	// quand. Absent quand aucune politique n'a été fournie.
+	if len(ex.Records) > 0 {
+		out["exemptions"] = ex
+	}
 	b, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		return err

--- a/cmd/styles.go
+++ b/cmd/styles.go
@@ -14,4 +14,9 @@ var (
 	titre    = lipgloss.NewStyle().Foreground(colTexte).Bold(true)
 	muted    = lipgloss.NewStyle().Foreground(colMuted)
 	errStyle = lipgloss.NewStyle().Foreground(colRouge)
+
+	// exemptStyle : les dérogations appliquées. En ambre et en gras, parce qu'une
+	// exemption discrète est une exemption qu'on oublie de revoir — et parce qu'elle
+	// n'est PAS une conformité : la couleur ne doit pas être celle d'un succès.
+	exemptStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#f0a338")).Bold(true)
 )

--- a/cmd/surface.go
+++ b/cmd/surface.go
@@ -18,6 +18,16 @@ const (
 	// exitStrict : porte --strict : couverture nulle hors gouvernance, ou écarts
 	// medium/low restants, que le code de sortie normal ignore volontairement.
 	exitStrict = 3
+	// exitDerogation : tout écart critical/high restant est couvert par une
+	// dérogation datée, justifiée et attribuée.
+	//
+	// Un code DÉDIÉ, et le choix se défend des deux côtés. Rendre 0 ferait d'une
+	// exemption un faux vert silencieux, exactement ce que le statut `exempted`
+	// existe pour empêcher. Rendre 1 rendrait la dérogation inutile — et une
+	// équipe qui ne peut pas déroger désactive le contrôle, ce qui est pire. 4
+	// est donc non nul (rien ne passe en silence) et distinct (un pipeline qui
+	// veut l'accepter doit l'écrire, donc le savoir).
+	exitDerogation = 4
 )
 
 // cliSurfaceVersion est la version de FORME de la CLI : ses verbes, leurs flags,
@@ -28,7 +38,13 @@ const (
 //
 // v2 : ajout du drapeau persistant `--lang` (fr | en). Ajout pur : aucun verbe,
 // aucun autre drapeau ni aucun code de sortie ne bouge.
-const cliSurfaceVersion = 2
+//
+// v3 : ajout de `scan --exceptions` (dérogations datées et attribuées) et du code
+// de sortie 4 (tout écart restant est couvert par une dérogation). Ajout pur là
+// encore : aucun code existant ne change de sens, mais un code de plus change ce
+// qu'un pipeline doit savoir interpréter — d'où l'incrément et sa ligne de
+// CHANGELOG.
+const cliSurfaceVersion = 3
 
 // findingsSurfaceVersion est la version de FORME de `--format json`
 // ({"findings": [...], "summary": {...}}), la sortie qu'un pipeline parse le

--- a/cmd/testdata/frozen/bundle.json
+++ b/cmd/testdata/frozen/bundle.json
@@ -45,6 +45,60 @@
           }
         }
       }
+    },
+    {
+      "schema_version": 2,
+      "content": {
+        "files": {
+          "assessment-oscal.json": "oscal-assessment-results",
+          "assessment.json": "assessment",
+          "checksums.txt": "checksums",
+          "exemptions.json": "applied-exemptions",
+          "input.json": "evaluated-input",
+          "manifest.json": "manifest"
+        },
+        "format": "pepin-assessment-bundle/v2",
+        "manifest": {
+          "artifacts": [
+            {
+              "bytes": "number",
+              "file": "string",
+              "role": "string",
+              "sha256": "string"
+            }
+          ],
+          "disclaimer": "string",
+          "exemptions": {
+            "applied": "number",
+            "expired": "number",
+            "orphan": "number",
+            "policy_digest": "string"
+          },
+          "format": "string",
+          "generated": "string",
+          "inventory_schema": "string",
+          "ruleset": {
+            "digest": "string",
+            "name": "string",
+            "version": "string"
+          },
+          "source": "string",
+          "summary": {
+            "*": "number"
+          },
+          "target": {
+            "id": "string",
+            "platform": "string",
+            "provider": "string",
+            "region": "string"
+          },
+          "tool": {
+            "digest": "string",
+            "name": "string",
+            "version": "string"
+          }
+        }
+      }
     }
   ]
 }

--- a/cmd/testdata/frozen/cli.json
+++ b/cmd/testdata/frozen/cli.json
@@ -116,6 +116,7 @@
       "content": {
         "exit_codes": {
           "conforme": 0,
+          "derogation": 4,
           "erreur": 2,
           "non_conformite": 1,
           "strict": 3

--- a/cmd/testdata/frozen/cli.json
+++ b/cmd/testdata/frozen/cli.json
@@ -110,6 +110,63 @@
           }
         }
       }
+    },
+    {
+      "schema_version": 3,
+      "content": {
+        "exit_codes": {
+          "conforme": 0,
+          "erreur": 2,
+          "non_conformite": 1,
+          "strict": 3
+        },
+        "verbs": {
+          "provider": {
+            "flags": {}
+          },
+          "provider list": {
+            "flags": {}
+          },
+          "provider new": {
+            "flags": {}
+          },
+          "provider validate": {
+            "flags": {}
+          },
+          "scan": {
+            "flags": {
+              "exceptions": "",
+              "format": "f",
+              "kubeconfig": "",
+              "lang": "",
+              "live": "",
+              "policy-dir": "p",
+              "profile": "",
+              "redact": "",
+              "region": "",
+              "s3-endpoint": "",
+              "seal": "",
+              "strict": "",
+              "terraform": "t"
+            }
+          },
+          "scsl": {
+            "flags": {
+              "index": ""
+            }
+          },
+          "verify": {
+            "flags": {
+              "bundle": "",
+              "pubkey": "",
+              "re-derive": ""
+            }
+          },
+          "version": {
+            "flags": {}
+          }
+        }
+      }
     }
   ]
 }

--- a/cmd/testdata/frozen/inventory.json
+++ b/cmd/testdata/frozen/inventory.json
@@ -1,0 +1,204 @@
+{
+  "history": [
+    {
+      "schema_version": 1,
+      "content": {
+        "envelope": {
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v1",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "expiration_date",
+            "owner_user",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "inbound_default_policy",
+            "security_group_id"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -9,11 +9,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/stephrobert/pepin/internal/assess"
 	"github.com/stephrobert/pepin/internal/commonrules"
+	"github.com/stephrobert/pepin/internal/exempt"
 	"github.com/stephrobert/pepin/internal/i18n"
 	"github.com/stephrobert/pepin/internal/provider"
 	"github.com/stephrobert/pepin/referentiel"
@@ -157,6 +159,15 @@ func reDerive(ctx context.Context, dir string) error {
 	if err != nil {
 		return fmt.Errorf(tr("re-dérivation : %w", "re-derivation: %w"), err)
 	}
+	// Les dérogations SCELLÉES sont rejouées : sans elles, un bundle parfaitement
+	// fidèle divergerait pour la seule raison que le vérificateur n'a pas le fichier
+	// de l'opérateur. Elles sont rejouées à l'instant d'évaluation du bundle, pas à
+	// celui du vérificateur — une dérogation valide au scan ne doit pas « expirer »
+	// entre-temps et faire crier à la falsification.
+	sealedPolicy, err := sealedExemptions(dir)
+	if err != nil {
+		return err
+	}
 	sealedJSON, _ := json.Marshal(assess.Canonical(sealed).Results)
 
 	// Un bundle porte la LANGUE du scan qui l'a produit ; le vérificateur, lui, tourne
@@ -166,7 +177,7 @@ func reDerive(ctx context.Context, dir string) error {
 	// qu'un vérificateur puisse rendre. On rejoue donc dans les deux langues : ce qui est
 	// comparé (statuts, sujets, références, provenance) est identique, seule la
 	// formulation change, et une seule concordance suffit à établir la fidélité.
-	got, matched := reDeriveInEitherLanguage(name, findings, input, sealed.Run, string(sealedJSON))
+	got, matched := reDeriveInEitherLanguage(name, findings, input, sealed.Run, string(sealedJSON), sealedPolicy)
 	if !matched {
 		return errors.New(tr(
 			"re-dérivation DIVERGE de l'assessment scellé : le bundle n'atteste PAS fidèlement input.json (résultat fabriqué ou config différente)",
@@ -196,7 +207,7 @@ func reDerive(ctx context.Context, dir string) error {
 // l'autre, et rend le premier qui coïncide avec les résultats scellés. Le second retour
 // dit si l'une des deux a coïncidé ; à défaut, le premier essai est rendu pour que
 // l'appelant dispose d'un assessment non nul.
-func reDeriveInEitherLanguage(name string, findings []finding.Finding, input any, run assessment.Run, sealedJSON string) (assessment.Assessment, bool) {
+func reDeriveInEitherLanguage(name string, findings []finding.Finding, input any, run assessment.Run, sealedJSON string, pol exempt.Policy) (assessment.Assessment, bool) {
 	restore := i18n.Current()
 	defer i18n.Set(restore)
 
@@ -212,6 +223,11 @@ func reDeriveInEitherLanguage(name string, findings []finding.Finding, input any
 		got := assess.Build(name, referentiel.All(), f, resourceTypesOf(input),
 			providerNAReasons(name), providerVerified(name), controlTypes(), attrsByTypeOf(input), run)
 		got = assess.WithProvenance(got, assess.ProvenanceOf(input), controlTypes())
+		at, terr := time.Parse(time.RFC3339, run.Timestamp)
+		if terr != nil {
+			at = time.Now().UTC()
+		}
+		got, _ = exempt.Apply(got, pol, at, subjectsOf(input), knownControls())
 		b, _ := json.Marshal(assess.Canonical(got).Results)
 		if string(b) == sealedJSON {
 			return got, true
@@ -221,6 +237,28 @@ func reDeriveInEitherLanguage(name string, findings []finding.Finding, input any
 		}
 	}
 	return first, false
+}
+
+// sealedExemptions relit la politique de dérogations scellée dans le bundle.
+// Absente, elle vaut politique vide : un bundle produit sans dérogations se
+// re-dérive exactement comme avant.
+//
+// Le fichier est un artefact du bundle, donc couvert par checksums.txt et par la
+// signature : une politique ajoutée après coup pour blanchir un écart casse
+// l'intégrité avant même d'être rejouée.
+func sealedExemptions(dir string) (exempt.Policy, error) {
+	raw, err := os.ReadFile(filepath.Join(dir, "exemptions.json")) // #nosec G304 -- dossier de bundle de l'opérateur.
+	if err != nil {
+		if os.IsNotExist(err) {
+			return exempt.Policy{}, nil
+		}
+		return exempt.Policy{}, fmt.Errorf(tr("lecture de exemptions.json : %w", "reading exemptions.json: %w"), err)
+	}
+	var rep exempt.Report
+	if err := json.Unmarshal(raw, &rep); err != nil {
+		return exempt.Policy{}, fmt.Errorf(tr("exemptions.json invalide : %w", "invalid exemptions.json: %w"), err)
+	}
+	return exempt.Policy{Exemptions: rep.Exemptions}, nil
 }
 
 // short abrège une empreinte pour l'affichage.

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -211,6 +211,7 @@ func reDeriveInEitherLanguage(name string, findings []finding.Finding, input any
 		localizeFindings(f)
 		got := assess.Build(name, referentiel.All(), f, resourceTypesOf(input),
 			providerNAReasons(name), providerVerified(name), controlTypes(), attrsByTypeOf(input), run)
+		got = assess.WithProvenance(got, assess.ProvenanceOf(input), controlTypes())
 		b, _ := json.Marshal(assess.Canonical(got).Results)
 		if string(b) == sealedJSON {
 			return got, true

--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -1,6 +1,6 @@
 > [🇬🇧 English](assessment-model.md) · 🇫🇷 Français
 
-# Le modèle d'assessment : `pass`, `fail`, `not-applicable`, `not-evaluated`
+# Le modèle d'assessment : `pass`, `fail`, `not-applicable`, `not-evaluated`, `exempted`
 
 Un scanner de posture ne vaut que son affirmation la plus faible. Chez Pépin, l'affirmation la
 plus faible est le `pass` : cette page porte donc surtout sur ce qui doit être vrai avant que
@@ -10,7 +10,7 @@ Chaque scan produit un **assessment** : un résultat typé par contrôle, portan
 normatives exactes et la provenance du run. Il se lit avec `--format assessment`, ou scellé
 dans un bundle `--seal`.
 
-## Les quatre statuts, en une phrase chacun
+## Les cinq statuts, en une phrase chacun
 
 | Statut | Ce que Pépin affirme |
 |---|---|
@@ -18,9 +18,12 @@ dans un bundle `--seal`.
 | `fail` | *J'ai regardé et j'ai trouvé un écart, sur ce sujet, avec cette preuve.* |
 | `not-applicable` | *Ce contrôle ne peut pas exister ici, et voici la justification consignée.* |
 | `not-evaluated` | *Je n'ai pas pu décider, et voici exactement ce qui m'a manqué.* |
+| `exempted` | *J'ai trouvé un écart, et quelqu'un l'a assumé : voici qui, pourquoi et jusqu'à quand.* |
 
-Il n'y a pas de cinquième statut, et surtout **pas de statut silencieux**. Un contrôle
-implémenté pour le fournisseur scanné revient toujours avec l'un de ces quatre.
+Les quatre premiers sont ce que Pépin **mesure** ; le cinquième est ce qu'une organisation
+**décide**, et il n'est jamais une conformité. Il n'y a pas de sixième statut, et surtout
+**pas de statut silencieux** : un contrôle implémenté pour le fournisseur scanné revient
+toujours avec l'un de ces cinq.
 
 ## La décision, exactement telle que le code la prend
 
@@ -388,6 +391,117 @@ aussi faux : rien n'a été observé de cassé non plus.
 Si vous voulez une porte qui refuse l'incertitude, utilisez `--strict` et lisez les codes de
 sortie ci-dessous.
 
+## `exempted` : écarté, jamais conforme
+
+Les quatre statuts ci-dessus sont ce que Pépin *mesure*. `exempted` est ce qu'une organisation
+*décide* : ce contrôle échoue, quelqu'un assume le risque, voici qui, pourquoi et jusqu'à quand.
+
+Un CSPM utilisé en production doit permettre des exceptions. Sans elles, une équipe désactive
+le contrôle, ou cesse de lire l'outil : deux issues pires que l'écart. Ce qu'un CSPM ne doit
+jamais permettre, c'est la forme muette (`ignore: true`), qui est un faux vert sous un autre nom.
+
+### Condition préalable
+
+Un résultat `fail` dont le couple `(contrôle, sujet)` est couvert par une entrée **valide** du
+fichier de dérogations passé à `scan --exceptions`. Valide signifie que les cinq champs
+obligatoires sont présents et que la date d'échéance n'est pas dépassée à l'instant
+d'évaluation.
+
+Seul un `fail` peut devenir `exempted`. Un `not-evaluated` ne le peut pas : déroger à un
+contrôle que personne n'a su mesurer reviendrait à cacher une absence de mesure derrière une
+exception, c'est-à-dire le même faux vert avec une étape de plus.
+
+### À quoi cela ressemble
+
+<!-- pepin:gen assessment-exempted -->
+```json
+{
+  "control": "network_securitygroup_allow_ingress_from_internet_to_tcp_port_22",
+  "evidence": {
+    "observed": "SSH (port 22) accepté depuis/vers Internet.",
+    "proves": [
+      "",
+      "",
+      ""
+    ],
+    "source": "export"
+  },
+  "labels": {
+    "category": "security",
+    "exemption_approved_by": "security@example.org",
+    "exemption_expires_at": "2099-12-31",
+    "exemption_owner": "platform-security",
+    "provider": "scaleway"
+  },
+  "references": [
+    {
+      "framework": "scsl",
+      "id": "CLD-NET-1"
+    },
+    {
+      "framework": "scsl",
+      "id": "CLD-IAM-6"
+    },
+    {
+      "framework": "scsl",
+      "id": "CLD-NET-6"
+    },
+    {
+      "framework": "cis-v8",
+      "id": "4.4"
+    },
+    {
+      "framework": "cis-v8",
+      "id": "12.2"
+    },
+    {
+      "framework": "iso-27001",
+      "id": "A.8.20"
+    },
+    {
+      "framework": "iso-27001",
+      "id": "A.8.22"
+    },
+    {
+      "framework": "secnumcloud-3.2",
+      "id": "13.2"
+    }
+  ],
+  "remediation": "Restreindre la règle à des sources/destinations et ports légitimes (CIDR d'administration, bastion, VPN) ; ne jamais exposer un service sensible à 0.0.0.0/0.",
+  "severity": "high",
+  "status": "exempted",
+  "subject": "sg-bastion",
+  "title": "SSH (port 22) ouvert à Internet",
+  "waiver": {
+    "justification": "Bastion administre, acces restreint par IP source en amont",
+    "until": "2099-12-31"
+  }
+}
+```
+<!-- /pepin:gen assessment-exempted -->
+
+La dérogation voyage avec le résultat (justification, échéance, responsable, approbateur),
+parce qu'un dossier qui ne dit pas ce qu'il a écarté, ni sous quelle autorité, n'est pas
+opposable.
+
+### Conséquence
+
+`exempted` est un statut de premier rang, et distinct de `pass` partout :
+
+- **Dans l'assessment**, la chaîne de statut est `exempted` ; le rendu OSCAL le traite, comme
+  tout statut autre que `pass`, en `not-satisfied`.
+- **Dans le rapport**, rien ne disparaît. Le finding reste dans `--format json`, dans le SARIF
+  et dans le décompte par sévérité ; `summary.conforme` reste faux. Une dérogation retire un
+  écart de la **porte**, jamais du dossier.
+- **Au terminal**, un bloc `EXEMPTIONS APPLIED` liste chaque dérogation avec son responsable,
+  son approbateur et sa date. Une exemption discrète est une exemption que personne ne revoit.
+- **Dans le verdict**, le bandeau annonce `NON CONFORME sous dérogation`. Jamais conforme.
+- **Dans le code de sortie**, un **4** dédié : voir [codes de sortie](../reference/exit-codes.md).
+
+Une dérogation expirée cesse de s'appliquer et le dit ; une dérogation qui nomme un contrôle ou
+un sujet inexistant est signalée comme orpheline. Les deux sont imprimées sur la sortie
+d'erreur, et les deux font échouer une porte `--strict`.
+
 ## Les scénarios, rangés
 
 | Scénario | Statut | D'où vient le motif |
@@ -406,7 +520,8 @@ scan n'est jamais globalement « fiable » ou non, chaque contrôle porte sa pro
 ## Répartition des statuts sur un scan réel
 
 Le scan du plan volontairement non conforme du
-[démarrage rapide](../getting-started/quickstart.fr.md) produit les quatre statuts à la fois :
+[démarrage rapide](../getting-started/quickstart.fr.md) produit les quatre statuts MESURÉS à la
+fois (`exempted` n'apparaît qu'avec un fichier de dérogations) :
 
 <!-- pepin:gen assessment-counts -->
 | Statut | Nombre |
@@ -431,6 +546,8 @@ rien mesuré. Pépin rend **3** dans ce cas, et le fait **sans exiger `--strict`
 | Rien n'a été mesuré (inventaire vide) : **sans avoir à demander `--strict`** | `./pepin scan scaleway empty-inventory.json` | **3** |
 | Écarts medium/low seulement, sans `--strict` | `./pepin scan scaleway tagless-inventory.json` | **0** |
 | Écarts medium/low seulement, avec `--strict` | `./pepin scan scaleway tagless-inventory.json --strict` | **3** |
+| Tout écart critical/high est couvert par une dérogation valide | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions.yaml` | **4** |
+| La même dérogation, échue : elle ne s'applique plus | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions-expired.yaml` | **1** |
 <!-- /pepin:gen exit-codes -->
 
 Les contrôles de gouvernance sont exclus de ce décompte à dessein.

--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -202,13 +202,14 @@ ressources, pas une liste à cocher de contrôles.
 {
   "control": "objectstorage_bucket_public_access",
   "evidence": {
+    "attribute": "acl",
     "observed": "Bucket « scaleway_object_bucket_acl.backups » accessible publiquement (ACL publique).",
     "proves": [
       "",
       "",
       ""
     ],
-    "source": "terraform-plan"
+    "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
     "category": "security",

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -1,6 +1,6 @@
 > 🇬🇧 English · [🇫🇷 Français](assessment-model.fr.md)
 
-# The assessment model — `pass`, `fail`, `not-applicable`, `not-evaluated`
+# The assessment model — `pass`, `fail`, `not-applicable`, `not-evaluated`, `exempted`
 
 A posture scanner is only worth its weakest claim. Pépin's weakest claim is `pass`, so this
 page is mostly about what has to be true before Pépin is allowed to say it.
@@ -13,7 +13,7 @@ The captured output on this page is in French: the CLI, the reference and the ru
 by repository convention, and quoting them verbatim is the only way this page can be checked
 against what the tool prints.
 
-## The four statuses in one sentence each
+## The five statuses in one sentence each
 
 | Status | Pépin asserts |
 |---|---|
@@ -21,9 +21,11 @@ against what the tool prints.
 | `fail` | *I looked at this and found a deviation, on this subject, with this evidence.* |
 | `not-applicable` | *This control cannot exist here, and here is the recorded justification.* |
 | `not-evaluated` | *I could not decide, and here is exactly what I was missing.* |
+| `exempted` | *I found a deviation, and someone accepted it — here is who, why and until when.* |
 
-There is no fifth status, and in particular **no silent one**. A control that is implemented
-for the scanned provider always comes back with one of these four.
+The first four are what Pépin **measures**; the fifth is what an organization **decides**, and
+it is never a compliance. There is no sixth status, and in particular **no silent one**: a
+control implemented for the scanned provider always comes back with one of these five.
 
 ## The decision, exactly as the code takes it
 
@@ -387,6 +389,117 @@ wrong: nothing was observed to be broken either.
 
 If you need a gate that refuses uncertainty, use `--strict`, and read the exit codes below.
 
+## `exempted` — set aside, never compliant
+
+The four statuses above are what Pépin *measures*. `exempted` is what an organization
+*decides*: this control fails, someone accepts the risk, here is who, why and until when.
+
+A CSPM used in production has to allow exceptions. Without them, a team disables the control,
+or stops reading the tool — both worse than the deviation. What a CSPM must never allow is the
+silent form of it (`ignore: true`), which is a false green under another name.
+
+### Precondition
+
+A `fail` result whose `(control, subject)` is covered by a **valid** entry of the exemptions
+file passed to `scan --exceptions`. Valid means all five mandatory fields are present and the
+expiry date has not passed at the instant of evaluation.
+
+Only a `fail` can become `exempted`. A `not-evaluated` cannot: waiving a control nobody managed
+to measure would hide a missing measurement behind an exception, which is the same false green
+with one more step.
+
+### What it looks like
+
+<!-- pepin:gen assessment-exempted -->
+```json
+{
+  "control": "network_securitygroup_allow_ingress_from_internet_to_tcp_port_22",
+  "evidence": {
+    "observed": "Security group \"sg-bastion\": SSH (port 22) accepted from/to the internet.",
+    "proves": [
+      "",
+      "",
+      ""
+    ],
+    "source": "export"
+  },
+  "labels": {
+    "category": "security",
+    "exemption_approved_by": "security@example.org",
+    "exemption_expires_at": "2099-12-31",
+    "exemption_owner": "platform-security",
+    "provider": "scaleway"
+  },
+  "references": [
+    {
+      "framework": "scsl",
+      "id": "CLD-NET-1"
+    },
+    {
+      "framework": "scsl",
+      "id": "CLD-IAM-6"
+    },
+    {
+      "framework": "scsl",
+      "id": "CLD-NET-6"
+    },
+    {
+      "framework": "cis-v8",
+      "id": "4.4"
+    },
+    {
+      "framework": "cis-v8",
+      "id": "12.2"
+    },
+    {
+      "framework": "iso-27001",
+      "id": "A.8.20"
+    },
+    {
+      "framework": "iso-27001",
+      "id": "A.8.22"
+    },
+    {
+      "framework": "secnumcloud-3.2",
+      "id": "13.2"
+    }
+  ],
+  "remediation": "Restrict the rule to legitimate sources/destinations and ports (administration CIDR, bastion, VPN); never expose a sensitive service to 0.0.0.0/0.",
+  "severity": "high",
+  "status": "exempted",
+  "subject": "sg-bastion",
+  "title": "SSH (port 22) open to the internet",
+  "waiver": {
+    "justification": "Bastion administre, acces restreint par IP source en amont",
+    "until": "2099-12-31"
+  }
+}
+```
+<!-- /pepin:gen assessment-exempted -->
+
+The waiver travels with the result — justification, expiry, owner and approver — because a
+dossier that does not say what it set aside, and on whose authority, is not defensible.
+
+### Consequence
+
+`exempted` is a first-class status, and distinct from `pass` everywhere:
+
+- **In the assessment**, the status string is `exempted`; the OSCAL rendering treats it, like
+  every non-`pass` status, as `not-satisfied`.
+- **In the report**, nothing disappears. The finding stays in `--format json`, in the SARIF and
+  in the severity counts; `summary.conforme` stays false. An exemption removes a deviation from
+  the **gate**, never from the record.
+- **In the terminal**, an `EXEMPTIONS APPLIED — accepted deviations, NOT compliant` block lists
+  each one with its owner, its approver and its date. A discreet exemption is an exemption
+  nobody reviews.
+- **In the verdict**, the headline reads `NON-COMPLIANT under waiver`. It never reads
+  compliant.
+- **In the exit code**, a dedicated **4** — see [exit codes](../reference/exit-codes.md).
+
+An expired exemption stops applying and says so; one naming a control or a subject that does
+not exist is reported as an orphan. Both are printed on standard error, and both fail a
+`--strict` gate.
+
 ## The scenarios, mapped
 
 | Scenario | Status | Where the reason comes from |
@@ -405,7 +518,8 @@ never globally "trustworthy" or not — each control carries its own answer.
 ## Status counts on a real scan
 
 Scanning the deliberately misconfigured plan of the
-[quickstart](../getting-started/quickstart.md) yields all four statuses at once:
+[quickstart](../getting-started/quickstart.md) yields the four measured statuses at once
+(`exempted` appears only when an exemptions file is supplied):
 
 <!-- pepin:gen assessment-counts -->
 | Status | Count |
@@ -430,6 +544,8 @@ measured nothing. Pépin returns **3** for it, and does so **without requiring `
 | Nothing was measured (empty inventory): **without having to ask for `--strict`** | `./pepin scan scaleway empty-inventory.json` | **3** |
 | Medium/low deviations only, without `--strict` | `./pepin scan scaleway tagless-inventory.json` | **0** |
 | Medium/low deviations only, with `--strict` | `./pepin scan scaleway tagless-inventory.json --strict` | **3** |
+| Every critical/high deviation is covered by a valid exemption | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions.yaml` | **4** |
+| The same exemption, lapsed: it no longer applies | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions-expired.yaml` | **1** |
 <!-- /pepin:gen exit-codes -->
 
 Governance controls are excluded from that count on purpose. `governance_provider_sovereignty`

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -203,13 +203,14 @@ resources, not a checklist of controls.
 {
   "control": "objectstorage_bucket_public_access",
   "evidence": {
+    "attribute": "acl",
     "observed": "Bucket \"scaleway_object_bucket_acl.backups\" is publicly accessible (public ACL).",
     "proves": [
       "",
       "",
       ""
     ],
-    "source": "terraform-plan"
+    "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
     "category": "security",

--- a/docs/concepts/terraform-vs-live.fr.md
+++ b/docs/concepts/terraform-vs-live.fr.md
@@ -68,13 +68,14 @@ de deviner :
 {
   "control": "compute_instance_has_security_group",
   "evidence": {
+    "attribute": "security_group_ids",
     "observed": "attribut « security_group_ids » non collecté sur les ressources de type « compute_instance » (garde de capacité)",
     "proves": [
       "",
       "",
       ""
     ],
-    "source": "terraform-plan"
+    "source": "security_group_ids=terraform-plan:scaleway_instance_server observed=0/1"
   },
   "references": [
     {

--- a/docs/concepts/terraform-vs-live.md
+++ b/docs/concepts/terraform-vs-live.md
@@ -66,13 +66,14 @@ control that reads instance filtering therefore cannot decide, and says so rathe
 {
   "control": "compute_instance_has_security_group",
   "evidence": {
+    "attribute": "security_group_ids",
     "observed": "attribute \"security_group_ids\" not collected on the resources of type \"compute_instance\" (capability guard)",
     "proves": [
       "",
       "",
       ""
     ],
-    "source": "terraform-plan"
+    "source": "security_group_ids=terraform-plan:scaleway_instance_server observed=0/1"
   },
   "references": [
     {

--- a/docs/getting-started/quickstart.fr.md
+++ b/docs/getting-started/quickstart.fr.md
@@ -239,6 +239,8 @@ ligne ci-dessous a été produite en exécutant la commande affichée.
 | Rien n'a été mesuré (inventaire vide) : **sans avoir à demander `--strict`** | `./pepin scan scaleway empty-inventory.json` | **3** |
 | Écarts medium/low seulement, sans `--strict` | `./pepin scan scaleway tagless-inventory.json` | **0** |
 | Écarts medium/low seulement, avec `--strict` | `./pepin scan scaleway tagless-inventory.json --strict` | **3** |
+| Tout écart critical/high est couvert par une dérogation valide | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions.yaml` | **4** |
+| La même dérogation, échue : elle ne s'applique plus | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions-expired.yaml` | **1** |
 <!-- /pepin:gen exit-codes -->
 
 Deux d'entre eux méritent l'attention :

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -235,6 +235,8 @@ produced by running the command shown:
 | Nothing was measured (empty inventory): **without having to ask for `--strict`** | `./pepin scan scaleway empty-inventory.json` | **3** |
 | Medium/low deviations only, without `--strict` | `./pepin scan scaleway tagless-inventory.json` | **0** |
 | Medium/low deviations only, with `--strict` | `./pepin scan scaleway tagless-inventory.json --strict` | **3** |
+| Every critical/high deviation is covered by a valid exemption | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions.yaml` | **4** |
+| The same exemption, lapsed: it no longer applies | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions-expired.yaml` | **1** |
 <!-- /pepin:gen exit-codes -->
 
 Two of these deserve attention:

--- a/docs/getting-started/understanding-a-scan.fr.md
+++ b/docs/getting-started/understanding-a-scan.fr.md
@@ -385,13 +385,14 @@ mot.
 {
   "control": "objectstorage_bucket_public_access",
   "evidence": {
+    "attribute": "acl",
     "observed": "Bucket « scaleway_object_bucket_acl.backups » accessible publiquement (ACL publique).",
     "proves": [
       "",
       "",
       ""
     ],
-    "source": "terraform-plan"
+    "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
     "category": "security",

--- a/docs/getting-started/understanding-a-scan.fr.md
+++ b/docs/getting-started/understanding-a-scan.fr.md
@@ -303,6 +303,8 @@ echo $?   # 1
 | Rien n'a été mesuré (inventaire vide) : **sans avoir à demander `--strict`** | `./pepin scan scaleway empty-inventory.json` | **3** |
 | Écarts medium/low seulement, sans `--strict` | `./pepin scan scaleway tagless-inventory.json` | **0** |
 | Écarts medium/low seulement, avec `--strict` | `./pepin scan scaleway tagless-inventory.json --strict` | **3** |
+| Tout écart critical/high est couvert par une dérogation valide | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions.yaml` | **4** |
+| La même dérogation, échue : elle ne s'applique plus | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions-expired.yaml` | **1** |
 <!-- /pepin:gen exit-codes -->
 
 ## Le même run, en assessment
@@ -363,7 +365,7 @@ marqueurs ; tout le reste est le document capturé.)*
 - `scope.included` liste les types de ressources réellement évalués. Un contrôle portant sur un
   type absent de cette liste ne peut pas avoir été mesuré, et l'assessment le dit.
 
-### Les quatre statuts, sur ce seul run
+### Les quatre statuts mesurés, sur ce seul run
 
 <!-- pepin:gen assessment-counts -->
 | Statut | Nombre |
@@ -374,7 +376,9 @@ marqueurs ; tout le reste est le document capturé.)*
 | `not-evaluated` | 9 |
 <!-- /pepin:gen assessment-counts -->
 
-Un unique scan sans compte cloud produit les quatre. Chacun est documenté dans
+Un unique scan sans compte cloud produit les quatre. Le cinquième statut, `exempted`, relève
+d'une décision et non d'une mesure : il n'apparaît qu'avec une dérogation fournie par
+`--exceptions`. Chacun est documenté dans
 [le modèle d'assessment](../concepts/assessment-model.fr.md) ; en voici un de chaque, mot pour
 mot.
 

--- a/docs/getting-started/understanding-a-scan.md
+++ b/docs/getting-started/understanding-a-scan.md
@@ -382,13 +382,14 @@ A single account-free scan produces all four. Each is documented in
 {
   "control": "objectstorage_bucket_public_access",
   "evidence": {
+    "attribute": "acl",
     "observed": "Bucket \"scaleway_object_bucket_acl.backups\" is publicly accessible (public ACL).",
     "proves": [
       "",
       "",
       ""
     ],
-    "source": "terraform-plan"
+    "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
     "category": "security",

--- a/docs/getting-started/understanding-a-scan.md
+++ b/docs/getting-started/understanding-a-scan.md
@@ -302,6 +302,8 @@ echo $?   # 1
 | Nothing was measured (empty inventory): **without having to ask for `--strict`** | `./pepin scan scaleway empty-inventory.json` | **3** |
 | Medium/low deviations only, without `--strict` | `./pepin scan scaleway tagless-inventory.json` | **0** |
 | Medium/low deviations only, with `--strict` | `./pepin scan scaleway tagless-inventory.json --strict` | **3** |
+| Every critical/high deviation is covered by a valid exemption | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions.yaml` | **4** |
+| The same exemption, lapsed: it no longer applies | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions-expired.yaml` | **1** |
 <!-- /pepin:gen exit-codes -->
 
 ## The same run, as an assessment
@@ -361,7 +363,7 @@ everything else is the captured document.)*
 - `scope.included` lists the resource types actually evaluated. A control about a type absent
   from that list cannot have been measured, and the assessment says so.
 
-### The four statuses, on this one run
+### The four measured statuses, on this one run
 
 <!-- pepin:gen assessment-counts -->
 | Status | Count |
@@ -372,7 +374,9 @@ everything else is the captured document.)*
 | `not-evaluated` | 9 |
 <!-- /pepin:gen assessment-counts -->
 
-A single account-free scan produces all four. Each is documented in
+A single account-free scan produces all four. The fifth status, `exempted`, is a decision
+rather than a measurement: it appears only when `--exceptions` supplies a waiver. Each is
+documented in
 [the assessment model](../concepts/assessment-model.md); here is one of each, verbatim.
 
 **`fail`** — a deviation, with its subject and evidence:

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -57,7 +57,8 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
 <!-- pepin:gen bundle-manifest -->
 ```json
 {
-  "format": "pepin-assessment-bundle/v1",
+  "format": "pepin-assessment-bundle/v2",
+  "inventory_schema": "pepin-inventory/v1",
   "disclaimer": "Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.",
   "generated": "<timestamp>",
   "tool": {
@@ -133,6 +134,23 @@ Format `sha256sum` standard, donc vérifiable sans Pépin du tout
 (`sha256sum -c checksums.txt`). C'est ce fichier que couvre une signature cosign : signer un
 seul fichier qui nomme les empreintes des autres est ce qui fait qu'une signature couvre tout le
 bundle.
+
+### `exemptions.json` : seulement si une dérogation a été appliquée
+
+Un dossier qui tait ce qu'il a écarté n'est pas opposable. Quand un scan reçoit
+`--exceptions`, le bundle porte un sixième artefact, qui consigne la politique telle qu'elle a
+été chargée et ce que chaque entrée a réellement produit (`applied`, `expired`, `orphan`).
+
+C'est un artefact comme les autres : son empreinte figure dans `checksums.txt`, donc il est
+couvert par la signature, et l'empreinte du bundle **dépend des dérogations**. Un dossier ne
+peut pas les retirer sans échouer à sa propre vérification. Le manifeste en porte le résumé
+(combien appliquées, échues, orphelines, et l'empreinte de la politique elle-même), pour qu'un
+vérificateur le voie avant d'ouvrir quoi que ce soit d'autre.
+
+`verify --re-derive` rejoue la politique scellée à l'instant d'évaluation scellé. Sans cela, un
+bundle parfaitement fidèle serait déclaré falsifié pour la seule raison que le vérificateur ne
+détient pas le fichier de l'opérateur, et une dérogation valide semblerait « expirer » entre le
+scan et la vérification.
 
 ## Vérifier un bundle
 

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -55,7 +55,8 @@ raises a version number and gets a CHANGELOG line.
 <!-- pepin:gen bundle-manifest -->
 ```json
 {
-  "format": "pepin-assessment-bundle/v1",
+  "format": "pepin-assessment-bundle/v2",
+  "inventory_schema": "pepin-inventory/v1",
   "disclaimer": "This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.",
   "generated": "<timestamp>",
   "tool": {
@@ -130,6 +131,23 @@ attention:
 Standard `sha256sum` format, so it can be checked without Pépin at all
 (`sha256sum -c checksums.txt`). This is the file a cosign signature covers: signing one file
 that names the digests of the others is what makes a single signature cover the whole bundle.
+
+### `exemptions.json` — only when a waiver was applied
+
+A dossier that does not say what it set aside is not defensible. When a scan is given
+`--exceptions`, the bundle carries a sixth artifact recording the policy as loaded and what
+each entry actually produced (`applied`, `expired`, `orphan`).
+
+It is an artifact like any other: its digest is in `checksums.txt`, so it is covered by the
+signature, and the bundle digest therefore **depends on the exemptions**. A dossier cannot
+drop them without failing its own verification. The manifest carries the summary — how many
+applied, expired, orphan, and the digest of the policy itself — so a verifier sees it before
+opening anything else.
+
+`verify --re-derive` replays the sealed policy at the sealed instant of evaluation. Without
+that, a perfectly faithful bundle would be declared falsified for the sole reason that the
+verifier does not hold the operator's exemptions file, and a valid waiver would appear to
+"expire" between the scan and the verification.
 
 ## Verifying a bundle
 

--- a/docs/guides/remediation.fr.md
+++ b/docs/guides/remediation.fr.md
@@ -52,13 +52,14 @@ Avant, sur `examples/scaleway/terraform/plan.json` :
 {
   "control": "objectstorage_bucket_public_access",
   "evidence": {
+    "attribute": "acl",
     "observed": "Bucket « scaleway_object_bucket_acl.backups » accessible publiquement (ACL publique).",
     "proves": [
       "",
       "",
       ""
     ],
-    "source": "terraform-plan"
+    "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
     "category": "security",
@@ -110,13 +111,14 @@ Après, sur `examples/scaleway/terraform-fixed/plan.json` :
 {
   "control": "objectstorage_bucket_public_access",
   "evidence": {
+    "attribute": "acl",
     "observed": "aucune non-conformité détectée sur les ressources de type « object_storage_bucket » collectées (contrat vérifié)",
     "proves": [
       "",
       "",
       ""
     ],
-    "source": "terraform-plan"
+    "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "references": [
     {

--- a/docs/guides/remediation.md
+++ b/docs/guides/remediation.md
@@ -50,13 +50,14 @@ Before, on `examples/scaleway/terraform/plan.json`:
 {
   "control": "objectstorage_bucket_public_access",
   "evidence": {
+    "attribute": "acl",
     "observed": "Bucket \"scaleway_object_bucket_acl.backups\" is publicly accessible (public ACL).",
     "proves": [
       "",
       "",
       ""
     ],
-    "source": "terraform-plan"
+    "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
     "category": "security",
@@ -108,13 +109,14 @@ After, on `examples/scaleway/terraform-fixed/plan.json`:
 {
   "control": "objectstorage_bucket_public_access",
   "evidence": {
+    "attribute": "acl",
     "observed": "no deviation detected on the collected resources of type \"object_storage_bucket\" (contract verified)",
     "proves": [
       "",
       "",
       ""
     ],
-    "source": "terraform-plan"
+    "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "references": [
     {

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -22,7 +22,7 @@ de drapeaux viennent de la surface gelée ; chaque aide ci-dessous est la sortie
 | `pepin provider list` | _(aucun drapeau propre)_ |
 | `pepin provider new` | _(aucun drapeau propre)_ |
 | `pepin provider validate` | _(aucun drapeau propre)_ |
-| `pepin scan` | `--format` / `-f`, `--kubeconfig`, `--lang`, `--live`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
+| `pepin scan` | `--exceptions`, `--format` / `-f`, `--kubeconfig`, `--lang`, `--live`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
 | `pepin scsl` | `--index` |
 | `pepin verify` | `--bundle`, `--pubkey`, `--re-derive` |
 | `pepin version` | _(aucun drapeau propre)_ |
@@ -37,10 +37,11 @@ séparément :
 <!-- pepin:gen surface-versions -->
 | Surface | Ce qui est gelé | Version |
 |---|---|:-:|
-| `cli` | verbes, drapeaux et codes de sortie | **v2** |
+| `cli` | verbes, drapeaux et codes de sortie | **v3** |
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
-| `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v1** |
+| `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v2** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v1** |
 <!-- /pepin:gen surface-versions -->
 
 Un numéro monte à **tout** changement de forme, ajout compris : il signifie « la surface a
@@ -112,6 +113,7 @@ Usage:
   pepin scan <provider> [export.json] [flags]
 
 Flags:
+      --exceptions fichier               fichier YAML de dérogations (control, justification, expires_at, owner, approved_by) : un écart couvert passe au statut exempted, jamais conforme
   -f, --format string                    format de sortie : table | json | assessment | oscal | sarif (default "table")
   -h, --help                             help for scan
       --kubeconfig string                chemin d'un kubeconfig pour auditer l'état DANS un cluster Kubernetes (utiliser un accès en LECTURE SEULE, TTL court — jamais cluster-admin)
@@ -353,6 +355,7 @@ cette sortie doit épingler `PEPIN_LANG`, ou couper sur l'espace.
 | **1** | `non_conformite` | au moins un écart critical ou high |
 | **2** | `erreur` | erreur technique : le scan n'a pas pu conclure |
 | **3** | `strict` | rien n'a été mesuré (sans `--strict`), ou écarts medium/low restants avec `--strict` |
+| **4** | `derogation` | tout écart critical/high restant est couvert par une dérogation datée et attribuée (`--exceptions`) |
 <!-- /pepin:gen cli-exit-codes -->
 
 La sémantique complète, situation par situation, avec les commandes qui produisent chaque

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -22,7 +22,7 @@ by running the binary. A public flag that is missing here fails
 | `pepin provider list` | _(no flag of its own)_ |
 | `pepin provider new` | _(no flag of its own)_ |
 | `pepin provider validate` | _(no flag of its own)_ |
-| `pepin scan` | `--format` / `-f`, `--kubeconfig`, `--lang`, `--live`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
+| `pepin scan` | `--exceptions`, `--format` / `-f`, `--kubeconfig`, `--lang`, `--live`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
 | `pepin scsl` | `--index` |
 | `pepin verify` | `--bundle`, `--pubkey`, `--re-derive` |
 | `pepin version` | _(no flag of its own)_ |
@@ -37,10 +37,11 @@ independently:
 <!-- pepin:gen surface-versions -->
 | Surface | What is frozen | Version |
 |---|---|:-:|
-| `cli` | verbs, flags and exit codes | **v2** |
+| `cli` | verbs, flags and exit codes | **v3** |
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
-| `bundle` | shape of the evidence bundle (files, roles, manifest) | **v1** |
+| `bundle` | shape of the evidence bundle (files, roles, manifest) | **v2** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v1** |
 <!-- /pepin:gen surface-versions -->
 
 A version rises on **any** shape change, additions included: the number means "the surface has
@@ -111,6 +112,7 @@ Usage:
   pepin scan <provider> [export.json] [flags]
 
 Flags:
+      --exceptions file                  exemptions YAML file (control, justification, expires_at, owner, approved_by) — a covered deviation becomes exempted, never compliant
   -f, --format string                    output format: table | json | assessment | oscal | sarif (default "table")
   -h, --help                             help for scan
       --kubeconfig string                path to a kubeconfig to audit the state INSIDE a Kubernetes cluster (use READ-ONLY, short-lived access — never cluster-admin)
@@ -352,6 +354,7 @@ output should pin `PEPIN_LANG`, or split on the space.
 | **1** | `non_conformite` | at least one critical or high deviation |
 | **2** | `erreur` | technical error: the scan could not conclude |
 | **3** | `strict` | nothing was measured (without `--strict`), or medium/low deviations remain with `--strict` |
+| **4** | `derogation` | every remaining critical/high deviation is covered by a dated, attributed exemption (`--exceptions`) |
 <!-- /pepin:gen cli-exit-codes -->
 
 The full semantics, one scenario at a time, with the commands that produce each code:

--- a/docs/reference/exit-codes.fr.md
+++ b/docs/reference/exit-codes.fr.md
@@ -13,6 +13,7 @@ changer leur signification est une rupture qui a sa propre ligne de CHANGELOG.
 | **1** | `non_conformite` | au moins un écart critical ou high |
 | **2** | `erreur` | erreur technique : le scan n'a pas pu conclure |
 | **3** | `strict` | rien n'a été mesuré (sans `--strict`), ou écarts medium/low restants avec `--strict` |
+| **4** | `derogation` | tout écart critical/high restant est couvert par une dérogation datée et attribuée (`--exceptions`) |
 <!-- /pepin:gen cli-exit-codes -->
 
 La distinction dont dépend toute cette page : **1 et 3 sont des verdicts sur un tenant, 2 est
@@ -20,7 +21,7 @@ une panne de la mesure elle-même.** Un pipeline peut légitimement décider de 
 verdict sans bloquer dessus. Il ne peut jamais le faire avec 2 : une erreur technique avalée
 rapporte une posture que personne n'a mesurée.
 
-## Un tableau, six situations, six exécutions réelles
+## Un tableau, huit situations, huit exécutions réelles
 
 Chaque commande de ce tableau a été exécutée par le générateur de documentation, et le code de
 la dernière colonne est celui que le processus a rendu.
@@ -34,10 +35,13 @@ la dernière colonne est celui que le processus a rendu.
 | Rien n'a été mesuré (inventaire vide) : **sans avoir à demander `--strict`** | `./pepin scan scaleway empty-inventory.json` | **3** |
 | Écarts medium/low seulement, sans `--strict` | `./pepin scan scaleway tagless-inventory.json` | **0** |
 | Écarts medium/low seulement, avec `--strict` | `./pepin scan scaleway tagless-inventory.json --strict` | **3** |
+| Tout écart critical/high est couvert par une dérogation valide | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions.yaml` | **4** |
+| La même dérogation, échue : elle ne s'applique plus | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions-expired.yaml` | **1** |
 <!-- /pepin:gen exit-codes -->
 
-Les deux dernières lignes sont le même inventaire, avec et sans `--strict`. Les deux qui les
-précèdent portent la distinction la plus importante, et c'est l'objet de la suite.
+Les lignes cinq et six sont le même inventaire, avec et sans `--strict` ; les deux dernières
+sont le même inventaire et la même dérogation, valide puis échue. Les deux lignes qui portent
+la distinction la plus importante sont la troisième et la quatrième, et c'est l'objet de la suite.
 
 ## `0` : conforme
 
@@ -193,6 +197,132 @@ $ echo $?
 `--strict` n'ajoute donc qu'un seul comportement : les écarts medium/low deviennent bloquants.
 Il ne crée pas la porte « rien n'a été mesuré », qui existe sans lui.
 
+## `4` : tout écart restant est sous dérogation
+
+Un CSPM utilisé en production doit permettre des exceptions. Sans elles, une équipe désactive
+le contrôle, ou cesse de lire l'outil : deux issues pires que l'écart lui-même. Mais une
+dérogation ne doit jamais rendre une porte verte en silence, d'où un code qui n'appartient
+qu'à elle.
+
+On donne au scan un fichier de dérogations versionné, avec `--exceptions` :
+
+<!-- pepin:gen fixture-exceptions -->
+```yaml
+exceptions:
+  - control: network_securitygroup_allow_ingress_from_internet_to_tcp_port_22
+    resource: sg-bastion
+    justification: "Bastion administre, acces restreint par IP source en amont"
+    expires_at: 2099-12-31
+    owner: platform-security
+    approved_by: security@example.org
+```
+<!-- /pepin:gen fixture-exceptions -->
+
+Appliqué à un inventaire dont le seul écart high est celui qu'il couvre :
+
+<!-- pepin:gen fixture-bastion-inventory -->
+```json
+{
+  "provider": "scaleway",
+  "resources": [
+    {
+      "provider": "scaleway",
+      "type": "security_group_rule",
+      "id": "vm-bastion",
+      "name": "vm-bastion",
+      "region": "fr-par",
+      "attributes": {
+        "security_group_id": "sg-bastion",
+        "direction": "inbound",
+        "action": "accept",
+        "protocol": "tcp",
+        "port_from": 22,
+        "port_to": 22,
+        "cidrs": ["0.0.0.0/0"],
+        "description": "Acces d administration du bastion"
+      }
+    }
+  ]
+}
+```
+<!-- /pepin:gen fixture-bastion-inventory -->
+
+<!-- pepin:gen exit-run-exempted -->
+```console
+$ ./pepin scan scaleway bastion-inventory.json --exceptions exceptions.yaml
+[…]
+  │ CLD-NET-1 │ SSH (port 22) ouvert à Internet │ HIGH │ scaleway │ 1 │
+  ╰───────────┴─────────────────────────────────┴──────┴──────────┴───╯
+──────────────────────────────────────────────────────────────────────────────
+ Summary
+
+ Verdict : NON CONFORME sous dérogation, 1 écart(s) critique/haut tous couverts par une dérogation datée et attribuée
+
+ 🔴 CRITICAL 0   🟠 HIGH 1   🟡 MEDIUM 0   🔵 LOW 0
+──────────────────────────────────────────────────────────────────────────────
+
+DÉROGATIONS APPLIQUÉES : écarts assumés, NON conformes
+  · network_securitygroup_allow_ingress_from_internet_to_tcp_port_22 (sg-bastion)
+    Bastion administre, acces restreint par IP source en amont
+    jusqu'au 2099-12-31 · responsable platform-security · approuvé par security@example.org
+$ echo $?
+4
+```
+<!-- /pepin:gen exit-run-exempted -->
+
+La ligne de verdict se lit telle quelle : **NON CONFORME sous dérogation**. L'écart n'a pas
+disparu, il a été écarté. Le statut du contrôle dans `--format assessment` est `exempted`,
+jamais `pass` ; le finding reste dans `--format json`, dans le SARIF et dans le décompte par
+sévérité ; seule la porte bouge.
+
+Pourquoi 4 plutôt que 0 ou 1. Rendre **0** ferait d'une exemption un faux vert silencieux,
+c'est-à-dire exactement ce que le statut `exempted` existe pour empêcher. Rendre **1**
+rendrait la dérogation inutile, et une équipe qui ne peut pas déroger à un contrôle finit par
+le supprimer. **4** est non nul, donc rien ne passe en silence, et distinct, donc un pipeline
+qui choisit de l'accepter doit écrire le chiffre, et par conséquent savoir qu'il existe.
+
+### Une dérogation expirée n'ouvre pas la porte
+
+Le même fichier, avec une date passée. La dérogation ne s'applique plus, l'écart redevient un
+écart, et l'expiration est signalée sur la sortie d'erreur :
+
+<!-- pepin:gen exit-run-expired -->
+```console
+$ ./pepin scan scaleway bastion-inventory.json --exceptions exceptions-expired.yaml
+
+ ██████╗ ███████╗██████╗ ██╗ ███╗   ██╗
+ ██╔══██╗██╔════╝██╔══██╗██║ ████╗  ██║
+ ██████╔╝█████╗  ██████╔╝██║ ██╔██╗ ██║
+ ██╔═══╝ ██╔══╝  ██╔═══╝ ██║ ██║╚██╗██║
+ ██║     ███████╗██║     ██║ ██║ ╚████║
+ ╚═╝     ╚══════╝╚═╝     ╚═╝ ╚═╝  ╚═══╝
+
+ v<version>  · scanner de posture cloud (sécurité · conformité)
+
+pepin: ⚠ dérogation EXPIRÉE le 2020-01-01 sur network_securitygroup_allow_ingress_from_internet_to_tcp_port_22 / sg-bastion : elle ne s'applique plus, l'écart redevient un écart (platform-security)
+
+ⓘ Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.
+$ echo $?
+1
+```
+<!-- /pepin:gen exit-run-expired -->
+
+Une dérogation qui nomme un contrôle ou une ressource inexistants est signalée de la même
+façon, comme `ORPHAN` : c'est le symptôme d'une exception oubliée après un renommage ou un
+retrait. Sous `--strict`, une dérogation expirée ou orpheline suffit à refuser la porte
+(code 3) : un pipeline qui demande la rigueur demande que son fichier de dérogations soit revu.
+
+### Ordre de priorité
+
+Quand plusieurs situations se présentent en même temps, les codes se décident dans cet ordre :
+
+1. **2** : une erreur technique, rien d'autre n'est un verdict.
+2. **1** : au moins un écart critical/high **non** couvert par une dérogation valide.
+3. **3** : rien n'a été mesuré (hors gouvernance).
+4. **4** : au moins une dérogation a été appliquée.
+5. **3** : `--strict` et des écarts medium/low subsistent, ou le fichier de dérogations est périmé.
+6. **0** : aucun des cas ci-dessus.
+
 ## Ce qui ne change pas le code de sortie
 
 - **Le format de sortie.** `--format json`, `sarif`, `oscal` ou `assessment` changent ce qui
@@ -213,6 +343,7 @@ case "$code" in
   0) echo "conforme" ;;
   1) echo "non-conformité : au moins un écart critical/high" ; exit 1 ;;
   3) echo "rien mesuré, ou écarts medium/low sous --strict" ; exit 1 ;;
+  4) echo "des écarts subsistent, tous sous dérogation datée" ; exit 1 ;;
   2) echo "erreur technique : le scan n'a pas pu conclure" ; exit 2 ;;
   *) echo "code inattendu $code" ; exit 2 ;;
 esac

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -13,6 +13,7 @@ meaning is a breaking change with its own CHANGELOG line.
 | **1** | `non_conformite` | at least one critical or high deviation |
 | **2** | `erreur` | technical error: the scan could not conclude |
 | **3** | `strict` | nothing was measured (without `--strict`), or medium/low deviations remain with `--strict` |
+| **4** | `derogation` | every remaining critical/high deviation is covered by a dated, attributed exemption (`--exceptions`) |
 <!-- /pepin:gen cli-exit-codes -->
 
 The distinction the whole page turns on: **1 and 3 are verdicts about a tenant, 2 is a failure
@@ -20,7 +21,7 @@ of the measurement itself.** A pipeline may legitimately decide to report a verd
 blocking on it. It may never do that with 2 — a swallowed technical error reports a posture
 nobody measured.
 
-## One table, six situations, six real runs
+## One table, eight situations, eight real runs
 
 Every command in this table was executed by the documentation generator, and the code in the
 last column is the one the process returned.
@@ -34,10 +35,13 @@ last column is the one the process returned.
 | Nothing was measured (empty inventory): **without having to ask for `--strict`** | `./pepin scan scaleway empty-inventory.json` | **3** |
 | Medium/low deviations only, without `--strict` | `./pepin scan scaleway tagless-inventory.json` | **0** |
 | Medium/low deviations only, with `--strict` | `./pepin scan scaleway tagless-inventory.json --strict` | **3** |
+| Every critical/high deviation is covered by a valid exemption | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions.yaml` | **4** |
+| The same exemption, lapsed: it no longer applies | `./pepin scan scaleway bastion-inventory.json --exceptions exceptions-expired.yaml` | **1** |
 <!-- /pepin:gen exit-codes -->
 
-The last two rows are the same inventory, with and without `--strict`. The two before them are
-the distinction that matters most, and the next section is about it.
+Rows five and six are the same inventory, with and without `--strict`; the last two are the
+same inventory and the same exemption, valid then lapsed. The two rows that matter most are
+the third and the fourth, and the next section is about them.
 
 ## `0` — compliant
 
@@ -191,6 +195,130 @@ $ echo $?
 `--strict` therefore adds one behaviour only: medium/low deviations become blocking. It does
 not create the "nothing measured" gate, which exists without it.
 
+## `4` — every remaining deviation is under a waiver
+
+A CSPM used in production must allow exceptions. Without them a team disables the control, or
+stops reading the tool — two outcomes worse than the deviation itself. But an exemption must
+never turn a gate green in silence, which is why it has a code of its own.
+
+Give the scan a versioned exemptions file with `--exceptions`:
+
+<!-- pepin:gen fixture-exceptions -->
+```yaml
+exceptions:
+  - control: network_securitygroup_allow_ingress_from_internet_to_tcp_port_22
+    resource: sg-bastion
+    justification: "Bastion administre, acces restreint par IP source en amont"
+    expires_at: 2099-12-31
+    owner: platform-security
+    approved_by: security@example.org
+```
+<!-- /pepin:gen fixture-exceptions -->
+
+Applied to an inventory whose only high deviation is the one it covers:
+
+<!-- pepin:gen fixture-bastion-inventory -->
+```json
+{
+  "provider": "scaleway",
+  "resources": [
+    {
+      "provider": "scaleway",
+      "type": "security_group_rule",
+      "id": "vm-bastion",
+      "name": "vm-bastion",
+      "region": "fr-par",
+      "attributes": {
+        "security_group_id": "sg-bastion",
+        "direction": "inbound",
+        "action": "accept",
+        "protocol": "tcp",
+        "port_from": 22,
+        "port_to": 22,
+        "cidrs": ["0.0.0.0/0"],
+        "description": "Acces d administration du bastion"
+      }
+    }
+  ]
+}
+```
+<!-- /pepin:gen fixture-bastion-inventory -->
+
+<!-- pepin:gen exit-run-exempted -->
+```console
+$ ./pepin scan scaleway bastion-inventory.json --exceptions exceptions.yaml
+[…]
+  │ CLD-NET-1 │ SSH (port 22) open to the internet │ HIGH │ scaleway │ 1 │
+  ╰───────────┴────────────────────────────────────┴──────┴──────────┴───╯
+──────────────────────────────────────────────────────────────────────────────
+ Summary
+
+ Verdict: NON-COMPLIANT under waiver — 1 critical/high deviation(s), all covered by a dated, attributed exemption
+
+ 🔴 CRITICAL 0   🟠 HIGH 1   🟡 MEDIUM 0   🔵 LOW 0
+──────────────────────────────────────────────────────────────────────────────
+
+EXEMPTIONS APPLIED — accepted deviations, NOT compliant
+  · network_securitygroup_allow_ingress_from_internet_to_tcp_port_22 (sg-bastion)
+    Bastion administre, acces restreint par IP source en amont
+    until 2099-12-31 · owner platform-security · approved by security@example.org
+$ echo $?
+4
+```
+<!-- /pepin:gen exit-run-exempted -->
+
+Read the verdict line: **NON-COMPLIANT under waiver**. The deviation did not disappear, it was
+set aside. The control's status in `--format assessment` is `exempted`, never `pass`; the
+finding stays in `--format json`, in the SARIF and in the severity counts; only the gate moves.
+
+Why 4 rather than 0 or 1. Returning **0** would make an exemption a silent false green, which
+is precisely what the `exempted` status exists to prevent. Returning **1** would make the
+exemption useless, and a team that cannot waive a control deletes it instead. **4** is non-zero
+— nothing passes in silence — and distinct, so a pipeline that chooses to accept it has to
+write the number down, therefore to know it exists.
+
+### An expired exemption does not open the gate
+
+The same file with a date in the past. The exemption stops applying, the deviation is a
+deviation again, and the expiry is reported on standard error:
+
+<!-- pepin:gen exit-run-expired -->
+```console
+$ ./pepin scan scaleway bastion-inventory.json --exceptions exceptions-expired.yaml
+
+ ██████╗ ███████╗██████╗ ██╗ ███╗   ██╗
+ ██╔══██╗██╔════╝██╔══██╗██║ ████╗  ██║
+ ██████╔╝█████╗  ██████╔╝██║ ██╔██╗ ██║
+ ██╔═══╝ ██╔══╝  ██╔═══╝ ██║ ██║╚██╗██║
+ ██║     ███████╗██║     ██║ ██║ ╚████║
+ ╚═╝     ╚══════╝╚═╝     ╚═╝ ╚═╝  ╚═══╝
+
+ v<version>  · cloud posture scanner (security · compliance)
+
+pepin: ⚠ exemption EXPIRED on 2020-01-01 for network_securitygroup_allow_ingress_from_internet_to_tcp_port_22 / sg-bastion: it no longer applies, the deviation is a deviation again (platform-security)
+
+ⓘ This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.
+$ echo $?
+1
+```
+<!-- /pepin:gen exit-run-expired -->
+
+An exemption that names a control or a resource which does not exist is reported the same way,
+as an `ORPHAN` — it is the symptom of an exception forgotten after a rename or a removal.
+Under `--strict`, an expired or orphan exemption is enough to fail the gate (code 3): a
+pipeline that asks for strictness is asking for its exemption file to be reviewed.
+
+### Order of precedence
+
+When several situations apply at once, the codes are decided in this order:
+
+1. **2** — a technical error: nothing else is a verdict.
+2. **1** — at least one critical/high deviation **not** covered by a valid exemption.
+3. **3** — nothing was measured (governance aside).
+4. **4** — at least one exemption was applied.
+5. **3** — `--strict` and medium/low deviations remain, or the exemption file is stale.
+6. **0** — none of the above.
+
 ## What does not change the exit code
 
 - **The output format.** `--format json`, `sarif`, `oscal` or `assessment` change what is
@@ -211,6 +339,7 @@ case "$code" in
   0) echo "compliant" ;;
   1) echo "non-compliance: at least one critical/high deviation" ; exit 1 ;;
   3) echo "nothing measured, or medium/low deviations under --strict" ; exit 1 ;;
+  4) echo "deviations remain, all under a dated exemption" ; exit 1 ;;
   2) echo "technical error: the scan could not conclude" ; exit 2 ;;
   *) echo "unexpected code $code" ; exit 2 ;;
 esac

--- a/docs/reference/inventory.fr.md
+++ b/docs/reference/inventory.fr.md
@@ -1,0 +1,144 @@
+> [🇬🇧 English](inventory.md) · 🇫🇷 Français
+
+# L'inventaire normalisé : un contrat interne
+
+Tout passe par l'inventaire normalisé. Les collecteurs y projettent, les règles s'y évaluent,
+l'assessment en dérive, le bundle de preuve le scelle. Tout ce qui consomme Pépin au-delà de sa
+CLI consomme cette forme.
+
+Tant qu'elle restait implicite, chaque nouvel usage la figeait un peu plus **par accident**, et
+une évolution du modèle cassait un consommateur en silence. Elle est donc nommée, versionnée et
+gelée, avec les mêmes égards que la surface CLI.
+
+<!-- pepin:gen inventory-format -->
+```text
+pepin-inventory/v1
+```
+<!-- /pepin:gen inventory-format -->
+
+La version voyage avec chaque bundle de preuve, dans `manifest.inventory_schema`. Un
+consommateur qui rencontre une version qu'il ne connaît pas doit s'arrêter plutôt que deviner.
+
+## L'enveloppe
+
+```json
+{
+  "provider": "scaleway",
+  "evaluated_at": "2026-08-19T10:11:12Z",
+  "resources": [ … ]
+}
+```
+
+- `provider` : l'identifiant du fournisseur scanné.
+- `resources` : le tableau des ressources normalisées, éventuellement vide.
+- `evaluated_at` : l'instant d'évaluation unique, RFC3339 UTC, posé par `scan`. Les règles
+  sensibles au temps s'y ancrent plutôt qu'à l'horloge, si bien que rejouer un `input.json`
+  scellé rend le même verdict. Il n'est **jamais** écrasé lors d'un rejeu.
+
+## La ressource
+
+```json
+{
+  "provider": "scaleway",
+  "type": "security_group_rule",
+  "id": "sg-bastion",
+  "name": "sg-bastion",
+  "region": "fr-par",
+  "attributes": { "protocol": "tcp", "port_from": 22 },
+  "provenance": { "protocol": { "origin": "api", "source": "GET https://api.scaleway.com/…", "path": "protocol", "observed": true } }
+}
+```
+
+- `provider`, `type`, `id`, `name`, `attributes` sont toujours présents.
+- `region` et `provenance` sont présents quand ils portent quelque chose.
+- `attributes` est une carte **plate** de nom d'attribut vers valeur JSON. C'est ce que lisent
+  les règles Rego, et c'est pourquoi une même règle vaut pour tous les clouds.
+- `provenance` est indexée par les **mêmes** noms d'attributs, jamais imbriquée dans une
+  valeur. Voir [le modèle d'assessment](../concepts/assessment-model.fr.md) pour ce que
+  signifie une origine `derived`.
+
+## Ce qui est garanti
+
+- Un nom d'attribut est en snake_case et **agnostique du fournisseur**. Le vocabulaire natif
+  vit dans la projection du descripteur, jamais dans le modèle.
+- Un type de ressource est en snake_case, au singulier, nommé d'après sa famille de service
+  (`compute_instance`, `security_group_rule`, `object_storage_bucket`…).
+- **Un attribut absent n'est jamais forcé à une valeur.** « Non collecté » et « collecté à
+  faux » ne se confondent pas. Toutes les garanties de confiance de Pépin reposent sur cet
+  invariant.
+- Une clé de `provenance` peut exister sans que l'attribut correspondant soit dans
+  `attributes` : cela signifie que le champ a été cherché à ce chemin et que la source ne le
+  portait pas.
+
+## Ce qui n'est pas garanti
+
+- **L'ordre** des ressources ni celui des attributs. Rien ne le fixe, et s'en servir casserait
+  au premier changement de pagination.
+- **La présence** d'un attribut donné sur une ressource donnée. Elle dépend du fournisseur, des
+  droits du jeton et de la source : un plan Terraform ignore tout de l'état effectif. C'est
+  exactement la question à laquelle `provenance` répond, attribut par attribut.
+- **L'exhaustivité** de l'inventaire. Un scan mesure ce à quoi ses identifiants donnent accès,
+  jamais « tout le tenant ».
+- **Les valeurs** elles-mêmes. Elles reflètent le contrat natif du fournisseur, qui peut
+  changer sans que Pépin en décide.
+
+## Le vocabulaire
+
+Chaque type de ressource et les attributs communs qu'il peut porter, dérivés des descripteurs
+de fournisseurs chargés et des collecteurs Go, jamais d'une liste tenue à la main à côté du
+code.
+
+<!-- pepin:gen inventory-types -->
+| Type de ressource lu | Attributs communs |
+|---|---|
+| `access_key` | `access_key_id` `expiration_date` `owner_user` `scope` `state` |
+| `api_access_policy` | `id` `max_access_key_expiration_seconds` `require_trusted_env` |
+| `api_access_rule` | `api_access_rule_id` `ca_ids` `cns` `ip_ranges` |
+| `api_access_summary` | `id` `rule_count` |
+| `blockstorage_snapshot` | `creation_date` `global_permission` `snapshot_id` `volume_id` |
+| `blockstorage_volume` | `encrypted` `state` `tags` `volume_id` |
+| `compute_image` | `image_id` `public` `state` `tags` |
+| `compute_instance` | `deletion_protection` `nic_public_ips` `public_ip` `security_group_ids` `state` `tags` `user_data` `vm_id` |
+| `governance_provider` | `capital_control` `eu_established` `extraterritorial_exposure` `jurisdiction` `secnumcloud` |
+| `iam_policy` | `manages_iam` `owner_group` `owner_user` `policy_id` `policy_name` `scope` `statements` |
+| `iam_role` | `admin_privileges` `editable` `manages_iam` `max_session_ttl` `name` `policy_has_expiration` `role_id` `source_ip_restricted` |
+| `iam_user` | `mfa_enabled` `user_id` `username` |
+| `k8s_cluster_role_binding` | `name` `role_ref` `subjects` |
+| `k8s_crd` | `name` |
+| `k8s_namespace` | `labels` `name` |
+| `k8s_network_policy` | `name` `namespace` |
+| `kubernetes_cluster` | `admin_whitelist` `audit_enabled` `auto_upgrade` `control_plane_multi_az` `deletion_protection` `name` `version` |
+| `load_balancer` | `access_log` `listeners` `load_balancer_name` `load_balancer_type` `tags` |
+| `managed_database` | `database_id` `disable_backup` `encryption_at_rest` `ip_filter` |
+| `network` | `cidr` `description` `name` `network_id` `state` `tags` |
+| `network_peering` | `accepter_account` `peering_id` `source_account` `state` |
+| `object_storage_bucket` | `acl` `acl_grants` `default_encryption_enabled` `kms_key_id` `name` `object_lock_enabled` `policy_public` `public_via_acl` `sse_kms_enabled` `tags` `versioning` |
+| `security_group` | `inbound_default_policy` `security_group_id` |
+| `security_group_rule` | `action` `cidrs` `description` `direction` `port_from` `port_to` `protocol` `security_group_id` `security_group_name` |
+| `subnet` | `map_public_ip_on_launch` `network_id` `state` `subnet_id` `tags` |
+<!-- /pepin:gen inventory-types -->
+
+Une entrée signifie ici « cet attribut existe dans le modèle, sur ce type ». Elle ne signifie
+**pas** qu'il est présent sur une ressource donnée d'un scan donné : cette question-là est
+celle de la provenance.
+
+## Comment il bouge
+
+La forme et ce vocabulaire sont gelés dans `cmd/testdata/frozen/inventory.json`. Ajouter un
+attribut à un descripteur fait rougir le gel, et le changement coûte alors trois choses :
+lancer `mise run frozen-update`, incrémenter `model.InventoryFormat`, écrire la ligne de
+CHANGELOG. Ce coût est délibéré : c'est ce que veut dire, concrètement, « l'inventaire cesse
+d'être un détail d'implémentation ».
+
+## Pour aller plus loin
+
+- [Formats de sortie](output-formats.fr.md) : les documents analysables dérivés de cet inventaire.
+- [Bundles de preuve](../guides/evidence-bundles.fr.md) : là où l'inventaire est scellé, avec
+  sa version de schéma.
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : comment un statut en découle.
+
+## Comment cette page reste vraie
+
+La chaîne de format, le vocabulaire et la forme viennent du code, par les régions générées
+ci-dessus. On régénère avec `mise run gen-docs` ; `TestGeneratedDocsAreUpToDate` échoue si la
+page committée et le code divergent.

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -1,0 +1,138 @@
+> 🇬🇧 English · [🇫🇷 Français](inventory.fr.md)
+
+# The normalized inventory — an internal contract
+
+Everything passes through the normalized inventory. Collectors project into it, rules evaluate
+on it, the assessment derives from it, the evidence bundle seals it. Anything that consumes
+Pépin beyond its CLI consumes this shape.
+
+As long as it stayed implicit, every new use froze it a little more **by accident**, and a
+change to the model would break a consumer in silence. So it is named, versioned and frozen,
+with the same regard as the CLI surface.
+
+<!-- pepin:gen inventory-format -->
+```text
+pepin-inventory/v1
+```
+<!-- /pepin:gen inventory-format -->
+
+The version travels with every evidence bundle, in `manifest.inventory_schema`. A consumer
+that meets a version it does not know must stop rather than guess.
+
+## The envelope
+
+```json
+{
+  "provider": "scaleway",
+  "evaluated_at": "2026-08-19T10:11:12Z",
+  "resources": [ … ]
+}
+```
+
+- `provider` — the identifier of the scanned provider.
+- `resources` — the array of normalized resources, possibly empty.
+- `evaluated_at` — the single instant of evaluation, RFC3339 UTC, added by `scan`. Time-sensitive
+  rules anchor on it rather than on the clock, so replaying a sealed `input.json` yields the
+  same verdict. It is **never** overwritten on a replay.
+
+## The resource
+
+```json
+{
+  "provider": "scaleway",
+  "type": "security_group_rule",
+  "id": "sg-bastion",
+  "name": "sg-bastion",
+  "region": "fr-par",
+  "attributes": { "protocol": "tcp", "port_from": 22 },
+  "provenance": { "protocol": { "origin": "api", "source": "GET https://api.scaleway.com/…", "path": "protocol", "observed": true } }
+}
+```
+
+- `provider`, `type`, `id`, `name`, `attributes` are always present.
+- `region` and `provenance` are present when they carry something.
+- `attributes` is a **flat** map from attribute name to JSON value. This is what the Rego rules
+  read, and it is why one rule can be common to every cloud.
+- `provenance` is indexed by the **same** attribute names, never nested inside a value. See
+  [the assessment model](../concepts/assessment-model.md) for what a `derived` origin means.
+
+## What is guaranteed
+
+- An attribute name is snake_case and **provider-agnostic**. The native vocabulary lives in the
+  descriptor's projection, never in the model.
+- A resource type is snake_case, singular, and named after its service family
+  (`compute_instance`, `security_group_rule`, `object_storage_bucket`, …).
+- **An absent attribute is never forced to a value.** "not collected" and "collected as false"
+  do not get confused. Every trust guarantee in Pépin rests on that one invariant.
+- A `provenance` key may exist without the matching attribute being in `attributes`: it means
+  the field was looked for at that path and the source did not carry it.
+
+## What is not guaranteed
+
+- **The order** of resources or of attributes. Nothing fixes it, and relying on it would break
+  at the first pagination change.
+- **The presence** of a given attribute on a given resource. It depends on the provider, on the
+  rights of the token, and on the source — a Terraform plan knows nothing of the effective
+  state. That question is exactly what `provenance` answers, per attribute.
+- **The completeness** of the inventory. A scan measures what its credentials reach, never
+  "the whole tenant".
+- **The values** themselves. They mirror the provider's native contract, which can change
+  without Pépin deciding anything.
+
+## The vocabulary
+
+Every resource type and the common attributes it can carry, derived from the loaded provider
+descriptors and from the Go collectors — never a hand-kept list beside the code.
+
+<!-- pepin:gen inventory-types -->
+| Resource type read | Common attributes |
+|---|---|
+| `access_key` | `access_key_id` `expiration_date` `owner_user` `scope` `state` |
+| `api_access_policy` | `id` `max_access_key_expiration_seconds` `require_trusted_env` |
+| `api_access_rule` | `api_access_rule_id` `ca_ids` `cns` `ip_ranges` |
+| `api_access_summary` | `id` `rule_count` |
+| `blockstorage_snapshot` | `creation_date` `global_permission` `snapshot_id` `volume_id` |
+| `blockstorage_volume` | `encrypted` `state` `tags` `volume_id` |
+| `compute_image` | `image_id` `public` `state` `tags` |
+| `compute_instance` | `deletion_protection` `nic_public_ips` `public_ip` `security_group_ids` `state` `tags` `user_data` `vm_id` |
+| `governance_provider` | `capital_control` `eu_established` `extraterritorial_exposure` `jurisdiction` `secnumcloud` |
+| `iam_policy` | `manages_iam` `owner_group` `owner_user` `policy_id` `policy_name` `scope` `statements` |
+| `iam_role` | `admin_privileges` `editable` `manages_iam` `max_session_ttl` `name` `policy_has_expiration` `role_id` `source_ip_restricted` |
+| `iam_user` | `mfa_enabled` `user_id` `username` |
+| `k8s_cluster_role_binding` | `name` `role_ref` `subjects` |
+| `k8s_crd` | `name` |
+| `k8s_namespace` | `labels` `name` |
+| `k8s_network_policy` | `name` `namespace` |
+| `kubernetes_cluster` | `admin_whitelist` `audit_enabled` `auto_upgrade` `control_plane_multi_az` `deletion_protection` `name` `version` |
+| `load_balancer` | `access_log` `listeners` `load_balancer_name` `load_balancer_type` `tags` |
+| `managed_database` | `database_id` `disable_backup` `encryption_at_rest` `ip_filter` |
+| `network` | `cidr` `description` `name` `network_id` `state` `tags` |
+| `network_peering` | `accepter_account` `peering_id` `source_account` `state` |
+| `object_storage_bucket` | `acl` `acl_grants` `default_encryption_enabled` `kms_key_id` `name` `object_lock_enabled` `policy_public` `public_via_acl` `sse_kms_enabled` `tags` `versioning` |
+| `security_group` | `inbound_default_policy` `security_group_id` |
+| `security_group_rule` | `action` `cidrs` `description` `direction` `port_from` `port_to` `protocol` `security_group_id` `security_group_name` |
+| `subnet` | `map_public_ip_on_launch` `network_id` `state` `subnet_id` `tags` |
+<!-- /pepin:gen inventory-types -->
+
+An entry here means "this attribute exists in the model, on this type". It does **not** mean it
+is present on a given resource of a given scan: that question belongs to the provenance.
+
+## How it moves
+
+The shape and this vocabulary are frozen in `cmd/testdata/frozen/inventory.json`. Adding an
+attribute to a descriptor turns the freeze red, and the change then costs three things: run
+`mise run frozen-update`, bump `model.InventoryFormat`, write the CHANGELOG line. That cost is
+deliberate — it is what "the inventory is no longer an implementation detail" means in practice.
+
+## Where to go next
+
+- [Output formats](output-formats.md) — the parsable documents derived from this inventory.
+- [Evidence bundles](../guides/evidence-bundles.md) — where the inventory is sealed, with its
+  schema version.
+- [The assessment model](../concepts/assessment-model.md) — how a status is derived from it.
+
+## How this page stays true
+
+The format string, the vocabulary and the shape come from the code through the generated
+regions above. Regenerate with `mise run gen-docs`; `TestGeneratedDocsAreUpToDate` fails if the
+committed page and the code disagree.

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -143,13 +143,14 @@ Un résultat :
 {
   "control": "objectstorage_bucket_public_access",
   "evidence": {
+    "attribute": "acl",
     "observed": "Bucket « scaleway_object_bucket_acl.backups » accessible publiquement (ACL publique).",
     "proves": [
       "",
       "",
       ""
     ],
-    "source": "terraform-plan"
+    "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
     "category": "security",

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -26,10 +26,11 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 <!-- pepin:gen surface-versions -->
 | Surface | Ce qui est gelé | Version |
 |---|---|:-:|
-| `cli` | verbes, drapeaux et codes de sortie | **v2** |
+| `cli` | verbes, drapeaux et codes de sortie | **v3** |
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
-| `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v1** |
+| `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v2** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v1** |
 <!-- /pepin:gen surface-versions -->
 
 « Gelé » signifie qu'un test échoue quand la forme bouge sans que sa version ait suivi : les
@@ -117,6 +118,25 @@ n'a été collecté ». Le booléen `summary.conforme` ne dit rien non plus de l
 cette distinction compte, et pour une porte de conformité elle compte, lire le code de sortie
 (3 signifie que rien n'a été mesuré) ou utiliser le format assessment.
 
+### `exemptions` : présent seulement avec `--exceptions`
+
+Quand un scan reçoit un fichier de dérogations, le document porte une troisième clé de premier
+niveau, à côté de `findings` et `summary` :
+
+```json
+{
+  "exemptions": {
+    "policy_digest": "sha256:…",
+    "exceptions": [ { "control": "…", "justification": "…", "expires_at": "…", "owner": "…", "approved_by": "…" } ],
+    "records": [ { "control": "…", "effect": "applied", "subjects": ["…"] } ]
+  }
+}
+```
+
+`effect` vaut `applied`, `expired` ou `orphan`. Rien n'est retiré de `findings` ni de `summary`
+au motif d'une dérogation : une exemption déplace le **code de sortie**, jamais le dossier. Un
+pipeline qui veut refuser toute dérogation vérifie que `exemptions` est absent.
+
 ## `assessment` : le document typé et opposable
 
 C'est le format bâti pour une chaîne de conformité : une entrée par contrôle, avec un statut
@@ -131,10 +151,19 @@ typé, une preuve, les références normatives et la provenance de l'exécution.
 | `not-evaluated` | 9 |
 <!-- /pepin:gen assessment-counts -->
 
-Quatre statuts, et les deux que les autres formats ne savent pas exprimer sont
+Quatre statuts mesurés, et les deux que les autres formats ne savent pas exprimer sont
 `not-applicable` (le contrat du fournisseur déclare le contrôle non testable, avec sa
-justification) et `not-evaluated` (Pépin n'a pas pu décider, et dit sur quoi il a buté). Leur
-sens exact est dans [Le modèle d'assessment](../concepts/assessment-model.fr.md).
+justification) et `not-evaluated` (Pépin n'a pas pu décider, et dit sur quoi il a buté). Un
+cinquième, `exempted`, apparaît quand `--exceptions` fournit une dérogation ; il n'est jamais
+une conformité. Leur sens exact est dans
+[Le modèle d'assessment](../concepts/assessment-model.fr.md).
+
+`evidence.attribute` et `evidence.source` portent la **provenance de l'attribut décisif**
+quand Pépin en a une : quel attribut le contrôle lit, d'où sa valeur vient (`api:` suivi de la
+requête réellement servie, `terraform-plan:` suivi du type de ressource du plan, ou `derived:`
+suivi de l'élément de descripteur), et sur combien de ressources la source la portait vraiment
+(`observed=n/m`). Une source `derived:` est le nom honnête d'une valeur qu'aucun appel d'API
+n'a produite.
 
 Un résultat :
 
@@ -362,6 +391,9 @@ Deux conséquences pour un pipeline :
    tout.**
 
 ## Pour aller plus loin
+
+- [L'inventaire normalisé](inventory.fr.md) : la forme dont tous ces documents dérivent, et sa
+  version gelée.
 
 - [Codes de sortie](exit-codes.fr.md) : sur quoi bloquer.
 - [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -143,13 +143,14 @@ One result:
 {
   "control": "objectstorage_bucket_public_access",
   "evidence": {
+    "attribute": "acl",
     "observed": "Bucket \"scaleway_object_bucket_acl.backups\" is publicly accessible (public ACL).",
     "proves": [
       "",
       "",
       ""
     ],
-    "source": "terraform-plan"
+    "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
     "category": "security",

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -26,10 +26,11 @@ See [Exit codes](exit-codes.md).
 <!-- pepin:gen surface-versions -->
 | Surface | What is frozen | Version |
 |---|---|:-:|
-| `cli` | verbs, flags and exit codes | **v2** |
+| `cli` | verbs, flags and exit codes | **v3** |
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
-| `bundle` | shape of the evidence bundle (files, roles, manifest) | **v1** |
+| `bundle` | shape of the evidence bundle (files, roles, manifest) | **v2** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v1** |
 <!-- /pepin:gen surface-versions -->
 
 "Frozen" means a test fails when the shape moves and its version has not: field paths and JSON
@@ -117,6 +118,25 @@ identifier, common to every provider. Both are stable across languages; `title`,
 and for a compliance gate it does — read the exit code (3 means nothing was measured) or use
 the assessment format.
 
+### `exemptions` — present only under `--exceptions`
+
+When a scan is given an exemptions file, the document carries a third top-level key next to
+`findings` and `summary`:
+
+```json
+{
+  "exemptions": {
+    "policy_digest": "sha256:…",
+    "exceptions": [ { "control": "…", "justification": "…", "expires_at": "…", "owner": "…", "approved_by": "…" } ],
+    "records": [ { "control": "…", "effect": "applied", "subjects": ["…"] } ]
+  }
+}
+```
+
+`effect` is `applied`, `expired` or `orphan`. Nothing is removed from `findings` or from
+`summary` for being exempted: an exemption moves the **exit code**, never the record. A
+pipeline that wants to refuse exemptions altogether checks that `exemptions` is absent.
+
 ## `assessment` — the typed, defensible document
 
 This is the format built for a compliance chain: one entry per control, with a typed status, a
@@ -131,10 +151,17 @@ piece of evidence, the normative references, and the provenance of the run.
 | `not-evaluated` | 9 |
 <!-- /pepin:gen assessment-counts -->
 
-Four statuses, and the two that the other formats cannot express are `not-applicable` (the
-provider contract declares the control untestable, with its justification) and `not-evaluated`
-(Pépin could not decide, and says on what it stumbled). Their exact meaning is in
-[The assessment model](../concepts/assessment-model.md).
+Four measured statuses, and the two that the other formats cannot express are
+`not-applicable` (the provider contract declares the control untestable, with its
+justification) and `not-evaluated` (Pépin could not decide, and says on what it stumbled). A
+fifth, `exempted`, appears when `--exceptions` supplies a waiver; it is never a compliance.
+Their exact meaning is in [The assessment model](../concepts/assessment-model.md).
+
+`evidence.attribute` and `evidence.source` carry the **provenance of the deciding attribute**
+when Pépin has one: which attribute the control reads, where its value came from (`api:` plus
+the request actually served, `terraform-plan:` plus the plan resource type, or `derived:` plus
+the descriptor element), and on how many resources the source really carried it
+(`observed=n/m`). A `derived:` source is the honest name for a value no API call produced.
 
 One result:
 
@@ -360,6 +387,9 @@ Two consequences for a pipeline:
 2. **Keying on `code`, `labels.check`, `status` and `severity` requires pinning nothing.**
 
 ## Where to go next
+
+- [The normalized inventory](inventory.md) — the shape every one of these documents derives
+  from, and its frozen version.
 
 - [Exit codes](exit-codes.md) — what to gate on.
 - [The assessment model](../concepts/assessment-model.md) — what each status asserts.

--- a/internal/assess/bundle.go
+++ b/internal/assess/bundle.go
@@ -13,6 +13,7 @@ import (
 	screport "github.com/stephrobert/scankit/report"
 
 	"github.com/stephrobert/pepin/internal/i18n"
+	"github.com/stephrobert/pepin/internal/model"
 )
 
 // BundleFormat identifie le schéma du bundle de preuve, version comprise (`/vN`).
@@ -21,7 +22,12 @@ import (
 // s'arrêter plutôt que deviner. La forme du bundle (fichiers, rôles, manifest)
 // est gelée par cmd/testdata/frozen/bundle.json : la changer sans incrémenter le
 // suffixe `/vN` fait échouer TestASurfaceChangeDemandsItsVersionBump.
-const BundleFormat = "pepin-assessment-bundle/v1"
+// v2 : le manifeste porte la version du schéma d'inventaire (l'inventaire est un
+// contrat, cf. internal/model.InventoryFormat) et le résumé des DÉROGATIONS
+// appliquées ; le bundle gagne l'artefact exemptions.json quand une politique de
+// dérogations a été appliquée. Un dossier qui tait ses exemptions n'est pas
+// opposable, donc elles sont scellées comme le reste.
+const BundleFormat = "pepin-assessment-bundle/v2"
 
 // ScopeDisclaimer : avertissement de PORTÉE, obligatoire pour l'opposabilité. pepin évalue la
 // configuration d'un TENANT (périmètre commanditaire) ; les référentiels cités (SecNumCloud,
@@ -48,15 +54,45 @@ func ScopeDisclaimerIn(l i18n.Lang) string {
 // status, and the digest of every artifact. Sealing it (a detached signature over
 // checksums.txt) is left to the operator's own identity — see `pepin verify`.
 type Manifest struct {
-	Format     string               `json:"format"`
-	Disclaimer string               `json:"disclaimer"` // portée prestataire/commanditaire (opposabilité)
-	Generated  string               `json:"generated"`  // Run.Timestamp (RFC3339 UTC)
-	Tool       assessment.Component `json:"tool"`
-	Ruleset    assessment.Component `json:"ruleset"`
-	Target     assessment.Target    `json:"target"`
-	Source     string               `json:"source"`
-	Summary    map[string]int       `json:"summary"` // status -> count
-	Artifacts  []Artifact           `json:"artifacts"`
+	Format string `json:"format"`
+	// InventorySchema : la version du schéma de l'inventaire normalisé que porte
+	// input.json. Elle VOYAGE avec le bundle pour qu'un consommateur sache quelle
+	// forme il lit, au lieu de la déduire de ce qu'il y trouve.
+	InventorySchema string               `json:"inventory_schema"`
+	Disclaimer      string               `json:"disclaimer"` // portée prestataire/commanditaire (opposabilité)
+	Generated       string               `json:"generated"`  // Run.Timestamp (RFC3339 UTC)
+	Tool            assessment.Component `json:"tool"`
+	Ruleset         assessment.Component `json:"ruleset"`
+	Target          assessment.Target    `json:"target"`
+	Source          string               `json:"source"`
+	Summary         map[string]int       `json:"summary"` // status -> count
+	// Exemptions : l'effet des dérogations sur CE dossier. Absent quand aucune
+	// politique n'a été fournie ; jamais silencieux quand il y en a une.
+	Exemptions *ExemptionSummary `json:"exemptions,omitempty"`
+	Artifacts  []Artifact        `json:"artifacts"`
+}
+
+// ExemptionSummary résume, dans le manifeste, ce que les dérogations ont changé.
+// Le détail est dans exemptions.json, lui aussi empreint et signé ; ce résumé est
+// ce qu'un vérificateur lit AVANT d'ouvrir le reste.
+type ExemptionSummary struct {
+	// PolicyDigest : empreinte de la politique appliquée (contenu normalisé).
+	PolicyDigest string `json:"policy_digest"`
+	// Applied / Expired / Orphan : combien de dérogations ont écarté un écart,
+	// combien étaient échues, combien visaient un contrôle ou une ressource absents.
+	Applied int `json:"applied"`
+	Expired int `json:"expired"`
+	Orphan  int `json:"orphan"`
+}
+
+// BundleExtras porte ce qui s'ajoute au trio input/assessment/OSCAL. Un struct
+// plutôt qu'un paramètre de plus : la liste des artefacts d'un bundle grandira
+// encore, et une signature à sept positions se lit mal au point de se tromper.
+type BundleExtras struct {
+	// Exemptions : le document exemptions.json (nil = aucune politique fournie).
+	Exemptions []byte
+	// ExemptionSummary : son résumé, porté par le manifeste.
+	ExemptionSummary *ExemptionSummary
 }
 
 // Artifact is one file of the bundle with its digest, so any tampering is detectable.
@@ -93,7 +129,7 @@ func canonical(a assessment.Assessment) assessment.Assessment {
 // assessment (JSON), its OSCAL assessment-results, a manifest with per-artifact digests, and a
 // checksums.txt an operator can sign. `inputJSON` is the inventory the rules were evaluated on
 // (nil to omit). Returns the path of checksums.txt (the thing to sign).
-func WriteBundle(dir string, a assessment.Assessment, inputJSON []byte) (string, error) {
+func WriteBundle(dir string, a assessment.Assessment, inputJSON []byte, extras BundleExtras) (string, error) {
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return "", fmt.Errorf(i18n.T("création du dossier bundle %s : %w", "creating the bundle directory %s: %w"), dir, err)
 	}
@@ -136,16 +172,27 @@ func WriteBundle(dir string, a assessment.Assessment, inputJSON []byte) (string,
 			data       []byte
 		}{{"input.json", "evaluated-input", inputJSON}}, files...)
 	}
+	if extras.Exemptions != nil {
+		// La dérogation APPLIQUÉE fait partie de la preuve : elle entre au bundle,
+		// donc au checksums.txt que l'opérateur signe. Le digest du dossier dépend
+		// ainsi des exemptions, et un dossier ne peut pas les taire sans se trahir.
+		files = append(files, struct {
+			name, role string
+			data       []byte
+		}{"exemptions.json", "applied-exemptions", extras.Exemptions})
+	}
 
 	manifest := Manifest{
-		Format:     BundleFormat,
-		Disclaimer: ScopeDisclaimer(),
-		Generated:  a.Run.Timestamp,
-		Tool:       a.Run.Tool,
-		Ruleset:    a.Run.Ruleset,
-		Target:     a.Run.Target,
-		Source:     a.Run.Source,
-		Summary:    summaryOf(a),
+		Format:          BundleFormat,
+		InventorySchema: model.InventoryFormat,
+		Disclaimer:      ScopeDisclaimer(),
+		Generated:       a.Run.Timestamp,
+		Tool:            a.Run.Tool,
+		Ruleset:         a.Run.Ruleset,
+		Target:          a.Run.Target,
+		Source:          a.Run.Source,
+		Summary:         summaryOf(a),
+		Exemptions:      extras.ExemptionSummary,
 	}
 	var checksums string
 	for _, f := range files {

--- a/internal/assess/bundle_test.go
+++ b/internal/assess/bundle_test.go
@@ -27,7 +27,7 @@ func bundleAssessment() assessment.Assessment {
 
 func TestWriteAndVerifyBundle(t *testing.T) {
 	dir := t.TempDir()
-	cs, err := WriteBundle(dir, bundleAssessment(), []byte(`{"resources":[]}`))
+	cs, err := WriteBundle(dir, bundleAssessment(), []byte(`{"resources":[]}`), BundleExtras{})
 	if err != nil {
 		t.Fatalf("WriteBundle: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestWriteAndVerifyBundle(t *testing.T) {
 
 func TestVerifyDetectsTampering(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := WriteBundle(dir, bundleAssessment(), []byte(`{"resources":[]}`)); err != nil {
+	if _, err := WriteBundle(dir, bundleAssessment(), []byte(`{"resources":[]}`), BundleExtras{}); err != nil {
 		t.Fatal(err)
 	}
 	// Tamper with the assessment after sealing.
@@ -63,7 +63,7 @@ func TestVerifyDetectsTampering(t *testing.T) {
 func TestVerifyManifestChecksumBijection(t *testing.T) {
 	// Retirer un artefact de checksums.txt (il ne serait plus vérifié) : rejeté via le manifeste.
 	dir := t.TempDir()
-	if _, err := WriteBundle(dir, bundleAssessment(), []byte(`{"resources":[]}`)); err != nil {
+	if _, err := WriteBundle(dir, bundleAssessment(), []byte(`{"resources":[]}`), BundleExtras{}); err != nil {
 		t.Fatal(err)
 	}
 	cs := filepath.Join(dir, "checksums.txt")
@@ -84,10 +84,10 @@ func TestVerifyManifestChecksumBijection(t *testing.T) {
 
 func TestBundleDeterministic(t *testing.T) {
 	d1, d2 := t.TempDir(), t.TempDir()
-	if _, err := WriteBundle(d1, bundleAssessment(), []byte(`{"resources":[]}`)); err != nil {
+	if _, err := WriteBundle(d1, bundleAssessment(), []byte(`{"resources":[]}`), BundleExtras{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := WriteBundle(d2, bundleAssessment(), []byte(`{"resources":[]}`)); err != nil {
+	if _, err := WriteBundle(d2, bundleAssessment(), []byte(`{"resources":[]}`), BundleExtras{}); err != nil {
 		t.Fatal(err)
 	}
 	// Same run (same timestamp) → identical assessment digest in checksums.txt.

--- a/internal/assess/provenance.go
+++ b/internal/assess/provenance.go
@@ -1,0 +1,207 @@
+package assess
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/stephrobert/pepin/internal/model"
+	"github.com/stephrobert/scankit/assessment"
+)
+
+// La provenance côté assessment : dire, pour l'attribut DÉCISIF de chaque contrôle,
+// d'où vient la donnée et si elle a réellement été observée.
+//
+// Le choix de conception, et son coût. Porter la provenance DANS chaque valeur
+// (`{"value": false, "observed": true, "source": …}`) obligerait à réécrire les
+// cinquante-neuf règles, qui lisent toutes `attributes.<nom>` — et une règle
+// réécrite est une règle qui peut changer de verdict. L'attestation vit donc à
+// côté, dans un index parallèle porté par la ressource (model.Provenance), et
+// l'assessment n'en publie qu'un RÉSUMÉ, sur les attributs qui décident d'un
+// « pass ». Le modèle grossit à la collecte (une entrée par attribut mappé), pas
+// dans le rapport.
+//
+// Ce que ce résumé rend visible, et qui ne l'était pas : deux contrôles franchissent
+// aujourd'hui leur garde d'attribut grâce à un littéral de descripteur
+// (`const: {encrypted: true}` chez Exoscale, `const: {scope: account}` chez
+// Outscale). Leur verdict ne change pas — ce lot ne touche pas au verrou — mais
+// leur preuve dit désormais « derived:descriptor:const » au lieu de laisser croire
+// à une mesure. Resserrer le verrou est une décision, et une décision se prend en
+// voyant.
+
+// AttrOrigin résume la provenance d'UN attribut sur les ressources d'un type.
+type AttrOrigin struct {
+	// Sources : les étiquettes « <origine>:<source> » distinctes rencontrées, triées.
+	Sources []string
+	// Observed : ressources dont la source portait réellement le champ.
+	Observed int
+	// Total : ressources du type qui déclarent cet attribut (attesté ou non).
+	Total int
+}
+
+// Label rend le résumé sous une forme compacte et SANS PROSE : il voyage dans
+// `evidence.source`, que des outils parsent, et une chaîne traduite y serait un
+// piège (le même bundle dirait deux choses selon la langue de son auteur).
+func (o AttrOrigin) Label() string {
+	return strings.Join(o.Sources, " + ") + " observed=" +
+		strconv.Itoa(o.Observed) + "/" + strconv.Itoa(o.Total)
+}
+
+// ProvenanceIndex : type de ressource -> attribut -> résumé de provenance.
+type ProvenanceIndex map[string]map[string]AttrOrigin
+
+// ProvenanceOf construit l'index depuis l'inventaire évalué. Il accepte les deux
+// formes que le scan manipule : les ressources typées (collecte live, plan
+// Terraform) et la forme générique d'un export JSON relu — dont l'input.json d'un
+// bundle scellé, pour que `verify --re-derive` reconstruise le MÊME assessment.
+//
+// Un export sans `provenance` produit un index vide : une attestation absente reste
+// absente, elle ne s'invente pas. C'est la raison pour laquelle un inventaire
+// importé n'a pas d'origine « export » : Pépin n'a pas observé cet inventaire, il
+// l'a reçu.
+func ProvenanceOf(input any) ProvenanceIndex {
+	idx := ProvenanceIndex{}
+	m, ok := input.(map[string]any)
+	if !ok {
+		return idx
+	}
+	switch rs := m["resources"].(type) {
+	case []model.Resource:
+		for _, r := range rs {
+			idx.add(r.Type, r.Provenance)
+		}
+	case []any:
+		for _, it := range rs {
+			rm, ok := it.(map[string]any)
+			if !ok {
+				continue
+			}
+			typ, _ := rm["type"].(string)
+			raw, _ := rm["provenance"].(map[string]any)
+			idx.add(typ, provenanceFromJSON(raw))
+		}
+	}
+	for _, byAttr := range idx {
+		for attr, o := range byAttr {
+			sort.Strings(o.Sources)
+			byAttr[attr] = o
+		}
+	}
+	return idx
+}
+
+// add fusionne l'attestation d'une ressource dans l'index de son type.
+func (idx ProvenanceIndex) add(typ string, prov model.Provenance) {
+	if typ == "" || len(prov) == 0 {
+		return
+	}
+	if idx[typ] == nil {
+		idx[typ] = map[string]AttrOrigin{}
+	}
+	for attr, att := range prov {
+		o := idx[typ][attr]
+		o.Total++
+		if att.Observed {
+			o.Observed++
+		}
+		if label := attestationLabel(att); label != "" && !containsStr(o.Sources, label) {
+			o.Sources = append(o.Sources, label)
+		}
+		idx[typ][attr] = o
+	}
+}
+
+// attestationLabel rend « <origine>:<source> » (ou la seule origine si la source
+// est vide). Un `derived` porte en plus la marque `~` quand il est calculé sur une
+// source réelle (agrégat), pour ne pas le confondre avec une valeur recopiée.
+func attestationLabel(a model.Attestation) string {
+	if a.Origin == "" {
+		return ""
+	}
+	label := string(a.Origin)
+	if a.Source != "" {
+		label += ":" + a.Source
+	}
+	if a.Derived && a.Origin != model.OriginDerived {
+		label += " (derived)"
+	}
+	return label
+}
+
+// provenanceFromJSON relit une carte d'attestations telle qu'elle sort d'un
+// input.json. Défensif : une entrée mal formée est ignorée, jamais une panique —
+// le bundle vient d'un tiers.
+func provenanceFromJSON(raw map[string]any) model.Provenance {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make(model.Provenance, len(raw))
+	for attr, v := range raw {
+		am, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		origin, _ := am["origin"].(string)
+		source, _ := am["source"].(string)
+		path, _ := am["path"].(string)
+		observed, _ := am["observed"].(bool)
+		derived, _ := am["derived"].(bool)
+		out[attr] = model.Attestation{
+			Origin: model.Origin(origin), Source: source, Path: path,
+			Observed: observed, Derived: derived,
+		}
+	}
+	return out
+}
+
+// WithProvenance annote chaque résultat dont le contrôle a un attribut DÉCISIF avec
+// l'attribut en question et l'attestation de sa donnée.
+//
+// C'est une PASSE POSTÉRIEURE, et elle l'est par conception : elle n'écrit que
+// `evidence.attribute` et `evidence.source`, ne lit jamais un statut et n'en écrit
+// aucun. La non-régression des verdicts n'est donc pas une propriété à vérifier au
+// cas par cas, elle est structurelle — et TestProvenanceNeverMovesAVerdict la
+// mesure quand même, parce qu'une propriété qu'on affirme sans la mesurer est une
+// propriété qu'on espère.
+func WithProvenance(a assessment.Assessment, idx ProvenanceIndex, controlType map[string]string) assessment.Assessment {
+	if len(idx) == 0 {
+		return a
+	}
+	res := append([]assessment.Result(nil), a.Results...)
+	for i := range res {
+		attrs := requiredAttr[res[i].Control]
+		if len(attrs) == 0 {
+			continue
+		}
+		byAttr := idx[controlType[res[i].Control]]
+		if byAttr == nil {
+			continue
+		}
+		var attested []string
+		var labels []string
+		for _, attr := range attrs {
+			o, ok := byAttr[attr]
+			if !ok {
+				continue
+			}
+			attested = append(attested, attr)
+			labels = append(labels, attr+"="+o.Label())
+		}
+		if len(attested) == 0 {
+			continue
+		}
+		res[i].Evidence.Attribute = strings.Join(attested, " / ")
+		res[i].Evidence.Source = strings.Join(labels, " ; ")
+	}
+	a.Results = res
+	return a
+}
+
+func containsStr(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/assess/provenance_test.go
+++ b/internal/assess/provenance_test.go
@@ -1,0 +1,143 @@
+package assess
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/pepin/internal/model"
+	"github.com/stephrobert/scankit/assessment"
+)
+
+// provenanceFixture : un inventaire attesté couvrant les trois origines et les deux
+// formes (ressources typées, export JSON relu).
+func provenanceFixture() map[string]any {
+	return map[string]any{
+		"provider": "essai",
+		"resources": []model.Resource{
+			{
+				Type: "blockstorage_volume", ID: "vol-1",
+				Attributes: map[string]any{"encrypted": true, "state": "attached"},
+				Provenance: model.Provenance{
+					"encrypted": {Origin: model.OriginDerived, Source: "descriptor:const", Derived: true},
+					"state":     {Origin: model.OriginAPI, Source: "GET https://api.exemple/block-storage", Observed: true},
+				},
+			},
+			{
+				Type: "blockstorage_volume", ID: "vol-2",
+				Attributes: map[string]any{"encrypted": true},
+				Provenance: model.Provenance{
+					"encrypted": {Origin: model.OriginDerived, Source: "descriptor:const", Derived: true},
+					"state":     {Origin: model.OriginAPI, Source: "GET https://api.exemple/block-storage", Observed: false},
+				},
+			},
+		},
+	}
+}
+
+// TestProvenanceIndexSeparatesTheDerivedFromTheObserved : c'est l'objet même de
+// l'issue. `encrypted` franchit la garde d'attribut de blockstorage_volume_encryption
+// alors qu'aucun appel ne l'a porté — l'index le dit, sans rien changer au verdict.
+func TestProvenanceIndexSeparatesTheDerivedFromTheObserved(t *testing.T) {
+	idx := ProvenanceOf(provenanceFixture())
+	enc := idx["blockstorage_volume"]["encrypted"]
+	if len(enc.Sources) != 1 || enc.Sources[0] != "derived:descriptor:const" {
+		t.Errorf("`encrypted` : sources %v, attendu [derived:descriptor:const]", enc.Sources)
+	}
+	if enc.Observed != 0 || enc.Total != 2 {
+		t.Errorf("`encrypted` : observed=%d/%d, attendu 0/2 (un littéral n'est jamais observé)", enc.Observed, enc.Total)
+	}
+	st := idx["blockstorage_volume"]["state"]
+	if st.Observed != 1 || st.Total != 2 {
+		t.Errorf("`state` : observed=%d/%d, attendu 1/2 — un champ cherché et absent chez l'une des deux", st.Observed, st.Total)
+	}
+	if !strings.Contains(st.Label(), "observed=1/2") {
+		t.Errorf("le libellé %q ne porte pas le compte d'observation", st.Label())
+	}
+}
+
+// TestProvenanceSurvivesTheJSONRoundTrip : l'attestation doit traverser input.json,
+// sinon `verify --re-derive` reconstruirait un assessment différent du scellé et
+// crierait à la falsification sur un bundle parfaitement fidèle.
+func TestProvenanceSurvivesTheJSONRoundTrip(t *testing.T) {
+	raw, err := json.Marshal(provenanceFixture())
+	if err != nil {
+		t.Fatalf("sérialisation : %v", err)
+	}
+	var back any
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("relecture : %v", err)
+	}
+	direct := ProvenanceOf(provenanceFixture())
+	roundTripped := ProvenanceOf(back)
+	a, _ := json.Marshal(direct)
+	b, _ := json.Marshal(roundTripped)
+	if string(a) != string(b) {
+		t.Errorf("l'index diffère après aller-retour JSON :\n  direct : %s\n  relu   : %s", a, b)
+	}
+}
+
+// TestProvenanceNeverMovesAVerdict : la mesure de la promesse. La passe de
+// provenance est appliquée sur un assessment de chaque statut, et AUCUN statut ne
+// bouge — seules `evidence.attribute` et `evidence.source` changent.
+func TestProvenanceNeverMovesAVerdict(t *testing.T) {
+	before := assessment.Assessment{Results: []assessment.Result{
+		{Control: "blockstorage_volume_encryption", Status: assessment.Pass, Subject: "essai",
+			Evidence: assessment.Evidence{Observed: "aucune non-conformité", Source: "live-api"}},
+		{Control: "blockstorage_volume_snapshots_exist", Status: assessment.NotEvaluated, Subject: "essai"},
+		{Control: "objectstorage_bucket_public_access", Status: assessment.Fail, Subject: "bucket-1"},
+		{Control: "governance_provider_sovereignty", Status: assessment.NotApplicable, Subject: "essai"},
+	}}
+	ct := map[string]string{
+		"blockstorage_volume_encryption":      "blockstorage_volume",
+		"blockstorage_volume_snapshots_exist": "blockstorage_volume",
+		"objectstorage_bucket_public_access":  "object_storage_bucket",
+		"governance_provider_sovereignty":     "",
+	}
+	after := WithProvenance(before, ProvenanceOf(provenanceFixture()), ct)
+
+	if len(after.Results) != len(before.Results) {
+		t.Fatalf("%d résultats après la passe, %d avant", len(after.Results), len(before.Results))
+	}
+	for i := range before.Results {
+		b, a := before.Results[i], after.Results[i]
+		if a.Status != b.Status {
+			t.Errorf("%s : statut %q → %q — la provenance a déplacé un verdict", b.Control, b.Status, a.Status)
+		}
+		if a.Control != b.Control || a.Subject != b.Subject || a.Severity != b.Severity {
+			t.Errorf("%s : identité du résultat modifiée", b.Control)
+		}
+		if a.Evidence.Observed != b.Evidence.Observed {
+			t.Errorf("%s : la preuve OBSERVÉE a changé (%q → %q)", b.Control, b.Evidence.Observed, a.Evidence.Observed)
+		}
+	}
+	// Et elle a bien fait son travail là où il y avait quelque chose à dire.
+	if got := after.Results[0].Evidence.Source; !strings.Contains(got, "derived:descriptor:const") {
+		t.Errorf("le `pass` de chiffrement n'expose pas la provenance de son attribut décisif : %q", got)
+	}
+	if got := after.Results[0].Evidence.Attribute; got != "encrypted" {
+		t.Errorf("attribut décisif exposé : %q, attendu `encrypted`", got)
+	}
+	// Un contrôle dont l'inventaire ne porte AUCUNE attestation garde sa preuve telle
+	// quelle : on n'invente pas une provenance pour combler un trou.
+	if after.Results[2].Evidence.Source != before.Results[2].Evidence.Source {
+		t.Error("une provenance a été fabriquée pour un type sans attestation")
+	}
+}
+
+// TestProvenanceOfToleratesHostileInput : input.json vient d'un tiers audité. Une
+// carte de provenance mal formée doit être ignorée, jamais provoquer une panique.
+func TestProvenanceOfToleratesHostileInput(t *testing.T) {
+	for _, bad := range []any{
+		nil,
+		"pas un objet",
+		map[string]any{"resources": "pas une liste"},
+		map[string]any{"resources": []any{"pas un objet"}},
+		map[string]any{"resources": []any{map[string]any{"type": "x", "provenance": "pas une carte"}}},
+		map[string]any{"resources": []any{map[string]any{"type": "x", "provenance": map[string]any{"a": 42}}}},
+	} {
+		if idx := ProvenanceOf(bad); idx == nil {
+			t.Errorf("index nil sur %v", bad)
+		}
+	}
+}

--- a/internal/collect/engine.go
+++ b/internal/collect/engine.go
@@ -118,20 +118,31 @@ func collectResource(ctx context.Context, hc *http.Client, spec Spec, auth Auth,
 	if r.ForEach != nil {
 		return collectForEach(ctx, hc, spec, auth, r, vars)
 	}
-	items, err := fetchItems(ctx, hc, auth, resourceURL(spec, r, r.Path, vars), r.Items, r.Paging, r.Method, subst(r.Body, vars))
+	items, called, err := fetchItems(ctx, hc, auth, resourceURL(spec, r, r.Path, vars), r.Items, r.Paging, r.Method, subst(r.Body, vars))
 	if err != nil {
 		return nil, err
 	}
+	src := Source{Origin: model.OriginAPI, Ref: called}
 	if r.Aggregate != "" {
 		attrs := map[string]any{r.Aggregate: int64(len(items))}
+		// L'agrégat est CALCULÉ sur une réponse réelle : origine `api`, valeur dérivée.
+		var prov model.Provenance
+		prov.Attest(r.Aggregate, model.Attestation{
+			Origin: model.OriginAPI, Source: called, Observed: true, Derived: true,
+		})
 		for k, v := range r.Const {
 			attrs[k] = v
 		}
+		AttestConst(&prov, r.Const, constRef)
 		id, _ := attrs[r.ID].(string)
-		return []model.Resource{{Provider: spec.Provider, Type: r.Type, ID: id, Name: id, Region: vars["region"], Attributes: attrs}}, nil
+		return []model.Resource{{Provider: spec.Provider, Type: r.Type, ID: id, Name: id, Region: vars["region"], Attributes: attrs, Provenance: prov}}, nil
 	}
-	return mapItems(spec, r, items, vars), nil
+	return mapItems(spec, r, items, vars, src), nil
 }
+
+// constRef nomme la source d'un attribut littéral : le `const:` du descripteur du
+// fournisseur. Ni un appel, ni une mesure — une déclaration.
+const constRef = "descriptor:const"
 
 // resourceURL construit l'URL complète d'une ressource : base_url de la ressource
 // (override, multi-API) sinon base_url global, + le chemin ; variables substituées.
@@ -147,7 +158,7 @@ func resourceURL(spec Spec, r ResourceSpec, path string, vars map[string]string)
 // (variables {<as>.<champ>} + `_parent`).
 func collectForEach(ctx context.Context, hc *http.Client, spec Spec, auth Auth, r ResourceSpec, vars map[string]string) ([]model.Resource, error) {
 	fe := r.ForEach
-	parents, err := fetchItems(ctx, hc, auth, resourceURL(spec, r, fe.Path, vars), fe.Items, fe.Paging, fe.Method, subst(fe.Body, vars))
+	parents, _, err := fetchItems(ctx, hc, auth, resourceURL(spec, r, fe.Path, vars), fe.Items, fe.Paging, fe.Method, subst(fe.Body, vars))
 	if err != nil {
 		return nil, fmt.Errorf("liste parente %s : %w", fe.Path, err)
 	}
@@ -155,14 +166,14 @@ func collectForEach(ctx context.Context, hc *http.Client, spec Spec, auth Auth, 
 	for _, p := range parents {
 		pm, _ := p.(map[string]any)
 		v2 := mergeVars(vars, fe.As, pm)
-		items, err := fetchItems(ctx, hc, auth, resourceURL(spec, r, r.Path, v2), r.Items, r.Paging, r.Method, subst(r.Body, v2))
+		items, called, err := fetchItems(ctx, hc, auth, resourceURL(spec, r, r.Path, v2), r.Items, r.Paging, r.Method, subst(r.Body, v2))
 		if err != nil {
 			return nil, err
 		}
 		for i := range items {
 			items[i] = withParent(items[i], pm)
 		}
-		out = append(out, mapItems(spec, r, items, v2)...)
+		out = append(out, mapItems(spec, r, items, v2, Source{Origin: model.OriginAPI, Ref: called})...)
 	}
 	return out, nil
 }
@@ -171,53 +182,57 @@ func collectForEach(ctx context.Context, hc *http.Client, spec Spec, auth Auth, 
 // Styles : "page" (numéro de page incrémenté jusqu'à un lot incomplet) et "token" (jeton de
 // page suivante lu dans la réponse jusqu'à épuisement). Une borne de pages empêche toute
 // boucle infinie et, si elle est atteinte, retourne une ERREUR (jamais une troncature muette).
-func fetchItems(ctx context.Context, hc *http.Client, auth Auth, fullURL, itemsPath string, paging *Paging, method, body string) ([]any, error) {
+func fetchItems(ctx context.Context, hc *http.Client, auth Auth, fullURL, itemsPath string, paging *Paging, method, body string) ([]any, string, error) {
 	max := defaultMaxPages
 	if paging != nil && paging.MaxPages > 0 {
 		max = paging.MaxPages
 	}
 	var items []any
+	called := ""
 	token := ""
 	for page := 1; page <= max; page++ {
 		// L'offset avance du nombre d'items RÉELLEMENT reçus, jamais de la taille
 		// demandée : un serveur qui plafonne la page sous `size` (Outscale borne à 100
 		// même si l'on demande 1000) ferait sinon sauter des items.
-		doc, err := fetch(ctx, hc, fullURL, auth, paging, page, len(items), token, method, body)
+		doc, endpoint, err := fetch(ctx, hc, fullURL, auth, paging, page, len(items), token, method, body)
+		if endpoint != "" {
+			called = endpoint
+		}
 		if err != nil {
-			return nil, err
+			return nil, called, err
 		}
 		batch := extractItems(doc, itemsPath)
 		items = append(items, batch...)
 		if paging == nil {
-			return items, nil
+			return items, called, nil
 		}
 		switch paging.Style {
 		case "page", "offset-body":
 			if len(batch) == 0 {
-				return items, nil
+				return items, called, nil
 			}
 			// Quand l'API dit elle-même s'il reste des items (HasMoreItems), on la croit :
 			// c'est le seul critère fiable si elle plafonne la page sous `size`.
 			if paging.MorePath != "" {
 				if !boolFromDoc(doc, paging.MorePath) {
-					return items, nil
+					return items, called, nil
 				}
 				continue
 			}
 			// À défaut : une page incomplète est la dernière.
 			if len(batch) < paging.Size {
-				return items, nil
+				return items, called, nil
 			}
 		case "token", "token-body":
 			token = tokenFromDoc(doc, paging.TokenPath)
 			if token == "" {
-				return items, nil
+				return items, called, nil
 			}
 		default:
-			return items, nil
+			return items, called, nil
 		}
 	}
-	return nil, fmt.Errorf(i18n.T("pagination : borne de %d pages atteinte sur %s — collecte tronquée (vérifier la config de pagination)", "pagination: reached the %d-page bound on %s — truncated collection (check the pagination config)"), max, fullURL)
+	return nil, called, fmt.Errorf(i18n.T("pagination : borne de %d pages atteinte sur %s — collecte tronquée (vérifier la config de pagination)", "pagination: reached the %d-page bound on %s — truncated collection (check the pagination config)"), max, fullURL)
 }
 
 // withBodyPaging fusionne les paramètres de pagination dans le body JSON d'un POST.
@@ -268,18 +283,29 @@ func tokenFromDoc(doc any, path string) string {
 // mapItems projette les items bruts vers des ressources normalisées (map +
 // transforms). La région de collecte (vars["region"]) est propagée sur chaque
 // ressource pour les contrôles de localisation (souveraineté, CLD-GVN-3).
-func mapItems(spec Spec, r ResourceSpec, items []any, vars map[string]string) []model.Resource {
+func mapItems(spec Spec, r ResourceSpec, items []any, vars map[string]string, src Source) []model.Resource {
 	region := vars["region"]
 	out := make([]model.Resource, 0, len(items))
 	for _, it := range items {
-		attrs := Project(it, r.Map, r.Transforms)
+		attrs, prov := ProjectAttested(it, r.Map, r.Transforms, src)
 		for k, v := range r.Const {
 			attrs[k] = v
 		}
+		AttestConst(&prov, r.Const, constRef)
 		id, _ := attrs[r.ID].(string)
-		out = append(out, model.Resource{Provider: spec.Provider, Type: r.Type, ID: id, Name: id, Region: region, Attributes: attrs})
+		out = append(out, model.Resource{Provider: spec.Provider, Type: r.Type, ID: id, Name: id, Region: region, Attributes: attrs, Provenance: prov})
 	}
 	return out
+}
+
+// Source décrit ce qui a produit un lot d'items, tel qu'il s'est réellement passé.
+// `Ref` d'une source `api` est la requête EFFECTIVEMENT émise (méthode + URL, lue
+// après la réponse), jamais le chemin déclaré par la spec : une provenance qui
+// nommerait un endpoint jamais appelé donnerait l'apparence de la traçabilité.
+// Une Source à zéro (Origin vide) désactive l'attestation.
+type Source struct {
+	Origin model.Origin
+	Ref    string
 }
 
 // Project applique une projection DÉCLARATIVE (map attribut_commun -> chemin dans
@@ -287,9 +313,34 @@ func mapItems(spec Spec, r ResourceSpec, items []any, vars map[string]string) []
 // `values` d'une ressource Terraform) et retourne les attributs normalisés. C'est
 // le cœur commun à la collecte live ET au mapping Terraform (mêmes specs YAML).
 func Project(item any, mapping map[string]string, transforms map[string]any) map[string]any {
+	attrs, _ := ProjectAttested(item, mapping, transforms, Source{})
+	return attrs
+}
+
+// ProjectAttested est Project qui rend EN PLUS l'attestation de chaque attribut du
+// mapping : d'où il vient, et si la source le portait réellement.
+//
+// L'attestation est posée pour TOUT attribut du mapping, y compris ceux que la
+// source n'expose pas et qui ne sont donc pas projetés. C'est l'information utile :
+// « on a cherché `encrypted` à ce chemin, la réponse ne le portait pas » n'est pas
+// « on n'a jamais regardé ». Les attributs projetés, eux, sortent exactement comme
+// avant : la provenance ne déplace aucune valeur.
+func ProjectAttested(item any, mapping map[string]string, transforms map[string]any, src Source) (map[string]any, model.Provenance) {
 	attrs := make(map[string]any, len(mapping))
+	var prov model.Provenance
+	attest := func(attr, path string, observed, derived bool) {
+		if src.Origin == "" {
+			return
+		}
+		prov.Attest(attr, model.Attestation{
+			Origin: src.Origin, Source: src.Ref, Path: path,
+			Observed: observed, Derived: derived,
+		})
+	}
 	for attr, path := range mapping {
 		v := lookupCoalesce(item, path)
+		present := sourcePresent(item, path)
+		derived := false
 		if t, ok := transforms[attr]; ok {
 			// `kv`/`list` fabriquent une COLLECTION VIDE même sur nil, pour préserver
 			// « présent mais vide » (des tags déclarés et vides sont une information).
@@ -299,21 +350,38 @@ func Project(item any, mapping map[string]string, transforms map[string]any) map
 			// à une collecte réussie, franchirait la garde de capacité de la règle et
 			// produirait un faux positif. C'est le cas d'une instance dont le groupe de
 			// sécurité est créé par le même plan — la configuration la plus courante.
-			if v == nil && !sourcePresent(item, path) {
+			if v == nil && !present {
+				attest(attr, path, false, false)
 				continue
 			}
 			v = applyTransform(v, t)
+			derived = true
 		}
 		if v == nil {
 			// Attribut absent de la source (l'API n'a rien renvoyé) : on ne le projette PAS,
 			// au lieu de le forcer à "". Sinon les gardes de capacité (`"k" in object.keys`)
 			// sont toujours vraies et un champ numérique absent devient une chaîne vide qui
 			// casse les comparaisons — doctrine « ce que le provider n'expose pas ne se teste pas ».
+			attest(attr, path, present, false)
 			continue
 		}
 		attrs[attr] = v
+		attest(attr, path, present, derived)
 	}
-	return attrs
+	return attrs, prov
+}
+
+// AttestConst atteste les attributs LITTÉRAUX d'une spec (`const:`). Ils ne viennent
+// d'aucun appel : leur origine est `derived`, et c'est précisément ce qu'un lecteur
+// doit pouvoir constater. Deux contrôles franchissent aujourd'hui leur garde d'attribut
+// grâce à un `const` (chiffrement transparent Exoscale, portée des clés Outscale) :
+// l'attestation ne change pas leur verdict, elle le rend LISIBLE.
+func AttestConst(prov *model.Provenance, consts map[string]any, ref string) {
+	for attr := range consts {
+		prov.Attest(attr, model.Attestation{
+			Origin: model.OriginDerived, Source: ref, Derived: true,
+		})
+	}
 }
 
 // mergeVars copie vars et y ajoute {<as>.<champ>} pour chaque champ scalaire du parent.
@@ -414,10 +482,14 @@ func lookupCoalesce(it any, path string) any {
 	return nil
 }
 
-func fetch(ctx context.Context, hc *http.Client, rawURL string, auth Auth, p *Paging, page, offset int, token, method, body string) (any, error) {
+// fetch émet UNE requête et rend le document ainsi que la ligne de requête
+// EFFECTIVEMENT servie (« GET https://hote/chemin », sans les paramètres de
+// pagination). Cette ligne est lue sur la requête après une réponse valide : elle
+// atteste un appel qui a eu lieu, jamais un endpoint que la spec déclare.
+func fetch(ctx context.Context, hc *http.Client, rawURL string, auth Auth, p *Paging, page, offset int, token, method, body string) (any, string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if p != nil && p.Style == "page" {
 		q := u.Query()
@@ -446,33 +518,37 @@ func fetch(ctx context.Context, hc *http.Client, rawURL string, auth Auth, p *Pa
 	}
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), bodyReader)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	if auth != nil {
 		if err := auth.Apply(req); err != nil {
-			return nil, err
+			return nil, "", err
 		}
 	}
 	resp, err := hc.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
+	// La requête telle qu'elle a été émise. Les paramètres de requête (page, jeton)
+	// sont écartés : ils varient d'une page à l'autre alors que l'endpoint, lui, est
+	// ce qui atteste la donnée.
+	called := req.Method + " " + req.URL.Scheme + "://" + req.URL.Host + req.URL.Path
 	respBody, rerr := io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
 	if rerr != nil {
-		return nil, fmt.Errorf(i18n.T("lecture de la reponse de %s : %w", "reading the response from %s: %w"), u.Host, rerr)
+		return nil, called, fmt.Errorf(i18n.T("lecture de la reponse de %s : %w", "reading the response from %s: %w"), u.Host, rerr)
 	}
 	if resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("HTTP %d : %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+		return nil, called, fmt.Errorf("HTTP %d : %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
 	var doc any
 	if err := json.Unmarshal(respBody, &doc); err != nil {
-		return nil, fmt.Errorf(i18n.T("réponse JSON invalide : %w", "invalid JSON response: %w"), err)
+		return nil, called, fmt.Errorf(i18n.T("réponse JSON invalide : %w", "invalid JSON response: %w"), err)
 	}
-	return doc, nil
+	return doc, called, nil
 }
 
 // ExtractItems expose extractItems pour le mapping Terraform (internal/tfmap) :

--- a/internal/collect/engine_test.go
+++ b/internal/collect/engine_test.go
@@ -596,7 +596,7 @@ func TestFetchItemsTokenPagination(t *testing.T) {
 	defer srv.Close()
 
 	p := &Paging{Style: "token", TokenParam: "page_token", TokenPath: "next"}
-	items, err := fetchItems(context.Background(), srv.Client(), nil, srv.URL, "items", p, "GET", "")
+	items, _, err := fetchItems(context.Background(), srv.Client(), nil, srv.URL, "items", p, "GET", "")
 	if err != nil {
 		t.Fatalf("fetchItems: %v", err)
 	}
@@ -613,7 +613,7 @@ func TestFetchItemsPageBoundGuardsInfiniteLoop(t *testing.T) {
 	defer srv.Close()
 
 	p := &Paging{Style: "page", Param: "page", Size: 2, MaxPages: 5}
-	_, err := fetchItems(context.Background(), srv.Client(), nil, srv.URL, "items", p, "GET", "")
+	_, _, err := fetchItems(context.Background(), srv.Client(), nil, srv.URL, "items", p, "GET", "")
 	if err == nil {
 		t.Error("un serveur qui ignore la pagination doit provoquer une ERREUR de borne, pas une boucle infinie")
 	}

--- a/internal/collect/provenance_test.go
+++ b/internal/collect/provenance_test.go
@@ -1,0 +1,141 @@
+package collect
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/pepin/internal/model"
+)
+
+// TestProvenanceNamesTheCallThatActuallyHappened est la garde centrale de la
+// provenance : la source d'un attribut `api` est la requête RÉELLEMENT servie, et
+// aucune source ne peut être fabriquée depuis la spec.
+//
+// La preuve est une MESURE, pas une lecture : un serveur de test enregistre ce
+// qu'il a servi, et l'attestation est comparée à cet enregistrement. C'est la
+// forme exacte de l'écart que ce dépôt a déjà connu (les policies EIM inline : la
+// règle était juste, la donnée n'arrivait jamais, et aucun test ne pouvait le
+// voir).
+func TestProvenanceNamesTheCallThatActuallyHappened(t *testing.T) {
+	var served []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		served = append(served, r.Method+" "+r.URL.Path)
+		_, _ = w.Write([]byte(`{"volumes":[{"id":"vol-1","state":"attached"}]}`))
+	}))
+	defer srv.Close()
+
+	spec := Spec{Provider: "essai", BaseURL: srv.URL}
+	rs := ResourceSpec{
+		Type:  "blockstorage_volume",
+		Path:  "/block-storage",
+		Items: "volumes",
+		ID:    "volume_id",
+		Map:   map[string]string{"volume_id": "id", "state": "state", "jamais_la": "absent_field"},
+		Const: map[string]any{"encrypted": true},
+	}
+	got, err := collectResource(context.Background(), srv.Client(), spec, nil, rs, nil)
+	if err != nil {
+		t.Fatalf("collecte : %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("%d ressources, attendu 1", len(got))
+	}
+	prov := got[0].Provenance
+
+	// 1. L'attribut lu porte l'appel qui l'a servi, et cet appel a bien été servi.
+	att, ok := prov["state"]
+	if !ok {
+		t.Fatal("aucune attestation pour `state`")
+	}
+	if att.Origin != model.OriginAPI || !att.Observed {
+		t.Errorf("`state` : origine %q observed=%v, attendu api/true", att.Origin, att.Observed)
+	}
+	if !strings.HasSuffix(att.Source, "/block-storage") || !strings.HasPrefix(att.Source, "GET ") {
+		t.Errorf("`state` : source %q ne nomme pas la requête émise", att.Source)
+	}
+	if len(served) != 1 || served[0] != "GET /block-storage" {
+		t.Fatalf("le serveur a servi %v — la mesure ne confirme pas l'attestation", served)
+	}
+
+	// 2. Le littéral du descripteur ne prétend PAS venir d'un appel.
+	c := prov["encrypted"]
+	if c.Origin != model.OriginDerived {
+		t.Errorf("`encrypted` (const) : origine %q, attendu %q", c.Origin, model.OriginDerived)
+	}
+	if c.Observed {
+		t.Error("`encrypted` (const) : observed=true — un littéral n'a jamais été observé")
+	}
+	if strings.Contains(c.Source, srv.URL) || strings.Contains(c.Source, "http") {
+		t.Errorf("`encrypted` (const) : source %q désigne un appel qui n'a pas eu lieu", c.Source)
+	}
+
+	// 3. Un champ cherché et absent de la réponse est attesté NON observé — et il
+	//    n'est pas projeté. « On a regardé, il n'y était pas » n'est pas « on n'a
+	//    jamais regardé ».
+	missing, ok := prov["jamais_la"]
+	if !ok {
+		t.Fatal("aucune attestation pour un champ absent de la réponse")
+	}
+	if missing.Observed {
+		t.Error("un champ absent de la réponse est attesté observé")
+	}
+	if _, projected := got[0].Attributes["jamais_la"]; projected {
+		t.Error("un champ absent de la réponse a été projeté")
+	}
+}
+
+// TestProvenanceIsAbsentWithoutASource : hors collecte attestée (Project nu, appelé
+// par des chemins qui n'ont pas de source à nommer), aucune attestation n'est
+// fabriquée. Une provenance inventée serait pire que pas de provenance.
+func TestProvenanceIsAbsentWithoutASource(t *testing.T) {
+	item := map[string]any{"id": "x"}
+	attrs, prov := ProjectAttested(item, map[string]string{"vm_id": "id"}, nil, Source{})
+	if len(prov) != 0 {
+		t.Errorf("provenance fabriquée sans source : %v", prov)
+	}
+	if attrs["vm_id"] != "x" {
+		t.Errorf("la projection a changé : %v", attrs)
+	}
+}
+
+// TestProjectStillProjectsExactlyTheSameAttributes : la refonte de Project en
+// ProjectAttested ne devait déplacer AUCUNE valeur. Les cas limites de la
+// projection (transform sur source absente, collection vide, coalescence) sont
+// rejoués ici sur les deux chemins.
+func TestProjectStillProjectsExactlyTheSameAttributes(t *testing.T) {
+	item := map[string]any{
+		"id":     "i-1",
+		"labels": map[string]any{"env": "prod"},
+		"empty":  []any{},
+		"nul":    nil,
+	}
+	mapping := map[string]string{
+		"vm_id":    "id",
+		"tags":     "labels",
+		"vide":     "empty",
+		"absent":   "pas_la",
+		"nul":      "nul",
+		"coalesce": "pas_la||id",
+	}
+	transforms := map[string]any{"tags": "kv", "vide": "list", "absent": "list"}
+
+	plain := Project(item, mapping, transforms)
+	attested, _ := ProjectAttested(item, mapping, transforms, Source{Origin: model.OriginAPI, Ref: "GET https://exemple/x"})
+	if len(plain) != len(attested) {
+		t.Fatalf("projections différentes : %v vs %v", plain, attested)
+	}
+	for k := range plain {
+		if _, ok := attested[k]; !ok {
+			t.Errorf("attribut %q perdu par la projection attestée", k)
+		}
+	}
+	if _, ok := plain["absent"]; ok {
+		t.Error("un transform `list` sur une clé ABSENTE de la source ne doit rien fabriquer")
+	}
+	if _, ok := plain["vide"]; !ok {
+		t.Error("une collection présente et VIDE reste une information collectée")
+	}
+}

--- a/internal/docgen/blocks.go
+++ b/internal/docgen/blocks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stephrobert/pepin/internal/assess"
 	"github.com/stephrobert/pepin/internal/genprovider"
 	"github.com/stephrobert/pepin/internal/i18n"
+	"github.com/stephrobert/pepin/internal/model"
 	"github.com/stephrobert/pepin/referentiel"
 )
 
@@ -40,6 +41,41 @@ const (
     }
   ]
 }`
+	// L'inventaire du code de sortie 4 : UN écart high, et un seul, pour que la page
+	// montre une dérogation entière plutôt qu'une liste. La règle SSH ouvert à
+	// l'Internet est le cas d'école de l'exception légitime, le bastion.
+	bastionInventory = `{
+  "provider": "scaleway",
+  "resources": [
+    {
+      "provider": "scaleway",
+      "type": "security_group_rule",
+      "id": "vm-bastion",
+      "name": "vm-bastion",
+      "region": "fr-par",
+      "attributes": {
+        "security_group_id": "sg-bastion",
+        "direction": "inbound",
+        "action": "accept",
+        "protocol": "tcp",
+        "port_from": 22,
+        "port_to": 22,
+        "cidrs": ["0.0.0.0/0"],
+        "description": "Acces d administration du bastion"
+      }
+    }
+  ]
+}`
+	// La dérogation qui couvre cet écart : datée, justifiée, attribuée. C'est le
+	// fichier exact que la page fait écrire au lecteur.
+	exceptionsFile = `exceptions:
+  - control: network_securitygroup_allow_ingress_from_internet_to_tcp_port_22
+    resource: sg-bastion
+    justification: "Bastion administre, acces restreint par IP source en amont"
+    expires_at: 2099-12-31
+    owner: platform-security
+    approved_by: security@example.org
+`
 )
 
 // remediationWitness : le contrôle que le guide de remédiation suit d'un scan à l'autre. Il
@@ -69,6 +105,11 @@ type captures struct {
 	empty           Capture
 	tagless         Capture
 	taglessStr      Capture
+	// Dérogations : le même inventaire, avec une exemption valide puis échue, et
+	// l'assessment qui montre le statut `exempted`.
+	exempted        Capture
+	exemptedExpired Capture
+	exemptedAsmt    Capture
 	providers       Capture
 
 	// Référence CLI : une aide par verbe, dans la langue de la page. Les captures y sont
@@ -102,7 +143,8 @@ type captures struct {
 // divergerait à chaque build sans qu'aucun comportement n'ait bougé.
 func (c *captures) all() []*Capture {
 	out := []*Capture{&c.vulnerable, &c.fixed, &c.assessment, &c.assessmentFixed, &c.missingFile, &c.empty,
-		&c.tagless, &c.taglessStr, &c.providers, &c.jsonReport, &c.sarif, &c.oscal,
+		&c.tagless, &c.taglessStr, &c.exempted, &c.exemptedExpired, &c.exemptedAsmt,
+		&c.providers, &c.jsonReport, &c.sarif, &c.oscal,
 		&c.driftLive, &c.outscalePlanJSON,
 		&c.bundle.seal, &c.bundle.verify, &c.bundle.reDerive, &c.bundle.tampered,
 		&c.bundle.redact, &c.bundle.redactRD, &c.bundle.crossVerify}
@@ -131,11 +173,19 @@ func captureAll(root, bin, lang string) (captures, error) {
 	defer func() { _ = os.RemoveAll(tmp) }()
 	emptyPath := filepath.Join(tmp, "empty-inventory.json")
 	taglessPath := filepath.Join(tmp, "tagless-inventory.json")
-	if werr := os.WriteFile(emptyPath, []byte(emptyInventory+"\n"), 0o600); werr != nil {
-		return captures{}, werr
-	}
-	if werr := os.WriteFile(taglessPath, []byte(taglessInventory+"\n"), 0o600); werr != nil {
-		return captures{}, werr
+	bastionPath := filepath.Join(tmp, "bastion-inventory.json")
+	exceptionsPath := filepath.Join(tmp, "exceptions.yaml")
+	expiredPath := filepath.Join(tmp, "exceptions-expired.yaml")
+	for path, body := range map[string]string{
+		emptyPath:      emptyInventory + "\n",
+		taglessPath:    taglessInventory + "\n",
+		bastionPath:    bastionInventory + "\n",
+		exceptionsPath: exceptionsFile,
+		expiredPath:    strings.ReplaceAll(exceptionsFile, "2099-12-31", "2020-01-01"),
+	} {
+		if werr := os.WriteFile(path, []byte(body), 0o600); werr != nil {
+			return captures{}, werr
+		}
 	}
 
 	var c captures
@@ -152,6 +202,12 @@ func captureAll(root, bin, lang string) (captures, error) {
 		{&c.empty, []string{"scan", "scaleway", emptyPath}, []string{"scan", "scaleway", "empty-inventory.json"}},
 		{&c.tagless, []string{"scan", "scaleway", taglessPath}, []string{"scan", "scaleway", "tagless-inventory.json"}},
 		{&c.taglessStr, []string{"scan", "scaleway", taglessPath, "--strict"}, []string{"scan", "scaleway", "tagless-inventory.json", "--strict"}},
+		{&c.exempted, []string{"scan", "scaleway", bastionPath, "--exceptions", exceptionsPath},
+			[]string{"scan", "scaleway", "bastion-inventory.json", "--exceptions", "exceptions.yaml"}},
+		{&c.exemptedExpired, []string{"scan", "scaleway", bastionPath, "--exceptions", expiredPath},
+			[]string{"scan", "scaleway", "bastion-inventory.json", "--exceptions", "exceptions-expired.yaml"}},
+		{&c.exemptedAsmt, []string{"scan", "scaleway", bastionPath, "--exceptions", exceptionsPath, "--format", "assessment"},
+			[]string{"scan", "scaleway", "bastion-inventory.json", "--exceptions", "exceptions.yaml", "--format", "assessment"}},
 		{&c.providers, []string{"provider", "list"}, nil},
 	}
 	for _, s := range steps {
@@ -228,7 +284,7 @@ func (c *captures) captureReference(r Runner, root, tmp string) error {
 	}
 	c.cliSurface = surface
 	c.frozenVersions = map[string]int{}
-	for _, name := range []string{"cli", "findings", "assessment", "bundle"} {
+	for _, name := range []string{"cli", "findings", "assessment", "bundle", "inventory"} {
 		v, _, ferr := loadFrozen(root, name)
 		if ferr != nil {
 			return ferr
@@ -360,6 +416,11 @@ func buildBlocks(lang string, m Matrix, c captures, rem []RemediationCoverage) m
 		"exit-run-nothing":          consoleRun(c.empty, Tail(c.empty.Stdout, 6)),
 		"exit-run-strict":           consoleRun(c.taglessStr, Tail(c.taglessStr.Stdout, 6)),
 		"exit-run-medium-plain":     consoleRun(c.tagless, Tail(c.tagless.Stdout, 6)),
+		"fixture-bastion-inventory": Fence("json", bastionInventory),
+		"fixture-exceptions":        Fence("yaml", strings.TrimRight(exceptionsFile, "\n")),
+		"exit-run-exempted":         consoleRun(c.exempted, Tail(c.exempted.Stdout, 14)),
+		"exit-run-expired":          consoleRun(c.exemptedExpired, c.exemptedExpired.Stderr),
+		"assessment-exempted":       assessmentExtract(t, c.withAssessment(c.exemptedAsmt), "exempted", "network_securitygroup_allow_ingress_from_internet_to_tcp_port_22"),
 		"assessment-run":            assessmentRunBlock(c),
 		"assessment-counts":         assessmentCountsTable(t, c),
 		"assessment-fail":           assessmentExtract(t, c, "fail", "objectstorage_bucket_public_access"),
@@ -376,6 +437,8 @@ func buildBlocks(lang string, m Matrix, c captures, rem []RemediationCoverage) m
 		"remediation-after":         assessmentControl(driftText(lang), c.assessmentFixed, remediationWitness),
 		"coverage-totals":           m.countsTable(coverageText(lang)),
 		"control-counts":            controlCountsTable(t, m),
+		"inventory-format":          inventoryFormatBlock(t),
+		"inventory-types":           inventoryTypesTable(t),
 	}
 	// Les régions des pages de la vague 2. Elles vivent dans leurs propres fichiers (la
 	// référence CLI, les formats, la comparaison plan/live, le bundle, les fournisseurs)
@@ -508,6 +571,8 @@ func exitCodeTable(t blockStrings, c captures) string {
 		{t.exitNothing, c.empty},
 		{t.exitMediumPlain, c.tagless},
 		{t.exitMediumStrict, c.taglessStr},
+		{t.exitExempted, c.exempted},
+		{t.exitExpired, c.exemptedExpired},
 	}
 	var b strings.Builder
 	b.WriteString("| " + t.colSituation + " | " + t.colCommand + " | " + t.colExit + " |\n|---|---|:-:|\n")
@@ -666,6 +731,34 @@ func generalizeReason(s, placeholder string) string {
 
 // requiredAttrTable rend la table des attributs décisifs telle qu'elle est APPLIQUÉE
 // (assess.RequiredAttrs), pas une paraphrase.
+// inventoryFormatBlock rend la chaîne de format du schéma d'inventaire, telle que le
+// code la publie. Recopiée dans la page, elle vieillirait au premier incrément.
+func inventoryFormatBlock(t blockStrings) string {
+	return Fence("text", model.InventoryFormat)
+}
+
+// inventoryTypesTable énumère le vocabulaire de l'inventaire : chaque type et ses
+// attributs communs. DÉRIVÉ des descripteurs chargés et des collecteurs, donc
+// impossible à laisser diverger — une énumération fausse est pire qu'absente.
+func inventoryTypesTable(t blockStrings) string {
+	cat := genprovider.InventoryCatalogue()
+	types := make([]string, 0, len(cat))
+	for typ := range cat {
+		types = append(types, typ)
+	}
+	sort.Strings(types)
+	var b strings.Builder
+	b.WriteString("| " + t.colType + " | " + t.colAttributes + " |\n|---|---|\n")
+	for _, typ := range types {
+		quoted := make([]string, 0, len(cat[typ]))
+		for _, a := range cat[typ] {
+			quoted = append(quoted, "`"+a+"`")
+		}
+		_, _ = fmt.Fprintf(&b, "| `%s` | %s |\n", typ, strings.Join(quoted, " "))
+	}
+	return b.String()
+}
+
 func requiredAttrTable(t blockStrings) string {
 	req := assess.RequiredAttrs()
 	codes := make([]string, 0, len(req))
@@ -826,6 +919,15 @@ func controlCountsTable(t blockStrings, m Matrix) string {
 		_, _ = fmt.Fprintf(&b, "| `%s` | %d |\n", s, bySeverity[s])
 	}
 	return b.String()
+}
+
+// withAssessment rend une COPIE du jeu de captures dont l'assessment est celui
+// passé en argument. Les extracteurs lisent `c.assessment` ; plusieurs pages ont
+// besoin d'un autre scan (ici celui qui porte une dérogation) sans qu'il faille
+// dupliquer l'extracteur.
+func (c captures) withAssessment(a Capture) captures {
+	c.assessment = a
+	return c
 }
 
 func parseAssessment(c captures) map[string]any {

--- a/internal/docgen/docgen.go
+++ b/internal/docgen/docgen.go
@@ -35,6 +35,8 @@ var injectedPages = []string{
 	"docs/reference/exit-codes.fr.md",
 	"docs/reference/output-formats.md",
 	"docs/reference/output-formats.fr.md",
+	"docs/reference/inventory.md",
+	"docs/reference/inventory.fr.md",
 	"docs/concepts/terraform-vs-live.md",
 	"docs/concepts/terraform-vs-live.fr.md",
 	"docs/contributing/adding-a-provider.md",

--- a/internal/docgen/reference.go
+++ b/internal/docgen/reference.go
@@ -175,6 +175,7 @@ func surfaceVersionsTable(t refStrings, versions map[string]int) string {
 		{"findings", t.surfFindings},
 		{"assessment", t.surfAssessment},
 		{"bundle", t.surfBundle},
+		{"inventory", t.surfInventory},
 	}
 	var b strings.Builder
 	b.WriteString("| " + t.colSurface + " | " + t.colWhat + " | " + t.colVersion + " |\n|---|---|:-:|\n")
@@ -218,6 +219,7 @@ type refStrings struct {
 	colSurface, colWhat, colVersion                        string
 	noFlag                                                 string
 	surfCLI, surfFindings, surfAssessment, surfBundle      string
+	surfInventory                                          string
 	exitMeaning                                            map[string]string
 }
 
@@ -232,11 +234,13 @@ func refText(lang string) refStrings {
 			surfFindings:   "forme de `--format json` (`findings` + `summary`)",
 			surfAssessment: "forme du document `--format assessment`",
 			surfBundle:     "forme du bundle de preuve (fichiers, rôles, manifest)",
+			surfInventory:  "forme de l'inventaire normalisé (enveloppe, ressource, types et attributs)",
 			exitMeaning: map[string]string{
 				"conforme":       "aucun écart critical/high, et au moins un contrôle réellement mesuré",
 				"non_conformite": "au moins un écart critical ou high",
 				"erreur":         "erreur technique : le scan n'a pas pu conclure",
 				"strict":         "rien n'a été mesuré (sans `--strict`), ou écarts medium/low restants avec `--strict`",
+				"derogation":     "tout écart critical/high restant est couvert par une dérogation datée et attribuée (`--exceptions`)",
 			},
 		}
 	}
@@ -249,11 +253,13 @@ func refText(lang string) refStrings {
 		surfFindings:   "shape of `--format json` (`findings` + `summary`)",
 		surfAssessment: "shape of the `--format assessment` document",
 		surfBundle:     "shape of the evidence bundle (files, roles, manifest)",
+		surfInventory:  "shape of the normalized inventory (envelope, resource, types and attributes)",
 		exitMeaning: map[string]string{
 			"conforme":       "no critical/high deviation, and at least one control actually measured",
 			"non_conformite": "at least one critical or high deviation",
 			"erreur":         "technical error: the scan could not conclude",
 			"strict":         "nothing was measured (without `--strict`), or medium/low deviations remain with `--strict`",
+			"derogation":     "every remaining critical/high deviation is covered by a dated, attributed exemption (`--exceptions`)",
 		},
 	}
 }

--- a/internal/docgen/strings.go
+++ b/internal/docgen/strings.go
@@ -11,6 +11,8 @@ type blockStrings struct {
 	colProofs, colFigure                              string
 	exitCompliant, exitNonCompliance, exitError       string
 	exitNothing, exitMediumPlain, exitMediumStrict    string
+	colAttributes                                     string
+	exitExempted, exitExpired                         string
 	orWord, none, totalWord, figControls, figDeclared string
 	noTypeWord                                        string
 	noDeviationFor, noResultFor, quotedPlaceholder    string
@@ -31,6 +33,9 @@ func blockText(lang string) blockStrings {
 			exitNothing:       "Rien n'a été mesuré (inventaire vide) : **sans avoir à demander `--strict`**",
 			exitMediumPlain:   "Écarts medium/low seulement, sans `--strict`",
 			exitMediumStrict:  "Écarts medium/low seulement, avec `--strict`",
+			exitExempted:      "Tout écart critical/high est couvert par une dérogation valide",
+			exitExpired:       "La même dérogation, échue : elle ne s'applique plus",
+			colAttributes:     "Attributs communs",
 			orWord:            "ou",
 			none:              "_Aucun._",
 			totalWord:         "Total",
@@ -55,6 +60,9 @@ func blockText(lang string) blockStrings {
 		exitNothing:       "Nothing was measured (empty inventory): **without having to ask for `--strict`**",
 		exitMediumPlain:   "Medium/low deviations only, without `--strict`",
 		exitMediumStrict:  "Medium/low deviations only, with `--strict`",
+		exitExempted:      "Every critical/high deviation is covered by a valid exemption",
+		exitExpired:       "The same exemption, lapsed: it no longer applies",
+		colAttributes:     "Common attributes",
 		orWord:            "or",
 		none:              "_None._",
 		totalWord:         "Total",

--- a/internal/eimpolicy/eimpolicy.go
+++ b/internal/eimpolicy/eimpolicy.go
@@ -40,8 +40,6 @@ const maxPages = 1000
 // scanner charge entierement en memoire (deni de service du job de CI).
 const maxRespBytes = 64 << 20 // 64 Mio
 
-// CollectInlinePolicies parcourt les utilisateurs EIM et projette chaque politique inline
-// en ressource `iam_policy` (scope: inline). `baseURL` est l'URL de l'OAPI déjà substituée.
 // PolicyAttributes énumère les attributs communs d'une politique EIM inline.
 // Déclaré à côté du collecteur qui les pose, et lu par le catalogue de
 // l'inventaire (genprovider.InventoryCatalogue).
@@ -49,6 +47,8 @@ func PolicyAttributes() []string {
 	return []string{"owner_group", "owner_user", "policy_id", "policy_name", "scope", "statements"}
 }
 
+// CollectInlinePolicies parcourt les utilisateurs EIM et projette chaque politique inline
+// en ressource `iam_policy` (scope: inline). `baseURL` est l'URL de l'OAPI déjà substituée.
 func CollectInlinePolicies(ctx context.Context, hc *http.Client, provider, baseURL string, auth collect.Auth) ([]model.Resource, error) {
 	// L'OAPI plafonne toute page à 100 items (MaxResultsLimit) et signale la suite par
 	// HasMoreItems : sans pagination, les utilisateurs 101+ — et donc leurs politiques

--- a/internal/eimpolicy/eimpolicy.go
+++ b/internal/eimpolicy/eimpolicy.go
@@ -42,6 +42,13 @@ const maxRespBytes = 64 << 20 // 64 Mio
 
 // CollectInlinePolicies parcourt les utilisateurs EIM et projette chaque politique inline
 // en ressource `iam_policy` (scope: inline). `baseURL` est l'URL de l'OAPI déjà substituée.
+// PolicyAttributes énumère les attributs communs d'une politique EIM inline.
+// Déclaré à côté du collecteur qui les pose, et lu par le catalogue de
+// l'inventaire (genprovider.InventoryCatalogue).
+func PolicyAttributes() []string {
+	return []string{"owner_group", "owner_user", "policy_id", "policy_name", "scope", "statements"}
+}
+
 func CollectInlinePolicies(ctx context.Context, hc *http.Client, provider, baseURL string, auth collect.Auth) ([]model.Resource, error) {
 	// L'OAPI plafonne toute page à 100 items (MaxResultsLimit) et signale la suite par
 	// HasMoreItems : sans pagination, les utilisateurs 101+ — et donc leurs politiques

--- a/internal/exempt/apply.go
+++ b/internal/exempt/apply.go
@@ -1,0 +1,233 @@
+package exempt
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/stephrobert/scankit/assessment"
+
+	"github.com/stephrobert/pepin/internal/i18n"
+)
+
+// StatusExempted est le CINQUIÈME statut d'un résultat, à côté de pass, fail,
+// not-applicable et not-evaluated.
+//
+// Il est de premier rang, et distinct de `pass` partout : dans le rendu terminal,
+// dans les formats analysables, dans le décompte. Un contrôle exempté n'est PAS
+// conforme — il est écarté, sciemment et de façon traçable. S'il pouvait compter
+// comme conforme quelque part, on aurait donné un nom respectable au faux vert.
+//
+// `assessment.Status` est un type chaîne : le statut s'ajoute sans modifier scankit,
+// et l'OSCAL le rend « not-satisfied » comme tout ce qui n'est pas `pass`, ce qui
+// est exactement la lecture voulue.
+const StatusExempted assessment.Status = "exempted"
+
+// Effect nomme ce qu'une dérogation a réellement produit sur un scan.
+type Effect string
+
+const (
+	// EffectApplied : la dérogation a écarté au moins un écart.
+	EffectApplied Effect = "applied"
+	// EffectExpired : sa date est passée ; elle ne s'applique plus, et le dit.
+	EffectExpired Effect = "expired"
+	// EffectOrphan : elle vise un contrôle ou une ressource qui n'existe pas.
+	// C'est le symptôme d'une exception oubliée — on la signale, jamais on
+	// l'ignore.
+	EffectOrphan Effect = "orphan"
+)
+
+// Record est ce qu'une dérogation a produit, scellé dans le bundle. Un dossier qui
+// tait ses exemptions n'est pas opposable.
+type Record struct {
+	Exemption
+	// Effect : applied | expired | orphan.
+	Effect Effect `json:"effect"`
+	// Subjects : les sujets réellement écartés (vide hors `applied`).
+	Subjects []string `json:"subjects,omitempty"`
+	// Reason : pourquoi elle est expirée ou orpheline, en clair.
+	Reason string `json:"reason,omitempty"`
+}
+
+// Report est l'effet complet d'une politique de dérogations sur un scan.
+type Report struct {
+	// PolicyDigest : empreinte de la politique appliquée.
+	PolicyDigest string `json:"policy_digest,omitempty"`
+	// Exemptions : la politique telle qu'elle a été chargée (rejouable).
+	Exemptions []Exemption `json:"exceptions,omitempty"`
+	// Records : ce que chacune a produit. Les dérogations DORMANTES (valides mais
+	// dont le contrôle ne défaille pas ce jour-là) n'y figurent pas : ce n'est pas
+	// une anomalie, c'est le cas normal d'un écart corrigé.
+	Records []Record `json:"records,omitempty"`
+}
+
+// Count compte les enregistrements d'un effet donné.
+func (r Report) Count(e Effect) int {
+	n := 0
+	for _, rec := range r.Records {
+		if rec.Effect == e {
+			n++
+		}
+	}
+	return n
+}
+
+// Applied indique qu'au moins une dérogation a réellement écarté un écart. C'est
+// le fait qui déplace le code de sortie — et rien d'autre ne le déplace.
+func (r Report) Applied() bool { return r.Count(EffectApplied) > 0 }
+
+// Stale indique qu'au moins une dérogation est périmée ou orpheline : le fichier
+// demande une revue. Sous `--strict`, ce fait suffit à refuser la porte.
+func (r Report) Stale() bool { return r.Count(EffectExpired)+r.Count(EffectOrphan) > 0 }
+
+// Notices rend les avertissements destinés à l'opérateur, dans la langue courante.
+// Une dérogation expirée ou orpheline se DIT ; elle ne disparaît pas en silence.
+func (r Report) Notices() []string {
+	var out []string
+	for _, rec := range r.Records {
+		switch rec.Effect {
+		case EffectExpired:
+			out = append(out, fmt.Sprintf(i18n.T(
+				"dérogation EXPIRÉE le %s sur %s%s : elle ne s'applique plus, l'écart redevient un écart (%s)",
+				"exemption EXPIRED on %s for %s%s: it no longer applies, the deviation is a deviation again (%s)"),
+				rec.ExpiresAt, rec.Control, subjectSuffix(rec.Resource), rec.Owner))
+		case EffectOrphan:
+			out = append(out, fmt.Sprintf(i18n.T(
+				"dérogation ORPHELINE sur %s%s : %s — exception probablement oubliée, à retirer du fichier",
+				"ORPHAN exemption for %s%s: %s — likely a forgotten exception, remove it from the file"),
+				rec.Control, subjectSuffix(rec.Resource), rec.Reason))
+		case EffectApplied:
+		}
+	}
+	return out
+}
+
+func subjectSuffix(resource string) string {
+	if resource == "" {
+		return ""
+	}
+	return " / " + resource
+}
+
+// Apply écarte les écarts couverts par une dérogation valide et rend l'effet complet.
+//
+// Trois invariants, et ils tiennent par construction :
+//
+//  1. SEUL un résultat `fail` peut devenir `exempted`. Un `not-evaluated` ne peut
+//     pas être exempté : on ne déroge pas à un contrôle qu'on n'a pas su mesurer,
+//     ce serait taire une absence de mesure derrière une exception.
+//  2. Aucun résultat ne devient `pass`. La fonction n'écrit jamais cette valeur.
+//  3. Une dérogation expirée ou orpheline ne change AUCUN statut.
+//
+// `now` est l'instant d'évaluation du scan (pas l'horloge), pour qu'un bundle
+// rejoué rende exactement le même verdict.
+func Apply(a assessment.Assessment, pol Policy, now time.Time, subjects, controls map[string]bool) (assessment.Assessment, Report) {
+	rep := Report{PolicyDigest: pol.Digest(), Exemptions: pol.Exemptions}
+	if len(pol.Exemptions) == 0 {
+		return a, Report{}
+	}
+
+	// Tri des dérogations en trois tas, AVANT de toucher au moindre résultat.
+	var candidates []*candidate
+	for _, e := range pol.Exemptions {
+		switch {
+		case !controls[e.Control]:
+			rep.Records = append(rep.Records, Record{Exemption: e, Effect: EffectOrphan,
+				Reason: fmt.Sprintf(i18n.T(
+					"aucun contrôle « %s » au référentiel", "no control %q in the reference"), e.Control)})
+		case e.Resource != "" && !subjects[e.Resource]:
+			rep.Records = append(rep.Records, Record{Exemption: e, Effect: EffectOrphan,
+				Reason: fmt.Sprintf(i18n.T(
+					"aucune ressource « %s » dans l'inventaire évalué", "no resource %q in the assessed inventory"), e.Resource)})
+		case expired(e, now):
+			rep.Records = append(rep.Records, Record{Exemption: e, Effect: EffectExpired,
+				Reason: fmt.Sprintf(i18n.T("échue depuis le %s", "lapsed since %s"), e.ExpiresAt)})
+		default:
+			candidates = append(candidates, &candidate{ex: e, subjects: map[string]bool{}})
+		}
+	}
+
+	res := append([]assessment.Result(nil), a.Results...)
+	for i := range res {
+		if res[i].Status != assessment.Fail {
+			continue // invariant 1 : rien d'autre qu'un `fail` ne s'exempte
+		}
+		c := match(candidates, res[i].Control, res[i].Subject)
+		if c == nil {
+			continue
+		}
+		c.subjects[res[i].Subject] = true
+		res[i].Status = StatusExempted // invariant 2 : jamais `pass`
+		res[i].Waiver = &assessment.Waiver{Justification: c.ex.Justification, Until: string(c.ex.ExpiresAt)}
+		res[i].Labels = withExemptionLabels(res[i].Labels, c.ex)
+	}
+	a.Results = res
+
+	for _, c := range candidates {
+		if len(c.subjects) == 0 {
+			continue // dormante : le contrôle ne défaille pas, rien à signaler
+		}
+		subs := make([]string, 0, len(c.subjects))
+		for s := range c.subjects {
+			subs = append(subs, s)
+		}
+		sort.Strings(subs)
+		rep.Records = append(rep.Records, Record{Exemption: c.ex, Effect: EffectApplied, Subjects: subs})
+	}
+	sort.SliceStable(rep.Records, func(i, j int) bool {
+		if rep.Records[i].Effect != rep.Records[j].Effect {
+			return rep.Records[i].Effect < rep.Records[j].Effect
+		}
+		if rep.Records[i].Control != rep.Records[j].Control {
+			return rep.Records[i].Control < rep.Records[j].Control
+		}
+		return rep.Records[i].Resource < rep.Records[j].Resource
+	})
+	return a, rep
+}
+
+// candidate est une dérogation VALIDE (contrôle et ressource connus, non échue),
+// et les sujets qu'elle a effectivement écartés.
+type candidate struct {
+	ex       Exemption
+	subjects map[string]bool
+}
+
+// match trouve la dérogation qui couvre un (contrôle, sujet). Une entrée sans
+// `resource` couvre tous les sujets du contrôle ; une entrée nommée ne couvre que
+// le sien. La PREMIÈRE qui couvre l'emporte : l'ordre du fichier décide, ce qui est
+// la seule règle qu'un relecteur peut vérifier de tête.
+func match(candidates []*candidate, control, subject string) *candidate {
+	for _, c := range candidates {
+		if c.ex.Control != control {
+			continue
+		}
+		if c.ex.Resource == "" || c.ex.Resource == subject {
+			return c
+		}
+	}
+	return nil
+}
+
+// expired dit si la dérogation a dépassé sa date à l'instant d'évaluation. Une date
+// illisible ne peut pas arriver ici (Load la refuse) ; par prudence, elle expire.
+func expired(e Exemption, now time.Time) bool {
+	t, err := e.ExpiresAt.Time()
+	if err != nil {
+		return true
+	}
+	return now.After(t)
+}
+
+// withExemptionLabels ajoute les labels de traçabilité de la dérogation, sans
+// muter la carte du résultat d'origine.
+func withExemptionLabels(labels map[string]string, e Exemption) map[string]string {
+	out := make(map[string]string, len(labels)+3)
+	for k, v := range labels {
+		out[k] = v
+	}
+	out["exemption_owner"] = e.Owner
+	out["exemption_approved_by"] = e.ApprovedBy
+	out["exemption_expires_at"] = string(e.ExpiresAt)
+	return out
+}

--- a/internal/exempt/apply.go
+++ b/internal/exempt/apply.go
@@ -93,7 +93,7 @@ func (r Report) Notices() []string {
 				rec.ExpiresAt, rec.Control, subjectSuffix(rec.Resource), rec.Owner))
 		case EffectOrphan:
 			out = append(out, fmt.Sprintf(i18n.T(
-				"dérogation ORPHELINE sur %s%s : %s — exception probablement oubliée, à retirer du fichier",
+				"dérogation ORPHELINE sur %s%s : %s. Exception probablement oubliée, à retirer du fichier",
 				"ORPHAN exemption for %s%s: %s — likely a forgotten exception, remove it from the file"),
 				rec.Control, subjectSuffix(rec.Resource), rec.Reason))
 		case EffectApplied:
@@ -120,11 +120,28 @@ func subjectSuffix(resource string) string {
 //  3. Une dérogation expirée ou orpheline ne change AUCUN statut.
 //
 // `now` est l'instant d'évaluation du scan (pas l'horloge), pour qu'un bundle
-// rejoué rende exactement le même verdict.
+// rejoué rende exactement le même verdict. `subjects` porte les sujets nommables de
+// l'inventaire ; les sujets des résultats s'y ajoutent (voir plus bas).
 func Apply(a assessment.Assessment, pol Policy, now time.Time, subjects, controls map[string]bool) (assessment.Assessment, Report) {
 	rep := Report{PolicyDigest: pol.Digest(), Exemptions: pol.Exemptions}
 	if len(pol.Exemptions) == 0 {
 		return a, Report{}
+	}
+
+	// Les sujets connus : ceux de l'inventaire ET ceux que les résultats portent
+	// réellement. La distinction compte. Une règle choisit son sujet, et ce n'est pas
+	// toujours l'identifiant de la ressource : la règle SSH ouvert désigne le GROUPE de
+	// sécurité, pas la règle qui le compose. Or `resource:` est écrit par un humain qui
+	// recopie ce que le rapport lui montre — c'est donc le sujet du rapport qui fait foi,
+	// sans quoi une dérogation parfaitement légitime serait déclarée orpheline.
+	known := make(map[string]bool, len(subjects)+len(a.Results))
+	for s := range subjects {
+		known[s] = true
+	}
+	for _, r := range a.Results {
+		if r.Subject != "" {
+			known[r.Subject] = true
+		}
 	}
 
 	// Tri des dérogations en trois tas, AVANT de toucher au moindre résultat.
@@ -135,7 +152,7 @@ func Apply(a assessment.Assessment, pol Policy, now time.Time, subjects, control
 			rep.Records = append(rep.Records, Record{Exemption: e, Effect: EffectOrphan,
 				Reason: fmt.Sprintf(i18n.T(
 					"aucun contrôle « %s » au référentiel", "no control %q in the reference"), e.Control)})
-		case e.Resource != "" && !subjects[e.Resource]:
+		case e.Resource != "" && !known[e.Resource]:
 			rep.Records = append(rep.Records, Record{Exemption: e, Effect: EffectOrphan,
 				Reason: fmt.Sprintf(i18n.T(
 					"aucune ressource « %s » dans l'inventaire évalué", "no resource %q in the assessed inventory"), e.Resource)})

--- a/internal/exempt/exempt.go
+++ b/internal/exempt/exempt.go
@@ -1,0 +1,174 @@
+// Package exempt charge, valide et applique les DÉROGATIONS : les écarts qu'une
+// organisation assume sciemment, avec une date, une justification et un
+// responsable.
+//
+// Un CSPM utilisé en production doit permettre des exceptions. Sans elles, une
+// équipe finit par désactiver le contrôle, ou par ignorer l'outil — deux issues
+// pires que l'écart lui-même. Mais une dérogation muette (`ignore: true`) est un
+// faux vert sous une autre étiquette : elle rend le rapport moins fiable, pas plus.
+//
+// D'où quatre propriétés obligatoires, chacune pour une raison :
+//
+//   - `expires_at`   : sans date, une dérogation devient permanente par oubli ;
+//   - `justification`: ce que lira l'auditeur, et la personne qui reprendra le
+//     sujet dans un an ;
+//   - `owner` et `approved_by` : une dérogation sans responsable n'engage personne.
+//
+// Ces champs sont validés AU CHARGEMENT, pas au moment de l'appliquer : un fichier
+// incomplet arrête le scan, il ne produit pas un rapport qui tait la moitié de ses
+// exceptions.
+//
+// Et la règle qui prime sur tout : **une dérogation écarte, elle ne déclare jamais
+// conforme.** Le statut produit est `exempted`, jamais `pass` ; le décompte de
+// conformité et les formats analysables gardent l'écart ; seul le code de sortie
+// change, et il change vers un code DÉDIÉ qu'un pipeline doit explicitement
+// accepter — jamais vers 0.
+package exempt
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	yaml "go.yaml.in/yaml/v3"
+
+	"github.com/stephrobert/pepin/internal/i18n"
+)
+
+// Date est une date de fin de validité. Type nommé sur `string` pour deux raisons :
+// yaml.v3 résout `2026-12-31` en horodatage et refuserait un champ `string` nu, et
+// la forme sérialisée doit rester la chaîne écrite par l'auteur (ce que relira un
+// humain dans le bundle), pas une représentation reformatée.
+type Date string
+
+// UnmarshalYAML lit la valeur scalaire telle qu'elle est écrite, quelle que soit
+// la balise que yaml lui aurait résolue.
+func (d *Date) UnmarshalYAML(n *yaml.Node) error {
+	*d = Date(n.Value)
+	return nil
+}
+
+// dateLayouts : les formes acceptées pour `expires_at`. La date seule est la forme
+// naturelle d'une revue (« ce trimestre »), RFC3339 celle d'un outil.
+var dateLayouts = []string{"2006-01-02", time.RFC3339}
+
+// Time convertit la date en instant. Une date seule expire à la FIN du jour : une
+// dérogation « jusqu'au 31 décembre » couvre le 31 décembre.
+func (d Date) Time() (time.Time, error) {
+	s := strings.TrimSpace(string(d))
+	for _, layout := range dateLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			if layout == "2006-01-02" {
+				return t.Add(24*time.Hour - time.Nanosecond).UTC(), nil
+			}
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf(i18n.T(
+		"date %q illisible (formes acceptées : 2006-01-02, RFC3339)",
+		"unreadable date %q (accepted forms: 2006-01-02, RFC3339)"), s)
+}
+
+// Exemption est une dérogation : un contrôle (éventuellement une ressource précise)
+// écarté sciemment, jusqu'à une date, par quelqu'un, pour une raison écrite.
+type Exemption struct {
+	// Control : le code de contrôle agnostique (celui du référentiel commun).
+	Control string `yaml:"control" json:"control"`
+	// Resource : l'identifiant ou le nom de la ressource visée. Vide = tous les
+	// sujets de ce contrôle sur cette cible — une portée large, donc à justifier.
+	Resource string `yaml:"resource" json:"resource,omitempty"`
+	// Justification : ce que lira l'auditeur.
+	Justification string `yaml:"justification" json:"justification"`
+	// ExpiresAt : la date au-delà de laquelle la dérogation ne s'applique plus.
+	ExpiresAt Date `yaml:"expires_at" json:"expires_at"`
+	// Owner : qui porte le risque.
+	Owner string `yaml:"owner" json:"owner"`
+	// ApprovedBy : qui l'a accepté.
+	ApprovedBy string `yaml:"approved_by" json:"approved_by"`
+}
+
+// Policy est le contenu d'un fichier de dérogations, versionné et revu comme du code.
+type Policy struct {
+	// Exemptions porte la clé YAML `exceptions` : c'est le mot du fichier que les
+	// équipes écrivent, et le renommer casserait tous les fichiers existants.
+	Exemptions []Exemption `yaml:"exceptions" json:"exceptions"`
+}
+
+// Digest empreinte la politique NORMALISÉE (entrées triées, forme canonique). Sert
+// à prouver quelle politique a été appliquée à un scan, indépendamment de la mise
+// en forme du fichier YAML.
+func (p Policy) Digest() string {
+	keys := make([]string, 0, len(p.Exemptions))
+	for _, e := range p.Exemptions {
+		keys = append(keys, strings.Join([]string{
+			e.Control, e.Resource, string(e.ExpiresAt), e.Owner, e.ApprovedBy, e.Justification,
+		}, "\x00"))
+	}
+	sort.Strings(keys)
+	h := sha256.New()
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte("\n"))
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// Load lit un fichier de dérogations et VALIDE chaque entrée. Toutes les erreurs
+// sont rendues d'un coup : corriger un fichier une ligne par exécution est le genre
+// de friction qui fait abandonner le fichier — et revenir au contrôle désactivé.
+func Load(path string) (Policy, error) {
+	raw, err := os.ReadFile(path) // #nosec G304 -- fichier de dérogations choisi par l'opérateur en option CLI.
+	if err != nil {
+		return Policy{}, fmt.Errorf(i18n.T("lecture des dérogations %s : %w", "reading the exemptions %s: %w"), path, err)
+	}
+	var p Policy
+	if err := yaml.Unmarshal(raw, &p); err != nil {
+		return Policy{}, fmt.Errorf(i18n.T("dérogations %s invalides : %w", "invalid exemptions %s: %w"), path, err)
+	}
+	if len(p.Exemptions) == 0 {
+		return Policy{}, fmt.Errorf(i18n.T(
+			"dérogations %s : aucune entrée sous la clé `exceptions`",
+			"exemptions %s: no entry under the `exceptions` key"), path)
+	}
+	var problems []string
+	for i, e := range p.Exemptions {
+		for _, pb := range e.validate() {
+			problems = append(problems, fmt.Sprintf("  exceptions[%d] : %s", i, pb))
+		}
+	}
+	if len(problems) > 0 {
+		return Policy{}, fmt.Errorf(i18n.T(
+			"dérogations %s : %d champ(s) obligatoire(s) manquant ou invalide —\n%s",
+			"exemptions %s: %d mandatory field(s) missing or invalid —\n%s"),
+			path, len(problems), strings.Join(problems, "\n"))
+	}
+	return p, nil
+}
+
+// validate rend les problèmes d'une entrée. Une dérogation incomplète n'engage
+// personne : le chargement la refuse plutôt que de l'appliquer à moitié.
+func (e Exemption) validate() []string {
+	var out []string
+	for _, f := range []struct{ name, value string }{
+		{"control", e.Control},
+		{"justification", e.Justification},
+		{"owner", e.Owner},
+		{"approved_by", e.ApprovedBy},
+	} {
+		if strings.TrimSpace(f.value) == "" {
+			out = append(out, fmt.Sprintf(i18n.T("champ `%s` obligatoire et vide", "mandatory field `%s` is empty"), f.name))
+		}
+	}
+	if strings.TrimSpace(string(e.ExpiresAt)) == "" {
+		out = append(out, i18n.T(
+			"champ `expires_at` obligatoire et vide (sans date, une dérogation devient permanente par oubli)",
+			"mandatory field `expires_at` is empty (without a date an exemption becomes permanent by oversight)"))
+	} else if _, err := e.ExpiresAt.Time(); err != nil {
+		out = append(out, err.Error())
+	}
+	return out
+}

--- a/internal/exempt/exempt.go
+++ b/internal/exempt/exempt.go
@@ -78,7 +78,8 @@ func (d Date) Time() (time.Time, error) {
 type Exemption struct {
 	// Control : le code de contrôle agnostique (celui du référentiel commun).
 	Control string `yaml:"control" json:"control"`
-	// Resource : l'identifiant ou le nom de la ressource visée. Vide = tous les
+	// Resource : le SUJET tel que le rapport le nomme (c'est ce qu'un humain y
+	// recopie), ou l'identifiant/nom d'une ressource de l'inventaire. Vide = tous les
 	// sujets de ce contrôle sur cette cible — une portée large, donc à justifier.
 	Resource string `yaml:"resource" json:"resource,omitempty"`
 	// Justification : ce que lira l'auditeur.
@@ -142,7 +143,7 @@ func Load(path string) (Policy, error) {
 	}
 	if len(problems) > 0 {
 		return Policy{}, fmt.Errorf(i18n.T(
-			"dérogations %s : %d champ(s) obligatoire(s) manquant ou invalide —\n%s",
+			"dérogations %s : %d champ(s) obligatoire(s) manquant ou invalide :\n%s",
 			"exemptions %s: %d mandatory field(s) missing or invalid —\n%s"),
 			path, len(problems), strings.Join(problems, "\n"))
 	}

--- a/internal/exempt/exempt_test.go
+++ b/internal/exempt/exempt_test.go
@@ -143,7 +143,10 @@ func TestAnOrphanExemptionIsReported(t *testing.T) {
 			subjects: subjectBastion, controls: knownSSH,
 		},
 		"ressource inconnue": {
-			body: validFile, subjects: map[string]bool{"vm-autre": true}, controls: knownSSH,
+			// Ni dans l'inventaire, ni dans les sujets du rapport : la dérogation ne
+			// désigne rien de ce scan.
+			body:     strings.Replace(validFile, "resource: vm-bastion", "resource: vm-supprimee-en-2024", 1),
+			subjects: map[string]bool{"vm-autre": true}, controls: knownSSH,
 		},
 	}
 	for name, c := range cases {
@@ -183,6 +186,25 @@ func TestOnlyAFailCanBeExempted(t *testing.T) {
 	}
 	if rep.Applied() {
 		t.Error("une dérogation sans écart à écarter se dit appliquée")
+	}
+}
+
+// TestAnExemptionMatchesTheSubjectTheReportPrints : une règle choisit son sujet, et
+// ce n'est pas toujours l'identifiant de la ressource — la règle « SSH ouvert »
+// désigne le GROUPE de sécurité, pas la règle qui le compose. L'humain qui écrit la
+// dérogation recopie ce que le rapport lui montre : c'est donc ce sujet-là qui doit
+// être reconnu, sans quoi une dérogation légitime serait déclarée orpheline.
+func TestAnExemptionMatchesTheSubjectTheReportPrints(t *testing.T) {
+	body := strings.Replace(validFile, "resource: vm-bastion", "resource: sg-bastion", 1)
+	// L'inventaire ne connaît que la ressource `vm-bastion` ; le rapport, lui, nomme
+	// `sg-bastion`.
+	got, rep := Apply(failing(sshControl, "sg-bastion"), policyOf(t, body),
+		at(t, "2026-08-19"), subjectBastion, knownSSH)
+	if got.Results[0].Status != StatusExempted {
+		t.Errorf("statut %q, attendu `exempted` — le sujet du rapport doit faire foi", got.Results[0].Status)
+	}
+	if rep.Count(EffectOrphan) != 0 {
+		t.Error("une dérogation qui nomme le sujet du rapport est déclarée orpheline")
 	}
 }
 

--- a/internal/exempt/exempt_test.go
+++ b/internal/exempt/exempt_test.go
@@ -1,0 +1,261 @@
+package exempt
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stephrobert/scankit/assessment"
+)
+
+func write(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "exceptions.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("écriture de la fixture : %v", err)
+	}
+	return path
+}
+
+const validFile = `exceptions:
+  - control: network_securitygroup_allow_ingress_from_internet_to_tcp_port_22
+    resource: vm-bastion
+    justification: "Bastion administré, accès restreint par IP source"
+    expires_at: 2026-12-31
+    owner: platform-security
+    approved_by: security@example.org
+`
+
+func at(t *testing.T, s string) time.Time {
+	t.Helper()
+	v, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("date de test %q : %v", s, err)
+	}
+	return v
+}
+
+func failing(control, subject string) assessment.Assessment {
+	return assessment.Assessment{Results: []assessment.Result{
+		{Control: control, Subject: subject, Status: assessment.Fail, Severity: "critical"},
+	}}
+}
+
+func policyOf(t *testing.T, body string) Policy {
+	t.Helper()
+	pol, err := Load(write(t, body))
+	if err != nil {
+		t.Fatalf("chargement : %v", err)
+	}
+	return pol
+}
+
+const sshControl = "network_securitygroup_allow_ingress_from_internet_to_tcp_port_22"
+
+var knownSSH = map[string]bool{sshControl: true}
+var subjectBastion = map[string]bool{"vm-bastion": true}
+
+// TestAnExemptionNeverTurnsAFailIntoAPass est L'INVARIANT de ce lot, et il est
+// écrit pour échouer si le statut produit devenait conforme de quelque manière que
+// ce soit : par la valeur du statut, par le décompte, ou par la lecture que scankit
+// en fait (Conformant()).
+//
+// Un contrôle exempté n'est pas conforme. Il est écarté, sciemment et de façon
+// traçable. S'il pouvait compter comme conforme, on aurait donné un nom
+// respectable au faux vert.
+func TestAnExemptionNeverTurnsAFailIntoAPass(t *testing.T) {
+	got, rep := Apply(failing(sshControl, "vm-bastion"), policyOf(t, validFile),
+		at(t, "2026-08-19"), subjectBastion, knownSSH)
+
+	r := got.Results[0]
+	if r.Status == assessment.Pass {
+		t.Fatal("une dérogation a produit un `pass` — c'est exactement le faux vert que le statut existe pour empêcher")
+	}
+	if r.Status != StatusExempted {
+		t.Fatalf("statut %q, attendu %q", r.Status, StatusExempted)
+	}
+	// Le décompte par statut ne doit compter l'exempté nulle part ailleurs.
+	sum := got.Summarize()
+	if sum.ByStatus[assessment.Pass] != 0 {
+		t.Errorf("%d résultat(s) comptés `pass` après exemption", sum.ByStatus[assessment.Pass])
+	}
+	if sum.ByStatus[StatusExempted] != 1 {
+		t.Errorf("%d résultat(s) comptés `exempted`, attendu 1", sum.ByStatus[StatusExempted])
+	}
+	// La dérogation est TRAÇABLE : qui, pourquoi, jusqu'à quand.
+	if r.Waiver == nil || r.Waiver.Justification == "" || r.Waiver.Until == "" {
+		t.Fatalf("dérogation appliquée sans waiver traçable : %+v", r.Waiver)
+	}
+	for _, label := range []string{"exemption_owner", "exemption_approved_by", "exemption_expires_at"} {
+		if r.Labels[label] == "" {
+			t.Errorf("label %q absent : une dérogation sans responsable n'engage personne", label)
+		}
+	}
+	if !rep.Applied() {
+		t.Error("l'effet `applied` n'est pas rapporté")
+	}
+}
+
+// TestAnExpiredExemptionStopsApplyingAndSaysSo : sans date, une dérogation devient
+// permanente par oubli. L'expiration la retire du jeu, et le dit.
+func TestAnExpiredExemptionStopsApplyingAndSaysSo(t *testing.T) {
+	got, rep := Apply(failing(sshControl, "vm-bastion"), policyOf(t, validFile),
+		at(t, "2027-01-02"), subjectBastion, knownSSH)
+
+	if got.Results[0].Status != assessment.Fail {
+		t.Errorf("statut %q après expiration, attendu `fail` — l'écart redevient un écart", got.Results[0].Status)
+	}
+	if rep.Applied() {
+		t.Error("une dérogation expirée compte comme appliquée")
+	}
+	if rep.Count(EffectExpired) != 1 {
+		t.Fatalf("%d dérogation(s) rapportée(s) expirée(s), attendu 1", rep.Count(EffectExpired))
+	}
+	notices := rep.Notices()
+	if len(notices) != 1 || !strings.Contains(strings.ToUpper(notices[0]), "EXPIR") {
+		t.Errorf("l'expiration ne se dit pas : %v", notices)
+	}
+}
+
+// TestTheLastDayOfValidityIsStillCovered : « jusqu'au 31 décembre » couvre le
+// 31 décembre. Une borne qui exclut son dernier jour surprend tout le monde.
+func TestTheLastDayOfValidityIsStillCovered(t *testing.T) {
+	got, _ := Apply(failing(sshControl, "vm-bastion"), policyOf(t, validFile),
+		at(t, "2026-12-31"), subjectBastion, knownSSH)
+	if got.Results[0].Status != StatusExempted {
+		t.Errorf("statut %q le jour même de l'échéance, attendu `exempted`", got.Results[0].Status)
+	}
+}
+
+// TestAnOrphanExemptionIsReported : une dérogation qui ne correspond à aucun
+// contrôle ni à aucune ressource est le symptôme d'une exception oubliée. On la
+// signale ; on ne l'ignore jamais.
+func TestAnOrphanExemptionIsReported(t *testing.T) {
+	cases := map[string]struct {
+		body     string
+		subjects map[string]bool
+		controls map[string]bool
+	}{
+		"contrôle inconnu": {
+			body:     strings.Replace(validFile, sshControl, "controle_qui_nexiste_plus", 1),
+			subjects: subjectBastion, controls: knownSSH,
+		},
+		"ressource inconnue": {
+			body: validFile, subjects: map[string]bool{"vm-autre": true}, controls: knownSSH,
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, rep := Apply(failing(sshControl, "vm-bastion"), policyOf(t, c.body),
+				at(t, "2026-08-19"), c.subjects, c.controls)
+			if got.Results[0].Status != assessment.Fail {
+				t.Errorf("statut %q, attendu `fail` — une dérogation orpheline n'écarte rien", got.Results[0].Status)
+			}
+			if rep.Count(EffectOrphan) != 1 {
+				t.Fatalf("%d orpheline(s) rapportée(s), attendu 1", rep.Count(EffectOrphan))
+			}
+			if len(rep.Notices()) != 1 {
+				t.Errorf("l'orpheline ne se dit pas : %v", rep.Notices())
+			}
+			if !rep.Stale() {
+				t.Error("un fichier portant une orpheline n'est pas signalé comme à revoir")
+			}
+		})
+	}
+}
+
+// TestOnlyAFailCanBeExempted : on ne déroge pas à un contrôle qu'on n'a pas su
+// mesurer. Exempter un `not-evaluated` reviendrait à cacher une absence de mesure
+// derrière une exception — le faux vert avec une étape de plus.
+func TestOnlyAFailCanBeExempted(t *testing.T) {
+	a := assessment.Assessment{Results: []assessment.Result{
+		{Control: sshControl, Subject: "vm-bastion", Status: assessment.NotEvaluated},
+		{Control: sshControl, Subject: "vm-bastion", Status: assessment.Pass},
+		{Control: sshControl, Subject: "vm-bastion", Status: assessment.NotApplicable},
+	}}
+	got, rep := Apply(a, policyOf(t, validFile), at(t, "2026-08-19"), subjectBastion, knownSSH)
+	for i, want := range []assessment.Status{assessment.NotEvaluated, assessment.Pass, assessment.NotApplicable} {
+		if got.Results[i].Status != want {
+			t.Errorf("statut %q déplacé en %q par une dérogation", want, got.Results[i].Status)
+		}
+	}
+	if rep.Applied() {
+		t.Error("une dérogation sans écart à écarter se dit appliquée")
+	}
+}
+
+// TestMandatoryFieldsAreValidatedAtLoadTime : les champs obligatoires se vérifient
+// au CHARGEMENT. Un fichier incomplet arrête le scan, il ne produit pas un rapport
+// qui tait la moitié de ses exceptions.
+func TestMandatoryFieldsAreValidatedAtLoadTime(t *testing.T) {
+	for name, body := range map[string]string{
+		"sans justification": strings.Replace(validFile, `    justification: "Bastion administré, accès restreint par IP source"`+"\n", "", 1),
+		"sans date":          strings.Replace(validFile, "    expires_at: 2026-12-31\n", "", 1),
+		"sans responsable":   strings.Replace(validFile, "    owner: platform-security\n", "", 1),
+		"sans approbateur":   strings.Replace(validFile, "    approved_by: security@example.org\n", "", 1),
+		"sans contrôle":      strings.Replace(validFile, "  - control: "+sshControl+"\n", "  - resource: x\n", 1),
+		"date illisible":     strings.Replace(validFile, "2026-12-31", "le mois prochain", 1),
+		"fichier vide":       "exceptions: []\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Load(write(t, body)); err == nil {
+				t.Error("chargement accepté — un champ obligatoire manquant doit arrêter le scan, pas l'appliquer à moitié")
+			}
+		})
+	}
+}
+
+// TestLoadAcceptsBothDateForms : la date seule est la forme naturelle d'une revue,
+// RFC3339 celle d'un outil. Les deux se chargent.
+func TestLoadAcceptsBothDateForms(t *testing.T) {
+	for _, form := range []string{"2026-12-31", `"2026-12-31T23:59:59Z"`} {
+		if _, err := Load(write(t, strings.Replace(validFile, "2026-12-31", form, 1))); err != nil {
+			t.Errorf("forme de date %s refusée : %v", form, err)
+		}
+	}
+}
+
+// TestAnExemptionWithoutResourceCoversEverySubject : une entrée sans `resource`
+// porte sur tout le contrôle. Portée large, donc à assumer — mais elle doit
+// fonctionner, sinon les équipes écrivent une entrée par ressource et la revue
+// devient impraticable.
+func TestAnExemptionWithoutResourceCoversEverySubject(t *testing.T) {
+	body := strings.Replace(validFile, "    resource: vm-bastion\n", "", 1)
+	a := assessment.Assessment{Results: []assessment.Result{
+		{Control: sshControl, Subject: "vm-a", Status: assessment.Fail},
+		{Control: sshControl, Subject: "vm-b", Status: assessment.Fail},
+	}}
+	got, rep := Apply(a, policyOf(t, body), at(t, "2026-08-19"), map[string]bool{}, knownSSH)
+	for _, r := range got.Results {
+		if r.Status != StatusExempted {
+			t.Errorf("%s : statut %q, attendu `exempted`", r.Subject, r.Status)
+		}
+	}
+	if n := len(rep.Records[0].Subjects); n != 2 {
+		t.Errorf("%d sujet(s) rapporté(s) écarté(s), attendu 2", n)
+	}
+}
+
+// TestTheDigestFollowsTheContentNotTheFormatting : l'empreinte prouve QUELLE
+// politique a été appliquée. Elle doit suivre le contenu, pas l'indentation.
+func TestTheDigestFollowsTheContentNotTheFormatting(t *testing.T) {
+	a := policyOf(t, validFile)
+	reordered := policyOf(t, validFile+strings.Replace(validFile, "exceptions:\n", "", 1))
+	if a.Digest() == reordered.Digest() {
+		t.Error("deux politiques différentes portent la même empreinte")
+	}
+	// Les mêmes entrées, clés dans un autre ordre : même politique, même empreinte.
+	const reformatted = `exceptions:
+  - owner: platform-security
+    approved_by: security@example.org
+    expires_at: 2026-12-31
+    resource: vm-bastion
+    justification: "Bastion administré, accès restreint par IP source"
+    control: ` + sshControl + `
+`
+	if a.Digest() != policyOf(t, reformatted).Digest() {
+		t.Error("l'empreinte a bougé pour un simple réordonnancement des clés")
+	}
+}

--- a/internal/genprovider/catalogue.go
+++ b/internal/genprovider/catalogue.go
@@ -1,0 +1,88 @@
+package genprovider
+
+import (
+	"sort"
+
+	"github.com/stephrobert/pepin/internal/eimpolicy"
+	"github.com/stephrobert/pepin/internal/objectstorage"
+	"github.com/stephrobert/pepin/internal/oks"
+)
+
+// InventoryCatalogue énumère le vocabulaire de l'inventaire normalisé : chaque
+// type de ressource et les attributs communs que Pépin sait y projeter, tous
+// fournisseurs et toutes sources confondus.
+//
+// Il est DÉRIVÉ des descripteurs chargés et des collecteurs Go, jamais recopié :
+// une liste tenue à la main à côté du code diverge au premier attribut ajouté, et
+// une énumération fausse est pire qu'une énumération absente. C'est cette
+// dérivation qui permet de geler le vocabulaire (cmd/testdata/frozen/inventory.json)
+// sans qu'un contributeur ait à penser à mettre une table à jour.
+//
+// Ce que le catalogue dit : « cet attribut existe dans le modèle, et voici sur
+// quel type ». Ce qu'il ne dit PAS : qu'il est présent sur une ressource donnée
+// d'un scan donné — cette question-là est celle de la provenance.
+func InventoryCatalogue() map[string][]string {
+	byType := map[string]map[string]bool{}
+	add := func(typ string, attrs ...string) {
+		if typ == "" {
+			return
+		}
+		if byType[typ] == nil {
+			byType[typ] = map[string]bool{}
+		}
+		for _, a := range attrs {
+			if a != "" {
+				byType[typ][a] = true
+			}
+		}
+	}
+	for _, d := range registry {
+		for _, r := range d.Collecte.Resources {
+			add(r.Type, keysOf(r.Map)...)
+			add(r.Type, keysOfAny(r.Const)...)
+			add(r.Type, r.Aggregate)
+		}
+		for _, r := range d.MappingTerraform.Resources {
+			add(r.Type, keysOf(r.Map)...)
+			add(r.Type, keysOfAny(r.Const)...)
+		}
+		// La ressource synthétique de souveraineté n'est collectée nulle part : ses
+		// attributs viennent du descripteur, et elle appartient pourtant au modèle.
+		if res, ok := (GenericProvider{desc: d}).GovernanceResource(); ok {
+			add(res.Type, keysOfAny(res.Attributes)...)
+		}
+	}
+	// Les collecteurs Go (stockage objet, Kubernetes managé, politiques EIM inline)
+	// projettent hors du moteur YAML : leurs attributs sont déclarés à côté de leur
+	// code, et lus ici — même principe, une seule source.
+	add("object_storage_bucket", objectstorage.BucketAttributes()...)
+	add("kubernetes_cluster", oks.ClusterAttributes()...)
+	add("iam_policy", eimpolicy.PolicyAttributes()...)
+
+	out := make(map[string][]string, len(byType))
+	for typ, attrs := range byType {
+		list := make([]string, 0, len(attrs))
+		for a := range attrs {
+			list = append(list, a)
+		}
+		sort.Strings(list)
+		out[typ] = list
+	}
+	return out
+}
+
+func keysOf(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func keysOfAny(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/genprovider/genprovider.go
+++ b/internal/genprovider/genprovider.go
@@ -231,12 +231,22 @@ func (g GenericProvider) GovernanceResource() (model.Resource, bool) {
 	if s.ExpositionExtraterritoriale != nil {
 		attrs["extraterritorial_exposure"] = *s.ExpositionExtraterritoriale
 	}
+	// Ces attributs sont des FAITS DÉCLARÉS au descripteur, jamais mesurés sur le
+	// tenant : leur attestation le dit explicitement. C'est la même honnêteté que la
+	// preuve d'un `pass` de gouvernance, portée cette fois par la donnée elle-même.
+	var prov model.Provenance
+	for attr := range attrs {
+		prov.Attest(attr, model.Attestation{
+			Origin: model.OriginDerived, Source: "descriptor:souverainete", Derived: true,
+		})
+	}
 	return model.Resource{
 		Provider:   g.desc.Name,
 		Type:       "governance_provider",
 		ID:         g.desc.Name,
 		Name:       g.desc.Name,
 		Attributes: attrs,
+		Provenance: prov,
 	}, true
 }
 

--- a/internal/model/provenance.go
+++ b/internal/model/provenance.go
@@ -1,0 +1,101 @@
+package model
+
+// Provenance : l'état d'observation de chaque attribut d'une ressource.
+//
+// Pour un outil de posture, ces deux situations ne disent PAS la même chose :
+//
+//	`false`                       →  observé, et la valeur est faux
+//	absent (donc zéro-value Go)   →  jamais observé
+//
+// La projection fait déjà la différence (collect.Project ne pose pas un attribut
+// que la source n'expose pas), mais elle la PERD aussitôt : une fois l'attribut
+// dans `attributes`, plus rien ne dit d'où il vient. Un attribut posé par le
+// `const:` d'un descripteur y est indiscernable d'un attribut lu dans une réponse
+// d'API — or l'un est une attestation du descripteur, l'autre une mesure.
+//
+// L'attestation vit À CÔTÉ de la valeur, jamais à sa place : `attributes` garde
+// exactement la forme que les règles Rego lisent, et `provenance` est un index
+// PARALLÈLE, indexé par le même nom d'attribut. Aucune règle n'a à changer, et
+// aucune ne peut changer de verdict du fait de la provenance.
+//
+// Règle de conception, non négociable : **la provenance ne désigne jamais un
+// appel d'API qui n'a pas eu lieu.** Le libellé d'une source `api` est construit
+// à partir de la requête RÉELLEMENT émise (méthode + URL, après réponse), pas de
+// ce que la spec YAML déclare appeler. Nommer un endpoint pour un attribut en
+// réalité dérivé donnerait l'APPARENCE de la traçabilité, ce qui est pire que son
+// absence.
+
+// Origin nomme la nature de la source d'un attribut. Trois natures, parce que ce
+// sont les trois que Pépin sait produire et distinguer.
+type Origin string
+
+const (
+	// OriginAPI : la valeur vient d'une réponse d'API live. `Source` porte alors
+	// la requête effectivement émise (« GET https://api.exemple/… »).
+	OriginAPI Origin = "api"
+	// OriginTerraform : la valeur vient d'un plan Terraform (état PLANIFIÉ, pas
+	// la configuration effective). `Source` porte le type de ressource du plan.
+	OriginTerraform Origin = "terraform-plan"
+	// OriginDerived : la valeur est produite LOCALEMENT — littéral `const:` d'un
+	// descripteur, fait déclaré (souveraineté), agrégat calculé. Aucun appel
+	// d'API ne l'a portée, et l'attestation le dit.
+	OriginDerived Origin = "derived"
+)
+
+// Attestation dit d'où vient UN attribut et s'il a réellement été observé.
+type Attestation struct {
+	// Origin : api | terraform-plan | derived.
+	Origin Origin `json:"origin"`
+	// Source : l'appel effectif (origine api), le type de ressource du plan
+	// (terraform-plan), ou l'élément de descripteur (derived).
+	Source string `json:"source,omitempty"`
+	// Path : le chemin natif LU dans le document source (champ de la réponse
+	// d'API, attribut du plan). Vide pour une valeur dérivée : il n'y a rien à
+	// désigner.
+	Path string `json:"path,omitempty"`
+	// Observed : le document source portait réellement `Path`. Faux quand la
+	// source ne l'expose pas — c'est la distinction « absent » / « présent et
+	// vide » rendue durable jusqu'au modèle.
+	Observed bool `json:"observed"`
+	// Derived : la valeur a été CALCULÉE (transform, agrégat, littéral) plutôt
+	// que recopiée telle quelle. Orthogonal à Origin : un agrégat calculé sur une
+	// réponse réelle est `api` + `derived`.
+	Derived bool `json:"derived,omitempty"`
+}
+
+// Provenance indexe les attestations par nom d'attribut. Une clé peut exister
+// SANS que l'attribut correspondant soit dans `attributes` : c'est le cas d'un
+// champ cherché dans la source et qu'elle n'exposait pas (Observed faux). C'est
+// la forme la plus utile de l'information — « on a regardé, il n'y était pas »
+// n'est pas « on n'a jamais regardé ».
+type Provenance map[string]Attestation
+
+// Attest enregistre l'attestation d'un attribut (crée la carte au besoin).
+func (p *Provenance) Attest(attr string, a Attestation) {
+	if *p == nil {
+		*p = Provenance{}
+	}
+	(*p)[attr] = a
+}
+
+// AttestPresent atteste les attributs PRÉSENTS de `attrs` à partir d'une table
+// attribut → appel. Réservé aux collecteurs Go dont chaque attribut a son propre
+// appel (stockage objet) : l'attribut n'est posé que si son appel a réussi, donc
+// l'attester est une lecture fidèle de ce qui s'est passé. Un attribut absent de
+// la table n'est PAS attesté — plutôt aucune attestation qu'une fausse.
+func AttestPresent(attrs map[string]any, calls map[string]string, derived map[string]bool) Provenance {
+	var p Provenance
+	for attr := range attrs {
+		call, ok := calls[attr]
+		if !ok {
+			continue
+		}
+		p.Attest(attr, Attestation{
+			Origin:   OriginAPI,
+			Source:   call,
+			Observed: true,
+			Derived:  derived[attr],
+		})
+	}
+	return p
+}

--- a/internal/model/resource.go
+++ b/internal/model/resource.go
@@ -6,6 +6,11 @@
 package model
 
 // Resource est une ressource cloud normalisée.
+//
+// `Provenance` est un index PARALLÈLE à `Attributes`, indexé par le même nom
+// d'attribut : il dit d'où vient chaque valeur et si elle a réellement été
+// observée. Il ne s'imbrique jamais DANS une valeur — les règles Rego lisent
+// `attributes.<nom>` et n'ont rien à savoir de la provenance.
 type Resource struct {
 	Provider   string         `json:"provider"`
 	Type       string         `json:"type"`
@@ -13,6 +18,7 @@ type Resource struct {
 	Name       string         `json:"name"`
 	Region     string         `json:"region,omitempty"`
 	Attributes map[string]any `json:"attributes"`
+	Provenance Provenance     `json:"provenance,omitempty"`
 }
 
 // Posture est l'export d'inventaire soumis à l'évaluation.

--- a/internal/model/schema.go
+++ b/internal/model/schema.go
@@ -1,0 +1,75 @@
+package model
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Le schéma de l'inventaire normalisé est un CONTRAT INTERNE, pas un détail
+// d'implémentation.
+//
+// L'inventaire est déjà le point de passage de tout : la collecte y projette, les
+// règles s'y évaluent, l'assessment en dérive, le bundle le scelle. Chaque nouvel
+// usage le fige un peu plus PAR ACCIDENT, et une évolution du modèle casse alors un
+// consommateur en silence. On le nomme donc, on le version, et on le gèle.
+//
+// # Ce qui est GARANTI
+//
+//   - L'enveloppe : un objet portant `provider` (chaîne) et `resources` (tableau).
+//     Le scan y ajoute `evaluated_at` (RFC3339 UTC), l'instant d'évaluation unique
+//     auquel les règles sensibles au temps s'ancrent.
+//   - La ressource : `provider`, `type`, `id`, `name`, `attributes` toujours
+//     présents ; `region` et `provenance` présents quand ils sont renseignés.
+//   - `attributes` est une carte PLATE de nom d'attribut vers valeur JSON. Un nom
+//     d'attribut est en snake_case et AGNOSTIQUE du fournisseur : c'est ce que les
+//     règles lisent, et c'est pourquoi une règle est commune à tous les clouds.
+//   - `provenance` est indexée par les MÊMES noms d'attributs, jamais imbriquée
+//     dans une valeur. Une clé peut y exister sans que l'attribut soit dans
+//     `attributes` : c'est un champ cherché et non exposé par la source.
+//   - Un type de ressource est en snake_case, au singulier, préfixé par sa famille
+//     de service neutre (compute_, network_, objectstorage_ côté contrôle, et côté
+//     ressource : compute_instance, security_group_rule, object_storage_bucket…).
+//   - Un attribut ABSENT n'est jamais forcé à une valeur : « non collecté » et
+//     « collecté à faux » ne se confondent pas. C'est l'invariant dont tout le
+//     modèle de confiance dépend.
+//
+// # Ce qui n'est PAS garanti
+//
+//   - L'ORDRE des ressources et des attributs : rien ne le fixe, et s'en servir
+//     casserait au premier changement de pagination.
+//   - La PRÉSENCE d'un attribut donné sur une ressource donnée : elle dépend du
+//     fournisseur, des droits du jeton et de la source (un plan Terraform ignore
+//     tout de l'état effectif). C'est précisément ce que `provenance` documente.
+//   - L'exhaustivité de l'inventaire : un scan mesure ce à quoi ses identifiants
+//     donnent accès, jamais « tout le tenant ».
+//   - Les valeurs elles-mêmes : elles reflètent le contrat natif du fournisseur,
+//     qui peut changer sans que Pépin en décide.
+//
+// # Comment il bouge
+//
+// La forme est gelée dans cmd/testdata/frozen/inventory.json, avec l'énumération
+// des types et de leurs attributs communs. Un changement de forme — un champ
+// d'enveloppe, un champ de ressource, un type, un attribut — fait rougir le gel :
+// il se décide, il incrémente `InventoryFormat`, et il s'écrit au CHANGELOG. C'est
+// volontairement le même égard que pour la surface CLI.
+
+// InventoryFormat identifie le schéma de l'inventaire normalisé, version comprise
+// (`/vN`). Il VOYAGE avec le bundle de preuve (manifest.inventory_schema) : un
+// consommateur qui rencontre une version qu'il ne connaît pas doit s'arrêter
+// plutôt que deviner la forme de ce qu'il lit.
+const InventoryFormat = "pepin-inventory/v1"
+
+// InventorySchemaVersion extrait le N du suffixe `/vN`. Comme pour le bundle, la
+// constante et le signal sur le fil sont la même chose : impossible de faire
+// diverger la version déclarée de la version publiée.
+func InventorySchemaVersion() int {
+	i := strings.LastIndex(InventoryFormat, "/v")
+	if i < 0 {
+		return 0
+	}
+	n, err := strconv.Atoi(InventoryFormat[i+2:])
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/objectstorage/s3.go
+++ b/internal/objectstorage/s3.go
@@ -129,7 +129,40 @@ func collectBucket(ctx context.Context, client *s3.Client, provider, region, nam
 		}
 	} // sinon (403, timeout) : attributs absents → not-evaluated, jamais un faux vert.
 
-	return model.Resource{Provider: provider, Type: "object_storage_bucket", ID: name, Name: name, Region: region, Attributes: attrs}
+	// Chaque attribut n'est posé QUE si son appel a réussi (voir ci-dessus) : attester
+	// l'appel qui le porte est donc une lecture fidèle de ce qui s'est passé, jamais une
+	// recopie de ce que le code déclare appeler. Un 403 sur GetBucketAcl laisse l'attribut
+	// absent ET non attesté — l'attestation ne peut pas nommer un appel qui a échoué.
+	return model.Resource{
+		Provider: provider, Type: "object_storage_bucket", ID: name, Name: name, Region: region,
+		Attributes: attrs,
+		Provenance: model.AttestPresent(attrs, bucketAttrCall, bucketAttrDerived),
+	}
+}
+
+// bucketAttrCall : l'appel S3 qui porte chaque attribut de bucket.
+var bucketAttrCall = map[string]string{
+	"name":                       "s3:ListBuckets",
+	"acl_grants":                 "s3:GetBucketAcl",
+	"public_via_acl":             "s3:GetBucketAcl",
+	"versioning":                 "s3:GetBucketVersioning",
+	"policy_public":              "s3:GetBucketPolicy",
+	"tags":                       "s3:GetBucketTagging",
+	"object_lock_enabled":        "s3:GetObjectLockConfiguration",
+	"default_encryption_enabled": "s3:GetBucketEncryption",
+	"sse_kms_enabled":            "s3:GetBucketEncryption",
+	"kms_key_id":                 "s3:GetBucketEncryption",
+}
+
+// bucketAttrDerived : les attributs CALCULÉS depuis la réponse (un booléen déduit
+// d'une liste de grants n'est pas un champ de l'API), par opposition à ceux qui en
+// sont recopiés.
+var bucketAttrDerived = map[string]bool{
+	"public_via_acl":             true,
+	"policy_public":              true,
+	"object_lock_enabled":        true,
+	"default_encryption_enabled": true,
+	"sse_kms_enabled":            true,
 }
 
 // isACLPublic — un grant cible le groupe public (AllUsers/AuthenticatedUsers).

--- a/internal/objectstorage/s3.go
+++ b/internal/objectstorage/s3.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -152,6 +153,18 @@ var bucketAttrCall = map[string]string{
 	"default_encryption_enabled": "s3:GetBucketEncryption",
 	"sse_kms_enabled":            "s3:GetBucketEncryption",
 	"kms_key_id":                 "s3:GetBucketEncryption",
+}
+
+// BucketAttributes énumère les attributs communs qu'un bucket peut porter. Dérivé
+// de la table des appels, donc impossible à laisser diverger du collecteur : le
+// catalogue de l'inventaire (genprovider.InventoryCatalogue) s'y adosse.
+func BucketAttributes() []string {
+	out := make([]string, 0, len(bucketAttrCall))
+	for a := range bucketAttrCall {
+		out = append(out, a)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // bucketAttrDerived : les attributs CALCULÉS depuis la réponse (un booléen déduit

--- a/internal/oks/oks.go
+++ b/internal/oks/oks.go
@@ -61,6 +61,13 @@ func CollectClusters(ctx context.Context, hc *http.Client, provider, endpoint, r
 	return out, nil
 }
 
+// ClusterAttributes énumère les attributs communs qu'un cluster managé collecté
+// par cette API peut porter. Déclaré à côté du projecteur qui les pose, et lu par
+// le catalogue de l'inventaire (genprovider.InventoryCatalogue).
+func ClusterAttributes() []string {
+	return []string{"admin_whitelist", "auto_upgrade", "control_plane_multi_az", "deletion_protection", "name", "version"}
+}
+
 // mapCluster projette un cluster OKS (champs natifs de l'API v2) vers le modèle normalisé.
 // Un attribut ABSENT n'est pas posé : les règles le traitent alors comme conforme par
 // défaut (object.get(..., true)), donc pas de faux échec.

--- a/internal/tfmap/tfmap.go
+++ b/internal/tfmap/tfmap.go
@@ -65,11 +65,17 @@ func Apply(spec Spec, resources []tfparse.Resource) []model.Resource {
 			if rs.Region != "" {
 				region, _ = res.Values[rs.Region].(string)
 			}
+			// La source atteste le TYPE de ressource du plan, pas l'adresse : l'adresse
+			// est déjà l'identifiant de la ressource, le type est ce qui dit d'où la
+			// valeur a été lue. Une valeur issue d'un plan n'est PAS une observation de
+			// la configuration effective, et l'origine `terraform-plan` le porte.
+			src := collect.Source{Origin: model.OriginTerraform, Ref: res.Type}
 			for _, it := range items {
-				attrs := collect.Project(it, rs.Map, rs.Transforms)
+				attrs, prov := collect.ProjectAttested(it, rs.Map, rs.Transforms, src)
 				for k, v := range rs.Const {
 					attrs[k] = v
 				}
+				collect.AttestConst(&prov, rs.Const, "descriptor:const")
 				id, _ := attrs[rs.ID].(string)
 				if id == "" {
 					id = res.Address
@@ -78,7 +84,7 @@ func Apply(spec Spec, resources []tfparse.Resource) []model.Resource {
 				if n, ok := res.Values["name"].(string); ok && n != "" {
 					name = n
 				}
-				out = append(out, model.Resource{Provider: spec.Provider, Type: rs.Type, ID: id, Name: name, Region: region, Attributes: attrs})
+				out = append(out, model.Resource{Provider: spec.Provider, Type: rs.Type, ID: id, Name: name, Region: region, Attributes: attrs, Provenance: prov})
 			}
 		}
 	}


### PR DESCRIPTION
Wave 4 lot 1: the foundations the rest of the wave builds on. Pépin must assert
exactly what it observed, no more, no less.

Closes #46
Closes #66
Closes #63
Closes #64

## The design calls, and why

**Provenance is a parallel index, not a wrapper around each value.** Wrapping
(`{"value": false, "observed": true, "source": …}`) would have meant rewriting the
59 Rego rules, and a rewritten rule is a rule that can change verdict. Instead
`model.Resource` gains a `provenance` map keyed by the *same* attribute names, a
sibling of `attributes`. The rules' input is byte-identical, so non-regression is
structural rather than hoped for. The cost is real and stated: the inventory grows
by one entry per mapped attribute, which lands in a sealed bundle's `input.json`.
The assessment publishes only a *summary*, on the attributes that decide a `pass`,
so the reports do not grow.

**An `api` source names the request actually served.** The request line is read off
`req` after a valid response, never taken from what the YAML spec declares. A
descriptor `const:` is `derived:descriptor:const`, an aggregate computed on a real
response is `api` + `derived`, the synthetic governance resource is
`derived:descriptor:souverainete`. A provenance pointing at a call that did not
happen would give the *appearance* of traceability, which is worse than its absence.
`TestProvenanceNamesTheCallThatActuallyHappened` proves it against a recording
server rather than by reading the code.

**Exit code for `EXEMPTED`: a dedicated 4.** Returning 0 would make an exemption a
silent false green, precisely what the status exists to prevent. Returning 1 would
make it useless, and a team that cannot waive a control deletes it instead. 4 is
non-zero — nothing passes in silence — and distinct, so a pipeline that accepts it
has to write the number down, therefore to know it exists. Precedence is documented
in `docs/reference/exit-codes.md`: 2 > 1 > 3 (nothing measured) > 4 > 3 (`--strict`).

**Only the gate moves; the record loses nothing.** An exempted deviation stays in
`--format json`, in the SARIF and in the severity counts, and `summary.conforme`
stays false. Dropping it from SARIF — the format most often wired to a merge gate —
would have been the exact false green this wave exists to fight. `--format json`
gains an additive `exemptions` key so a pipeline that accepts code 4 can see what it
is accepting.

**Bundle digest depends on the exemptions.** `exemptions.json` is a bundle artifact
like any other: its digest is in `checksums.txt`, therefore under the signature. A
dossier cannot drop its exemptions without failing its own verification.
`verify --re-derive` replays the sealed policy at the sealed instant of evaluation —
without that, a faithful bundle would be declared falsified merely because the
verifier does not hold the operator's file, and a valid waiver would appear to
"expire" between the scan and the check.

**An expired exemption stops applying and says so; an orphan one is reported.**
Expiry is evaluated against `evaluated_at`, not the clock, so a replayed bundle
returns the same verdict. `resource:` matches the subject *the report prints* (a
rule picks its own subject: the SSH rule names the security group, not the rule
row), so a legitimate waiver is not declared orphan. Under `--strict`, an expired or
orphan entry fails the gate: a pipeline that asks for strictness is asking for its
exemption file to be reviewed.

**The frozen inventory vocabulary is deliberately strict.** Adding an attribute to a
descriptor turns `cmd/testdata/frozen/inventory.json` red and costs a
`frozen-update`, a bump of `model.InventoryFormat` and a CHANGELOG line. That is the
point: the inventory stops being an implementation detail. The catalogue is
*derived* from the descriptors and the Go collectors, so a contributor never has to
remember to update a list.

## Proof of verdict non-regression (#46)

9 repository fixtures (4 JSON inventories, 5 Terraform plans) × {`--format json`,
`--format assessment`} × {fr, en} = **36 runs**, comparing per-finding
`code|severity|subject`, the severity summary, per-result `control|subject|status`,
and the exit code.

```
$ diff before/verdicts.txt after/verdicts.txt && echo "NO VERDICT DIFFERENCE"
NO VERDICT DIFFERENCE
```

762 compared lines, zero difference — measured again after the exemption and
inventory commits, with the same result. What did change, by design:
`evidence.attribute` and `evidence.source` on results whose control has a deciding
attribute. The generated documentation captures the difference.

## Proof that each invariant fails when it must

Each property was broken in the code, the guarding test run, and the code restored:

| Mutation | Test | Result |
|---|---|---|
| `exempted` written as `pass` | `TestAnExemptionNeverTurnsAFailIntoAPass` | red |
| exit 4 suppressed | `TestAnExemptionNeverProducesAZeroExitCode` | red |
| expiry never checked | `TestAnExpiredExemptionStopsApplyingAndSaysSo` | red |
| unknown control not reported | `TestAnOrphanExemptionIsReported` | red |
| any status exemptable | `TestOnlyAFailCanBeExempted` | red |
| load-time validation skipped | `TestMandatoryFieldsAreValidatedAtLoadTime` | red |
| a `const` labelled with an API endpoint | `TestProvenanceNamesTheCallThatActuallyHappened` | red |
| an absent field projected anyway | `TestProvenanceNamesTheCallThatActuallyHappened` | red |
| provenance pass writes a status | `TestProvenanceNeverMovesAVerdict` | red |
| inventory shape moved, version unchanged | `TestTheFrozenSurfacesStillMatchTheirFixture` | red |

All four packages are green without mutation.

## What provenance makes visible (without changing it)

Two controls cross their required-attribute gate thanks to a descriptor literal
rather than a measurement: `blockstorage_volume_encryption` on Exoscale
(`const: {encrypted: true}`, transparent encryption — a legitimate attestation) and
`iam_no_root_access_key` on Outscale (`const: {scope: account}`). Their verdict is
unchanged — tightening the gate is a decision for a later lot — but their evidence
now reads `derived:descriptor:const` instead of implying a measurement. That is the
whole point of #46: the gap becomes *detectable*.

## What I could not do, or could not verify

- **No live scan.** No cloud account in this environment. Every measurement here is
  on repository fixtures and Terraform plans. The `api:` provenance is proven
  against an `httptest` server, not against Scaleway or Outscale.
- **Two Go collectors are not attested.** The managed-Kubernetes (`internal/oks`)
  and inline EIM policy (`internal/eimpolicy`) collectors build resources without
  provenance. Their attributes therefore carry *no* attestation, which the model
  expresses as absence rather than as a false claim. `internal/collect` (all
  declarative specs), `internal/tfmap`, the governance resource and the S3 bucket
  collector are attested.
- **`--format sarif` cannot express a suppression** through the shared scankit
  renderer, so exempted findings appear there as plain deviations. That is the
  deliberate side to err on, but it means a SARIF consumer sees no difference
  between an open and a waived deviation. Expressing it properly needs a change in
  scankit, which this lot does not touch.
- **The inventory carries provenance for live and Terraform sources only.** A JSON
  export replayed from a third party has no attestation, and none is invented for
  it. Origin `export` deliberately does not exist: Pépin did not observe that
  inventory, it received it.
- **Provenance does bloat `input.json`** for live and plan scans, one entry per
  mapped attribute. I chose to keep it always on rather than behind a flag: an
  evidence bundle whose provenance is optional is a bundle that can be produced
  without it. If the size proves a problem on large tenants, the honest fix is a
  compaction of the attestation, not making it optional.
- **`--exceptions` was exercised end to end on fixtures**, including seal and
  re-derive, but never with a cosign signature (no key here).
- **One em-dash remains in `docs/reference/exit-codes.fr.md`**, in a verdict string
  that predates this branch. Every French string this branch adds avoids it; fixing
  the older ones would be a cleanup outside this change.

## Gates

`go test ./...`, `mise run validate`, `golangci-lint run` (0 issues), `gosec` (0),
`go vet` — all green. `mise run gen-docs` was run and its output committed; the new
`docs/reference/inventory.{md,fr.md}` pages carry generated regions for the format
string and the type/attribute vocabulary, so they cannot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
