### PR TITLE
feat: wave 4 lot 3 — configurable controls, bound to their normative mappings

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: stephanerobert89902

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -232,6 +232,19 @@ l'une ni l'autre appartient au `git log`.
   étaient exclus. Le profil livré est documenté comme une **recommandation, pas comme une
   norme**.
 
+- **Le contrôle de fraîcheur des snapshots dit ce qu'il mesure, et ce qu'il ne prouve
+  pas.** `blockstorage_volume_snapshots_exist` vérifie désormais l'**état natif** de la
+  snapshot en plus de sa date : une snapshot en `error`, `pending` ou `creating` ne compte
+  plus comme une sauvegarde. Le délai est configurable (7 jours par défaut). Le titre
+  devient « Absence de snapshot récente et terminée », et la description énonce
+  franchement ce que le contrôle ne prouve pas — restaurabilité, complétude applicative,
+  rétention, existence d'une politique de sauvegarde. Le code est inchangé, pour la même
+  raison que ci-dessus. Ancré sur Outscale `Snapshot.State` et Exoscale
+  `block-storage-snapshot.state`, désormais projetés par les collecteurs. L'inventaire
+  normalisé gagne donc un attribut, ce qui est un changement de contrat : schéma
+  d'inventaire v4, dont la note consigne aussi la clé d'enveloppe `config` ajoutée
+  plus haut.
+
 - **`--strict` refuse aussi une correspondance normative tombée.** Il refusait déjà une
   couverture nulle, des écarts medium/low restants et un fichier de dérogations périmé ;
   il rend maintenant `3` quand un réglage assoupli a coûté sa correspondance à un

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -209,6 +209,17 @@ l'une ni l'autre appartient au `git log`.
 
 ### Modifié
 
+- **`network_documented` vérifie enfin ce qu'il annonce.** La règle promettait
+  propriétaire, projet et environnement, et évaluait `count(tags) > 0` : un unique
+  `foo=bar` suffisait à déclarer un réseau documenté — une conformité affirmée sans avoir
+  été mesurée. Elle exige désormais les étiquettes qui documentent réellement (par défaut
+  `Owner, Project, Env`, configurables), et elle se tait quand l'attribut `tags` n'a pas
+  été collecté, là où elle signalait un écart. Le **code est inchangé** : il voyage dans
+  les `ruleId` SARIF, les assessments archivés et les fichiers de dérogations, où un
+  renommage transformerait du jour au lendemain une dérogation valide en dérogation
+  orpheline et ferait réapparaître l'écart qu'elle couvrait. Titre et description sont
+  réécrits dans les deux langues.
+
 - **`--strict` refuse aussi une correspondance normative tombée.** Il refusait déjà une
   couverture nulle, des écarts medium/low restants et un fichier de dérogations périmé ;
   il rend maintenant `3` quand un réglage assoupli a coûté sa correspondance à un

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -199,6 +199,15 @@ l'une ni l'autre appartient au `git log`.
   exclusifs**, parce que deux fichiers de politique sont deux fichiers qui divergeront.
   Surface CLI v4.
 
+- **La détection de secrets porte un niveau de confiance.** Chaque finding de
+  `compute_instance_no_secrets_in_user_data` publie `labels.confidence` : `high` pour un
+  bloc PEM de clé privée, `medium` pour un préfixe reconnu au format attendu (`ghp_`,
+  `AKIA`, `SCW`, `EXO`, `glpat-`, JWT), `low` pour une heuristique générique
+  (`password=…`, `api_key=…`). Le seuil de signalement par défaut est `low` : tout est
+  signalé, exactement comme avant. La valeur détectée n'apparaît toujours jamais, quel
+  que soit le niveau, et cette propriété est désormais testée aux trois niveaux, sur le
+  message et sur la remédiation, dans les deux langues.
+
 - **L'inventaire évalué porte sa configuration.** L'enveloppe gagne `config`, la
   configuration effective des contrôles, à côté de `evaluated_at` — l'`input.json` d'un
   bundle scellé rejoue donc sous les réglages de son propre jour, et

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -174,6 +174,48 @@ l'une ni l'autre appartient au `git log`.
   (`gh attestation verify` sans jeton) : ces tags ne doivent être épinglés par
   personne.
 
+- **Les contrôles deviennent réglables, et un réglage assoupli ne garde pas son badge.**
+  Quatre contrôles lisent désormais un fichier de politique : le profil d'étiquetage
+  obligatoire, la fenêtre de fraîcheur et les états acceptés d'une snapshot, le seuil de
+  détection de secrets. Chaque réglage est une poignée qui permet de fabriquer du vert :
+  chaque correspondance normative du référentiel porte donc les **contraintes sous
+  lesquelles elle vaut** (`config_requise`, quatre sens interprétables :
+  `au_plus_le_defaut`, `superset_du_defaut`, `sous_ensemble_du_defaut`,
+  `au_moins_aussi_strict_que_le_defaut`). Une
+  configuration qui sort d'une contrainte fait **perdre au contrôle ses `references`**
+  dans l'assessment — il cesse de prétendre couvrir CIS, ISO ou SecNumCloud — et
+  l'assouplissement apparaît en cinq endroits à la fois : le terminal (`CONFIGURATION
+  ASSOUPLIE`), les labels et la preuve de l'assessment, `--format json`
+  (`config.relaxations`), le bandeau de verdict, et le bundle scellé (`config.json` plus
+  une entrée `config` au manifeste, tous deux couverts par `checksums.txt`). Durcir un
+  réglage n'est pas un assouplissement et n'est signalé nulle part. `mise run validate`
+  refuse une contrainte qui nomme un réglage que le moteur de politique ne sait pas
+  évaluer. Voir `docs/guides/control-configuration.fr.md`.
+
+- **Un seul fichier de politique : `scan --policy`.** Il porte `controls:` (les réglages)
+  et `exceptions:` (les dérogations, format inchangé). `--exceptions` reste le nom
+  historique du même fichier et lit le même schéma : une invocation existante et un
+  fichier existant continuent de fonctionner. Les deux drapeaux sont **mutuellement
+  exclusifs**, parce que deux fichiers de politique sont deux fichiers qui divergeront.
+  Surface CLI v4.
+
+- **L'inventaire évalué porte sa configuration.** L'enveloppe gagne `config`, la
+  configuration effective des contrôles, à côté de `evaluated_at` — l'`input.json` d'un
+  bundle scellé rejoue donc sous les réglages de son propre jour, et
+  `verify --re-derive` reste fidèle sans qu'on lui redonne le fichier de politique.
+  `--format json` publie `config.policy_digest` et `config.effective` sur **chaque**
+  scan, le défaut compris : un lecteur doit pouvoir vérifier qu'un scan a tourné sous les
+  réglages attendus, pas seulement constater qu'il n'a rien dit. Format de bundle v3.
+
+### Modifié
+
+- **`--strict` refuse aussi une correspondance normative tombée.** Il refusait déjà une
+  couverture nulle, des écarts medium/low restants et un fichier de dérogations périmé ;
+  il rend maintenant `3` quand un réglage assoupli a coûté sa correspondance à un
+  contrôle. Aucun nouveau code de sortie : l'incomplétude et l'assouplissement disent la
+  même chose — ne lisez pas ce scan comme un feu vert — et les deux occupent déjà la
+  place de `3`.
+
 ## [0.2.0] - 2026-08-19
 
 ### Ajouté

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -220,6 +220,18 @@ l'une ni l'autre appartient au `git log`.
   orpheline et ferait réapparaître l'écart qu'elle couvrait. Titre et description sont
   réécrits dans les deux langues.
 
+- **La politique d'étiquetage obligatoire est configurable, et la comparaison est
+  indifférente aux conventions.** `governance_resource_required_tags` n'exige plus quatre
+  littéraux figés. La comparaison est insensible à la casse et aux séparateurs
+  (`cost-center` ≡ `CostCenter`), et les alias élargissent chaque nom logique (`team`
+  pour `Owner`, `environment` pour `Env`) : une organisation qui écrit `cost-center,
+  application, environment, team` n'est plus signalée comme non gouvernée. Les types de
+  ressources visés sont explicites et justifiés, et quatre types facturables entrent dans
+  le périmètre — `blockstorage_snapshot`, `compute_image`, `managed_database`,
+  `kubernetes_cluster` —, ce qui comble un faux négatif sur des services payants qui en
+  étaient exclus. Le profil livré est documenté comme une **recommandation, pas comme une
+  norme**.
+
 - **`--strict` refuse aussi une correspondance normative tombée.** Il refusait déjà une
   couverture nulle, des écarts medium/low restants et un fichier de dérogations périmé ;
   il rend maintenant `3` quand un réglage assoupli a coûté sa correspondance à un

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,15 @@ belongs in `git log`.
   and an existing file keep working; the two flags are **mutually exclusive**, because
   two policy files are two files that will drift. CLI surface v4.
 
+- **Secret detection carries a confidence level.** Every finding of
+  `compute_instance_no_secrets_in_user_data` publishes `labels.confidence`: `high` for a
+  PEM private-key block, `medium` for a recognized prefix in the expected format
+  (`ghp_`, `AKIA`, `SCW`, `EXO`, `glpat-`, JWT), `low` for a generic heuristic
+  (`password=…`, `api_key=…`). The default reporting threshold is `low` — everything is
+  reported, exactly as before. The detected value still never appears, at any level, and
+  that property is now tested at all three levels, on the message and the remediation,
+  in both languages.
+
 - **The evaluated inventory carries its configuration.** The envelope gains `config`,
   the effective control configuration, next to `evaluated_at` — so a sealed bundle's
   `input.json` replays under the settings of its own day, and `verify --re-derive` stays

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,44 @@ belongs in `git log`.
   action of v0.1.0 and v0.1.1 could not install anything (`gh attestation verify`
   without a token), so those tags should not be pinned by anyone.
 
+- **Controls become configurable, and a relaxed setting cannot keep its badge.** Four
+  controls now read a policy file — the mandatory tagging profile, the snapshot
+  freshness window and accepted states, the secret-detection threshold. Every setting
+  is a handle that can manufacture green, so each normative mapping in the reference
+  carries the **constraints under which it holds** (`config_requise`, with four
+  interpretable senses: `au_plus_le_defaut`, `superset_du_defaut`,
+  `sous_ensemble_du_defaut`, `au_moins_aussi_strict_que_le_defaut`). A configuration that falls outside a constraint makes the
+  control **lose its `references`** in the assessment — it stops claiming CIS,
+  ISO or SecNumCloud — and the relaxation appears in five places at once: the terminal
+  (`RELAXED CONFIGURATION`), the assessment labels and evidence, `--format json`
+  (`config.relaxations`), the verdict banner, and the sealed bundle (`config.json`
+  plus a `config` entry in the manifest, both covered by `checksums.txt`). Tightening a
+  setting is not a relaxation and is reported nowhere. `mise run validate` refuses a
+  constraint naming a setting the policy engine cannot evaluate. See
+  `docs/guides/control-configuration.md`.
+
+- **One policy file: `scan --policy`.** It carries `controls:` (the settings) and
+  `exceptions:` (the exemptions, unchanged format). `--exceptions` remains as the
+  historic name of the same file and reads the same schema, so an existing invocation
+  and an existing file keep working; the two flags are **mutually exclusive**, because
+  two policy files are two files that will drift. CLI surface v4.
+
+- **The evaluated inventory carries its configuration.** The envelope gains `config`,
+  the effective control configuration, next to `evaluated_at` — so a sealed bundle's
+  `input.json` replays under the settings of its own day, and `verify --re-derive` stays
+  faithful without being handed the policy file. `--format json` publishes
+  `config.policy_digest` and `config.effective` on **every** scan, default included: a
+  reader must be able to check that a scan ran under the expected settings, not merely
+  observe that it said nothing. Bundle format v3.
+
+### Changed
+
+- **`--strict` also refuses a dropped normative mapping.** It already refused zero
+  coverage, remaining medium/low deviations and a stale exemptions file; it now returns
+  `3` when a relaxed setting cost a control its mapping. No new exit code: incompleteness
+  and relaxation say the same thing — do not read this scan as a green light — and both
+  already sit where `3` sits.
+
 ## [0.2.0] - 2026-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,16 @@ belongs in `git log`.
 
 ### Changed
 
+- **`network_documented` now checks what it announces.** The rule promised owner, project
+  and environment, and evaluated `count(tags) > 0`: a single `foo=bar` was enough to
+  declare a network documented — a compliance asserted without being measured. It now
+  requires the tags that actually document (default `Owner, Project, Env`, configurable),
+  and it stays silent when the `tags` attribute was not collected, where it used to report
+  a deviation. The **code is unchanged**: it travels in SARIF `ruleId`s, archived
+  assessments and exemption files, where a rename would turn a valid exemption into an
+  orphan overnight and bring back the deviation it covered. Title and description are
+  rewritten in both languages.
+
 - **`--strict` also refuses a dropped normative mapping.** It already refused zero
   coverage, remaining medium/low deviations and a stale exemptions file; it now returns
   `3` when a relaxed setting cost a control its mapping. No new exit code: incompleteness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,16 @@ belongs in `git log`.
   orphan overnight and bring back the deviation it covered. Title and description are
   rewritten in both languages.
 
+- **The mandatory tagging policy is configurable, and the comparison is
+  convention-agnostic.** `governance_resource_required_tags` no longer demands four frozen
+  literals. The comparison ignores case and separators (`cost-center` = `CostCenter`), and
+  aliases widen each logical name (`team` for `Owner`, `environment` for `Env`), so an
+  organisation writing `cost-center, application, environment, team` is no longer reported
+  as ungoverned. The targeted resource types are explicit and justified, and four billable
+  types join the scope — `blockstorage_snapshot`, `compute_image`, `managed_database`,
+  `kubernetes_cluster` — which closes a false-negative on paid services that were outside
+  it. The shipped profile is documented as a **recommendation, not a standard**.
+
 - **`--strict` also refuses a dropped normative mapping.** It already refused zero
   coverage, remaining medium/low deviations and a stale exemptions file; it now returns
   `3` when a relaxed setting cost a control its mapping. No new exit code: incompleteness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,18 @@ belongs in `git log`.
   `kubernetes_cluster` — which closes a false-negative on paid services that were outside
   it. The shipped profile is documented as a **recommendation, not a standard**.
 
+- **The snapshot freshness control says what it measures, and what it does not prove.**
+  `blockstorage_volume_snapshots_exist` now checks the snapshot's **native state** as well
+  as its date: a snapshot in `error`, `pending` or `creating` no longer counts as a backup.
+  The window is configurable (7 days by default). The title becomes "No recent, completed
+  snapshot", and the description states plainly what the control does not prove —
+  restorability, application completeness, retention, the existence of a backup policy.
+  The code is unchanged, for the same reason as above. Anchored on Outscale
+  `Snapshot.State` and Exoscale `block-storage-snapshot.state`, both projected by the
+  collectors from this version on. The normalized inventory therefore gains an attribute,
+  which is a contract change: inventory schema v4, whose note also records the `config`
+  envelope key added above.
+
 - **`--strict` also refuses a dropped normative mapping.** It already refused zero
   coverage, remaining medium/low deviations and a stale exemptions file; it now returns
   `3` when a relaxed setting cost a control its mapping. No new exit code: incompleteness

--- a/README.fr.md
+++ b/README.fr.md
@@ -129,6 +129,8 @@ d'un contrôle qui fait foi.
   [Formats de sortie](docs/reference/output-formats.fr.md) ·
   [Inventaire normalisé](docs/reference/inventory.fr.md).
 - Guides : [Remédiation](docs/guides/remediation.fr.md) ·
+  [Configurer les contrôles](docs/guides/control-configuration.fr.md) — le fichier de
+  politique, et ce qu'un assouplissement fait perdre ·
   [Le bundle de preuve](docs/guides/evidence-bundles.fr.md) ·
   [GitHub Actions](docs/guides/github-actions.fr.md) ·
   [GitLab CI](docs/guides/gitlab-ci.fr.md).

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ control is the one that governs.
   [Output formats](docs/reference/output-formats.md) ·
   [Normalized inventory](docs/reference/inventory.md).
 - Guides: [Remediation](docs/guides/remediation.md) ·
+  [Configuring controls](docs/guides/control-configuration.md) — the policy file, and what a
+  relaxation costs ·
   [Evidence bundles](docs/guides/evidence-bundles.md) ·
   [GitHub Actions](docs/guides/github-actions.md) · [GitLab CI](docs/guides/gitlab-ci.md).
 - Contributing: [Adding a control](docs/contributing/adding-a-control.md) ·

--- a/cmd/i18n.go
+++ b/cmd/i18n.go
@@ -122,9 +122,12 @@ func localize() {
 	setUsage(scanCmd, "exceptions", tr(
 		"`fichier` YAML de dérogations (control, justification, expires_at, owner, approved_by) : un écart couvert passe au statut exempted, jamais conforme",
 		"exemptions YAML `file` (control, justification, expires_at, owner, approved_by) — a covered deviation becomes exempted, never compliant"))
+	setUsage(scanCmd, "policy", tr(
+		"`fichier` YAML de politique : réglages des contrôles (`controls:`) ET dérogations (`exceptions:`) — un seul fichier, nom moderne de --exceptions",
+		"policy YAML `file`: control settings (`controls:`) AND exemptions (`exceptions:`) — one single file, the modern name of --exceptions"))
 	setUsage(scanCmd, "strict", tr(
-		"porte CI stricte : code de sortie ≠ 0 si aucun contrôle n'est mesuré (hors gouvernance) ou s'il subsiste un écart medium/low",
-		"strict CI gate: non-zero exit code if no control is measured (governance aside) or if medium/low deviations remain"))
+		"porte CI stricte : code de sortie ≠ 0 si aucun contrôle n'est mesuré (hors gouvernance), s'il subsiste un écart medium/low, ou si un réglage assoupli a fait tomber une correspondance normative",
+		"strict CI gate: non-zero exit code if no control is measured (governance aside), if medium/low deviations remain, or if a relaxed setting dropped a normative mapping"))
 	setUsage(scanCmd, "redact", tr(
 		"caviarder les valeurs sensibles (user-data, policies) de l'input.json du bundle — pour partage à un tiers ; INCOMPATIBLE avec verify --re-derive",
 		"redact the sensitive values (user-data, policies) from the bundle's input.json — for sharing with a third party; INCOMPATIBLE with verify --re-derive"))

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/stephrobert/pepin/internal/assess"
+	"github.com/stephrobert/pepin/internal/exempt"
+	"github.com/stephrobert/pepin/internal/policy"
+	"github.com/stephrobert/pepin/referentiel"
+)
+
+// La POLITIQUE d'un scan : un seul fichier, deux sections.
+//
+// `--policy` lit `controls:` (les réglages) et `exceptions:` (les dérogations).
+// `--exceptions` est le nom historique du MÊME fichier et lit le MÊME schéma :
+// une ligne de commande existante ne bouge pas, et un fichier de dérogations
+// peut gagner une section `controls:` sans changer d'invocation. Les deux
+// drapeaux sont mutuellement exclusifs, parce que deux fichiers de politique
+// sont deux fichiers qui divergeront.
+
+// scanConfig porte l'état de la politique pour la durée d'un scan. Un struct
+// plutôt que cinq variables de paquet : les trois choses (configuration résolue,
+// assouplissements, empreinte) sont dérivées les unes des autres et se lisent
+// ensemble.
+type scanConfig struct {
+	// File : le fichier chargé, s'il y en avait un.
+	File *policy.File
+	// Resolved : la configuration EFFECTIVE, défauts compris. Toujours renseignée.
+	Resolved policy.Resolved
+	// Relaxations : par contrôle, les assouplissements qui ont fait tomber ses
+	// correspondances normatives. Vide au profil par défaut, par construction.
+	Relaxations map[string][]policy.Relaxation
+}
+
+// loadPolicy résout la politique du scan depuis les deux drapeaux. Un fichier
+// absent n'est pas une erreur : c'est le profil par défaut, et c'est le cas
+// courant.
+func loadPolicy(policyPath, exceptionsPath string) (scanConfig, exempt.Policy, error) {
+	path := policyPath
+	if path == "" {
+		path = exceptionsPath
+	}
+	cfg := scanConfig{Resolved: policy.Defaults()}
+	if path == "" {
+		return cfg, exempt.Policy{}, nil
+	}
+	f, err := policy.Load(path)
+	if err != nil {
+		return scanConfig{}, exempt.Policy{}, err
+	}
+	cfg.File = &f
+	cfg.Resolved = policy.Resolve(f.Controls)
+	cfg.Relaxations = policy.Relaxations(cfg.Resolved, referentiel.ConfigConstraintsByControl(), controlReferences())
+	return cfg, f.Exemptions(), nil
+}
+
+// controlReferences rend, par contrôle, ses correspondances normatives sous la
+// forme `framework:id`. C'est ce qu'un assouplissement fait PERDRE, et le rapport
+// doit pouvoir le nommer plutôt que d'annoncer une perte abstraite.
+func controlReferences() map[string][]string {
+	out := map[string][]string{}
+	for code, c := range referentiel.All() {
+		out[code] = assess.ReferencesOf(assess.References(c))
+	}
+	return out
+}
+
+// relaxedControls rend les contrôles assouplis, triés.
+func (c scanConfig) relaxedControls() []string {
+	out := make([]string, 0, len(c.Relaxations))
+	for code := range c.Relaxations {
+		out = append(out, code)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// droppedReferences rend l'ensemble des correspondances normatives abandonnées,
+// triées et dédoublonnées.
+func (c scanConfig) droppedReferences() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, rs := range c.Relaxations {
+		for _, r := range rs {
+			for _, ref := range r.DroppedReferences {
+				if !seen[ref] {
+					seen[ref] = true
+					out = append(out, ref)
+				}
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// configDocument est le document config.json du bundle : la configuration
+// effective, son empreinte, et les assouplissements qu'elle produit. C'est la
+// pièce qui permet à un tiers de dire, sans lire le code, sous quelle exigence le
+// dossier a été rendu.
+type configDocument struct {
+	PolicyDigest string              `json:"policy_digest"`
+	Effective    policy.Resolved     `json:"effective"`
+	Relaxations  []policy.Relaxation `json:"relaxations,omitempty"`
+	Notice       map[string]string   `json:"notice,omitempty"`
+}
+
+// bundleConfig sérialise la configuration appliquée pour la sceller au bundle.
+// Rendue seulement quand un fichier de politique a été fourni : au profil par
+// défaut, il n'y a rien à déclarer que l'input.json ne porte déjà.
+func bundleConfig(cfg scanConfig) (assess.BundleExtras, error) {
+	if cfg.File == nil {
+		return assess.BundleExtras{}, nil
+	}
+	doc := configDocument{PolicyDigest: cfg.Resolved.Digest(), Effective: cfg.Resolved}
+	for _, code := range cfg.relaxedControls() {
+		doc.Relaxations = append(doc.Relaxations, cfg.Relaxations[code]...)
+	}
+	if len(doc.Relaxations) > 0 {
+		// L'avertissement est écrit DANS le document scellé, et dans les deux
+		// langues : un auditeur qui ouvre config.json ne lit pas forcément le
+		// terminal de celui qui a lancé le scan.
+		doc.Notice = map[string]string{
+			"fr": "Configuration assouplie : les correspondances normatives listées ne sont plus tenues par ce scan.",
+			"en": "Relaxed configuration: the normative mappings listed here are no longer held by this scan.",
+		}
+	}
+	raw, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return assess.BundleExtras{}, fmt.Errorf(tr("sérialisation de la configuration : %w",
+			"serializing the configuration: %w"), err)
+	}
+	return assess.BundleExtras{
+		Config: raw,
+		ConfigSummary: &assess.ConfigSummary{
+			PolicyDigest:      doc.PolicyDigest,
+			RelaxedControls:   cfg.relaxedControls(),
+			DroppedReferences: cfg.droppedReferences(),
+		},
+	}, nil
+}
+
+// renderRelaxations affiche les assouplissements, en clair et en évidence, juste
+// comme les dérogations. Un réglage discret est un réglage que personne ne revoit :
+// il porte donc ce qu'il change ET ce qu'il fait perdre.
+func renderRelaxations(w io.Writer, cfg scanConfig) {
+	codes := cfg.relaxedControls()
+	if len(codes) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "\n%s\n", exemptStyle.Render(tr(
+		"CONFIGURATION ASSOUPLIE : correspondances normatives NON TENUES",
+		"RELAXED CONFIGURATION — normative mappings NOT held")))
+	for _, code := range codes {
+		_, _ = fmt.Fprintf(w, "  · %s\n", code)
+		for _, r := range cfg.Relaxations[code] {
+			_, _ = fmt.Fprintf(w, "    %s\n", r.Sentence())
+			if len(r.DroppedReferences) > 0 {
+				_, _ = fmt.Fprintf(w, "    %s %s\n", tr("correspondances abandonnées :",
+					"mappings dropped:"), strings.Join(r.DroppedReferences, ", "))
+			}
+		}
+	}
+}
+
+// replayedConfig relit la configuration DÉJÀ PRÉSENTE dans un input (rejeu de
+// l'input.json d'un bundle scellé). Le dossier a été rendu sous cette
+// configuration-là, pas sous celle du jour : la rejouer est ce qui rend
+// `verify --re-derive` fidèle. Défensif — l'input peut venir d'un tiers : une
+// configuration illisible retombe sur celle du scan courant plutôt que de faire
+// paniquer un vérificateur.
+func replayedConfig(raw any, fallback policy.Resolved) policy.Resolved {
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return fallback
+	}
+	var out policy.Resolved
+	if err := json.Unmarshal(b, &out); err != nil {
+		return fallback
+	}
+	return out
+}
+
+// jsonConfig rend la configuration pour `--format json` : l'empreinte de la
+// politique effective et les assouplissements qu'elle produit. Toujours publiée,
+// y compris au profil par défaut — un pipeline doit pouvoir vérifier qu'un scan
+// a bien tourné sous la configuration attendue, pas seulement constater qu'il
+// n'a rien dit.
+func jsonConfig(cfg scanConfig) map[string]any {
+	out := map[string]any{
+		"policy_digest": cfg.Resolved.Digest(),
+		"effective":     cfg.Resolved,
+	}
+	if len(cfg.Relaxations) == 0 {
+		return out
+	}
+	var rs []policy.Relaxation
+	for _, code := range cfg.relaxedControls() {
+		rs = append(rs, cfg.Relaxations[code]...)
+	}
+	out["relaxations"] = rs
+	out["dropped_references"] = cfg.droppedReferences()
+	return out
+}

--- a/cmd/policy_test.go
+++ b/cmd/policy_test.go
@@ -1,0 +1,375 @@
+package cmd
+
+// Les deux propriétés directrices de la configuration des contrôles, mesurées sur
+// le PRODUIT : on compile le binaire, on lui donne un fichier de politique, et on
+// lit ce qu'il imprime, ce qu'il scelle et ce qu'il rend comme code de sortie.
+//
+//  1. À configuration par DÉFAUT, aucun verdict ne bouge. Un réglage qui change le
+//     comportement par défaut n'est pas un réglage, c'est un changement de contrôle
+//     déguisé.
+//  2. Aucune configuration ne peut produire un `pass` que la configuration par
+//     défaut ne produirait pas SANS que le rapport le dise — dans le rendu
+//     terminal, dans l'assessment, dans les formats analysables ET dans le bundle
+//     scellé. Une configuration qui n'apparaît pas dans la preuve est une porte
+//     dérobée vers le vert.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// policyFixture : le plan Terraform non conforme du dépôt, le même que celui des
+// dérogations. Il porte l'écart d'étiquetage sur lequel la politique se règle.
+const policyFixture = "examples/scaleway/terraform/plan.json"
+
+// writePolicy écrit un fichier de politique jetable et rend son chemin ABSOLU :
+// le binaire tourne depuis la racine du dépôt.
+func writePolicy(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pepin-policy.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("écriture du fichier de politique : %v", err)
+	}
+	return path
+}
+
+// defaultPolicy : le profil par défaut, écrit EXPLICITEMENT. Le donner à un scan
+// doit produire, octet pour octet, la sortie d'un scan sans fichier du tout.
+const defaultPolicy = `controls:
+  tagging:
+    required_tags: [CostCenter, Project, Env, Owner]
+    network_required_tags: [Owner, Project, Env]
+    aliases:
+      CostCenter: [CostCenter, cost-center, cc, billing-code, billing]
+      Project: [Project, app, application, service]
+      Env: [Env, environment, stage]
+      Owner: [Owner, team, responsible, contact]
+    resource_types:
+      - compute_instance
+      - blockstorage_volume
+      - blockstorage_snapshot
+      - compute_image
+      - load_balancer
+      - object_storage_bucket
+      - managed_database
+      - kubernetes_cluster
+  snapshots:
+    max_age_days: 7
+    accepted_states: [completed, created]
+  secrets:
+    min_confidence: low
+`
+
+// TestAnExplicitDefaultPolicyMovesNoVerdict est la PROPRIÉTÉ 1, mesurée de bout en
+// bout : le profil par défaut écrit à la main et l'absence de fichier rendent la
+// même sortie et le même code. Sans elle, « configurable » voudrait dire « le
+// comportement dépend de si vous avez écrit un fichier », ce qui n'est pas un
+// réglage mais un piège.
+func TestAnExplicitDefaultPolicyMovesNoVerdict(t *testing.T) {
+	bin := buildPepin(t)
+	bare, _, bareCode := runScan(t, bin, "scan", "scaleway", "-t", policyFixture)
+	withFile, _, fileCode := runScan(t, bin, "scan", "scaleway", "-t", policyFixture,
+		"--policy", writePolicy(t, defaultPolicy))
+
+	if bareCode != fileCode {
+		t.Errorf("code de sortie %d sans fichier, %d avec le profil par défaut écrit — un réglage par défaut ne doit rien déplacer", bareCode, fileCode)
+	}
+	if bare != withFile {
+		t.Errorf("la sortie a bougé sous le profil par défaut écrit explicitement :\n%s", firstDiff(bare, withFile))
+	}
+}
+
+// TestADefaultScanDeclaresItsConfiguration : même sans fichier, le rapport DIT
+// sous quelle configuration il a été rendu. Une preuve muette sur sa politique
+// laisserait un lecteur supposer le défaut sans pouvoir le vérifier.
+func TestADefaultScanDeclaresItsConfiguration(t *testing.T) {
+	bin := buildPepin(t)
+	stdout, _, _ := runScan(t, bin, "scan", "scaleway", "-t", policyFixture, "--format", "json")
+	var doc struct {
+		Config struct {
+			PolicyDigest string `json:"policy_digest"`
+			Relaxations  []any  `json:"relaxations"`
+			Effective    struct {
+				Snapshots struct {
+					MaxAgeDays int `json:"max_age_days"`
+				} `json:"snapshots"`
+				Secrets struct {
+					MinConfidence string `json:"min_confidence"`
+				} `json:"secrets"`
+			} `json:"effective"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
+		t.Fatalf("sortie JSON illisible : %v", err)
+	}
+	if !strings.HasPrefix(doc.Config.PolicyDigest, "sha256:") {
+		t.Errorf("la configuration doit porter son empreinte, obtenu %q", doc.Config.PolicyDigest)
+	}
+	if len(doc.Config.Relaxations) != 0 {
+		t.Errorf("un scan par défaut ne doit annoncer AUCUN assouplissement, obtenu %d", len(doc.Config.Relaxations))
+	}
+	if doc.Config.Effective.Snapshots.MaxAgeDays != 7 || doc.Config.Effective.Secrets.MinConfidence != "low" {
+		t.Errorf("la configuration effective publiée ne correspond pas au profil par défaut : %+v", doc.Config.Effective)
+	}
+}
+
+// relaxedPolicy : une politique qui desserre les trois contrôles réglables, dans le
+// sens que les contraintes normatives refusent.
+const relaxedPolicy = `controls:
+  tagging:
+    required_tags: [Owner]
+  snapshots:
+    max_age_days: 90
+  secrets:
+    min_confidence: high
+`
+
+// TestARelaxedConfigurationIsVisibleEverywhere est la PROPRIÉTÉ 2, mesurée aux
+// QUATRE endroits où un lecteur peut arriver : le terminal, l'assessment, les
+// formats analysables et le bundle scellé. Un seul de ces quatre qui se tait
+// suffirait à faire de la configuration une porte dérobée vers le vert.
+func TestARelaxedConfigurationIsVisibleEverywhere(t *testing.T) {
+	bin := buildPepin(t)
+	pol := writePolicy(t, relaxedPolicy)
+
+	t.Run("terminal", func(t *testing.T) {
+		stdout, _, _ := runScan(t, bin, "scan", "scaleway", "-t", policyFixture, "--policy", pol)
+		if !strings.Contains(stdout, "RELAXED CONFIGURATION") {
+			t.Errorf("le rendu terminal ne nomme pas l'assouplissement :\n%s", stdout)
+		}
+		if !strings.Contains(stdout, "governance_resource_required_tags") {
+			t.Errorf("le rendu terminal ne nomme pas le contrôle assoupli :\n%s", stdout)
+		}
+		if !strings.Contains(stdout, "scsl:CLD-GVN-1") {
+			t.Errorf("le rendu terminal ne nomme pas la correspondance abandonnée :\n%s", stdout)
+		}
+	})
+
+	t.Run("assessment", func(t *testing.T) {
+		stdout, _, _ := runScan(t, bin, "scan", "scaleway", "-t", policyFixture,
+			"--policy", pol, "--format", "assessment")
+		var doc struct {
+			Results []struct {
+				Control    string            `json:"control"`
+				References []any             `json:"references"`
+				Labels     map[string]string `json:"labels"`
+				Evidence   struct {
+					Observed string `json:"observed"`
+				} `json:"evidence"`
+			} `json:"results"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
+			t.Fatalf("assessment illisible : %v", err)
+		}
+		seen := false
+		for _, r := range doc.Results {
+			if r.Control != "governance_resource_required_tags" {
+				continue
+			}
+			seen = true
+			if len(r.References) != 0 {
+				t.Errorf("un contrôle assoupli garde ses correspondances normatives : %+v", r.References)
+			}
+			if r.Labels["config_relaxed"] != "true" {
+				t.Errorf("le résultat ne porte pas `config_relaxed` : %+v", r.Labels)
+			}
+			if !strings.Contains(r.Labels["references_dropped"], "CLD-GVN-1") {
+				t.Errorf("le résultat ne nomme pas ce qui est abandonné : %q", r.Labels["references_dropped"])
+			}
+			if !strings.Contains(r.Evidence.Observed, "RELAXED CONFIGURATION") {
+				t.Errorf("la preuve ne porte pas l'assouplissement : %q", r.Evidence.Observed)
+			}
+		}
+		if !seen {
+			t.Fatal("le contrôle assoupli est absent de l'assessment")
+		}
+	})
+
+	t.Run("format analysable", func(t *testing.T) {
+		stdout, _, _ := runScan(t, bin, "scan", "scaleway", "-t", policyFixture,
+			"--policy", pol, "--format", "json")
+		var doc struct {
+			Config struct {
+				Relaxations []struct {
+					Control           string   `json:"control"`
+					Parameter         string   `json:"parameter"`
+					Default           string   `json:"default"`
+					Effective         string   `json:"effective"`
+					DroppedReferences []string `json:"dropped_references"`
+				} `json:"relaxations"`
+				DroppedReferences []string `json:"dropped_references"`
+			} `json:"config"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
+			t.Fatalf("sortie JSON illisible : %v", err)
+		}
+		if len(doc.Config.Relaxations) == 0 {
+			t.Fatal("`--format json` ne publie aucun assouplissement")
+		}
+		if len(doc.Config.DroppedReferences) == 0 {
+			t.Error("`--format json` ne publie pas les correspondances abandonnées")
+		}
+		for _, r := range doc.Config.Relaxations {
+			if r.Default == "" || r.Effective == "" || r.Default == r.Effective {
+				t.Errorf("un assouplissement doit publier deux valeurs distinctes : %+v", r)
+			}
+		}
+	})
+
+	t.Run("bundle scellé", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "bundle")
+		runScan(t, bin, "scan", "scaleway", "-t", policyFixture, "--policy", pol, "--seal", dir)
+
+		manifest := readJSON(t, filepath.Join(dir, "manifest.json"))
+		cfg, ok := manifest["config"].(map[string]any)
+		if !ok {
+			t.Fatalf("le manifeste ne porte pas la configuration appliquée : %v", manifest["config"])
+		}
+		if relaxed, _ := cfg["relaxed_controls"].([]any); len(relaxed) == 0 {
+			t.Error("le manifeste ne nomme aucun contrôle assoupli")
+		}
+		if dropped, _ := cfg["dropped_references"].([]any); len(dropped) == 0 {
+			t.Error("le manifeste ne nomme aucune correspondance abandonnée")
+		}
+		// L'artefact est SCELLÉ : il figure au manifeste et à checksums.txt, donc le
+		// digest du dossier dépend des réglages. Un dossier ne peut pas taire
+		// l'assouplissement sous lequel il a été rendu sans se trahir.
+		sums, err := os.ReadFile(filepath.Join(dir, "checksums.txt")) // #nosec G304 -- dossier de test.
+		if err != nil {
+			t.Fatalf("checksums.txt illisible : %v", err)
+		}
+		if !strings.Contains(string(sums), "config.json") {
+			t.Errorf("config.json n'est pas scellé :\n%s", sums)
+		}
+		doc := readJSON(t, filepath.Join(dir, "config.json"))
+		if doc["notice"] == nil {
+			t.Error("config.json ne porte pas l'avertissement bilingue d'assouplissement")
+		}
+		// La configuration EFFECTIVE voyage aussi dans l'inventaire scellé : c'est
+		// elle qui rend `verify --re-derive` fidèle.
+		input := readJSON(t, filepath.Join(dir, "input.json"))
+		if input["config"] == nil {
+			t.Error("input.json ne porte pas la configuration effective : un rejeu appliquerait la politique du jour")
+		}
+	})
+}
+
+// readJSON lit un document JSON d'un bundle.
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path) // #nosec G304 -- dossier de test.
+	if err != nil {
+		t.Fatalf("lecture de %s : %v", path, err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("%s illisible : %v", path, err)
+	}
+	return out
+}
+
+// TestARelaxedConfigurationFailsTheStrictGate : `--strict` est la porte de CI plus
+// exigeante. Elle refusait déjà une couverture nulle, un écart medium/low et un
+// fichier de dérogations périmé ; elle refuse maintenant aussi une correspondance
+// normative tombée. Un pipeline qui vend de la conformité ne doit pas rendre 0 sur
+// un contrôle qu'il a lui-même abaissé.
+func TestARelaxedConfigurationFailsTheStrictGate(t *testing.T) {
+	bin := buildPepin(t)
+	// Une fixture CONFORME : sans elle, le code 1 de la non-conformité masquerait
+	// ce que la porte stricte ajoute, et le test ne mesurerait rien.
+	_, _, code := runScan(t, bin, "scan", "scaleway", "-t", "examples/scaleway/terraform-fixed/plan.json",
+		"--strict", "--policy", writePolicy(t, relaxedPolicy))
+	if code == exitConforme {
+		t.Error("une correspondance normative tombée a rendu 0 sous --strict — un assouplissement ne doit pas passer la porte stricte en silence")
+	}
+	if code != exitStrict {
+		t.Errorf("code de sortie %d, attendu %d (porte stricte)", code, exitStrict)
+	}
+}
+
+// TestATightenedConfigurationDropsNoMapping : durcir n'est pas assouplir. Sans
+// cette propriété, la seule configuration confortable serait le défaut, et la
+// configurabilité n'aurait servi à personne.
+func TestATightenedConfigurationDropsNoMapping(t *testing.T) {
+	bin := buildPepin(t)
+	tightened := `controls:
+  tagging:
+    required_tags: [CostCenter, Project, Env, Owner, DataClassification]
+  snapshots:
+    max_age_days: 1
+`
+	stdout, _, _ := runScan(t, bin, "scan", "scaleway", "-t", policyFixture,
+		"--policy", writePolicy(t, tightened), "--format", "json")
+	var doc struct {
+		Config struct {
+			Relaxations []any `json:"relaxations"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
+		t.Fatalf("sortie JSON illisible : %v", err)
+	}
+	if len(doc.Config.Relaxations) != 0 {
+		t.Errorf("un durcissement a été signalé comme un assouplissement : %+v", doc.Config.Relaxations)
+	}
+}
+
+// TestTwoPolicyFilesAreRefused : `--policy` et `--exceptions` désignent le MÊME
+// fichier, sous deux noms. En accepter deux différents, c'est garantir que l'un des
+// deux dérivera — et une politique qui diverge d'elle-même n'engage plus personne.
+func TestTwoPolicyFilesAreRefused(t *testing.T) {
+	bin := buildPepin(t)
+	_, stderr, code := runScan(t, bin, "scan", "scaleway", "-t", policyFixture,
+		"--policy", writePolicy(t, defaultPolicy),
+		"--exceptions", writePolicy(t, defaultPolicy))
+	if code == exitConforme {
+		t.Fatal("deux fichiers de politique ont été acceptés")
+	}
+	if !strings.Contains(stderr, "policy") || !strings.Contains(stderr, "exceptions") {
+		t.Errorf("le refus doit nommer les deux drapeaux :\n%s", stderr)
+	}
+}
+
+// TestAnExceptionsFileStillWorksUnderItsHistoricName : le fichier de dérogations
+// d'hier reste un fichier de politique valide. Sans cette propriété, l'unification
+// aurait cassé toutes les invocations en place — et un opérateur aurait vu ses
+// dérogations disparaître d'un rapport, sans rien avoir changé.
+func TestAnExceptionsFileStillWorksUnderItsHistoricName(t *testing.T) {
+	bin := buildPepin(t)
+	_, _, code := runScan(t, bin, "scan", "scaleway", "-t", exemptFixture,
+		"--exceptions", writeExceptions(t, allDeviations))
+	if code != exitDerogation {
+		t.Errorf("code de sortie %d, attendu %d — un fichier `--exceptions` doit continuer de fonctionner", code, exitDerogation)
+	}
+}
+
+// TestASecretConfidenceTravelsInTheParsableFormats : le niveau de confiance de
+// chaque détection est publié (issue #48), et la VALEUR du secret ne l'est jamais.
+func TestASecretConfidenceTravelsInTheParsableFormats(t *testing.T) {
+	bin := buildPepin(t)
+	stdout, _, _ := runScan(t, bin, "scan", "scaleway", "-t", policyFixture, "--format", "json")
+	var doc struct {
+		Findings []struct {
+			Labels map[string]string `json:"labels"`
+		} `json:"findings"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
+		t.Fatalf("sortie JSON illisible : %v", err)
+	}
+	levels := map[string]bool{"low": true, "medium": true, "high": true}
+	found := 0
+	for _, f := range doc.Findings {
+		if f.Labels["check"] != "compute_instance_no_secrets_in_user_data" {
+			continue
+		}
+		found++
+		if !levels[f.Labels["confidence"]] {
+			t.Errorf("détection sans niveau de confiance lisible : %q", f.Labels["confidence"])
+		}
+	}
+	if found == 0 {
+		t.Fatal("aucune détection de secret dans la fixture : le test ne mesure rien")
+	}
+}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -46,7 +46,8 @@ var (
 	scanKubeconfig string
 	scanS3Endpoint string
 	scanSeal       string
-	scanExceptions string // fichier de dérogations (versionné, revu comme du code)
+	scanExceptions string // nom HISTORIQUE du fichier de politique (dérogations seules)
+	scanPolicy     string // fichier de politique : réglages des contrôles + dérogations
 	scanRedact     bool   // caviarder les valeurs sensibles de l'input.json embarqué
 	scanStrict     bool   // porte CI stricte : échec sur couverture nulle ou écart medium/low
 	scanTimestamp  string // instant d'évaluation (RFC3339 UTC), partagé input.evaluated_at + Run.Timestamp
@@ -82,13 +83,14 @@ var scanCmd = &cobra.Command{
 		// incomplet arrête le scan ici, plutôt que de produire un rapport qui tairait la
 		// moitié de ses exceptions. Les champs obligatoires se vérifient au chargement,
 		// jamais au moment de l'appliquer.
-		var exPolicy exempt.Policy
-		if scanExceptions != "" {
-			pol, lerr := exempt.Load(scanExceptions)
-			if lerr != nil {
-				return lerr
-			}
-			exPolicy = pol
+		// La POLITIQUE du scan tient dans un seul fichier, deux sections : les
+		// réglages des contrôles et les dérogations (cf. cmd/policy.go). Elle est
+		// chargée et validée AVANT toute collecte pour la même raison que les
+		// dérogations l'étaient déjà : un fichier à moitié compris produirait un
+		// rapport dont personne ne saurait dire sous quelle exigence il a été rendu.
+		cfg, exPolicy, perr := loadPolicy(scanPolicy, scanExceptions)
+		if perr != nil {
+			return perr
 		}
 
 		opts := scanReportOptions(name, scanSource(path))
@@ -114,6 +116,18 @@ var scanCmd = &cobra.Command{
 		if m, ok := input.(map[string]any); ok {
 			if _, present := m["evaluated_at"]; !present {
 				m["evaluated_at"] = scanTimestamp
+			}
+			// La CONFIGURATION EFFECTIVE voyage elle aussi dans l'input, et pour la
+			// même raison : le moteur partagé ne passe que l'input aux règles, et une
+			// configuration laissée en mémoire ne serait pas rejouable. Portée par
+			// l'input.json d'un bundle, elle rend `verify --re-derive` fidèle sans
+			// qu'on ait à redonner le fichier de politique. Elle n'est PAS écrasée si
+			// elle est déjà présente (rejeu d'un input.json scellé) : sinon le rejeu
+			// appliquerait la politique du jour à un dossier d'hier.
+			if _, present := m["config"]; !present {
+				m["config"] = cfg.Resolved
+			} else {
+				cfg.Resolved = replayedConfig(m["config"], cfg.Resolved)
 			}
 		}
 
@@ -174,6 +188,11 @@ var scanCmd = &cobra.Command{
 		// qu'un `fail`, et ne produisent jamais un `pass`. L'instant de référence est
 		// celui du scan (pas l'horloge), pour qu'un bundle rejoué rende le même verdict.
 		asmt, exReport := exempt.Apply(asmt, exPolicy, evaluatedAt(), subjectsOf(input), knownControls())
+		// Les ASSOUPLISSEMENTS, en dernière passe : un contrôle réglé sous la barre
+		// de son exigence perd la correspondance normative qu'il ne tient plus. En
+		// dernier parce que la mention doit survivre à tout ce qui précède —
+		// dégradation et dérogations réécrivent l'un le motif, l'autre le statut.
+		asmt = assess.WithRelaxations(asmt, cfg.Relaxations)
 		for _, notice := range exReport.Notices() {
 			_, _ = fmt.Fprintln(os.Stderr, tr("pepin: ⚠ ", "pepin: ⚠ ")+notice)
 		}
@@ -197,6 +216,11 @@ var scanCmd = &cobra.Command{
 			if eerr != nil {
 				return eerr
 			}
+			cextras, cerr := bundleConfig(cfg)
+			if cerr != nil {
+				return cerr
+			}
+			extras.Config, extras.ConfigSummary = cextras.Config, cextras.ConfigSummary
 			cs, err := assess.WriteBundle(scanSeal, asmt, inputJSON, extras)
 			if err != nil {
 				return err
@@ -218,11 +242,11 @@ var scanCmd = &cobra.Command{
 		enrichFromReferentiel(findings)
 		res := scoring.Summarize(findings)
 		gate := scoring.Summarize(open)
-		opts.SummaryHeadline = verdictHeadline(res, gate, asmt, exReport, asmt.Run.Source, len(degraded))
+		opts.SummaryHeadline = verdictHeadline(res, gate, asmt, exReport, asmt.Run.Source, len(degraded), len(cfg.Relaxations))
 
 		switch scanFormat {
 		case "json":
-			if err := renderJSON(findings, res, exReport, coll); err != nil {
+			if err := renderJSON(findings, res, exReport, coll, cfg); err != nil {
 				return err
 			}
 		case "assessment":
@@ -247,6 +271,7 @@ var scanCmd = &cobra.Command{
 		default:
 			_ = screport.Terminal(os.Stdout, opts, findings, scscoring.Summarize(findings)) // best-effort render
 			renderExemptions(os.Stdout, exReport)
+			renderRelaxations(os.Stdout, cfg)
 		}
 		// Portée prestataire/commanditaire : obligatoire pour l'opposabilité (un rapport pepin
 		// ne prouve pas une qualification, seulement la posture d'un tenant).
@@ -297,6 +322,15 @@ var scanCmd = &cobra.Command{
 			os.Exit(exitStrict)
 		}
 		if scanStrict && exReport.Stale() {
+			os.Exit(exitStrict)
+		}
+		// --strict refuse aussi une correspondance normative TOMBÉE. Le contrôle a
+		// bien été évalué, mais contre une barre plus basse que celle de l'exigence
+		// citée : un pipeline qui vend de la conformité ne doit pas rendre 0 dessus.
+		// Le code 3 dit déjà « ne lisez pas ce scan comme un feu vert » ; c'est
+		// exactement ce qu'un assouplissement impose de lire, et il n'y a
+		// délibérément pas de cinquième code (cf. surface.go).
+		if scanStrict && len(cfg.Relaxations) > 0 {
 			os.Exit(exitStrict)
 		}
 		return nil
@@ -552,10 +586,14 @@ func init() {
 	scanCmd.Flags().StringVar(&scanS3Endpoint, "s3-endpoint", "", "endpoint S3 custom pour le stockage objet (collecte live ; ex. MinIO http://localhost:9000)")
 	scanCmd.Flags().StringVar(&scanSeal, "seal", "", "écrire un bundle de preuve opposable (assessment + OSCAL + manifest + checksums) dans ce dossier")
 	scanCmd.Flags().StringVar(&scanExceptions, "exceptions", "", "`fichier` YAML de dérogations (control, justification, expires_at, owner, approved_by) : un écart couvert passe au statut exempted, jamais conforme")
-	scanCmd.Flags().BoolVar(&scanStrict, "strict", false, "porte CI stricte : code de sortie ≠ 0 si aucun contrôle n'est mesuré (hors gouvernance) ou s'il subsiste un écart medium/low")
+	scanCmd.Flags().StringVar(&scanPolicy, "policy", "", "`fichier` YAML de politique : réglages des contrôles (`controls:`) ET dérogations (`exceptions:`) — un seul fichier, nom moderne de --exceptions")
+	scanCmd.Flags().BoolVar(&scanStrict, "strict", false, "porte CI stricte : code de sortie ≠ 0 si aucun contrôle n'est mesuré (hors gouvernance), s'il subsiste un écart medium/low, ou si un réglage assoupli a fait tomber une correspondance normative")
 	scanCmd.Flags().BoolVar(&scanRedact, "redact", false, "caviarder les valeurs sensibles (user-data, policies) de l'input.json du bundle — pour partage à un tiers ; INCOMPATIBLE avec verify --re-derive")
 	// --live et --terraform sont exclusifs : sinon loadInput privilégie le live et ignore le plan en silence.
 	scanCmd.MarkFlagsMutuallyExclusive("live", "terraform")
+	// --policy et --exceptions désignent le MÊME fichier, sous deux noms. En
+	// accepter deux différents, c'est garantir que l'un des deux dérivera.
+	scanCmd.MarkFlagsMutuallyExclusive("policy", "exceptions")
 }
 
 // enrichFromReferentiel rattache chaque finding à l'index SCSL. Les règles Rego
@@ -1060,7 +1098,7 @@ func docURL(f finding.Finding) string {
 // un scan où RIEN n'a été évalué (collecte vide, gardes de capacité) ne doit jamais s'afficher
 // « CONFORME », et un verdict sur un plan Terraform est qualifié « périmètre déclaré » (état
 // planifié, pas configuration effective). Le code de sortie reste piloté par res.Conforme.
-func verdictHeadline(res scoring.Result, gate scoring.Result, asmt assessment.Assessment, ex exempt.Report, source string, degraded int) string {
+func verdictHeadline(res scoring.Result, gate scoring.Result, asmt assessment.Assessment, ex exempt.Report, source string, degraded, relaxed int) string {
 	// `evaluated` ne compte QUE des contrôles mesurés sur des ressources collectées : les
 	// contrôles de gouvernance passent sur des faits AUTO-DÉCLARÉS (souveraineté) et ne doivent
 	// pas empêcher INDÉTERMINÉ sur un inventaire par ailleurs vide (sinon un tenant vidé de ses
@@ -1122,6 +1160,16 @@ func verdictHeadline(res scoring.Result, gate scoring.Result, asmt assessment.As
 			"Verdict : INCOMPLET — %d contrôle(s) non évaluables faute d'une collecte complète, %d écart(s) medium/low sur ce qui a pu être lu",
 			"Verdict: INCOMPLETE — %d control(s) are not evaluable because the collection is incomplete, %d medium/low deviation(s) on what could be read"),
 			degraded, res.Medium+res.Low)
+	case relaxed > 0:
+		// Aucun écart critique/haut, mais un ou plusieurs contrôles ont été évalués
+		// sous une barre PLUS BASSE que celle de l'exigence qu'ils citent. Afficher
+		// « conforme » ici serait le faux vert le plus coûteux de tous : celui qu'on
+		// a soi-même réglé. Le bandeau nomme donc le nombre de correspondances
+		// tombées, et le détail suit sous le rapport.
+		return fmt.Sprintf(tr(
+			"Verdict : SOUS CONFIGURATION ASSOUPLIE — %d contrôle(s) évalué(s) sous une exigence abaissée, leur correspondance normative n'est pas tenue (%d écart(s) medium/low)",
+			"Verdict: UNDER RELAXED CONFIGURATION — %d control(s) assessed against a lowered requirement, their normative mapping does not hold (%d medium/low deviation(s))"),
+			relaxed, res.Medium+res.Low)
 	case res.Medium+res.Low > 0:
 		// Pas d'écart critique/haut, MAIS des écarts medium/low subsistent : ne pas laisser lire « conforme ».
 		return fmt.Sprintf(tr(
@@ -1176,7 +1224,7 @@ func pepinBanner() []string {
 	return lines
 }
 
-func renderJSON(findings []finding.Finding, res scoring.Result, ex exempt.Report, coll model.Collection) error {
+func renderJSON(findings []finding.Finding, res scoring.Result, ex exempt.Report, coll model.Collection, cfg scanConfig) error {
 	out := map[string]any{"findings": findings, "summary": res}
 	// L'état de collecte est une SURFACE ANALYSABLE, au même titre que les
 	// dérogations : un pipeline qui accepte le code de sortie d'une collecte
@@ -1191,6 +1239,12 @@ func renderJSON(findings []finding.Finding, res scoring.Result, ex exempt.Report
 	if len(ex.Records) > 0 {
 		out["exemptions"] = ex
 	}
+	// La CONFIGURATION est une surface analysable elle aussi, et c'est celle qui
+	// décide de ce que le rapport a le droit d'affirmer : un pipeline doit pouvoir
+	// lire l'empreinte de la politique appliquée et, surtout, les correspondances
+	// normatives qu'elle a fait tomber. Toujours présente : une configuration par
+	// défaut est une information, pas un silence.
+	out["config"] = jsonConfig(cfg)
 	b, err := json.MarshalIndent(out, "", "  ")
 	if err != nil {
 		return err

--- a/cmd/surface.go
+++ b/cmd/surface.go
@@ -44,7 +44,14 @@ const (
 // encore : aucun code existant ne change de sens, mais un code de plus change ce
 // qu'un pipeline doit savoir interpréter — d'où l'incrément et sa ligne de
 // CHANGELOG.
-const cliSurfaceVersion = 3
+//
+// v4 : ajout de `scan --policy`, le fichier de politique UNIQUE (réglages des
+// contrôles sous `controls:`, dérogations sous `exceptions:`). `--exceptions`
+// reste, inchangé, comme nom historique du même fichier ; les deux drapeaux sont
+// mutuellement exclusifs. Aucun code de sortie n'est ajouté ni redéfini, mais
+// `--strict` refuse désormais aussi une correspondance normative tombée sous un
+// réglage assoupli — un pipeline qui utilise --strict doit le savoir.
+const cliSurfaceVersion = 4
 
 // findingsSurfaceVersion est la version de FORME de `--format json`
 // ({"findings": [...], "summary": {...}}), la sortie qu'un pipeline parse le

--- a/cmd/testdata/frozen/bundle.json
+++ b/cmd/testdata/frozen/bundle.json
@@ -99,6 +99,69 @@
           }
         }
       }
+    },
+    {
+      "schema_version": 3,
+      "content": {
+        "files": {
+          "assessment-oscal.json": "oscal-assessment-results",
+          "assessment.json": "assessment",
+          "checksums.txt": "checksums",
+          "exemptions.json": "applied-exemptions",
+          "input.json": "evaluated-input",
+          "manifest.json": "manifest"
+        },
+        "format": "pepin-assessment-bundle/v3",
+        "manifest": {
+          "artifacts": [
+            {
+              "bytes": "number",
+              "file": "string",
+              "role": "string",
+              "sha256": "string"
+            }
+          ],
+          "config": {
+            "dropped_references": [
+              "string"
+            ],
+            "policy_digest": "string",
+            "relaxed_controls": [
+              "string"
+            ]
+          },
+          "disclaimer": "string",
+          "exemptions": {
+            "applied": "number",
+            "expired": "number",
+            "orphan": "number",
+            "policy_digest": "string"
+          },
+          "format": "string",
+          "generated": "string",
+          "inventory_schema": "string",
+          "ruleset": {
+            "digest": "string",
+            "name": "string",
+            "version": "string"
+          },
+          "source": "string",
+          "summary": {
+            "*": "number"
+          },
+          "target": {
+            "id": "string",
+            "platform": "string",
+            "provider": "string",
+            "region": "string"
+          },
+          "tool": {
+            "digest": "string",
+            "name": "string",
+            "version": "string"
+          }
+        }
+      }
     }
   ]
 }

--- a/cmd/testdata/frozen/cli.json
+++ b/cmd/testdata/frozen/cli.json
@@ -168,6 +168,65 @@
           }
         }
       }
+    },
+    {
+      "schema_version": 4,
+      "content": {
+        "exit_codes": {
+          "conforme": 0,
+          "derogation": 4,
+          "erreur": 2,
+          "non_conformite": 1,
+          "strict": 3
+        },
+        "verbs": {
+          "provider": {
+            "flags": {}
+          },
+          "provider list": {
+            "flags": {}
+          },
+          "provider new": {
+            "flags": {}
+          },
+          "provider validate": {
+            "flags": {}
+          },
+          "scan": {
+            "flags": {
+              "exceptions": "",
+              "format": "f",
+              "kubeconfig": "",
+              "lang": "",
+              "live": "",
+              "policy": "",
+              "policy-dir": "p",
+              "profile": "",
+              "redact": "",
+              "region": "",
+              "s3-endpoint": "",
+              "seal": "",
+              "strict": "",
+              "terraform": "t"
+            }
+          },
+          "scsl": {
+            "flags": {
+              "index": ""
+            }
+          },
+          "verify": {
+            "flags": {
+              "bundle": "",
+              "pubkey": "",
+              "re-derive": ""
+            }
+          },
+          "version": {
+            "flags": {}
+          }
+        }
+      }
     }
   ]
 }

--- a/cmd/testdata/frozen/inventory.json
+++ b/cmd/testdata/frozen/inventory.json
@@ -644,6 +644,232 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 4,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "source": {
+                "file": "string",
+                "line": "number",
+                "module": "string"
+              },
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v4",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "expiration_date",
+            "owner_user",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "state",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "inbound_default_policy",
+            "security_group_id"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
+        }
+      }
     }
   ]
 }

--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -110,6 +110,7 @@ Le tableau ci-dessous est rendu depuis cette table même, il n'en est pas la cop
 | `kubernetes_cluster_not_publicly_accessible` | `kubernetes_cluster` | `admin_whitelist` |
 | `loadbalancer_http_redirect_to_https` | `load_balancer` | `redirect_to_https` |
 | `loadbalancer_ssl_listeners` | `load_balancer` | `load_balancer_type` |
+| `network_documented` | `network` | `tags` |
 | `network_flow_matrix_documented` | `security_group_rule` | `description` |
 | `network_peering_cross_organization` | `network_peering` | `accepter_account` ou `source_account` |
 | `network_securitygroup_default_deny` | `security_group` | `inbound_default_policy` |

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -110,6 +110,7 @@ The table below is rendered from that very map — not transcribed from it:
 | `kubernetes_cluster_not_publicly_accessible` | `kubernetes_cluster` | `admin_whitelist` |
 | `loadbalancer_http_redirect_to_https` | `load_balancer` | `redirect_to_https` |
 | `loadbalancer_ssl_listeners` | `load_balancer` | `load_balancer_type` |
+| `network_documented` | `network` | `tags` |
 | `network_flow_matrix_documented` | `security_group_rule` | `description` |
 | `network_peering_cross_organization` | `network_peering` | `accepter_account` or `source_account` |
 | `network_securitygroup_default_deny` | `security_group` | `inbound_default_policy` |

--- a/docs/controls/blockstorage_volume_snapshots_exist.fr.md
+++ b/docs/controls/blockstorage_volume_snapshots_exist.fr.md
@@ -4,7 +4,7 @@
 
 # `blockstorage_volume_snapshots_exist`
 
-**Absence de sauvegarde récente**
+**Absence de snapshot récente et terminée**
 
 [Retour au catalogue](index.fr.md)
 
@@ -22,7 +22,7 @@
 
 ## Le risque
 
-Un volume de données en usage n'a pas d'instantané/sauvegarde récent : la restauration après incident n'est pas garantie.
+CE QUI EST MESURÉ : un volume en usage a-t-il, dans la fenêtre configurée (par défaut 7 jours, `controls.snapshots.max_age_days`), au moins une snapshot dont l'état natif la dit TERMINÉE ? L'état est vérifié, pas seulement la date : une snapshot en erreur ou en cours ne restaure rien. CE QUE LE CONTRÔLE NE PROUVE PAS : ni que la snapshot soit restaurable (aucune restauration n'est tentée), ni qu'elle soit complète au sens applicatif, ni qu'une rétention soit respectée, ni qu'une politique de sauvegarde existe. Un volume sauvegardé autrement (sauvegarde applicative, réplication, service du fournisseur) sera signalé ici : c'est un faux positif assumé, à traiter par une dérogation datée, jamais en désactivant le contrôle. Ce contrôle ne participe donc pas à une affirmation « sauvegarde conforme ».
 
 Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
 langue du lecteur.
@@ -84,7 +84,7 @@ contient aucune ressource du type visé : « rien à voir » n'est pas « confor
 
 ## Comment corriger
 
-Mettre en place une politique de sauvegarde régulière avec test de restauration ; chiffrer et appliquer une rétention documentée.
+Mettre en place un snapshot régulier automatisé et tester la restauration périodiquement. Si le volume est sauvegardé autrement, poser une dérogation datée et justifiée plutôt que de désactiver le contrôle.
 
 | Fournisseur | Montage déployable |
 |---|---|

--- a/docs/controls/blockstorage_volume_snapshots_exist.md
+++ b/docs/controls/blockstorage_volume_snapshots_exist.md
@@ -4,7 +4,7 @@
 
 # `blockstorage_volume_snapshots_exist`
 
-**No recent backup**
+**No recent, completed snapshot**
 
 [Back to the catalogue](index.md)
 
@@ -22,7 +22,7 @@
 
 ## The risk
 
-A data volume in use has no recent snapshot or backup: restoring after an incident is not guaranteed.
+WHAT IS MEASURED: does a volume in use have, within the configured window (7 days by default, `controls.snapshots.max_age_days`), at least one snapshot whose native state says it is COMPLETED? The state is checked, not just the date: a failed or in-progress snapshot restores nothing. WHAT THIS CONTROL DOES NOT PROVE: neither that the snapshot is restorable (no restore is attempted), nor that it is complete in the application sense, nor that a retention is honoured, nor that a backup policy exists. A volume backed up by other means (application backup, replication, provider service) will be reported here: an accepted false positive, to be handled with a dated exemption rather than by disabling the control. This control therefore takes no part in a "backup compliant" claim.
 
 This description comes from the reference: it is the text the report quotes, in the
 reader's language.
@@ -83,7 +83,7 @@ resource of the targeted type: "nothing to look at" is not "compliant".
 
 ## How to remediate
 
-Set up a regular backup policy with restore testing; encrypt the backups and apply a documented retention.
+Set up an automated, regular snapshot schedule and test the restore periodically. If the volume is backed up by other means, file a dated, justified exemption rather than disabling the control.
 
 | Provider | Deployable setup |
 |---|---|

--- a/docs/controls/governance_resource_required_tags.fr.md
+++ b/docs/controls/governance_resource_required_tags.fr.md
@@ -22,7 +22,7 @@
 
 ## Le risque
 
-Des ressources n'ont pas les étiquettes de gouvernance (propriétaire, projet, environnement) : l'inventaire et la responsabilité ne sont pas tenus.
+CE QUI EST VÉRIFIÉ : une ressource facturable porte les étiquettes de gouvernance exigées — par défaut centre de coût, projet, environnement et propriétaire. Ce qui est exigé, ce sont les QUESTIONS auxquelles un inventaire doit répondre (qui paye, pour quoi, à quel stade, qui répond), jamais des mots précis : la comparaison est insensible à la casse et aux séparateurs (`cost-center` ≡ `CostCenter`), et le profil, les alias et les types de ressources visés sont configurables (`controls.tagging`). Le profil livré est une RECOMMANDATION, pas une norme. Sans étiquettes collectées, le contrôle rend « non évalué ».
 
 Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
 langue du lecteur.
@@ -88,7 +88,7 @@ contient aucune ressource du type visé : « rien à voir » n'est pas « confor
 
 ## Comment corriger
 
-Imposer des étiquettes obligatoires (propriétaire, projet, environnement) ; contrôler leur présence à la création.
+Ajouter les étiquettes de gouvernance manquantes ; contrôler leur présence à la création. Si votre convention diffère, la déclarer dans le fichier de politique plutôt que de désactiver le contrôle.
 
 | Fournisseur | Montage déployable |
 |---|---|

--- a/docs/controls/governance_resource_required_tags.md
+++ b/docs/controls/governance_resource_required_tags.md
@@ -22,7 +22,7 @@
 
 ## The risk
 
-Some resources do not carry the governance tags (owner, project, environment): the inventory and the accountability are not maintained.
+WHAT IS CHECKED: a billable resource carries the required governance tags - by default cost centre, project, environment and owner. What is required are the QUESTIONS an inventory must answer (who pays, for what, at which stage, who is accountable), never exact words: the comparison ignores case and separators (`cost-center` = `CostCenter`), and the profile, its aliases and the targeted resource types are configurable (`controls.tagging`). The shipped profile is a RECOMMENDATION, not a standard. Without collected tags the control returns "not evaluated".
 
 This description comes from the reference: it is the text the report quotes, in the
 reader's language.
@@ -87,7 +87,7 @@ resource of the targeted type: "nothing to look at" is not "compliant".
 
 ## How to remediate
 
-Enforce mandatory tags (owner, project, environment); check their presence at creation time.
+Add the missing governance tags; check their presence at creation time. If your convention differs, declare it in the policy file rather than disabling the control.
 
 | Provider | Deployable setup |
 |---|---|

--- a/docs/controls/index.fr.md
+++ b/docs/controls/index.fr.md
@@ -96,7 +96,7 @@ vue d'ensemble par fournisseur et par source, voir la [matrice de couverture](..
 | Contrôle | Sévérité | SCSL | Actif pour | Preuves |
 |---|---|---|---|---|
 | [`blockstorage_snapshot_not_public`](blockstorage_snapshot_not_public.fr.md) Instantané ou image partagé publiquement | high | `CLD-STO-2` | `outscale` | 0 / 1 |
-| [`blockstorage_volume_snapshots_exist`](blockstorage_volume_snapshots_exist.fr.md) Absence de sauvegarde récente | high | `CLD-STO-3` | `exoscale`, `outscale` | 1 / 2 |
+| [`blockstorage_volume_snapshots_exist`](blockstorage_volume_snapshots_exist.fr.md) Absence de snapshot récente et terminée | high | `CLD-STO-3` | `exoscale`, `outscale` | 1 / 2 |
 | [`compute_image_not_public`](compute_image_not_public.fr.md) Image machine partagée publiquement | high | `CLD-STO-2` | `outscale` | 0 / 1 |
 | [`database_backup_enabled`](database_backup_enabled.fr.md) Sauvegardes automatiques d'une base managée désactivées | high | `CLD-STO-3` | `scaleway` | 0 / 1 |
 | [`objectstorage_bucket_object_lock_enabled`](objectstorage_bucket_object_lock_enabled.fr.md) Object Lock (immutabilité) désactivé sur le stockage objet | low | `CLD-STO-8` | `exoscale`, `outscale`, `scaleway` | 1 / 3 |

--- a/docs/controls/index.fr.md
+++ b/docs/controls/index.fr.md
@@ -64,7 +64,7 @@ vue d'ensemble par fournisseur et par source, voir la [matrice de couverture](..
 | [`compute_instance_public_ip_with_open_securitygroup`](compute_instance_public_ip_with_open_securitygroup.fr.md) Machine exposée publiquement sans filtrage restrictif | critical | `CLD-NET-3` | `exoscale`, `outscale`, `scaleway` | 1 / 3 |
 | [`database_service_not_open_to_internet`](database_service_not_open_to_internet.fr.md) Base de données managée joignable depuis Internet | high | `CLD-NET-1` | `scaleway` | 0 / 1 |
 | [`k8s_namespace_network_policy_defined`](k8s_namespace_network_policy_defined.fr.md) Namespace sans NetworkPolicy (réseau plat) | high | `CLD-K8S-6` | `kubernetes` | 0 / 1 |
-| [`network_documented`](network_documented.fr.md) Réseau non documenté (cartographie non tenue) | low | `CLD-NET-5` | `exoscale`, `outscale`, `scaleway` | 1 / 3 |
+| [`network_documented`](network_documented.fr.md) Réseau sans étiquettes de cartographie | low | `CLD-NET-5` | `exoscale`, `outscale`, `scaleway` | 1 / 3 |
 | [`network_flow_matrix_documented`](network_flow_matrix_documented.fr.md) Flux entrant sans justification dans la matrice des flux | medium | `CLD-NET-5` | `exoscale` | 1 / 1 |
 | [`network_peering_cross_organization`](network_peering_cross_organization.fr.md) Appairage réseau vers un autre système d'information | high | `CLD-NET-7` | `outscale` | 0 / 1 |
 | [`network_securitygroup_allow_ingress_from_internet_to_all_ports`](network_securitygroup_allow_ingress_from_internet_to_all_ports.fr.md) Tout le trafic entrant autorisé depuis Internet (any/any) | critical | `CLD-NET-2` | `exoscale`, `outscale`, `scaleway` | 1 / 3 |

--- a/docs/controls/index.md
+++ b/docs/controls/index.md
@@ -64,7 +64,7 @@ overview per provider and per source, see the [coverage matrix](../coverage.md).
 | [`compute_instance_public_ip_with_open_securitygroup`](compute_instance_public_ip_with_open_securitygroup.md) Instance publicly exposed without restrictive filtering | critical | `CLD-NET-3` | `exoscale`, `outscale`, `scaleway` | 1 / 3 |
 | [`database_service_not_open_to_internet`](database_service_not_open_to_internet.md) Managed database reachable from the internet | high | `CLD-NET-1` | `scaleway` | 0 / 1 |
 | [`k8s_namespace_network_policy_defined`](k8s_namespace_network_policy_defined.md) Namespace without a NetworkPolicy (flat network) | high | `CLD-K8S-6` | `kubernetes` | 0 / 1 |
-| [`network_documented`](network_documented.md) Undocumented network (mapping not maintained) | low | `CLD-NET-5` | `exoscale`, `outscale`, `scaleway` | 1 / 3 |
+| [`network_documented`](network_documented.md) Network without mapping tags | low | `CLD-NET-5` | `exoscale`, `outscale`, `scaleway` | 1 / 3 |
 | [`network_flow_matrix_documented`](network_flow_matrix_documented.md) Inbound flow without a justification in the flow matrix | medium | `CLD-NET-5` | `exoscale` | 1 / 1 |
 | [`network_peering_cross_organization`](network_peering_cross_organization.md) Network peering towards another information system | high | `CLD-NET-7` | `outscale` | 0 / 1 |
 | [`network_securitygroup_allow_ingress_from_internet_to_all_ports`](network_securitygroup_allow_ingress_from_internet_to_all_ports.md) All inbound traffic allowed from the internet (any/any) | critical | `CLD-NET-2` | `exoscale`, `outscale`, `scaleway` | 1 / 3 |

--- a/docs/controls/index.md
+++ b/docs/controls/index.md
@@ -96,7 +96,7 @@ overview per provider and per source, see the [coverage matrix](../coverage.md).
 | Control | Severity | SCSL | Active for | Proofs |
 |---|---|---|---|---|
 | [`blockstorage_snapshot_not_public`](blockstorage_snapshot_not_public.md) Snapshot or image shared publicly | high | `CLD-STO-2` | `outscale` | 0 / 1 |
-| [`blockstorage_volume_snapshots_exist`](blockstorage_volume_snapshots_exist.md) No recent backup | high | `CLD-STO-3` | `exoscale`, `outscale` | 1 / 2 |
+| [`blockstorage_volume_snapshots_exist`](blockstorage_volume_snapshots_exist.md) No recent, completed snapshot | high | `CLD-STO-3` | `exoscale`, `outscale` | 1 / 2 |
 | [`compute_image_not_public`](compute_image_not_public.md) Machine image shared publicly | high | `CLD-STO-2` | `outscale` | 0 / 1 |
 | [`database_backup_enabled`](database_backup_enabled.md) Automatic backups disabled on a managed database | high | `CLD-STO-3` | `scaleway` | 0 / 1 |
 | [`objectstorage_bucket_object_lock_enabled`](objectstorage_bucket_object_lock_enabled.md) Object Lock (immutability) disabled on object storage | low | `CLD-STO-8` | `exoscale`, `outscale`, `scaleway` | 1 / 3 |

--- a/docs/controls/network_documented.fr.md
+++ b/docs/controls/network_documented.fr.md
@@ -4,7 +4,7 @@
 
 # `network_documented`
 
-**Réseau non documenté (cartographie non tenue)**
+**Réseau sans étiquettes de cartographie**
 
 [Retour au catalogue](index.fr.md)
 
@@ -15,14 +15,14 @@
 | Sévérité | `low` |
 | Exigence SCSL (index gelé) | `CLD-NET-5` |
 | Type de ressource lu | `network` |
-| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| Attribut décisif | `tags` |
 | État | actif |
 | Déclaré pour | `exoscale`, `outscale`, `scaleway` |
 | Preuves de remédiation | 1 / 3 |
 
 ## Le risque
 
-Un réseau (VPC / Net / réseau privé) n'a pas de nom ou d'étiquettes de gouvernance : la cartographie réseau (inventaire, propriétaire, projet) n'est pas tenue à jour, ce qui nuit à la revue et à la réponse aux incidents.
+CE QUI EST VÉRIFIÉ : chaque réseau (VPC / Net / réseau privé) porte les étiquettes de gouvernance qui le documentent — par défaut propriétaire, projet et environnement. Une étiquette hors sujet ne documente rien : la présence d'un tag quelconque ne suffit pas. La comparaison est insensible à la casse et aux séparateurs, et le profil d'étiquetage est configurable (`controls.tagging.network_required_tags`) ; le profil livré est une recommandation, pas une norme. Sans étiquettes collectées, le contrôle rend « non évalué » plutôt que de conclure.
 
 Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
 langue du lecteur.
@@ -77,13 +77,14 @@ contient aucune ressource du type visé : « rien à voir » n'est pas « confor
 ## Comment enquêter
 
 - Type de ressource normalisé lu par la règle : `network`
-- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Attribut dont la décision dépend : `tags`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
 - Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
 - La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
 
 ## Comment corriger
 
-Nommer et étiqueter chaque réseau (propriétaire, projet, environnement) ; tenir à jour la cartographie réseau et la réviser périodiquement.
+Étiqueter chaque réseau avec son propriétaire, son projet et son environnement ; tenir à jour la cartographie réseau et la réviser périodiquement.
 
 | Fournisseur | Montage déployable |
 |---|---|

--- a/docs/controls/network_documented.md
+++ b/docs/controls/network_documented.md
@@ -4,7 +4,7 @@
 
 # `network_documented`
 
-**Undocumented network (mapping not maintained)**
+**Network without mapping tags**
 
 [Back to the catalogue](index.md)
 
@@ -15,14 +15,14 @@
 | Severity | `low` |
 | SCSL requirement (frozen index) | `CLD-NET-5` |
 | Resource type read | `network` |
-| Deciding attribute | _none: judged on the presence of a deviation_ |
+| Deciding attribute | `tags` |
 | State | active |
 | Declared for | `exoscale`, `outscale`, `scaleway` |
 | Remediation proofs | 1 / 3 |
 
 ## The risk
 
-A network (VPC / Net / private network) has no name and no governance tags: the network mapping (inventory, owner, project) is not kept up to date, which hurts review and incident response.
+WHAT IS CHECKED: every network (VPC / Net / private network) carries the governance tags that document it - by default owner, project and environment. An off-topic tag documents nothing: the mere presence of some tag is not enough. The comparison ignores case and separators, and the tagging profile is configurable (`controls.tagging.network_required_tags`); the shipped profile is a recommendation, not a standard. Without collected tags the control returns "not evaluated" rather than concluding.
 
 This description comes from the reference: it is the text the report quotes, in the
 reader's language.
@@ -76,13 +76,14 @@ resource of the targeted type: "nothing to look at" is not "compliant".
 ## How to investigate
 
 - Normalized resource type the rule reads: `network`
-- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- Attribute the decision depends on: `tags`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
 - What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
 - The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
 
 ## How to remediate
 
-Name and tag every network (owner, project, environment); keep the network mapping up to date and review it periodically.
+Tag every network with its owner, project and environment; keep the network mapping up to date and review it periodically.
 
 | Provider | Deployable setup |
 |---|---|

--- a/docs/guides/control-configuration.fr.md
+++ b/docs/guides/control-configuration.fr.md
@@ -1,0 +1,244 @@
+> [🇬🇧 English](control-configuration.md) · 🇫🇷 Français
+
+# Configurer les contrôles — et ce qu'un assouplissement fait perdre
+
+Certains contrôles doivent être réglables. Une convention d'étiquetage n'est pas une norme ;
+une fenêtre de fraîcheur est une décision d'exploitation ; une heuristique générique de secret
+est plus bruyante qu'un bloc PEM. Un contrôle qu'on ne peut pas régler finit désactivé, et un
+contrôle désactivé ne mesure rien.
+
+Mais chaque réglage est une poignée qui permet de fabriquer du vert. Desserrer un seuil,
+retirer une étiquette exigée, allonger un délai — et continuer d'afficher la même
+correspondance CIS ou SecNumCloud. Un `pass` obtenu en abaissant l'exigence est très
+exactement le `PASS` non prouvé que ce projet refuse de produire.
+
+Pépin lie donc la configuration à la correspondance normative. **Vous pouvez abaisser la
+barre. Vous ne pouvez pas l'abaisser et garder le badge.**
+
+## Un seul fichier, deux sections
+
+Il n'y a qu'un fichier de politique. Il porte les réglages des contrôles et les dérogations,
+parce que les deux répondent à la même question — *ce que cette organisation assume
+sciemment* — et se relisent au même moment, par les mêmes personnes. Deux fichiers auraient
+deux cycles de revue, et un utilisateur qui doit tenir trois fichiers de politique en fera
+diverger deux.
+
+```yaml
+# pepin-policy.yaml
+controls:
+  tagging:
+    required_tags: [CostCenter, Project, Env, Owner]
+    network_required_tags: [Owner, Project, Env]
+    aliases:
+      Owner: [Owner, team, responsible, contact]
+    resource_types: [compute_instance, blockstorage_volume, object_storage_bucket]
+  snapshots:
+    max_age_days: 7
+    accepted_states: [completed, created]
+  secrets:
+    min_confidence: low
+
+exceptions:
+  - control: objectstorage_bucket_public_access
+    resource: public-assets
+    justification: "Bucket de diffusion publique assumé, contenu non sensible"
+    expires_at: 2026-12-31
+    owner: platform-security
+    approved_by: security@example.org
+```
+
+```console
+$ pepin scan scaleway --terraform plan.json --policy pepin-policy.yaml
+```
+
+`--exceptions` est le nom historique du même fichier et lit le même schéma : une invocation
+existante continue de fonctionner, et un fichier de dérogations peut gagner une section
+`controls:` sans changer de ligne de commande. **Les deux drapeaux sont mutuellement
+exclusifs** — accepter deux fichiers de politique différents, c'est garantir que l'un des deux
+dérivera.
+
+Chaque section est facultative. Une section absente laisse le profil par défaut intact : un
+fichier de politique partiel n'assouplit que ce qu'il nomme.
+
+## Le profil par défaut est une recommandation, pas une norme
+
+Aucune convention d'étiquetage ne fait autorité, et Pépin ne prétend pas le contraire. Ce que
+le profil par défaut encode, ce sont les **questions auxquelles un inventaire doit savoir
+répondre** — qui paye, pour quoi, à quel stade, qui répond —, jamais des mots précis.
+
+| Réglage | Défaut | Ce qu'il désigne |
+|---|---|---|
+| `tagging.required_tags` | `CostCenter, Project, Env, Owner` | étiquettes exigées sur une ressource facturable |
+| `tagging.network_required_tags` | `Owner, Project, Env` | étiquettes exigées sur un réseau (cartographie) |
+| `tagging.aliases` | voir plus bas | autres écritures qu'un nom logique accepte |
+| `tagging.resource_types` | 8 types, listés plus bas | où l'étiquetage est exigé |
+| `snapshots.max_age_days` | `7` | fenêtre de fraîcheur d'une snapshot |
+| `snapshots.accepted_states` | `completed, created` | états natifs d'une snapshot exploitable |
+| `secrets.min_confidence` | `low` | tout signaler, heuristiques génériques comprises |
+
+**La comparaison est insensible à la casse et aux séparateurs.** `cost-center`,
+`cost_center`, `Cost Center` et `CostCenter` sont la même exigence — un outil qui crie au loup
+sur une typographie finit désactivé. Par-dessus, les alias élargissent chaque nom logique :
+
+| Nom logique | Écritures acceptées |
+|---|---|
+| `CostCenter` | `CostCenter`, `cost-center`, `cc`, `billing-code`, `billing` |
+| `Project` | `Project`, `app`, `application`, `service` |
+| `Env` | `Env`, `environment`, `stage` |
+| `Owner` | `Owner`, `team`, `responsible`, `contact` |
+
+Les noms du tableau sont des **noms d'affichage** : ce sont eux qu'un message de finding
+énumère comme manquants. La correspondance, elle, passe par les alias normalisés.
+
+**Quels types de ressources sont visés, et pourquoi.** Le critère est *facturable et
+étiquetable* : une ressource qui coûte sans propriétaire connu est un coût orphelin autant
+qu'un risque orphelin.
+
+- Dans le périmètre : `compute_instance`, `blockstorage_volume`, `blockstorage_snapshot`,
+  `compute_image`, `load_balancer`, `object_storage_bucket`, `managed_database`,
+  `kubernetes_cluster`.
+- Hors périmètre, avec les raisons : `network`, `subnet`, `network_peering`,
+  `security_group*` (non facturés en propre ; le réseau a sa propre exigence de cartographie,
+  CLD-NET-5) ; `iam_*`, `access_key`, `api_access_*` (ni facturés ni porteurs d'étiquettes) ;
+  `governance_provider` (ressource synthétique, pas une ressource du tenant) ; `k8s_*`
+  (portée intra-cluster, hors posture cloud).
+
+## Ce qu'un assouplissement fait perdre
+
+Chaque correspondance du référentiel porte les contraintes de configuration sous lesquelles
+elle vaut :
+
+```yaml
+- code: blockstorage_volume_snapshots_exist
+  scsl: [CLD-STO-3]
+  frameworks:
+    secnumcloud_3_2: ["12.5"]
+    cis_controls_v8: ["11.2"]
+    iso_27001_2022: ["A.8.13"]
+  config_requise:
+    - parametre: snapshots.max_age_days
+      contrainte: au_plus_le_defaut
+    - parametre: snapshots.accepted_states
+      contrainte: sous_ensemble_du_defaut
+```
+
+Quatre sens de contrainte, chacun nommant le côté du défaut où la promesse survit :
+
+| Contrainte | Tient tant que | L'assouplir signifie |
+|---|---|---|
+| `au_plus_le_defaut` | la valeur ne dépasse pas le défaut | une valeur au-delà tait ce que l'exigence demandait de voir |
+| `superset_du_defaut` | la valeur contient au moins le défaut | en retirer un membre, c'est cesser de vérifier ce que l'exigence demande |
+| `sous_ensemble_du_defaut` | la valeur reste contenue dans le défaut | l'élargir, c'est accepter ce que l'exigence rejette |
+| `au_moins_aussi_strict_que_le_defaut` | chaque exigence du profil par défaut a encore une contrepartie au moins aussi stricte | une exigence a été retirée, ou ce qu'elle accepte a été élargi |
+
+Le dernier est celui qu'emploie le profil d'étiquetage, et il ne revient pas à comparer des
+noms. Le défaut exige « la question de l'environnement est répondue par l'une des écritures
+`env`, `environment`, `stage` ». Une organisation qui écrit `environment` accepte **moins**
+d'écritures, donc exige davantage : c'est un durcissement. Comparer les noms l'aurait signalée
+comme assouplie et lui aurait retiré sa correspondance normative pour avoir resserré sa propre
+convention — le faux positif le plus coûteux qui soit, puisqu'il punit le bon comportement.
+
+**Durcir n'est pas assouplir.** Exiger une étiquette de plus, raccourcir la fenêtre, rétrécir
+les états acceptés ou les écritures acceptées : la correspondance tient et rien n'est signalé.
+La contrainte ne dit pas « ne touche à rien », elle dit de quel côté du défaut la promesse
+survit.
+
+Quand la configuration effective sort d'une contrainte, le contrôle est **assoupli**, et cinq
+choses arrivent en même temps :
+
+1. le résultat **perd ses références normatives** dans l'assessment — il ne prétend plus
+   couvrir CLD-STO-3, CIS 11.2 ni ISO A.8.13 ;
+2. le résultat porte `labels.config_relaxed`, `labels.config_relaxed_detail` et
+   `labels.references_dropped` ;
+3. la preuve (`evidence.observed`, donc l'OSCAL) énonce l'assouplissement en toutes lettres ;
+4. le terminal imprime un bloc `CONFIGURATION ASSOUPLIE` nommant le réglage, le défaut, la
+   valeur effective et les correspondances abandonnées ;
+5. `--format json` publie `config.relaxations` et `config.dropped_references`, et un bundle
+   scellé gagne `config.json` plus une entrée `config` à son manifeste — les deux couverts par
+   `checksums.txt`, donc l'empreinte du dossier dépend des réglages.
+
+Le bandeau de verdict change lui aussi, et `--strict` rend le code de sortie `3`. Un pipeline
+qui vend de la conformité ne doit pas rendre `0` sur un contrôle qu'il a lui-même abaissé.
+
+Le statut, lui, ne change **pas**. Le contrôle a bel et bien été évalué — contre une barre
+plus basse. On retire la seule chose qui a cessé d'être vraie, la correspondance, et on garde
+la mesure.
+
+## Régler le seuil bloquant de la détection de secrets en CI
+
+Chaque détection porte son niveau de confiance, dans `labels.confidence` :
+
+| Niveau | Fondement | Exemple |
+|---|---|---|
+| `high` | confirmé par sa forme | `-----BEGIN … PRIVATE KEY-----` |
+| `medium` | préfixe reconnu et format attendu | `ghp_…`, `AKIA…`, `SCW…`, `glpat-…`, JWT |
+| `low` | heuristique générique | `password=…`, `api_key=…` |
+
+Le défaut est `low` : tout est signalé. C'est le seul défaut défendable pour un détecteur de
+secrets — taire par défaut ce qu'on ne sait pas confirmer, c'est échanger un faux positif
+contre un faux négatif, sur le seul sujet où le faux négatif se paye en fuite.
+
+Trier en CI sans changer le scan :
+
+```console
+$ pepin scan scaleway --terraform plan.json --format json \
+  | jq '[.findings[] | select(.labels.check == "compute_instance_no_secrets_in_user_data")
+        | {subject, confidence: .labels.confidence}]'
+```
+
+Rendre le scan lui-même plus silencieux — et en assumer le prix :
+
+```yaml
+controls:
+  secrets:
+    min_confidence: medium   # les heuristiques génériques ne sont plus signalées
+```
+
+Cela fait tomber la correspondance CLD-CMP-9 / SecNumCloud 10.5, et le rapport le dit.
+« Aucun secret en clair » ne se prouve plus dès lors qu'on a choisi de ne pas regarder une
+partie de ce qui a été trouvé.
+
+**La valeur détectée n'apparaît jamais**, quel que soit le niveau. Le message n'interpole que
+le libellé du motif, jamais ce qui a matché — un rapport voyage en SARIF, dans les artefacts
+de CI et dans un bundle scellé, et un détecteur de secrets qui recopie le secret dans son
+rapport transforme le rapport en fuite. C'est tenu par des tests, pas par une intention.
+
+## Ce que le contrôle de snapshot ne prouve pas
+
+`blockstorage_volume_snapshots_exist` mesure une chose : un volume en usage a-t-il, dans la
+fenêtre configurée, au moins une snapshot dont l'état natif la dit terminée ? L'état est
+vérifié, pas seulement la date — une snapshot en erreur ou en cours ne restaure rien.
+
+Il ne prouve **pas** :
+
+- que la snapshot soit **restaurable** — aucune restauration n'est tentée ;
+- qu'elle soit **complète** au sens applicatif (bases à chaud, volumes multiples) ;
+- qu'une **rétention** soit respectée — une seule snapshot suffit à satisfaire le contrôle ;
+- qu'une **politique de sauvegarde** existe.
+
+Un volume sauvegardé autrement — sauvegarde applicative, réplication, service de backup du
+fournisseur, outil externe — sera signalé ici. C'est un faux positif assumé : il se traite par
+une dérogation datée et justifiée, jamais en désactivant le contrôle. Ce contrôle ne participe
+à aucune affirmation « sauvegarde conforme ».
+
+Il n'est pas non plus **évaluable sur un plan Terraform** : `state` y arrive en
+`after_unknown` et aucun `blockstorage_snapshot` n'y figure. Le scan rend `not-evaluated`,
+avec son motif.
+
+## La configuration voyage avec la preuve
+
+La configuration effective est injectée dans l'inventaire évalué sous la clé `config`,
+exactement comme `evaluated_at`. Elle atterrit donc dans l'`input.json` d'un bundle scellé, et
+`verify --re-derive` rejoue le même verdict sous la même politique sans qu'on ait à lui
+redonner le fichier. Un `input.json` rejoué garde sa propre `config` : le rejeu n'applique
+jamais la politique du jour à un dossier d'hier.
+
+Ce qui signifie aussi qu'un scan par défaut n'est jamais muet sur sa politique :
+`--format json` publie toujours `config.policy_digest` et `config.effective`. Deux scans que
+seul un réglage sépare ne peuvent pas porter la même empreinte.
+
+## Voir aussi
+
+- [Codes de sortie](../reference/exit-codes.fr.md) — dont `--strict` et les dérogations.
+- [Bundles de preuve](evidence-bundles.fr.md) — ce qui est scellé, et comment le vérifier.
+- [Limites connues](../known-limitations.fr.md) — les angles morts, nommés.

--- a/docs/guides/control-configuration.md
+++ b/docs/guides/control-configuration.md
@@ -1,0 +1,236 @@
+> 🇬🇧 English · [🇫🇷 Français](control-configuration.fr.md)
+
+# Configuring controls — and what a relaxation costs you
+
+Some controls have to be adjustable. A tagging convention is not a standard; a snapshot
+window is an operational decision; a generic secret heuristic is noisier than a PEM block.
+A control that cannot be adjusted gets disabled, and a disabled control measures nothing.
+
+But every setting is a handle that can manufacture green. Loosen a threshold, drop a required
+tag, stretch a freshness window — and keep displaying the same CIS or SecNumCloud mapping. A
+`pass` obtained by lowering the bar is exactly the unproven `PASS` this project refuses to
+produce.
+
+So Pépin ties configuration to normative mapping. **You can lower the bar. You cannot lower
+it and keep the badge.**
+
+## One file, two sections
+
+There is a single policy file. It carries the control settings and the exemptions, because
+both answer the same question — *what this organisation knowingly accepts* — and both are
+reviewed at the same moment, by the same people. Two files would have two review cycles, and
+anyone made to maintain three policy files will let two of them drift.
+
+```yaml
+# pepin-policy.yaml
+controls:
+  tagging:
+    required_tags: [CostCenter, Project, Env, Owner]
+    network_required_tags: [Owner, Project, Env]
+    aliases:
+      Owner: [Owner, team, responsible, contact]
+    resource_types: [compute_instance, blockstorage_volume, object_storage_bucket]
+  snapshots:
+    max_age_days: 7
+    accepted_states: [completed, created]
+  secrets:
+    min_confidence: low
+
+exceptions:
+  - control: objectstorage_bucket_public_access
+    resource: public-assets
+    justification: "Public distribution bucket, non-sensitive content"
+    expires_at: 2026-12-31
+    owner: platform-security
+    approved_by: security@example.org
+```
+
+```console
+$ pepin scan scaleway --terraform plan.json --policy pepin-policy.yaml
+```
+
+`--exceptions` is the historic name of the same file and reads the same schema: an existing
+invocation keeps working, and an existing exemptions file can grow a `controls:` section
+without changing a command line. **The two flags are mutually exclusive** — accepting two
+different policy files is a guarantee that one of them will drift.
+
+Every section is optional. An absent section leaves the default profile untouched: a partial
+policy file relaxes only what it names.
+
+## The default profile is a recommendation, not a standard
+
+No tagging convention is authoritative, and Pépin does not pretend otherwise. What the
+default profile encodes are the **questions an inventory must be able to answer** — who pays,
+for what, at which stage, who is accountable — never the exact words.
+
+| Setting | Default | What it means |
+|---|---|---|
+| `tagging.required_tags` | `CostCenter, Project, Env, Owner` | tags required on a billable resource |
+| `tagging.network_required_tags` | `Owner, Project, Env` | tags required on a network (mapping) |
+| `tagging.aliases` | see below | other spellings a logical name accepts |
+| `tagging.resource_types` | 8 types, listed below | where tagging is required |
+| `snapshots.max_age_days` | `7` | freshness window of a snapshot |
+| `snapshots.accepted_states` | `completed, created` | native states of a usable snapshot |
+| `secrets.min_confidence` | `low` | report everything, including generic heuristics |
+
+**The comparison ignores case and separators.** `cost-center`, `cost_center`, `Cost Center`
+and `CostCenter` are the same requirement — a tool that cries wolf over typography gets
+switched off. On top of that, aliases widen each logical name:
+
+| Logical name | Accepted spellings |
+|---|---|
+| `CostCenter` | `CostCenter`, `cost-center`, `cc`, `billing-code`, `billing` |
+| `Project` | `Project`, `app`, `application`, `service` |
+| `Env` | `Env`, `environment`, `stage` |
+| `Owner` | `Owner`, `team`, `responsible`, `contact` |
+
+The names in the table are **display names**: they are what a finding message lists as
+missing. Matching goes through the normalized aliases.
+
+**Which resource types are in scope, and why.** The criterion is *billable and taggable*: a
+resource that costs money without a known owner is an orphan cost as much as an orphan risk.
+
+- In scope: `compute_instance`, `blockstorage_volume`, `blockstorage_snapshot`,
+  `compute_image`, `load_balancer`, `object_storage_bucket`, `managed_database`,
+  `kubernetes_cluster`.
+- Out of scope, with reasons: `network`, `subnet`, `network_peering`, `security_group*` (not
+  billed in their own right; a network has its own mapping requirement, CLD-NET-5);
+  `iam_*`, `access_key`, `api_access_*` (neither billed nor tag-bearing);
+  `governance_provider` (a synthetic resource, not a tenant resource); `k8s_*` (in-cluster
+  scope, outside cloud posture).
+
+## What a relaxation costs
+
+Each mapping in the reference carries the configuration constraints under which it holds:
+
+```yaml
+- code: blockstorage_volume_snapshots_exist
+  scsl: [CLD-STO-3]
+  frameworks:
+    secnumcloud_3_2: ["12.5"]
+    cis_controls_v8: ["11.2"]
+    iso_27001_2022: ["A.8.13"]
+  config_requise:
+    - parametre: snapshots.max_age_days
+      contrainte: au_plus_le_defaut
+    - parametre: snapshots.accepted_states
+      contrainte: sous_ensemble_du_defaut
+```
+
+Four constraint kinds, each naming the side of the default where the promise survives:
+
+| Constraint | Holds while | Relaxing it means |
+|---|---|---|
+| `au_plus_le_defaut` | the value stays at or below the default | a value beyond the default silences what the requirement asked to see |
+| `superset_du_defaut` | the value contains at least the default | dropping a member means no longer checking what the requirement asks |
+| `sous_ensemble_du_defaut` | the value stays within the default | widening means accepting what the requirement rejects |
+| `au_moins_aussi_strict_que_le_defaut` | every requirement of the default profile still has a counterpart at least as strict | a requirement was dropped, or what it accepts was widened |
+
+The last one is what the tagging profile uses, and it is not the same as comparing names.
+The default requires *"the environment question is answered by one of `env`, `environment`,
+`stage`"*. An organisation that writes `environment` accepts **fewer** spellings, so it
+requires more: that is a tightening. Comparing names would have flagged it as relaxed and
+taken away the normative mapping of someone who narrowed their own convention — the most
+expensive false positive there is, because it punishes the right behaviour.
+
+**Tightening is not relaxing.** Requiring one more tag, shortening the window, narrowing the
+accepted states or the accepted spellings: the mapping holds and nothing is reported. The
+constraint does not say *do not touch anything*, it says which side of the default the
+promise survives on.
+
+When the effective configuration falls outside a constraint, the control is **relaxed**, and
+five things happen at once:
+
+1. the result **loses its normative references** in the assessment — it no longer claims to
+   cover CLD-STO-3, CIS 11.2 or ISO A.8.13;
+2. the result carries `labels.config_relaxed`, `labels.config_relaxed_detail` and
+   `labels.references_dropped`;
+3. the evidence (`evidence.observed`, hence the OSCAL) states the relaxation in words;
+4. the terminal prints a `RELAXED CONFIGURATION` block naming the setting, the default, the
+   effective value and the mappings dropped;
+5. `--format json` publishes `config.relaxations` and `config.dropped_references`, and a
+   sealed bundle gains `config.json` plus a `config` entry in its manifest — both covered by
+   `checksums.txt`, so the bundle digest depends on the settings.
+
+The verdict banner changes too, and `--strict` returns exit code `3`. A pipeline that sells
+compliance must not return `0` on a control it lowered itself.
+
+The status does **not** change. The control was genuinely evaluated — against a lower bar. We
+remove the one thing that stopped being true, the mapping, and keep the measurement.
+
+## Setting the blocking threshold for secret detection in CI
+
+Secret detection carries a confidence level on every finding, in `labels.confidence`:
+
+| Level | Basis | Example |
+|---|---|---|
+| `high` | confirmed by its shape | `-----BEGIN … PRIVATE KEY-----` |
+| `medium` | recognized prefix and expected format | `ghp_…`, `AKIA…`, `SCW…`, `glpat-…`, JWT |
+| `low` | generic heuristic | `password=…`, `api_key=…` |
+
+The default is `low`: everything is reported. That is the only defensible default for a
+secret detector — silencing by default what you cannot confirm trades a false positive for a
+false negative, on the one subject where a false negative is paid in a leak.
+
+Triage in CI without changing the scan:
+
+```console
+$ pepin scan scaleway --terraform plan.json --format json \
+  | jq '[.findings[] | select(.labels.check == "compute_instance_no_secrets_in_user_data")
+        | {subject, confidence: .labels.confidence}]'
+```
+
+Make the scan itself quieter — and accept the cost:
+
+```yaml
+controls:
+  secrets:
+    min_confidence: medium   # generic heuristics are no longer reported
+```
+
+This drops the CLD-CMP-9 / SecNumCloud 10.5 mapping, and the report says so. "No cleartext
+secret" cannot be proven once you have chosen not to look at part of what was found.
+
+**The detected value never appears**, at any level. The message interpolates the pattern's
+label only, never what matched — a report travels through SARIF, CI artifacts and sealed
+bundles, and a secret detector that copies the secret into its report turns the report into
+the leak. This is enforced by tests, not by intent.
+
+## What the snapshot control does not prove
+
+`blockstorage_volume_snapshots_exist` measures one thing: does a volume in use have, within
+the configured window, at least one snapshot whose native state says it is completed? The
+state is checked, not just the date — a failed or in-progress snapshot restores nothing.
+
+It does **not** prove:
+
+- that the snapshot is **restorable** — no restore is attempted;
+- that it is **complete** in the application sense (hot databases, multi-volume layouts);
+- that a **retention** is honoured — a single snapshot satisfies the control;
+- that a **backup policy** exists.
+
+A volume backed up by other means — application backup, replication, a provider backup
+service, an external tool — will be reported here. That is an accepted false positive: handle
+it with a dated, justified exemption rather than by disabling the control. This control takes
+no part in any "backup compliant" claim.
+
+It is also **not evaluable on a Terraform plan**: `state` arrives as `after_unknown` and no
+`blockstorage_snapshot` exists in a plan. The scan returns `not-evaluated`, with its reason.
+
+## The configuration travels with the proof
+
+The effective configuration is injected into the evaluated inventory under `config`, exactly
+like `evaluated_at`. It therefore lands in a sealed bundle's `input.json`, and
+`verify --re-derive` replays the same verdict under the same policy without being handed the
+policy file again. A replayed `input.json` keeps its own `config`: replaying never applies
+today's policy to yesterday's dossier.
+
+Which also means a default scan is never silent about its policy: `--format json` always
+publishes `config.policy_digest` and `config.effective`. Two scans separated only by a
+setting cannot carry the same digest.
+
+## See also
+
+- [Exit codes](../reference/exit-codes.md) — including `--strict` and exemptions.
+- [Evidence bundles](evidence-bundles.md) — what is sealed, and how to verify it.
+- [Known limitations](../known-limitations.md) — the blind spots, named.

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -57,7 +57,7 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
 <!-- pepin:gen bundle-manifest -->
 ```json
 {
-  "format": "pepin-assessment-bundle/v2",
+  "format": "pepin-assessment-bundle/v3",
   "inventory_schema": "pepin-inventory/v3",
   "disclaimer": "Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.",
   "generated": "<timestamp>",
@@ -151,6 +151,26 @@ vérificateur le voie avant d'ouvrir quoi que ce soit d'autre.
 bundle parfaitement fidèle serait déclaré falsifié pour la seule raison que le vérificateur ne
 détient pas le fichier de l'opérateur, et une dérogation valide semblerait « expirer » entre le
 scan et la vérification.
+
+### `config.json` : seulement quand un fichier de politique a été donné
+
+Le même principe, un cran plus tôt : un dossier qui ne dit pas **sous quelle exigence** il a
+été rendu n'est pas opposable non plus. Quand un scan reçoit `--policy` (ou un `--exceptions`
+portant une section `controls:`), le bundle porte un artefact qui enregistre la configuration
+effective des contrôles, son empreinte, et chaque **assouplissement** — un réglage sorti de la
+contrainte sous laquelle la correspondance normative d'un contrôle vaut, avec les
+correspondances qu'il a coûtées.
+
+Son empreinte est dans `checksums.txt` elle aussi, donc l'empreinte du bundle **dépend des
+réglages** : un dossier ne peut pas cacher la barre qu'il a abaissée sans échouer à sa propre
+vérification. Le manifeste porte le résumé — `policy_digest`, `relaxed_controls`,
+`dropped_references` — et `relaxed_controls` est la ligne qu'un vérificateur doit lire en
+premier.
+
+La configuration effective voyage également dans `input.json`, à côté de `evaluated_at`. C'est
+ce qui rend `verify --re-derive` fidèle : le rejeu utilise les réglages du jour où le bundle a
+été scellé, jamais ceux d'aujourd'hui. Voir
+[Configurer les contrôles](control-configuration.fr.md).
 
 ## Vérifier un bundle
 

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -58,7 +58,7 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v3",
+  "inventory_schema": "pepin-inventory/v4",
   "disclaimer": "Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -55,7 +55,7 @@ raises a version number and gets a CHANGELOG line.
 <!-- pepin:gen bundle-manifest -->
 ```json
 {
-  "format": "pepin-assessment-bundle/v2",
+  "format": "pepin-assessment-bundle/v3",
   "inventory_schema": "pepin-inventory/v3",
   "disclaimer": "This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.",
   "generated": "<timestamp>",
@@ -148,6 +148,24 @@ opening anything else.
 that, a perfectly faithful bundle would be declared falsified for the sole reason that the
 verifier does not hold the operator's exemptions file, and a valid waiver would appear to
 "expire" between the scan and the verification.
+
+### `config.json` — only when a policy file was given
+
+The same principle, one step earlier: a dossier that does not say **under which requirement**
+it was rendered is not defensible either. When a scan is given `--policy` (or `--exceptions`
+carrying a `controls:` section), the bundle carries an artifact recording the effective
+control configuration, its digest, and every **relaxation** — a setting that fell outside the
+constraint under which a control's normative mapping holds, with the mappings it cost.
+
+Its digest is in `checksums.txt` too, so the bundle digest **depends on the settings**: a
+dossier cannot hide the bar it lowered without failing its own verification. The manifest
+carries the summary — `policy_digest`, `relaxed_controls`, `dropped_references` — and
+`relaxed_controls` is the line a verifier should read first.
+
+The effective configuration also travels inside `input.json`, next to `evaluated_at`. That is
+what makes `verify --re-derive` faithful: the replay uses the settings of the day the bundle
+was sealed, never today's. See
+[Configuring controls](control-configuration.md).
 
 ## Verifying a bundle
 

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -56,7 +56,7 @@ raises a version number and gets a CHANGELOG line.
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v3",
+  "inventory_schema": "pepin-inventory/v4",
   "disclaimer": "This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -334,6 +334,16 @@ dérogation datée plutôt qu'en désactivant le contrôle.
 Ce contrôle ne participe donc à aucune affirmation « sauvegarde conforme ». Son libellé le dit,
 dans les deux langues, et le référentiel le consigne dans la description du contrôle.
 
+### La détection de secrets a des niveaux de confiance, pas des certitudes
+
+Les heuristiques génériques (`password=…`, `api_key=…`) ne distinguent pas
+`password=changeme123456` d'un vrai secret. Chaque finding porte `labels.confidence`
+(`high` | `medium` | `low`) pour qu'un pipeline puisse trier, et le seuil de signalement est
+configurable. Le relever est un assouplissement : « aucun secret en clair » ne se prouve plus
+dès lors qu'on a choisi de ne pas regarder une partie de ce qui a été trouvé, donc la
+correspondance CLD-CMP-9 tombe et le rapport le dit. La valeur détectée, elle, n'apparaît
+jamais, quel que soit le niveau.
+
 ### Un réglage assoupli retire la correspondance, pas la mesure
 
 Un contrôle dont la configuration sort de sa contrainte normative garde son statut : il a bel

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -318,6 +318,15 @@ Un résultat décrit un instant. Pépin n'a ni agent, ni mode veille, ni histori
 continue est un problème d'ordonnancement que vous résolvez en CI, et les bundles scellés sont
 ce que vous conservez.
 
+### Un réglage assoupli retire la correspondance, pas la mesure
+
+Un contrôle dont la configuration sort de sa contrainte normative garde son statut : il a bel
+et bien été évalué, contre une barre plus basse. Ce qu'il perd, ce sont ses `references` — il
+ne prétend plus couvrir CIS, ISO ni SecNumCloud. Pépin ne sait pas vous dire si votre propre
+barre convient à votre contexte ; il sait seulement refuser qu'une barre abaissée conserve un
+badge qu'elle ne mérite plus. Voir
+[Configurer les contrôles](guides/control-configuration.fr.md).
+
 ## 5 : les exigences auxquelles un scanner ne peut pas répondre
 
 Certaines exigences SCSL, SecNumCloud et ISO portent sur l'organisation, les contrats, les

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -318,6 +318,22 @@ Un résultat décrit un instant. Pépin n'a ni agent, ni mode veille, ni histori
 continue est un problème d'ordonnancement que vous résolvez en CI, et les bundles scellés sont
 ce que vous conservez.
 
+### Une snapshot récente n'est pas une politique de sauvegarde
+
+`blockstorage_volume_snapshots_exist` mesure une chose : un volume en usage a-t-il, dans la
+fenêtre configurée (7 jours par défaut), au moins une snapshot dont l'état natif la dit
+terminée ? L'état est vérifié, pas seulement la date.
+
+Il ne prouve pas que la snapshot soit **restaurable** — aucune restauration n'est tentée —,
+qu'elle soit **complète** au sens applicatif, qu'une **rétention** soit respectée (une seule
+snapshot satisfait le contrôle), ni qu'une **politique de sauvegarde** existe. Symétriquement,
+un volume sauvegardé autrement — sauvegarde applicative, réplication, service de backup du
+fournisseur, outil externe — est signalé ici : un faux positif assumé, à traiter par une
+dérogation datée plutôt qu'en désactivant le contrôle.
+
+Ce contrôle ne participe donc à aucune affirmation « sauvegarde conforme ». Son libellé le dit,
+dans les deux langues, et le référentiel le consigne dans la description du contrôle.
+
 ### Un réglage assoupli retire la correspondance, pas la mesure
 
 Un contrôle dont la configuration sort de sa contrainte normative garde son statut : il a bel

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -329,6 +329,15 @@ exemption rather than by disabling the control.
 This control therefore takes no part in any "backup compliant" claim. Its wording says so, in
 both languages, and the reference records it in the control description.
 
+### Secret detection has confidence levels, not certainty
+
+Generic heuristics (`password=…`, `api_key=…`) cannot tell `password=changeme123456` from a
+real secret. Each finding carries `labels.confidence` (`high` | `medium` | `low`) so a
+pipeline can triage, and the reporting threshold is configurable. Raising it is a relaxation:
+"no cleartext secret" cannot be proven once you have chosen not to look at part of what was
+found, so the CLD-CMP-9 mapping is dropped and the report says so. The detected value never
+appears, at any level.
+
 ### A relaxed setting removes the mapping, not the measurement
 
 A control whose configuration falls outside its normative constraint keeps its status: it was

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -313,6 +313,22 @@ is worse than no line at all.
 A result describes an instant. Pépin has no agent, no watch mode and no history. Continuous
 posture is a scheduling problem you solve in CI, and the sealed bundles are what you keep.
 
+### A recent snapshot is not a backup policy
+
+`blockstorage_volume_snapshots_exist` measures one thing: does a volume in use have, within
+the configured window (7 days by default), at least one snapshot whose native state says it is
+completed? The state is checked, not just the date.
+
+It does not prove that the snapshot is **restorable** — no restore is attempted —, that it is
+**complete** in the application sense, that a **retention** is honoured (one snapshot
+satisfies the control), or that a **backup policy** exists at all. Symmetrically, a volume
+backed up by other means — application backup, replication, a provider backup service, an
+external tool — is reported here: an accepted false positive, to be handled with a dated
+exemption rather than by disabling the control.
+
+This control therefore takes no part in any "backup compliant" claim. Its wording says so, in
+both languages, and the reference records it in the control description.
+
 ### A relaxed setting removes the mapping, not the measurement
 
 A control whose configuration falls outside its normative constraint keeps its status: it was

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -313,6 +313,14 @@ is worse than no line at all.
 A result describes an instant. Pépin has no agent, no watch mode and no history. Continuous
 posture is a scheduling problem you solve in CI, and the sealed bundles are what you keep.
 
+### A relaxed setting removes the mapping, not the measurement
+
+A control whose configuration falls outside its normative constraint keeps its status: it was
+genuinely evaluated, against a lower bar. What it loses are its `references` — it no longer
+claims to cover CIS, ISO or SecNumCloud. Pépin cannot tell you whether your own bar is
+appropriate for your context; it can only refuse to let a lowered bar keep a badge it no
+longer earns. See [Configuring controls](guides/control-configuration.md).
+
 ## 5 — requirements a scanner cannot answer
 
 Some SCSL, SecNumCloud and ISO requirements are about organisation, contracts, procedures or

--- a/docs/providers/outscale.fr.md
+++ b/docs/providers/outscale.fr.md
@@ -284,7 +284,7 @@ pepin scan outscale --terraform examples/outscale/terraform/plan.json
   │ CLD-STO-2  │ Image machine partagée publiquement              │ HIGH     │ outscale │ 1 │
   │ CLD-GVN-1  │ Inventaire et étiquetage incomplets              │ MEDIUM   │ outscale │ 1 │
   │ CLD-NET-3  │ Sous-réseau attribuant une IP publique par défa… │ MEDIUM   │ outscale │ 1 │
-  │ CLD-NET-5  │ Réseau non documenté (cartographie non tenue)    │ LOW      │ outscale │ 1 │
+  │ CLD-NET-5  │ Réseau sans étiquettes de cartographie           │ LOW      │ outscale │ 1 │
   ╰────────────┴──────────────────────────────────────────────────┴──────────┴──────────┴───╯
 ──────────────────────────────────────────────────────────────────────────────
  Summary

--- a/docs/providers/outscale.md
+++ b/docs/providers/outscale.md
@@ -278,7 +278,7 @@ pepin scan outscale --terraform examples/outscale/terraform/plan.json
   │ CLD-STO-2  │ Machine image shared publicly                    │ HIGH     │ outscale │ 1 │
   │ CLD-GVN-1  │ Incomplete inventory and tagging                 │ MEDIUM   │ outscale │ 1 │
   │ CLD-NET-3  │ Subnet assigning a public IP by default          │ MEDIUM   │ outscale │ 1 │
-  │ CLD-NET-5  │ Undocumented network (mapping not maintained)    │ LOW      │ outscale │ 1 │
+  │ CLD-NET-5  │ Network without mapping tags                     │ LOW      │ outscale │ 1 │
   ╰────────────┴──────────────────────────────────────────────────┴──────────┴──────────┴───╯
 ──────────────────────────────────────────────────────────────────────────────
  Summary

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -22,7 +22,7 @@ de drapeaux viennent de la surface gelée ; chaque aide ci-dessous est la sortie
 | `pepin provider list` | _(aucun drapeau propre)_ |
 | `pepin provider new` | _(aucun drapeau propre)_ |
 | `pepin provider validate` | _(aucun drapeau propre)_ |
-| `pepin scan` | `--exceptions`, `--format` / `-f`, `--kubeconfig`, `--lang`, `--live`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
+| `pepin scan` | `--exceptions`, `--format` / `-f`, `--kubeconfig`, `--lang`, `--live`, `--policy`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
 | `pepin scsl` | `--index` |
 | `pepin verify` | `--bundle`, `--pubkey`, `--re-derive` |
 | `pepin version` | _(aucun drapeau propre)_ |
@@ -37,10 +37,10 @@ séparément :
 <!-- pepin:gen surface-versions -->
 | Surface | Ce qui est gelé | Version |
 |---|---|:-:|
-| `cli` | verbes, drapeaux et codes de sortie | **v3** |
+| `cli` | verbes, drapeaux et codes de sortie | **v4** |
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
-| `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v2** |
+| `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
 | `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v3** |
 <!-- /pepin:gen surface-versions -->
 
@@ -118,13 +118,14 @@ Flags:
   -h, --help                             help for scan
       --kubeconfig string                chemin d'un kubeconfig pour auditer l'état DANS un cluster Kubernetes (utiliser un accès en LECTURE SEULE, TTL court — jamais cluster-admin)
       --live                             collecter l'inventaire en direct via l'API du provider (identifiants requis)
+      --policy fichier                   fichier YAML de politique : réglages des contrôles (`controls:`) ET dérogations (`exceptions:`) — un seul fichier, nom moderne de --exceptions
   -p, --policy-dir stringArray           répertoire de règles externes (.rego), répétable — chargé sans recompilation
       --profile string                   profil d'identifiants pour la collecte live (ex. ~/.osc/config.json)
       --redact                           caviarder les valeurs sensibles (user-data, policies) de l'input.json du bundle — pour partage à un tiers ; INCOMPATIBLE avec verify --re-derive
       --region string                    région cible pour la collecte live
       --s3-endpoint string               endpoint S3 custom pour le stockage objet (collecte live ; ex. MinIO http://localhost:9000)
       --seal string                      écrire un bundle de preuve opposable (assessment + OSCAL + manifest + checksums) dans ce dossier
-      --strict                           porte CI stricte : code de sortie ≠ 0 si aucun contrôle n'est mesuré (hors gouvernance) ou s'il subsiste un écart medium/low
+      --strict                           porte CI stricte : code de sortie ≠ 0 si aucun contrôle n'est mesuré (hors gouvernance), s'il subsiste un écart medium/low, ou si un réglage assoupli a fait tomber une correspondance normative
   -t, --terraform terraform show -json   auditer un plan Terraform (terraform show -json) au lieu d'un export d'inventaire
 
 Global Flags:

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -41,7 +41,7 @@ séparément :
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v3** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v4** |
 <!-- /pepin:gen surface-versions -->
 
 Un numéro monte à **tout** changement de forme, ajout compris : il signifie « la surface a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -41,7 +41,7 @@ independently:
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v3** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v4** |
 <!-- /pepin:gen surface-versions -->
 
 A version rises on **any** shape change, additions included: the number means "the surface has

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -22,7 +22,7 @@ by running the binary. A public flag that is missing here fails
 | `pepin provider list` | _(no flag of its own)_ |
 | `pepin provider new` | _(no flag of its own)_ |
 | `pepin provider validate` | _(no flag of its own)_ |
-| `pepin scan` | `--exceptions`, `--format` / `-f`, `--kubeconfig`, `--lang`, `--live`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
+| `pepin scan` | `--exceptions`, `--format` / `-f`, `--kubeconfig`, `--lang`, `--live`, `--policy`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
 | `pepin scsl` | `--index` |
 | `pepin verify` | `--bundle`, `--pubkey`, `--re-derive` |
 | `pepin version` | _(no flag of its own)_ |
@@ -37,10 +37,10 @@ independently:
 <!-- pepin:gen surface-versions -->
 | Surface | What is frozen | Version |
 |---|---|:-:|
-| `cli` | verbs, flags and exit codes | **v3** |
+| `cli` | verbs, flags and exit codes | **v4** |
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
-| `bundle` | shape of the evidence bundle (files, roles, manifest) | **v2** |
+| `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
 | `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v3** |
 <!-- /pepin:gen surface-versions -->
 
@@ -117,13 +117,14 @@ Flags:
   -h, --help                             help for scan
       --kubeconfig string                path to a kubeconfig to audit the state INSIDE a Kubernetes cluster (use READ-ONLY, short-lived access — never cluster-admin)
       --live                             collect the inventory live through the provider API (credentials required)
+      --policy file                      policy YAML file: control settings (`controls:`) AND exemptions (`exceptions:`) — one single file, the modern name of --exceptions
   -p, --policy-dir stringArray           directory of external rules (.rego), repeatable — loaded without recompiling
       --profile string                   credentials profile for the live collection (e.g. ~/.osc/config.json)
       --redact                           redact the sensitive values (user-data, policies) from the bundle's input.json — for sharing with a third party; INCOMPATIBLE with verify --re-derive
       --region string                    target region for the live collection
       --s3-endpoint string               custom S3 endpoint for object storage (live collection; e.g. MinIO http://localhost:9000)
       --seal string                      write a defensible evidence bundle (assessment + OSCAL + manifest + checksums) into this directory
-      --strict                           strict CI gate: non-zero exit code if no control is measured (governance aside) or if medium/low deviations remain
+      --strict                           strict CI gate: non-zero exit code if no control is measured (governance aside), if medium/low deviations remain, or if a relaxed setting dropped a normative mapping
   -t, --terraform terraform show -json   audit a Terraform plan (terraform show -json) instead of an inventory export
 
 Global Flags:

--- a/docs/reference/exit-codes.fr.md
+++ b/docs/reference/exit-codes.fr.md
@@ -196,7 +196,16 @@ $ echo $?
 ```
 <!-- /pepin:gen exit-run-strict -->
 
-`--strict` n'ajoute donc qu'un seul comportement : les écarts medium/low deviennent bloquants.
+`--strict` n'ajoute donc que deux comportements, et seulement deux : les écarts medium/low
+deviennent bloquants, et une **correspondance normative tombée sous un réglage assoupli**
+l'est aussi.
+
+Un réglage assoupli est un réglage qui sort de la contrainte sous laquelle la correspondance
+d'un contrôle vaut — une fenêtre de snapshot allongée, une étiquette exigée retirée, un seuil
+de détection de secrets relevé. Le contrôle est toujours évalué, mais contre une barre plus
+basse que l'exigence qu'il cite, donc il ne prétend plus la couvrir. Un pipeline qui vend de
+la conformité ne doit pas rendre `0` sur un contrôle qu'il a lui-même abaissé. Voir
+[Configurer les contrôles](../guides/control-configuration.fr.md).
 Il ne crée pas la porte « rien n'a été mesuré », qui existe sans lui.
 
 ### La collecte n'a pas pu lire tout le périmètre
@@ -428,7 +437,8 @@ Quand plusieurs situations se présentent en même temps, les codes se décident
 4. **3** : la collecte était incomplète, et au moins un contrôle y a perdu son `pass` faute
    d'avoir pu lire la donnée dont il dépend.
 5. **4** : au moins une dérogation a été appliquée.
-6. **3** : `--strict` et des écarts medium/low subsistent, ou le fichier de dérogations est périmé.
+6. **3** : `--strict` et des écarts medium/low subsistent, le fichier de dérogations est
+   périmé, ou un réglage assoupli a fait tomber une correspondance normative.
 7. **0** : aucun des cas ci-dessus.
 
 ## Ce qui ne change pas le code de sortie

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -195,8 +195,16 @@ $ echo $?
 ```
 <!-- /pepin:gen exit-run-strict -->
 
-`--strict` therefore adds one behaviour only: medium/low deviations become blocking. It does
-not create the "nothing measured" gate, which exists without it.
+`--strict` therefore adds two behaviours, and only two: medium/low deviations become
+blocking, and so does a **normative mapping dropped by a relaxed setting**. It does not
+create the "nothing measured" gate, which exists without it.
+
+A relaxed setting is one that falls outside the constraint under which a control's mapping
+holds — a longer snapshot window, a required tag removed, a raised secret-detection
+threshold. The control is still evaluated, but against a lower bar than the requirement it
+cites, so it no longer claims to cover it. A pipeline that sells compliance must not return
+`0` on a control it lowered itself. See
+[Configuring controls](../guides/control-configuration.md).
 
 ### The collection could not read the whole scope
 
@@ -423,7 +431,8 @@ When several situations apply at once, the codes are decided in this order:
 4. **3** — the collection was incomplete: at least one control lost its `pass` because the
    data it needed could not be read.
 5. **4** — at least one exemption was applied.
-6. **3** — `--strict` and medium/low deviations remain, or the exemption file is stale.
+6. **3** — `--strict` and medium/low deviations remain, the exemption file is stale, or a
+   relaxed setting dropped a normative mapping.
 7. **0** — none of the above.
 
 ## What does not change the exit code

--- a/docs/reference/inventory.fr.md
+++ b/docs/reference/inventory.fr.md
@@ -12,7 +12,7 @@ gelée, avec les mêmes égards que la surface CLI.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v3
+pepin-inventory/v4
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -140,7 +140,7 @@ code.
 | `api_access_policy` | `id` `max_access_key_expiration_seconds` `require_trusted_env` |
 | `api_access_rule` | `api_access_rule_id` `ca_ids` `cns` `ip_ranges` |
 | `api_access_summary` | `id` `rule_count` |
-| `blockstorage_snapshot` | `creation_date` `global_permission` `snapshot_id` `volume_id` |
+| `blockstorage_snapshot` | `creation_date` `global_permission` `snapshot_id` `state` `volume_id` |
 | `blockstorage_volume` | `encrypted` `state` `tags` `volume_id` |
 | `compute_image` | `image_id` `public` `state` `tags` |
 | `compute_instance` | `deletion_protection` `nic_public_ips` `public_ip` `security_group_ids` `state` `tags` `user_data` `vm_id` |

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -12,7 +12,7 @@ with the same regard as the CLI surface.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v3
+pepin-inventory/v4
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -133,7 +133,7 @@ descriptors and from the Go collectors — never a hand-kept list beside the cod
 | `api_access_policy` | `id` `max_access_key_expiration_seconds` `require_trusted_env` |
 | `api_access_rule` | `api_access_rule_id` `ca_ids` `cns` `ip_ranges` |
 | `api_access_summary` | `id` `rule_count` |
-| `blockstorage_snapshot` | `creation_date` `global_permission` `snapshot_id` `volume_id` |
+| `blockstorage_snapshot` | `creation_date` `global_permission` `snapshot_id` `state` `volume_id` |
 | `blockstorage_volume` | `encrypted` `state` `tags` `volume_id` |
 | `compute_image` | `image_id` `public` `state` `tags` |
 | `compute_instance` | `deletion_protection` `nic_public_ips` `public_ip` `security_group_ids` `state` `tags` `user_data` `vm_id` |

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -30,7 +30,7 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v3** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v4** |
 <!-- /pepin:gen surface-versions -->
 
 « Gelé » signifie qu'un test échoue quand la forme bouge sans que sa version ait suivi : les

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -26,10 +26,10 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 <!-- pepin:gen surface-versions -->
 | Surface | Ce qui est gelé | Version |
 |---|---|:-:|
-| `cli` | verbes, drapeaux et codes de sortie | **v3** |
+| `cli` | verbes, drapeaux et codes de sortie | **v4** |
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
-| `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v2** |
+| `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
 | `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v3** |
 <!-- /pepin:gen surface-versions -->
 
@@ -114,14 +114,25 @@ Forme gelée : `{"findings": [...], "summary": {...}}`.
 agnostique, commun à tous les fournisseurs. Les deux sont stables d'une langue à l'autre ;
 `title`, `message` et `remediation` sont traduits.
 
-Deux clés additives apparaissent quand elles ont quelque chose à dire, et toutes deux existent
-pour qu'un pipeline lise ce qu'il accepte au lieu de le déduire :
+Trois clés additives se tiennent à côté de `findings` et `summary`, et elles existent pour
+qu'un pipeline lise ce qu'il accepte au lieu de le déduire :
 
-- `exemptions` : présente quand `--exceptions` a été donné (voir ci-dessous) ;
+- `config` : **toujours présente** — l'empreinte de la configuration effective des contrôles,
+  la configuration elle-même, et, quand un réglage sort d'une contrainte normative, les
+  `relaxations` et les `dropped_references` qu'elles coûtent. Un scan par défaut n'est jamais
+  muet sur sa politique : un lecteur doit pouvoir vérifier qu'un scan a bien tourné sous les
+  réglages attendus, pas seulement constater qu'il n'a rien dit. Voir
+  [Configurer les contrôles](../guides/control-configuration.fr.md) ;
+- `exemptions` : présente quand `--exceptions` (ou `--policy`) a fourni des dérogations
+  (voir ci-dessous) ;
 - `collection` : présente quand Pépin a **mesuré** l'inventaire — l'état de chaque unité de
   collecte, et les types de ressources que la source portait sans qu'aucune spec ne les
   projette. Sa forme est décrite dans
   [l'inventaire normalisé](inventory.fr.md#létat-de-collecte).
+
+Un finding de détection de secret porte en outre `labels.confidence` (`high` | `medium` |
+`low`), pour qu'un pipeline trie les heuristiques génériques à part des secrets confirmés sans
+changer le scan. La valeur détectée, elle, n'apparaît jamais, quel que soit le niveau.
 
 **Ce que ce format ne sait pas dire** : il liste des écarts, donc un tableau `findings` vide
 signifie « aucun écart trouvé », ce qui recouvre aussi bien « le tenant est propre » que « rien
@@ -129,6 +140,33 @@ n'a été collecté ». Le booléen `summary.conforme` ne dit rien non plus de l
 cette distinction compte, et pour une porte de conformité elle compte, lire le code de sortie
 (3 signifie que le scan n'établit pas la conformité : rien de mesuré, ou un périmètre lu en
 partie seulement), lire `collection`, ou utiliser le format assessment.
+
+### `config` : toujours présente
+
+```json
+{
+  "config": {
+    "policy_digest": "sha256:…",
+    "effective": { "tagging": { "…": "…" }, "snapshots": { "…": "…" }, "secrets": { "…": "…" } },
+    "relaxations": [
+      {
+        "control": "blockstorage_volume_snapshots_exist",
+        "parameter": "snapshots.max_age_days",
+        "constraint": "au_plus_le_defaut",
+        "default": "7 jours",
+        "effective": "90 jours",
+        "dropped_references": ["scsl:CLD-STO-3", "cis-v8:11.2", "iso-27001:A.8.13", "secnumcloud-3.2:12.5"]
+      }
+    ],
+    "dropped_references": ["cis-v8:11.2", "iso-27001:A.8.13", "scsl:CLD-STO-3", "secnumcloud-3.2:12.5"]
+  }
+}
+```
+
+`relaxations` et `dropped_references` sont absentes sous le profil par défaut. Quand elles
+apparaissent, les résultats correspondants du format `assessment` ont **perdu leurs
+`references`** et portent `labels.config_relaxed` : le contrôle a bien été évalué, mais contre
+une barre plus basse que l'exigence qu'il citait, donc il ne prétend plus la couvrir.
 
 ### `exemptions` : présent seulement avec `--exceptions`
 

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -26,10 +26,10 @@ See [Exit codes](exit-codes.md).
 <!-- pepin:gen surface-versions -->
 | Surface | What is frozen | Version |
 |---|---|:-:|
-| `cli` | verbs, flags and exit codes | **v3** |
+| `cli` | verbs, flags and exit codes | **v4** |
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
-| `bundle` | shape of the evidence bundle (files, roles, manifest) | **v2** |
+| `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
 | `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v3** |
 <!-- /pepin:gen surface-versions -->
 
@@ -114,14 +114,24 @@ Frozen shape: `{"findings": [...], "summary": {...}}`.
 identifier, common to every provider. Both are stable across languages; `title`, `message` and
 `remediation` are translated.
 
-Two additive keys appear when they have something to say, and both exist so a pipeline can
+Three additive keys sit next to `findings` and `summary`, and they exist so a pipeline can
 read what it is accepting rather than infer it:
 
-- `exemptions` — present when `--exceptions` was given: which deviations were waived, by whom,
-  and until when.
+- `config` — **always present**: the digest of the effective control configuration, the
+  configuration itself, and, when a setting falls outside a normative constraint, the
+  `relaxations` and the `dropped_references` they cost. A default scan is never silent about
+  its policy: a reader must be able to verify that a scan ran under the expected settings, not
+  merely observe that it said nothing. See
+  [Configuring controls](../guides/control-configuration.md).
+- `exemptions` — present when `--exceptions` (or `--policy`) supplied waivers: which
+  deviations were waived, by whom, and until when.
 - `collection` — present when Pépin **measured** the inventory: the state of each collection
   unit, and the resource types the source carried that no spec projects. Its shape is described
   in [the normalized inventory](inventory.md#the-collection-state).
+
+A secret-detection finding also carries `labels.confidence` (`high` | `medium` | `low`), so a
+pipeline can triage generic heuristics apart from confirmed secrets without changing the scan.
+The detected value itself never appears, at any level.
 
 **What this format cannot tell you**: it lists deviations, so an empty `findings` array means
 "no deviation found", which covers both "the tenant is clean" and "nothing was collected". The
@@ -129,6 +139,33 @@ read what it is accepting rather than infer it:
 and for a compliance gate it does — read the exit code (3 means the scan does not establish
 compliance: nothing measured, or a scope only partially read), read `collection`, or use the
 assessment format.
+
+### `config` — always present
+
+```json
+{
+  "config": {
+    "policy_digest": "sha256:…",
+    "effective": { "tagging": { "…": "…" }, "snapshots": { "…": "…" }, "secrets": { "…": "…" } },
+    "relaxations": [
+      {
+        "control": "blockstorage_volume_snapshots_exist",
+        "parameter": "snapshots.max_age_days",
+        "constraint": "au_plus_le_defaut",
+        "default": "7 days",
+        "effective": "90 days",
+        "dropped_references": ["scsl:CLD-STO-3", "cis-v8:11.2", "iso-27001:A.8.13", "secnumcloud-3.2:12.5"]
+      }
+    ],
+    "dropped_references": ["cis-v8:11.2", "iso-27001:A.8.13", "scsl:CLD-STO-3", "secnumcloud-3.2:12.5"]
+  }
+}
+```
+
+`relaxations` and `dropped_references` are absent under the default profile. When they appear,
+the matching results in the `assessment` format have **lost their `references`** and carry
+`labels.config_relaxed`: the control was evaluated, but against a lower bar than the
+requirement it used to cite, so it no longer claims to cover it.
 
 ### `exemptions` — present only under `--exceptions`
 

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -30,7 +30,7 @@ See [Exit codes](exit-codes.md).
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v3** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v4** |
 <!-- /pepin:gen surface-versions -->
 
 "Frozen" means a test fails when the shape moves and its version has not: field paths and JSON

--- a/internal/assess/assess.go
+++ b/internal/assess/assess.go
@@ -110,6 +110,12 @@ var requiredAttr = map[string][]string{
 	"network_securitygroup_default_deny": {"inbound_default_policy"},
 	"network_flow_matrix_documented":     {"description"},
 
+	// La cartographie réseau se juge sur les ÉTIQUETTES du réseau. Sans elles, la
+	// règle se tait (garde de capacité) et le contrôle s'affichait « conforme » : le
+	// faux vert exact que l'issue #47 décrit, un contrôle qui valide une conformité
+	// qu'il n'a pas mesurée.
+	"network_documented": {"tags"},
+
 	// Sur un plan Terraform, `state` arrive en after_unknown et aucun
 	// blockstorage_snapshot n'existe : le contrôle ne peut PAS y être évalué,
 	// et s'affichait pourtant vert sur l'exemple livré dans le dépôt.

--- a/internal/assess/bundle.go
+++ b/internal/assess/bundle.go
@@ -27,7 +27,13 @@ import (
 // appliquées ; le bundle gagne l'artefact exemptions.json quand une politique de
 // dérogations a été appliquée. Un dossier qui tait ses exemptions n'est pas
 // opposable, donc elles sont scellées comme le reste.
-const BundleFormat = "pepin-assessment-bundle/v2"
+// v3 : le manifeste porte la CONFIGURATION appliquée — l'empreinte de la
+// politique résolue et, le cas échéant, les assouplissements qui ont fait tomber
+// une correspondance normative ; le bundle gagne l'artefact config.json quand un
+// fichier de politique a été fourni. Un dossier qui tait sous quelle exigence il
+// a été rendu n'est pas opposable : c'est très exactement la porte dérobée vers
+// le vert que la configurabilité ouvrirait sans lui.
+const BundleFormat = "pepin-assessment-bundle/v3"
 
 // ScopeDisclaimer : avertissement de PORTÉE, obligatoire pour l'opposabilité. pepin évalue la
 // configuration d'un TENANT (périmètre commanditaire) ; les référentiels cités (SecNumCloud,
@@ -69,7 +75,25 @@ type Manifest struct {
 	// Exemptions : l'effet des dérogations sur CE dossier. Absent quand aucune
 	// politique n'a été fournie ; jamais silencieux quand il y en a une.
 	Exemptions *ExemptionSummary `json:"exemptions,omitempty"`
-	Artifacts  []Artifact        `json:"artifacts"`
+	// Config : la configuration des contrôles sous laquelle ce dossier a été
+	// rendu. Absente quand aucun fichier de politique n'a été fourni — la
+	// configuration EFFECTIVE, elle, voyage toujours dans input.json, ce qui rend
+	// le dossier re-dérivable dans les deux cas.
+	Config    *ConfigSummary `json:"config,omitempty"`
+	Artifacts []Artifact     `json:"artifacts"`
+}
+
+// ConfigSummary résume, dans le manifeste, sous quels réglages ce dossier a été
+// rendu et ce qu'ils ont fait perdre. Le détail est dans config.json, lui aussi
+// empreint et signé ; ce résumé est ce qu'un vérificateur lit AVANT d'ouvrir le
+// reste — et `relaxed_controls` est la ligne qu'il doit lire en premier.
+type ConfigSummary struct {
+	// PolicyDigest : empreinte de la configuration RÉSOLUE (défauts compris).
+	PolicyDigest string `json:"policy_digest"`
+	// RelaxedControls : les contrôles dont une correspondance normative est tombée.
+	RelaxedControls []string `json:"relaxed_controls,omitempty"`
+	// DroppedReferences : les correspondances abandonnées, `framework:id`.
+	DroppedReferences []string `json:"dropped_references,omitempty"`
 }
 
 // ExemptionSummary résume, dans le manifeste, ce que les dérogations ont changé.
@@ -93,6 +117,10 @@ type BundleExtras struct {
 	Exemptions []byte
 	// ExemptionSummary : son résumé, porté par le manifeste.
 	ExemptionSummary *ExemptionSummary
+	// Config : le document config.json (nil = aucun fichier de politique fourni).
+	Config []byte
+	// ConfigSummary : son résumé, porté par le manifeste.
+	ConfigSummary *ConfigSummary
 }
 
 // Artifact is one file of the bundle with its digest, so any tampering is detectable.
@@ -172,6 +200,16 @@ func WriteBundle(dir string, a assessment.Assessment, inputJSON []byte, extras B
 			data       []byte
 		}{{"input.json", "evaluated-input", inputJSON}}, files...)
 	}
+	if extras.Config != nil {
+		// La configuration APPLIQUÉE fait partie de la preuve, au même titre que les
+		// dérogations : elle entre au bundle, donc au checksums.txt que l'opérateur
+		// signe. Le digest du dossier dépend ainsi des réglages, et un dossier ne
+		// peut pas taire l'assouplissement sous lequel il a été rendu.
+		files = append(files, struct {
+			name, role string
+			data       []byte
+		}{"config.json", "applied-configuration", extras.Config})
+	}
 	if extras.Exemptions != nil {
 		// La dérogation APPLIQUÉE fait partie de la preuve : elle entre au bundle,
 		// donc au checksums.txt que l'opérateur signe. Le digest du dossier dépend
@@ -193,6 +231,7 @@ func WriteBundle(dir string, a assessment.Assessment, inputJSON []byte, extras B
 		Source:          a.Run.Source,
 		Summary:         summaryOf(a),
 		Exemptions:      extras.ExemptionSummary,
+		Config:          extras.ConfigSummary,
 	}
 	var checksums string
 	for _, f := range files {

--- a/internal/assess/relaxation.go
+++ b/internal/assess/relaxation.go
@@ -1,0 +1,86 @@
+package assess
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/stephrobert/scankit/assessment"
+
+	"github.com/stephrobert/pepin/internal/i18n"
+	"github.com/stephrobert/pepin/internal/policy"
+)
+
+// Labels par lesquels un résultat porte l'assouplissement sous lequel il a été
+// rendu. `Result.Labels` est la carte « spécificités produit » du modèle amont :
+// la mention voyage donc jusqu'à `--format assessment`, jusqu'à l'OSCAL et
+// jusqu'au bundle scellé, sans qu'une ligne de scankit ne bouge.
+const (
+	// LabelConfigRelaxed vaut "true" sur tout résultat d'un contrôle assoupli.
+	LabelConfigRelaxed = "config_relaxed"
+	// LabelConfigRelaxedDetail porte les réglages en cause, en clair.
+	LabelConfigRelaxedDetail = "config_relaxed_detail"
+	// LabelReferencesDropped porte les correspondances normatives abandonnées.
+	LabelReferencesDropped = "references_dropped"
+)
+
+// ReferencesOf rend, par contrôle, ses correspondances normatives sous leur forme
+// `framework:id` — la forme qu'un rapport affiche quand il annonce ce qu'un
+// assouplissement fait perdre.
+func ReferencesOf(refs []assessment.Reference) []string {
+	out := make([]string, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, r.Framework+":"+r.ID)
+	}
+	return out
+}
+
+// WithRelaxations retire à chaque contrôle ASSOUPLI ses correspondances
+// normatives, et dit pourquoi.
+//
+// C'est la clé de voûte du modèle de configuration. Un réglage desserré qui
+// continuerait d'afficher « CIS 11.2 » transformerait le rapport en affirmation
+// fausse : le contrôle a bien été évalué, mais contre une barre plus basse que
+// celle de l'exigence citée. On ne touche donc PAS au statut — la mesure a eu
+// lieu, elle reste publiée telle quelle — et on retire la seule chose qui n'est
+// plus vraie : la correspondance.
+//
+// Passe POSTÉRIEURE, comme la provenance et les dérogations : elle n'invente
+// aucun résultat et n'en fait disparaître aucun.
+func WithRelaxations(a assessment.Assessment, relax map[string][]policy.Relaxation) assessment.Assessment {
+	if len(relax) == 0 {
+		return a
+	}
+	res := append([]assessment.Result(nil), a.Results...)
+	for i := range res {
+		rs := relax[res[i].Control]
+		if len(rs) == 0 {
+			continue
+		}
+		dropped := ReferencesOf(res[i].References)
+		res[i].References = nil
+		details := make([]string, 0, len(rs))
+		for _, r := range rs {
+			details = append(details, r.Sentence())
+		}
+		labels := map[string]string{}
+		for k, v := range res[i].Labels {
+			labels[k] = v
+		}
+		labels[LabelConfigRelaxed] = "true"
+		labels[LabelConfigRelaxedDetail] = strings.Join(details, " · ")
+		if len(dropped) > 0 {
+			sort.Strings(dropped)
+			labels[LabelReferencesDropped] = strings.Join(dropped, ", ")
+		}
+		res[i].Labels = labels
+		// La preuve dit ce qu'elle vaut. Un auditeur qui ne lit que l'OSCAL doit
+		// trouver l'assouplissement DANS l'observation, pas seulement dans un label.
+		res[i].Evidence.Observed = strings.TrimSpace(res[i].Evidence.Observed + " " + fmt.Sprintf(i18n.T(
+			"— CONFIGURATION ASSOUPLIE : %s. La correspondance normative de ce contrôle n'est plus tenue.",
+			"— RELAXED CONFIGURATION: %s. This control's normative mapping no longer holds."),
+			strings.Join(details, " · ")))
+	}
+	a.Results = res
+	return a
+}

--- a/internal/commonrules/defaults_test.go
+++ b/internal/commonrules/defaults_test.go
@@ -1,0 +1,161 @@
+package commonrules_test
+
+// Le profil par défaut existe DEUX FOIS : en Go (internal/policy, ce que le scan
+// injecte dans `input.config`) et en Rego (lib.rego, le repli quand aucune
+// configuration n'est présente — `opa test`, une règle externe, ou l'input.json
+// d'une version antérieure).
+//
+// Deux définitions d'une même chose finissent par diverger, et cette divergence-là
+// serait invisible : les règles rendraient un verdict sous un profil, la
+// documentation et les contraintes normatives en décriraient un autre. Ce test
+// mesure l'égalité au lieu de l'affirmer — il évalue les MÊMES inventaires par les
+// DEUX chemins et exige des findings identiques.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stephrobert/scankit/engine"
+
+	"github.com/stephrobert/pepin/internal/commonrules"
+	"github.com/stephrobert/pepin/internal/policy"
+)
+
+// Des inventaires qui exercent les QUATRE contrôles réglables. Les fixtures du
+// dépôt ne portent ni réseau ni volume : s'en contenter ferait passer le test sur
+// la moitié du sujet.
+func inventories() map[string]map[string]any {
+	res := func(rs ...map[string]any) map[string]any {
+		return map[string]any{"evaluated_at": "2026-07-19T12:00:00Z", "resources": rs}
+	}
+	tag := func(k, v string) map[string]any { return map[string]any{"key": k, "value": v} }
+	return map[string]map[string]any{
+		"réseau sans étiquette": res(map[string]any{
+			"provider": "outscale", "type": "network", "id": "n1",
+			"attributes": map[string]any{"name": "prod", "tags": []any{}},
+		}),
+		"réseau à étiquette hors sujet": res(map[string]any{
+			"provider": "outscale", "type": "network", "id": "n1",
+			"attributes": map[string]any{"tags": []any{tag("foo", "bar")}},
+		}),
+		"réseau documenté par alias": res(map[string]any{
+			"provider": "outscale", "type": "network", "id": "n1",
+			"attributes": map[string]any{"tags": []any{tag("Team", "sre"), tag("Project", "p"), tag("Env", "prod")}},
+		}),
+		"ressource facturable sans étiquette": res(map[string]any{
+			"provider": "scaleway", "type": "compute_instance", "id": "i1", "name": "web",
+			"attributes": map[string]any{"tags": []any{}},
+		}),
+		"ressource facturable étiquetée à l'ancienne": res(map[string]any{
+			"provider": "scaleway", "type": "compute_instance", "id": "i1", "name": "web",
+			"attributes": map[string]any{"tags": []any{
+				tag("CostCenter", "cc"), tag("Project", "p"), tag("Env", "prod"), tag("Owner", "sre"),
+			}},
+		}),
+		"base managée sans étiquette": res(map[string]any{
+			"provider": "scaleway", "type": "managed_database", "id": "db1",
+			"attributes": map[string]any{"tags": []any{}},
+		}),
+		"volume sans snapshot": res(map[string]any{
+			"provider": "outscale", "type": "blockstorage_volume", "id": "vol-1",
+			"attributes": map[string]any{"volume_id": "vol-1", "state": "in-use"},
+		}),
+		"volume avec snapshot terminée": res(
+			map[string]any{
+				"provider": "outscale", "type": "blockstorage_volume", "id": "vol-1",
+				"attributes": map[string]any{"volume_id": "vol-1", "state": "in-use"},
+			},
+			map[string]any{
+				"provider": "outscale", "type": "blockstorage_snapshot", "id": "snap-1",
+				"attributes": map[string]any{"volume_id": "vol-1", "creation_date": "2026-07-18T12:00:00Z", "state": "completed"},
+			},
+		),
+		"volume avec snapshot en erreur": res(
+			map[string]any{
+				"provider": "outscale", "type": "blockstorage_volume", "id": "vol-1",
+				"attributes": map[string]any{"volume_id": "vol-1", "state": "in-use"},
+			},
+			map[string]any{
+				"provider": "outscale", "type": "blockstorage_snapshot", "id": "snap-1",
+				"attributes": map[string]any{"volume_id": "vol-1", "creation_date": "2026-07-18T12:00:00Z", "state": "error"},
+			},
+		),
+		"user-data à secret confirmé": res(map[string]any{
+			"provider": "exoscale", "type": "compute_instance", "id": "i1",
+			"attributes": map[string]any{"vm_id": "i1", "user_data": "-----BEGIN RSA PRIVATE KEY-----\nZZZZ\n-----END RSA PRIVATE KEY-----"},
+		}),
+		"user-data à heuristique générique": res(map[string]any{
+			"provider": "exoscale", "type": "compute_instance", "id": "i1",
+			"attributes": map[string]any{"vm_id": "i1", "user_data": "#cloud-config\npassword=hunter2000plus\n"},
+		}),
+	}
+}
+
+// TestTheRegoFallbackProfileEqualsTheGoDefaultProfile : sur chaque inventaire, le
+// jeu de findings est le MÊME avec la configuration Go injectée et sans aucune
+// configuration. C'est la mesure de l'égalité des deux profils par défaut, et
+// c'est aussi ce qui garantit que l'injection de `input.config` n'a, par
+// elle-même, déplacé aucun verdict.
+func TestTheRegoFallbackProfileEqualsTheGoDefaultProfile(t *testing.T) {
+	ctx := context.Background()
+	for name, inv := range inventories() {
+		t.Run(name, func(t *testing.T) {
+			withCfg := map[string]any{}
+			for k, v := range inv {
+				withCfg[k] = v
+			}
+			withCfg["config"] = policy.Defaults()
+
+			bare, err := engine.Evaluate(ctx, inv, commonrules.FS())
+			if err != nil {
+				t.Fatalf("évaluation sans configuration : %v", err)
+			}
+			injected, err := engine.Evaluate(ctx, withCfg, commonrules.FS())
+			if err != nil {
+				t.Fatalf("évaluation avec la configuration par défaut : %v", err)
+			}
+			if a, b := mustJSON(t, bare), mustJSON(t, injected); a != b {
+				t.Errorf("le repli Rego et le profil Go par défaut divergent.\n  sans config : %s\n  avec config : %s", a, b)
+			}
+		})
+	}
+}
+
+// TestTheInjectedConfigurationIsActuallyRead est l'autre moitié : si les règles
+// ignoraient `input.config`, le test ci-dessus serait vert pour la pire des
+// raisons — les deux chemins seraient le même. Une configuration DIFFÉRENTE doit
+// donc produire un résultat différent.
+func TestTheInjectedConfigurationIsActuallyRead(t *testing.T) {
+	ctx := context.Background()
+	inv := inventories()["user-data à heuristique générique"]
+	strict := map[string]any{}
+	for k, v := range inv {
+		strict[k] = v
+	}
+	strict["config"] = policy.Resolve(&policy.Controls{Secrets: &policy.Secrets{MinConfidence: "high"}})
+
+	bare, err := engine.Evaluate(ctx, inv, commonrules.FS())
+	if err != nil {
+		t.Fatalf("évaluation sans configuration : %v", err)
+	}
+	raised, err := engine.Evaluate(ctx, strict, commonrules.FS())
+	if err != nil {
+		t.Fatalf("évaluation à seuil relevé : %v", err)
+	}
+	if len(bare) == 0 {
+		t.Fatal("l'inventaire témoin ne produit aucun finding : le test ne mesure rien")
+	}
+	if len(raised) >= len(bare) {
+		t.Errorf("un seuil de confiance relevé n'a rien changé : les règles ne lisent pas `input.config` (%d → %d findings)", len(bare), len(raised))
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("sérialisation : %v", err)
+	}
+	return string(b)
+}

--- a/internal/commonrules/rules/blockstorage_volume_snapshots_exist.rego
+++ b/internal/commonrules/rules/blockstorage_volume_snapshots_exist.rego
@@ -1,17 +1,41 @@
-# blockstorage_volume_snapshots_exist
-#   Volume block storage en usage sans snapshot récent (< 7 jours) — restauration
-#   après incident non garantie.
+# blockstorage_volume_snapshots_exist — FRAÎCHEUR d'une snapshot de volume.
+#
+# Ce que le contrôle mesure, exactement : un volume en usage a-t-il, dans la
+# fenêtre configurée (par défaut 7 jours), au moins une snapshot dont l'état natif
+# la dit TERMINÉE ?
+#
+# Ce que le contrôle ne prouve PAS, et il faut le lire avant de s'en servir :
+#   · que la snapshot soit RESTAURABLE — aucune restauration n'est tentée ;
+#   · qu'elle soit COMPLÈTE au sens applicatif (bases à chaud, volumes multiples) ;
+#   · qu'une RÉTENTION soit respectée — une seule snapshot suffit à le satisfaire ;
+#   · qu'une POLITIQUE DE SAUVEGARDE existe. Un volume peut être parfaitement
+#     sauvegardé autrement (sauvegarde applicative, réplication, service de backup
+#     du fournisseur, outil externe) et être signalé ici : c'est un faux positif
+#     assumé, qui se traite par une dérogation datée et justifiée, jamais en
+#     désactivant le contrôle.
+# Autrement dit : ce contrôle ne participe pas à une affirmation « sauvegarde
+# conforme ». Il mesure une fraîcheur, et il ne dit que ça.
+#
+# Le CODE n'est PAS renommé en `blockstorage_recent_snapshot_exists` : il voyage
+# dans les `ruleId` SARIF, dans les assessments archivés et dans les fichiers de
+# dérogations, où un renommage transformerait du jour au lendemain une dérogation
+# valide en dérogation orpheline, et ferait réapparaître l'écart qu'elle couvrait.
+# C'est le TITRE, la description et le message qui disent désormais la vérité.
+#
+# Non évaluable sur un plan Terraform : `state` y arrive en `after_unknown` et
+# aucun `blockstorage_snapshot` n'y figure — d'où le verrou `requiredAttr`.
+#
 # Origine : osc-policy OSC-VOL-006. SCSL : CLD-STO-3.
-# Contrat : types normalisés agnostiques `blockstorage_volume` (volume_id, state)
-#   et `blockstorage_snapshot` (volume_id, creation_date RFC3339/ISO 8601).
-#   État « en usage » normalisé via volume_in_use (Outscale `in-use`, Exoscale
-#   `attached`, cf. lib.rego). Sources : OAPI Volume.State ; egoscale/v3
-#   block-storage-volume.state + block-storage-snapshot (block-storage-volume ref, created-at).
+# Contrat : types normalisés `blockstorage_volume` (volume_id, state) et
+#   `blockstorage_snapshot` (volume_id, creation_date RFC3339/ISO 8601, state).
+#   « En usage » normalisé via volume_in_use (Outscale `in-use`, Exoscale
+#   `attached`, cf. lib.rego). Sources : OAPI Volume.State / Snapshot.State
+#   (in-queue|pending|completed|error|deleting) ; egoscale/v3
+#   block-storage-volume.state + block-storage-snapshot (block-storage-volume
+#   ref, created-at, state ∈ …|creating|created|promoting|error|…).
 package pepin.rules
 
 import rego.v1
-
-_recent_window_ns := ((7 * 24) * 3600) * 1000000000
 
 deny contains f if {
 	some v in resources_of_type("blockstorage_volume")
@@ -22,22 +46,43 @@ deny contains f if {
 		"code": "blockstorage_volume_snapshots_exist",
 		"severity": "high",
 		"subject": vid,
-		"message": sprintf("Volume « %s » (en usage) sans snapshot dans les 7 derniers jours.", [vid]),
-		"remediation": "Mettre en place un snapshot régulier automatisé ; tester la restauration périodiquement.",
+		"message": sprintf("Volume « %s » (en usage) sans snapshot terminée depuis moins de %d jours.", [vid, snapshot_max_age_days]),
+		"remediation": "Mettre en place un snapshot régulier automatisé ; tester la restauration périodiquement. Si ce volume est sauvegardé autrement, poser une dérogation datée et justifiée plutôt que de désactiver le contrôle.",
 		"labels": {
 			"provider": provider_of(v),
 			"category": "compliance",
-			"message_en": sprintf("Volume \"%s\" (in use) has no snapshot in the last 7 days.", [vid]),
-			"remediation_en": "Set up an automated, regular snapshot schedule; test the restore periodically.",
+			"message_en": sprintf("Volume \"%s\" (in use) has no completed snapshot younger than %d days.", [vid, snapshot_max_age_days]),
+			"remediation_en": "Set up an automated, regular snapshot schedule; test the restore periodically. If this volume is backed up by other means, file a dated, justified exemption rather than disabling the control.",
 		},
 	}
 }
 
+# _has_recent_snapshot — une snapshot du volume, dans la fenêtre ET dans un état
+# exploitable. L'état est vérifié, pas seulement la date : une snapshot `error`,
+# `creating` ou `deleting` ne restaure rien, et la compter reviendrait à rendre
+# vert sur une sauvegarde qui n'existe pas.
 _has_recent_snapshot(vid) if {
 	some s in resources_of_type("blockstorage_snapshot")
 	object.get(s.attributes, "volume_id", "") == vid
+	_snapshot_usable(s)
 	date := object.get(s.attributes, "creation_date", "")
 	is_string(date)
 	date != ""
-	_eval_now_ns - time.parse_rfc3339_ns(date) <= _recent_window_ns
+	_eval_now_ns - time.parse_rfc3339_ns(date) <= snapshot_max_age_ns
+}
+
+# _snapshot_usable — l'état de la snapshot est ACCEPTÉ. Deux cas, et le second
+# est une garde de capacité, pas une complaisance : quand le collecteur n'a pas
+# projeté `state` (source qui ne l'expose pas), on ne SAIT pas si la snapshot est
+# terminée. Inventer « inexploitable » ferait un faux positif sur une sauvegarde
+# réelle ; ce qui manque se dit ailleurs, par le verrou d'attribut de l'assessment.
+_snapshot_usable(s) if object.get(s.attributes, "state", "") in snapshot_accepted_states
+
+_snapshot_usable(s) if not _snapshot_state_collected(s)
+
+_snapshot_state_collected(s) if {
+	"state" in object.keys(s.attributes)
+	st := object.get(s.attributes, "state", "")
+	is_string(st)
+	st != ""
 }

--- a/internal/commonrules/rules/blockstorage_volume_snapshots_exist_test.rego
+++ b/internal/commonrules/rules/blockstorage_volume_snapshots_exist_test.rego
@@ -1,0 +1,91 @@
+package pepin.rules
+
+import rego.v1
+
+# Un instant d'évaluation FIGÉ dans tous les cas : une fenêtre de fraîcheur testée
+# contre l'horloge de la machine est un test qui change de verdict à minuit.
+_now := "2026-07-19T12:00:00Z"
+
+_vol_and_snap(snapAttrs) := {
+	"evaluated_at": _now,
+	"resources": [
+		{"provider": "outscale", "type": "blockstorage_volume", "id": "vol-1", "attributes": {"volume_id": "vol-1", "state": "in-use"}},
+		{"provider": "outscale", "type": "blockstorage_snapshot", "id": "snap-1", "attributes": snapAttrs},
+	],
+}
+
+_snapshot_findings := {f | some f in deny; f.code == "blockstorage_volume_snapshots_exist"}
+
+# ✗ ÉTAT VÉRIFIÉ, PAS SEULEMENT LA DATE : une snapshot d'hier, mais en `error`,
+# ne restaure rien. La compter reviendrait à rendre vert sur une sauvegarde qui
+# n'existe pas (issue #49). État natif Outscale : Snapshot.State.
+test_snapshot_in_error_does_not_count if {
+	some f in deny with input as _vol_and_snap({"volume_id": "vol-1", "creation_date": "2026-07-18T12:00:00Z", "state": "error"})
+	f.code == "blockstorage_volume_snapshots_exist"
+}
+
+# ✗ … de même pour une snapshot ENCORE EN COURS (`pending`) : elle n'est pas une
+# sauvegarde tant qu'elle n'est pas terminée.
+test_snapshot_pending_does_not_count if {
+	some f in deny with input as _vol_and_snap({"volume_id": "vol-1", "creation_date": "2026-07-18T12:00:00Z", "state": "pending"})
+	f.code == "blockstorage_volume_snapshots_exist"
+}
+
+# ✓ état `completed` (Outscale) dans la fenêtre → la snapshot compte.
+test_snapshot_completed_counts if {
+	count(_snapshot_findings) == 0 with input as _vol_and_snap({"volume_id": "vol-1", "creation_date": "2026-07-18T12:00:00Z", "state": "completed"})
+}
+
+# ✓ état `created` (Exoscale, block-storage-snapshot.state) dans la fenêtre.
+test_snapshot_created_counts if {
+	count(_snapshot_findings) == 0 with input as _vol_and_snap({"volume_id": "vol-1", "creation_date": "2026-07-18T12:00:00Z", "state": "created"})
+}
+
+# ✓ GARDE DE CAPACITÉ : `state` non collecté → la snapshot compte quand même.
+# Inventer « inexploitable » ferait un faux positif sur une sauvegarde réelle ;
+# c'est le verrou d'attribut de l'assessment qui dit ce qui n'a pas été lu.
+test_snapshot_state_not_collected_still_counts if {
+	count(_snapshot_findings) == 0 with input as _vol_and_snap({"volume_id": "vol-1", "creation_date": "2026-07-18T12:00:00Z"})
+}
+
+# ✗ DÉLAI CONFIGURABLE, sens du DURCISSEMENT : une fenêtre d'un jour refuse une
+# snapshot vieille de trois jours que le défaut acceptait.
+test_configured_shorter_window_denies if {
+	inv := object.union(
+		_vol_and_snap({"volume_id": "vol-1", "creation_date": "2026-07-16T12:00:00Z", "state": "completed"}),
+		{"config": {"snapshots": {"max_age_days": 1, "accepted_states": ["completed", "created"]}}},
+	)
+	some f in deny with input as inv
+	f.code == "blockstorage_volume_snapshots_exist"
+	contains(f.message, "1 jours")
+}
+
+# ✓ DÉLAI CONFIGURABLE, sens de l'ASSOUPLISSEMENT : une fenêtre de trente jours
+# accepte une snapshot vieille de vingt jours. Le verdict change, et c'est
+# précisément pour cela que le référentiel adosse la correspondance CLD-STO-3 à
+# `snapshots.max_age_days: au_plus_le_defaut` — le rapport dira que la
+# correspondance n'est plus tenue.
+test_configured_longer_window_passes if {
+	inv := object.union(
+		_vol_and_snap({"volume_id": "vol-1", "creation_date": "2026-06-29T12:00:00Z", "state": "completed"}),
+		{"config": {"snapshots": {"max_age_days": 30, "accepted_states": ["completed", "created"]}}},
+	)
+	count(_snapshot_findings) == 0 with input as inv
+}
+
+# ✓ ÉTATS ACCEPTÉS CONFIGURABLES : une politique qui accepte `promoting` compte
+# une snapshot dans cet état. Élargir l'ensemble est un assouplissement
+# (`accepted_states: sous_ensemble_du_defaut`), et il est signalé comme tel.
+test_configured_accepted_states if {
+	inv := object.union(
+		_vol_and_snap({"volume_id": "vol-1", "creation_date": "2026-07-18T12:00:00Z", "state": "promoting"}),
+		{"config": {"snapshots": {"max_age_days": 7, "accepted_states": ["completed", "created", "promoting"]}}},
+	)
+	count(_snapshot_findings) == 0 with input as inv
+}
+
+# ✗ une snapshot d'un AUTRE volume ne sauve pas celui-ci.
+test_snapshot_of_another_volume_does_not_count if {
+	some f in deny with input as _vol_and_snap({"volume_id": "vol-9", "creation_date": "2026-07-18T12:00:00Z", "state": "completed"})
+	f.code == "blockstorage_volume_snapshots_exist"
+}

--- a/internal/commonrules/rules/compute_instance_no_secrets_confidence_test.rego
+++ b/internal/commonrules/rules/compute_instance_no_secrets_confidence_test.rego
@@ -1,0 +1,110 @@
+package pepin.rules
+
+import rego.v1
+
+_ud_vm(userdata) := {"resources": [{
+	"provider": "outscale",
+	"type": "compute_instance",
+	"id": "i-1",
+	"attributes": {"vm_id": "i-1", "user_data": userdata},
+}]}
+
+_ud_vm_with(userdata, cfg) := object.union(_ud_vm(userdata), {"config": {"secrets": cfg}})
+
+_secret_findings := {f | some f in deny; f.code == "compute_instance_no_secrets_in_user_data"}
+
+# La VALEUR d'un secret, telle qu'elle ne doit JAMAIS ressortir. Les trois
+# niveaux sont représentés : la propriété ne dépend pas de la confiance.
+_pem := "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAxTOP53CRET53CRET53CRET\n-----END RSA PRIVATE KEY-----"
+
+_token := "ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+_weak := "password=hunter2000plus"
+
+# ── Le niveau voyage avec la détection ───────────────────────────────────────
+
+# ✗ bloc PEM → confiance HIGH (secret confirmé par sa forme).
+test_private_key_is_high_confidence if {
+	some f in deny with input as _ud_vm(_pem)
+	f.code == "compute_instance_no_secrets_in_user_data"
+	f.labels.confidence == "high"
+}
+
+# ✗ jeton de forge à préfixe reconnu → confiance MEDIUM.
+test_prefixed_token_is_medium_confidence if {
+	some f in deny with input as _ud_vm(_token)
+	f.code == "compute_instance_no_secrets_in_user_data"
+	f.labels.confidence == "medium"
+}
+
+# ✗ heuristique générique → confiance LOW.
+test_generic_password_is_low_confidence if {
+	some f in deny with input as _ud_vm(_weak)
+	f.code == "compute_instance_no_secrets_in_user_data"
+	f.labels.confidence == "low"
+}
+
+# ── LA VALEUR NE SORT JAMAIS, quel que soit le niveau ────────────────────────
+#
+# C'est la propriété la plus coûteuse à perdre : un rapport voyage en SARIF, dans
+# les artefacts de CI et dans un bundle scellé. Elle est donc testée aux trois
+# niveaux, sur le message ET sur la remédiation, français et anglais.
+
+test_secret_value_never_leaks_high if {
+	every f in _secret_findings {
+		not contains(f.message, "MIIEowIBAAKCAQEA")
+		not contains(f.remediation, "MIIEowIBAAKCAQEA")
+		not contains(f.labels.message_en, "MIIEowIBAAKCAQEA")
+		not contains(f.labels.remediation_en, "MIIEowIBAAKCAQEA")
+	}
+		with input as _ud_vm(_pem)
+}
+
+test_secret_value_never_leaks_medium if {
+	every f in _secret_findings {
+		not contains(f.message, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+		not contains(f.labels.message_en, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	}
+		with input as _ud_vm(_token)
+}
+
+test_secret_value_never_leaks_low if {
+	every f in _secret_findings {
+		not contains(f.message, "hunter2000plus")
+		not contains(f.labels.message_en, "hunter2000plus")
+	}
+		with input as _ud_vm(_weak)
+}
+
+# ── Le SEUIL est réglable, et il ne l'est que dans un sens visible ───────────
+
+# ✓ seuil `medium` : l'heuristique générique se tait. C'est l'assouplissement que
+# le référentiel adosse à `secrets.min_confidence: au_plus_le_defaut` — le
+# rapport dira que la correspondance CLD-CMP-9 n'est plus tenue.
+test_threshold_medium_silences_low if {
+	count(_secret_findings) == 0 with input as _ud_vm_with(_weak, {"min_confidence": "medium"})
+}
+
+# ✗ … mais il ne tait PAS ce qui l'atteint : un jeton reconnu passe toujours.
+test_threshold_medium_keeps_medium if {
+	some f in deny with input as _ud_vm_with(_token, {"min_confidence": "medium"})
+	f.code == "compute_instance_no_secrets_in_user_data"
+}
+
+# ✓ seuil `high` : seul un secret confirmé subsiste.
+test_threshold_high_silences_medium if {
+	count(_secret_findings) == 0 with input as _ud_vm_with(_token, {"min_confidence": "high"})
+}
+
+test_threshold_high_keeps_high if {
+	some f in deny with input as _ud_vm_with(_pem, {"min_confidence": "high"})
+	f.code == "compute_instance_no_secrets_in_user_data"
+}
+
+# ✗ DÉFAUT INCHANGÉ : sans configuration, `low` — donc tout est signalé, comme
+# avant ce lot. Un réglage qui change le comportement par défaut n'est pas un
+# réglage, c'est un changement de contrôle déguisé.
+test_default_threshold_reports_everything if {
+	some f in deny with input as _ud_vm(_weak)
+	f.code == "compute_instance_no_secrets_in_user_data"
+}

--- a/internal/commonrules/rules/compute_instance_no_secrets_in_user_data.rego
+++ b/internal/commonrules/rules/compute_instance_no_secrets_in_user_data.rego
@@ -1,6 +1,41 @@
 # compute_instance_no_secrets_in_user_data
 #   Secret en clair détecté dans les données utilisateur (user-data) d'une VM :
 #   un accès aux métadonnées ou un SSRF peut l'exfiltrer.
+#
+# # NIVEAUX DE CONFIANCE (issue #48)
+#
+# Chaque motif porte son niveau, et le finding le publie (`labels.confidence`) :
+#
+#   high   — secret CONFIRMÉ par sa forme : un bloc PEM `-----BEGIN … PRIVATE KEY-----`
+#            n'est pas autre chose qu'une clé privée ;
+#   medium — secret PROBABLE : préfixe reconnu ET format attendu (AKIA…, SCW…,
+#            EXO…, ghp_…, glpat-…, JWT à trois segments) ;
+#   low    — SUSPECT : heuristique générique (`password=…`, `api_key=…`), qui ne
+#            distingue pas `password=changeme123456` d'un vrai secret.
+#
+# Pourquoi ça compte : donner à `password=…` le même poids qu'une clé privée rend
+# l'outil irritant en CI, et un outil irritant finit désactivé — ce qui coûte plus
+# cher que le faux positif qu'on voulait éviter. Le seuil est donc RÉGLABLE
+# (`secrets.min_confidence`, défaut `low` = tout signaler, le comportement
+# d'avant). Le monter est un ASSOUPLISSEMENT : le référentiel adosse la
+# correspondance CLD-CMP-9 à `secrets.min_confidence: au_plus_le_defaut`, et un
+# seuil plus haut la fait tomber, visiblement.
+#
+# Le niveau voyage dans `labels.confidence`, PAS dans le message. Deux raisons :
+# le message d'un contrôle est une surface que des captures, des tickets et des
+# annotations de forge recopient — le déplacer d'un octet pour une information
+# structurée serait le payer partout —, et un niveau est fait pour être FILTRÉ
+# (`jq '.findings[] | select(.labels.confidence == "low")'`), pas lu au milieu
+# d'une phrase. Le rendu par défaut n'a donc pas bougé d'un caractère.
+#
+# # LA VALEUR DÉTECTÉE NE SORT JAMAIS
+#
+# Le message n'interpole que le LIBELLÉ du motif, jamais ce qui a matché — quel
+# que soit le niveau. Un détecteur de secrets qui recopie le secret dans son
+# rapport transforme le rapport en fuite, et ce rapport voyage en SARIF, dans les
+# artefacts de CI et dans un bundle scellé. La propriété est TESTÉE
+# (`test_secret_value_never_leaks_*`), pas seulement écrite ici.
+#
 # SCSL : CLD-CMP-9 (aucun secret en clair dans les user-data).
 # Contrat : type normalisé agnostique `compute_instance` ; attribut user_data
 #   (string ; osc-sdk-go Vm.UserData renvoyé en base64 par l'API).
@@ -13,6 +48,7 @@ deny contains f if {
 	raw := _user_data(vm.attributes)
 	raw != ""
 	some pattern in _secret_patterns(raw)
+	meets_confidence(pattern.confidence)
 	id := object.get(vm.attributes, "vm_id", vm.id)
 	f := {
 		"code": "compute_instance_no_secrets_in_user_data",
@@ -23,6 +59,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(vm),
 			"category": "security",
+			"confidence": pattern.confidence,
 			"message_en": sprintf("VM \"%s\": cleartext secret in user-data (%s).", [id, pattern.en]),
 			"remediation_en": "Ban secrets from user data; use a secrets vault and inject them at boot. Revoke the exposed secret.",
 		},
@@ -64,47 +101,60 @@ _is_base64(s) if {
 }
 
 # _secret_regexes : motifs de détection, chacun avec son LIBELLÉ dans les deux
-# langues. Le libellé est interpolé dans le message du finding : le garder
-# monolingue produirait une phrase anglaise à moitié française, exactement ce que
-# l'internationalisation corrige. La clé de la carte est le libellé français
-# (langue de référence) ; `en` en est la traduction, `re` le motif.
+# langues et son NIVEAU DE CONFIANCE. Le libellé est interpolé dans le message du
+# finding : le garder monolingue produirait une phrase anglaise à moitié
+# française, exactement ce que l'internationalisation corrige. La clé de la carte
+# est le libellé français (langue de référence) ; `en` en est la traduction, `re`
+# le motif, `confidence` ce que la détection vaut.
 _secret_regexes := {
-	# Clés d'accès cloud, y compris SOUVERAINES (préfixes documentés).
+	# Clés d'accès cloud, y compris SOUVERAINES (préfixes documentés). PRÉFIXE
+	# RECONNU + FORMAT ATTENDU : probable, pas confirmé — une documentation peut
+	# citer un exemple de clé.
 	"clé d'accès Outscale (format AKIA…)": {
 		"en": "Outscale access key (AKIA… format)",
 		"re": `AKIA[0-9A-Z]{16}`,
+		"confidence": "medium",
 	},
 	"clé d'accès Scaleway (SCW…)": {
 		"en": "Scaleway access key (SCW…)",
 		"re": `SCW[A-Z0-9]{17,}`,
+		"confidence": "medium",
 	},
 	"clé d'accès Exoscale (EXO…)": {
 		"en": "Exoscale access key (EXO…)",
 		"re": `EXO[A-Za-z0-9]{16,}`,
+		"confidence": "medium",
 	},
 	# Jetons de forge / d'identité fréquemment collés dans le user-data.
 	"jeton GitHub": {
 		"en": "GitHub token",
 		"re": `(gh[pousr]_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{22,})`,
+		"confidence": "medium",
 	},
 	"jeton GitLab (glpat-)": {
 		"en": "GitLab token (glpat-)",
 		"re": `glpat-[A-Za-z0-9_-]{20}`,
+		"confidence": "medium",
 	},
 	"jeton JWT": {
 		"en": "JWT token",
 		"re": `eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}`,
+		"confidence": "medium",
 	},
 	"en-tête Authorization Bearer": {
 		"en": "Authorization Bearer header",
 		"re": `(?i)authorization\s*:\s*bearer\s+[A-Za-z0-9._-]{12,}`,
+		"confidence": "medium",
 	},
 	# Affectation de mot de passe EN CLAIR. La valeur doit suivre le séparateur SUR LA MÊME
 	# LIGNE (>=4 caractères non blancs) : évite le faux positif sur les blocs cloud-init
 	# `chpasswd:` / `password:` suivis d'un bloc YAML (la valeur passe alors à la ligne).
+	# HEURISTIQUE GÉNÉRIQUE : elle ne distingue pas un vrai mot de passe d'un
+	# `password=changeme` de gabarit → `low`.
 	"mot de passe en clair": {
 		"en": "cleartext password",
 		"re": `(?i)(password|passwd|pwd)[ \t]*[:=][ \t]*['"]?[^\s'"]{4,}`,
+		"confidence": "low",
 	},
 	# Bloc cloud-init `chpasswd` : la façon la PLUS courante de poser un mot de passe.
 	# La valeur est sur une ligne indentée `utilisateur:motdepasse` — sans espace après
@@ -112,23 +162,28 @@ _secret_regexes := {
 	"mot de passe cloud-init (chpasswd)": {
 		"en": "cloud-init password (chpasswd)",
 		"re": `(?i)chpasswd:[\s\S]{0,300}?\n[ \t]+[A-Za-z0-9_.-]+:[^\s]{6,}`,
+		"confidence": "low",
 	},
 	"clé/API générique affectée": {
 		"en": "generic key/API assignment",
 		"re": `(?i)(api[_-]?key|secret[_-]?key|access[_-]?key|secret[_-]?access[_-]?key|auth[_-]?token|api[_-]?token)\s*[:=]\s*['"]?[A-Za-z0-9/+._-]{16,}`,
+		"confidence": "low",
 	},
 }
 
 # _secret_patterns — ENSEMBLE des types de secrets détectés (un user-data peut en
 # cumuler plusieurs : clé d'accès ET mot de passe…). Un set évite le conflit d'une
 # fonction single-value à clauses non exclusives. Chaque élément porte le libellé
-# dans les deux langues (`fr`, `en`).
+# dans les deux langues (`fr`, `en`) et son niveau (`confidence`) — jamais la
+# valeur qui a matché.
 _secret_patterns(s) := patterns if {
-	by_regex := {{"fr": label, "en": spec.en} |
+	by_regex := {{"fr": label, "en": spec.en, "confidence": spec.confidence} |
 		some label, spec in _secret_regexes
 		regex.match(spec.re, s)
 	}
-	private_key := {{"fr": "bloc PRIVATE KEY", "en": "PRIVATE KEY block"} |
+
+	# Un bloc PEM est un secret CONFIRMÉ : sa forme ne laisse pas de place au doute.
+	private_key := {{"fr": "bloc PRIVATE KEY", "en": "PRIVATE KEY block", "confidence": "high"} |
 		contains(s, "BEGIN ")
 		contains(s, "PRIVATE KEY")
 	}

--- a/internal/commonrules/rules/governance_resource_required_tags.rego
+++ b/internal/commonrules/rules/governance_resource_required_tags.rego
@@ -1,23 +1,35 @@
 # governance_resource_required_tags — COMMUN à tous les providers.
-#   Ressource facturable sans les étiquettes de gouvernance obligatoires
-#   (CostCenter, Project, Env, Owner) — inventaire et responsabilité non tenus.
-# SCSL : CLD-GVN-1. S'applique aux types normalisés facturables ; attribut tags[]
-#   ({key,value}). required_tags défini dans lib.rego.
+#
+# Ce que la règle vérifie : une ressource FACTURABLE porte les étiquettes de
+# gouvernance exigées par la politique d'étiquetage (`tagging.required_tags`),
+# par défaut centre de coût, projet, environnement et propriétaire.
+#
+# La politique est CONFIGURABLE, et elle ne l'est pas par confort. Le profil par
+# défaut est une RECOMMANDATION, pas une norme : une organisation parfaitement
+# gouvernée peut écrire `cost-center, application, environment, team` là où le
+# profil dit `cost-center, project, environment, owner`, et récolter un FAIL sur
+# une convention d'écriture. La comparaison est donc insensible à la casse et aux
+# séparateurs (`cost-center` ≡ `CostCenter`), et les alias élargissent chaque nom
+# logique. Ce qui est exigé, ce sont les QUESTIONS auxquelles un inventaire doit
+# répondre — qui paye, pour quoi, à quel stade, qui répond —, jamais les mots.
+#
+# Les TYPES visés sont eux aussi explicites (`tagging.resource_types`) : le
+# critère est « facturable et étiquetable », et le détail de ce qui est inclus,
+# de ce qui est exclu et pourquoi vit dans internal/policy (defaultTaggedTypes).
+#
+# SCSL : CLD-GVN-1. Attribut lu : tags[] ({key,value}).
 package pepin.rules
 
 import rego.v1
 
-_billable_types := {"compute_instance", "blockstorage_volume", "load_balancer", "object_storage_bucket"}
-
 deny contains f if {
 	some r in input.resources
-	r.type in _billable_types
+	r.type in tagged_resource_types
 	"tags" in object.keys(r.attributes) # garde de capacité : le provider EXPOSE les étiquettes
 
 	# (sinon, un provider qui ne collecte pas les tags — ex. Exoscale live — déclencherait un
 	# finding « 4 étiquettes manquantes » sur CHAQUE ressource : tempête de faux positifs).
-	tags := object.get(r.attributes, "tags", [])
-	missing := [t | some t in required_tags; not has_tag(tags, t)]
+	missing := missing_required_tags(object.get(r.attributes, "tags", []), required_tags_billable)
 	count(missing) > 0
 	name := object.get(r, "name", r.id)
 	f := {
@@ -25,12 +37,12 @@ deny contains f if {
 		"severity": "medium",
 		"subject": name,
 		"message": sprintf("Ressource « %s » : étiquettes de gouvernance manquantes (%s).", [name, concat(", ", missing)]),
-		"remediation": "Ajouter les étiquettes obligatoires (CostCenter, Project, Env, Owner) sur la ressource.",
+		"remediation": sprintf("Ajouter les étiquettes obligatoires (%s) sur la ressource.", [required_tags_label(required_tags_billable)]),
 		"labels": {
 			"provider": provider_of(r),
 			"category": "compliance",
 			"message_en": sprintf("Resource \"%s\": governance tags missing (%s).", [name, concat(", ", missing)]),
-			"remediation_en": "Add the mandatory tags (CostCenter, Project, Env, Owner) to the resource.",
+			"remediation_en": sprintf("Add the mandatory tags (%s) to the resource.", [required_tags_label(required_tags_billable)]),
 		},
 	}
 }

--- a/internal/commonrules/rules/governance_resource_required_tags_test.rego
+++ b/internal/commonrules/rules/governance_resource_required_tags_test.rego
@@ -1,0 +1,105 @@
+package pepin.rules
+
+import rego.v1
+
+_tagged(typ, tags) := {"resources": [{
+	"provider": "scaleway",
+	"type": typ,
+	"id": "r1",
+	"name": "web",
+	"attributes": {"tags": tags},
+}]}
+
+_gvn_count := {f | some f in deny; f.code == "governance_resource_required_tags"}
+
+_full := [
+	{"key": "CostCenter", "value": "cc-1"},
+	{"key": "Project", "value": "billing"},
+	{"key": "Env", "value": "prod"},
+	{"key": "Owner", "value": "sre"},
+]
+
+# ✓ NON-RÉGRESSION : les quatre étiquettes historiques (CostCenter, Project, Env,
+# Owner) satisfont toujours le profil par défaut. C'est la propriété qui garantit
+# qu'ouvrir la politique à la configuration n'a déplacé aucun verdict.
+test_historic_tag_names_still_pass if {
+	count(_gvn_count) == 0 with input as _tagged("compute_instance", _full)
+}
+
+# ✓ FAUX POSITIF CORRIGÉ : une organisation qui écrit `cost-center, application,
+# environment, team` est gouvernée, et ne doit plus récolter un FAIL sur sa
+# convention d'écriture (issue #61).
+test_other_writing_conventions_pass if {
+	count(_gvn_count) == 0 with input as _tagged("compute_instance", [
+		{"key": "cost-center", "value": "cc-1"},
+		{"key": "application", "value": "billing"},
+		{"key": "environment", "value": "prod"},
+		{"key": "team", "value": "sre"},
+	])
+}
+
+# ✗ aucune étiquette → les quatre manquent, et elles sont nommées.
+test_no_tag_denied if {
+	some f in deny with input as _tagged("compute_instance", [])
+	f.code == "governance_resource_required_tags"
+	contains(f.message, "Owner")
+	contains(f.message, "CostCenter")
+}
+
+# ✗ étiquetage partiel : seul le propriétaire est posé.
+test_partial_tags_denied if {
+	some f in deny with input as _tagged("compute_instance", [{"key": "Owner", "value": "sre"}])
+	f.code == "governance_resource_required_tags"
+	not contains(f.message, "Owner")
+	contains(f.message, "Project")
+}
+
+# ✗ FAUX NÉGATIF CORRIGÉ : une base managée est facturée et étiquetable ; elle
+# entre dans le périmètre au même titre qu'une instance (issue #61).
+test_managed_database_in_scope if {
+	some f in deny with input as _tagged("managed_database", [])
+	f.code == "governance_resource_required_tags"
+}
+
+# ✓ un type HORS périmètre (règle de security group : ni facturée, ni étiquetable)
+# ne déclenche rien : le périmètre est explicite, pas « tout ce qui a des tags ».
+test_out_of_scope_type_silent if {
+	count(_gvn_count) == 0 with input as _tagged("security_group_rule", [])
+}
+
+# ✓ GARDE DE CAPACITÉ : `tags` non collecté → la règle se tait.
+test_tags_not_collected_silent if {
+	count(_gvn_count) == 0 with input as {"resources": [{
+		"provider": "exoscale",
+		"type": "compute_instance",
+		"id": "r1",
+		"attributes": {"state": "running"},
+	}]}
+}
+
+# ✓ la CONFIGURATION est lue : une politique qui n'exige que le propriétaire
+# laisse passer une ressource qui ne porte que lui.
+test_configured_required_tags if {
+	inv := object.union(
+		_tagged("compute_instance", [{"key": "Owner", "value": "sre"}]),
+		{"config": {"tagging": {
+			"resource_types": ["compute_instance"],
+			"required": [{"name": "owner", "keys": ["owner"]}],
+		}}},
+	)
+	count(_gvn_count) == 0 with input as inv
+}
+
+# ✗ … et une politique qui RESTREINT le périmètre ne désarme pas le contrôle sur
+# ce qu'elle y garde.
+test_configured_scope_still_denies if {
+	inv := object.union(
+		_tagged("compute_instance", []),
+		{"config": {"tagging": {
+			"resource_types": ["compute_instance"],
+			"required": [{"name": "owner", "keys": ["owner"]}],
+		}}},
+	)
+	some f in deny with input as inv
+	f.code == "governance_resource_required_tags"
+}

--- a/internal/commonrules/rules/lib.rego
+++ b/internal/commonrules/rules/lib.rego
@@ -218,9 +218,6 @@ sensitive_udp_ports := {
 	5353, # mDNS
 }
 
-# required_tags — étiquettes de gouvernance obligatoires.
-required_tags := ["CostCenter", "Project", "Env", "Owner"]
-
 # provider_of — provider d'une ressource (pour `labels.provider` des règles
 # communes ; tiré de la ressource, jamais codé en dur).
 provider_of(r) := object.get(r, "provider", "")

--- a/internal/commonrules/rules/lib.rego
+++ b/internal/commonrules/rules/lib.rego
@@ -267,3 +267,135 @@ region_known(p, reg) if reg in _eu_regions[p]
 region_known(p, reg) if reg in _trusted_regions[p]
 
 region_known(p, reg) if reg in _noneu_regions[p]
+
+# ─────────────────────────── Configuration des contrôles ───────────────────────────
+#
+# Quatre contrôles sont RÉGLABLES (issues #47, #48, #49, #61). Leur configuration
+# effective est injectée par `pepin scan` dans `input.config`, exactement comme
+# `input.evaluated_at` : le moteur partagé ne passe que l'input, et une
+# configuration portée par l'input est scellée dans l'input.json du bundle — donc
+# rejouée à l'identique par `verify --re-derive`.
+#
+# Chaque lecture porte son DÉFAUT ici. Ce défaut a deux emplois, et un seul est
+# celui du produit :
+#
+#   - `opa test` évalue les règles sans passer par le scan : sans défaut local,
+#     tous les tests de règles deviendraient des tests de configuration ;
+#   - une règle externe (--policy-dir) ou un input.json d'une version antérieure
+#     n'apportent pas de `config` : le repli est alors le comportement d'avant.
+#
+# Le défaut Rego et le profil par défaut Go (internal/policy) doivent donc dire la
+# MÊME chose. Ce n'est pas laissé à la relecture : TestDefaultConfigMatchesTheRegoFallback
+# scanne chaque fixture du dépôt avec et sans configuration injectée et exige des
+# findings identiques.
+
+_config := object.get(input, "config", {})
+
+_config_tagging := object.get(_config, "tagging", {})
+
+_config_snapshots := object.get(_config, "snapshots", {})
+
+_config_secrets := object.get(_config, "secrets", {})
+
+# normalize_tag_key — forme COMPARABLE d'un nom d'étiquette : minuscules, sans
+# séparateur. `CostCenter`, `cost-center`, `cost_center` et `Cost Center` s'y
+# réduisent tous à `costcenter`. Une convention d'écriture n'est pas une norme :
+# refuser `cost-center` à qui n'écrit pas `CostCenter` est un faux positif, et un
+# outil qui crie au loup sur une typographie finit désactivé.
+normalize_tag_key(k) := lower(regex.replace(k, `[-_. /:]`, ""))
+
+# required_tags_billable / required_tags_network — les étiquettes exigées, sous la
+# forme [{name, keys}] : le nom LOGIQUE (celui que lit un humain dans le message)
+# et les écritures acceptées, déjà normalisées côté Go.
+required_tags_billable := object.get(_config_tagging, "required", _default_required_billable)
+
+required_tags_network := object.get(_config_tagging, "network_required", _default_required_network)
+
+# tagged_resource_types — les types de ressources sur lesquels l'étiquetage de
+# gouvernance est exigé (critère : facturable ET étiquetable, cf. internal/policy).
+tagged_resource_types := object.get(_config_tagging, "resource_types", _default_tagged_types)
+
+# missing_required_tags — les noms logiques d'étiquettes qui MANQUENT sur la liste
+# de tags donnée. Une étiquette présente mais vide ne documente rien : elle compte
+# comme manquante, comme dans has_tag.
+missing_required_tags(tags, required) := [req.name |
+	some req in required
+	not _tag_satisfied(tags, req)
+]
+
+_tag_satisfied(tags, req) if {
+	some t in tags
+	normalize_tag_key(object.get(t, "key", "")) in req.keys
+	object.get(t, "value", "") != ""
+}
+
+# required_tags_label — la liste des étiquettes exigées, telle qu'une remédiation
+# la cite. Dérivée de la politique EFFECTIVE et non écrite en dur : une
+# remédiation qui nommerait quatre étiquettes figées serait fausse dès qu'une
+# organisation en déclare d'autres — et une remédiation fausse coûte plus cher
+# qu'une remédiation absente, parce qu'elle est suivie.
+required_tags_label(required) := concat(", ", [req.name | some req in required])
+
+# snapshot_max_age_days / snapshot_max_age_ns — la fenêtre de fraîcheur d'une
+# snapshot. Les deux formes existent parce que le message la cite en JOURS (ce
+# qu'un humain règle) et que la comparaison se fait en nanosecondes (ce que
+# time.parse_rfc3339_ns rend).
+snapshot_max_age_days := object.get(_config_snapshots, "max_age_days", _default_snapshot_max_age_days)
+
+snapshot_max_age_ns := ((snapshot_max_age_days * 24) * 3600) * 1000000000
+
+# snapshot_accepted_states — les états NATIFS d'une snapshot réellement
+# exploitable. Ancrés sur le contrat de chaque API, jamais devinés :
+#   Outscale Snapshot.State ∈ in-queue|pending|completed|error|deleting
+#     (osc-api/outscale.yaml, schéma Snapshot) → `completed` ;
+#   Exoscale block-storage-snapshot.state ∈ partially-destroyed|destroying|
+#     creating|created|promoting|error|destroyed|allocated
+#     (openapi-v2.exoscale.com, schéma block-storage-snapshot) → `created`.
+snapshot_accepted_states := object.get(_config_snapshots, "accepted_states", _default_snapshot_states)
+
+# secret_min_confidence — le niveau de confiance minimal qu'une détection doit
+# porter pour être signalée.
+secret_min_confidence := object.get(_config_secrets, "min_confidence", _default_min_confidence)
+
+# confidence_rank — rang ordonné d'un niveau de confiance. Un niveau inconnu vaut
+# le rang le plus bas : une détection ne se perd pas parce qu'on n'a pas su lire
+# son étiquette.
+confidence_rank(level) := r if {
+	ranks := {"low": 0, "medium": 1, "high": 2}
+	r := object.get(ranks, level, 0)
+}
+
+# meets_confidence — la détection atteint le seuil configuré.
+meets_confidence(level) if confidence_rank(level) >= confidence_rank(secret_min_confidence)
+
+# ── Le profil PAR DÉFAUT, répliqué pour `opa test` (cf. commentaire d'en-tête) ──
+
+_default_required_billable := [
+	{"name": "CostCenter", "keys": ["billing", "billingcode", "cc", "costcenter"]},
+	{"name": "Project", "keys": ["app", "application", "project", "service"]},
+	{"name": "Env", "keys": ["env", "environment", "stage"]},
+	{"name": "Owner", "keys": ["contact", "owner", "responsible", "team"]},
+]
+
+_default_required_network := [
+	{"name": "Owner", "keys": ["contact", "owner", "responsible", "team"]},
+	{"name": "Project", "keys": ["app", "application", "project", "service"]},
+	{"name": "Env", "keys": ["env", "environment", "stage"]},
+]
+
+_default_tagged_types := [
+	"blockstorage_snapshot",
+	"blockstorage_volume",
+	"compute_image",
+	"compute_instance",
+	"kubernetes_cluster",
+	"load_balancer",
+	"managed_database",
+	"object_storage_bucket",
+]
+
+_default_snapshot_max_age_days := 7
+
+_default_snapshot_states := ["completed", "created"]
+
+_default_min_confidence := "low"

--- a/internal/commonrules/rules/network_documented.rego
+++ b/internal/commonrules/rules/network_documented.rego
@@ -1,32 +1,45 @@
-# Cartographie réseau tenue : chaque réseau (VPC / Net / private network) doit être
-#   identifié (nom) et étiqueté (propriétaire/projet/environnement) pour figurer dans
-#   une cartographie exploitable. Type normalisé `network`, attributs name + tags
-#   ([{key,value}]). Ne se déclenche que pour les réseaux collectés (le type existe).
-# Ancrage : Exoscale private-network (labels), Scaleway vpc_private_network (tags),
-#   Outscale Net (Tags). SCSL : CLD-NET-5 (cartographie réseau tenue à jour).
+# network_documented — cartographie réseau tenue.
+#
+# Ce que la règle vérifie, exactement : chaque réseau (VPC / Net / réseau privé)
+# porte les étiquettes de gouvernance qui le DOCUMENTENT — par défaut
+# propriétaire, projet et environnement (profil `tagging.network_required_tags`).
+#
+# Pourquoi ce n'est plus `count(tags) > 0` : la règle annonçait « propriétaire,
+# projet, environnement » et se contentait d'un tag quelconque. Un unique
+# `foo=bar` suffisait à déclarer un réseau documenté — une conformité affirmée
+# sans avoir été mesurée, c'est-à-dire le `PASS` non prouvé que cette vague
+# combat. Le CODE du contrôle, lui, n'est PAS renommé : il voyage dans les
+# `ruleId` SARIF, dans les assessments archivés et dans les fichiers de
+# dérogations, où un renommage transformerait du jour au lendemain une dérogation
+# valide en dérogation orpheline. On corrige la promesse, pas l'identifiant.
+#
+# Garde de capacité : la règle ne se déclenche que si l'attribut `tags` a été
+# COLLECTÉ. Sans lui, on ne sait pas si le réseau est documenté — et « je ne sais
+# pas » ne se dit pas « non conforme ».
+#
+# Ancrage : Exoscale private-network (labels), Scaleway vpc_private_network
+# (tags), Outscale Net (Tags). SCSL : CLD-NET-5 (cartographie réseau tenue).
 package pepin.rules
 
 import rego.v1
 
 deny contains f if {
 	some n in resources_of_type("network")
-	not _network_documented(n)
+	"tags" in object.keys(n.attributes) # garde de capacité : le provider EXPOSE les étiquettes
+	missing := missing_required_tags(object.get(n.attributes, "tags", []), required_tags_network)
+	count(missing) > 0
 	name := object.get(n.attributes, "name", n.id)
 	f := {
 		"code": "network_documented",
 		"severity": "low",
 		"subject": name,
-		"message": sprintf("Réseau « %s » sans étiquettes de gouvernance — cartographie réseau non tenue (propriétaire/projet/environnement).", [name]),
-		"remediation": "Étiqueter chaque réseau (propriétaire, projet, environnement) ; tenir la cartographie réseau à jour.",
+		"message": sprintf("Réseau « %s » : étiquettes de cartographie manquantes (%s) — la cartographie réseau n'est pas tenue.", [name, concat(", ", missing)]),
+		"remediation": sprintf("Étiqueter chaque réseau (%s) ; tenir la cartographie réseau à jour.", [required_tags_label(required_tags_network)]),
 		"labels": {
 			"provider": provider_of(n),
 			"category": "compliance",
-			"message_en": sprintf("Network \"%s\" has no governance tags — the network mapping is not maintained (owner/project/environment).", [name]),
-			"remediation_en": "Tag every network (owner, project, environment); keep the network mapping up to date.",
+			"message_en": sprintf("Network \"%s\": mapping tags missing (%s) — the network mapping is not maintained.", [name, concat(", ", missing)]),
+			"remediation_en": sprintf("Tag every network (%s); keep the network mapping up to date.", [required_tags_label(required_tags_network)]),
 		},
 	}
 }
-
-# Réseau documenté : porte au moins une étiquette de gouvernance. (Le nom est, selon
-# le provider, un champ natif ou un tag « Name » — on s'appuie donc sur les tags.)
-_network_documented(n) if count(object.get(n.attributes, "tags", [])) > 0

--- a/internal/commonrules/rules/network_documented_test.rego
+++ b/internal/commonrules/rules/network_documented_test.rego
@@ -10,17 +10,83 @@ test_network_untagged_denied if {
 	f.code == "network_documented"
 }
 
-# ✓ réseau étiqueté (étiquettes présentes, nom porté par un tag) → pas de finding.
-test_network_tagged_ok if {
-	count({f | some f in deny; f.code == "network_documented"}) == 0 with input as _net({"tags": [{"key": "Name", "value": "prod-net"}, {"key": "env", "value": "prod"}]})
+# ✗ TAG UNIQUE ET HORS SUJET : `foo=bar` ne documente rien. C'est le cas que la
+# règle validait autrefois (`count(tags) > 0`) et qui faisait annoncer au contrôle
+# plus qu'il ne vérifiait. Il doit désormais échouer, et nommer ce qui manque.
+test_network_single_irrelevant_tag_denied if {
+	some f in deny with input as _net({"name": "prod-net", "tags": [{"key": "foo", "value": "bar"}]})
+	f.code == "network_documented"
+	contains(f.message, "Owner")
+	contains(f.message, "Project")
+	contains(f.message, "Env")
 }
 
-# ✓ réseau nommé ET étiqueté → pas de finding.
+# ✗ documentation PARTIELLE : propriétaire posé, projet et environnement absents.
+test_network_partially_tagged_denied if {
+	some f in deny with input as _net({"tags": [{"key": "owner", "value": "team-x"}]})
+	f.code == "network_documented"
+	contains(f.message, "Project")
+	not contains(f.message, "Owner")
+}
+
+# ✗ étiquette présente mais VIDE : elle ne documente pas davantage qu'une absence.
+test_network_empty_tag_value_denied if {
+	some f in deny with input as _net({"tags": [
+		{"key": "owner", "value": ""},
+		{"key": "project", "value": "p"},
+		{"key": "environment", "value": "prod"},
+	]})
+	f.code == "network_documented"
+	contains(f.message, "Owner")
+}
+
+# ✓ les trois étiquettes de cartographie, écrites autrement : `Team` pour owner,
+# `Env` pour environment — casse et séparateurs indifférents.
+test_network_documented_by_aliases_ok if {
+	count({f | some f in deny; f.code == "network_documented"}) == 0 with input as _net({"tags": [
+		{"key": "Team", "value": "sre"},
+		{"key": "Project", "value": "billing"},
+		{"key": "Env", "value": "prod"},
+	]})
+}
+
+# ✓ les trois étiquettes exactes → pas de finding.
 test_network_documented_ok if {
-	count({f | some f in deny; f.code == "network_documented"}) == 0 with input as _net({"name": "prod-net", "tags": [{"key": "owner", "value": "team-x"}]})
+	count({f | some f in deny; f.code == "network_documented"}) == 0 with input as _net({"name": "prod-net", "tags": [
+		{"key": "owner", "value": "team-x"},
+		{"key": "project", "value": "billing"},
+		{"key": "environment", "value": "prod"},
+	]})
+}
+
+# ✓ GARDE DE CAPACITÉ : `tags` non collecté → la règle se tait. « Je ne sais pas »
+# ne se dit pas « non conforme » ; l'assessment rendra `not-evaluated`.
+test_network_tags_not_collected_silent if {
+	count({f | some f in deny; f.code == "network_documented"}) == 0 with input as _net({"name": "prod-net"})
 }
 
 # ✓ autre type (pas de network) → pas de finding.
 test_network_absent_ok if {
 	count({f | some f in deny; f.code == "network_documented"}) == 0 with input as {"resources": [{"provider": "outscale", "type": "compute_instance", "id": "v1", "attributes": {}}]}
+}
+
+# ✓ la CONFIGURATION est lue : une politique qui n'exige que le propriétaire
+# laisse passer un réseau qui ne porte que lui.
+test_network_configured_required_tags if {
+	inv := object.union(
+		_net({"tags": [{"key": "owner", "value": "team-x"}]}),
+		{"config": {"tagging": {"network_required": [{"name": "owner", "keys": ["owner"]}]}}},
+	)
+	count({f | some f in deny; f.code == "network_documented"}) == 0 with input as inv
+}
+
+# ✗ … et la même politique refuse toujours un réseau qui ne le porte PAS : une
+# configuration lue n'est pas une configuration qui désarme.
+test_network_configured_still_denies if {
+	inv := object.union(
+		_net({"tags": [{"key": "foo", "value": "bar"}]}),
+		{"config": {"tagging": {"network_required": [{"name": "owner", "keys": ["owner"]}]}}},
+	)
+	some f in deny with input as inv
+	f.code == "network_documented"
 }

--- a/internal/exempt/exempt.go
+++ b/internal/exempt/exempt.go
@@ -135,12 +135,7 @@ func Load(path string) (Policy, error) {
 			"dérogations %s : aucune entrée sous la clé `exceptions`",
 			"exemptions %s: no entry under the `exceptions` key"), path)
 	}
-	var problems []string
-	for i, e := range p.Exemptions {
-		for _, pb := range e.validate() {
-			problems = append(problems, fmt.Sprintf("  exceptions[%d] : %s", i, pb))
-		}
-	}
+	problems := Problems(p.Exemptions)
 	if len(problems) > 0 {
 		return Policy{}, fmt.Errorf(i18n.T(
 			"dérogations %s : %d champ(s) obligatoire(s) manquant ou invalide :\n%s",
@@ -148,6 +143,21 @@ func Load(path string) (Policy, error) {
 			path, len(problems), strings.Join(problems, "\n"))
 	}
 	return p, nil
+}
+
+// Problems rend les problèmes de chaque dérogation, préfixés de sa position dans
+// le fichier. Exportée pour que le chargeur de POLITIQUE (internal/policy), qui lit
+// le même schéma dans un fichier à deux sections, applique EXACTEMENT la même
+// validation : deux validations parallèles finiraient par diverger, et c'est
+// précisément sur une dérogation mal formée qu'un rapport tairait ses exceptions.
+func Problems(exemptions []Exemption) []string {
+	var out []string
+	for i, e := range exemptions {
+		for _, pb := range e.validate() {
+			out = append(out, fmt.Sprintf("  exceptions[%d] : %s", i, pb))
+		}
+	}
+	return out
 }
 
 // validate rend les problèmes d'une entrée. Une dérogation incomplète n'engage

--- a/internal/model/schema.go
+++ b/internal/model/schema.go
@@ -17,7 +17,11 @@ import (
 //
 //   - L'enveloppe : un objet portant `provider` (chaîne) et `resources` (tableau).
 //     Le scan y ajoute `evaluated_at` (RFC3339 UTC), l'instant d'évaluation unique
-//     auquel les règles sensibles au temps s'ancrent.
+//     auquel les règles sensibles au temps s'ancrent, et `config`, la
+//     configuration effective des contrôles à laquelle les règles réglables
+//     s'ancrent. Les deux sont ÉCRITS UNE FOIS : un input.json rejoué garde les
+//     siens, sans quoi le rejeu appliquerait l'horloge et la politique du jour à
+//     un dossier d'hier.
 //   - La ressource : `provider`, `type`, `id`, `name`, `attributes` toujours
 //     présents ; `region` et `provenance` présents quand ils sont renseignés.
 //   - `attributes` est une carte PLATE de nom d'attribut vers valeur JSON. Un nom
@@ -68,7 +72,18 @@ import (
 // déclare (fichier, ligne, module). Présente sur un plan Terraform quand les
 // sources HCL ont pu être lues, ABSENTE partout ailleurs — une collecte live ne
 // sait pas d'où vient une ressource, et rien n'y est inventé.
-const InventoryFormat = "pepin-inventory/v3"
+// v4 : deux ajouts, tous deux PURS.
+//   - L'enveloppe porte `config`, la configuration EFFECTIVE des contrôles sous
+//     laquelle l'inventaire a été évalué (réglages d'étiquetage, de fraîcheur de
+//     snapshot, de détection de secrets). Elle voyage AVEC l'inventaire pour la
+//     même raison que `evaluated_at` : un input.json rejoué doit rendre le même
+//     verdict, or un verdict dépend désormais aussi des réglages. Un consommateur
+//     qui l'ignore lirait un résultat sans savoir sous quelle exigence il a été
+//     rendu — ce que ce champ existe précisément pour empêcher.
+//   - Une `blockstorage_snapshot` porte `state`, l'état natif qui dit si la
+//     snapshot est terminée (Outscale Snapshot.State, Exoscale
+//     block-storage-snapshot.state).
+const InventoryFormat = "pepin-inventory/v4"
 
 // InventorySchemaVersion extrait le N du suffixe `/vN`. Comme pour le bundle, la
 // constante et le signal sur le fil sont la même chose : impossible de faire

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,0 +1,252 @@
+// Package policy charge la POLITIQUE d'un scan : les réglages des contrôles et
+// les dérogations, dans UN SEUL fichier.
+//
+// # Pourquoi un seul fichier
+//
+// Les dérogations (`--exceptions`, vague 4 lot 2) et les réglages de contrôles
+// (ce lot) répondent à la même question — « ce que cette organisation assume » —
+// et se relisent au même moment, par les mêmes personnes. Deux fichiers auraient
+// deux cycles de revue, et un utilisateur qui doit tenir trois fichiers de
+// politique en fera diverger deux. Le fichier porte donc deux sections :
+//
+//	controls:     # les réglages (étiquetage, fraîcheur des snapshots, secrets)
+//	exceptions:   # les dérogations, format INCHANGÉ
+//
+// `--exceptions` reste accepté et lit exactement le même schéma : un fichier
+// existant continue de fonctionner, et peut gagner une section `controls:` sans
+// qu'une ligne de ligne de commande ne bouge. Les deux drapeaux sont
+// MUTUELLEMENT EXCLUSIFS : deux fichiers de politique, c'est très exactement la
+// divergence que cette conception refuse.
+//
+// # Pourquoi un réglage ne peut pas fabriquer du vert en silence
+//
+// Chaque réglage est une poignée qui permet d'abaisser une exigence : desserrer
+// un seuil, retirer une étiquette exigée, allonger un délai — et continuer
+// d'afficher la même correspondance CIS ou SecNumCloud. Un `pass` obtenu en
+// abaissant l'exigence est le `PASS` non prouvé que cette vague combat.
+//
+// D'où deux propriétés, tenues par construction :
+//
+//  1. La configuration par DÉFAUT reproduit exactement le comportement figé
+//     d'avant ce lot. Un réglage qui change le comportement par défaut n'est pas
+//     un réglage, c'est un changement de contrôle déguisé.
+//  2. Tout écart au défaut qui ROMPT une contrainte normative (referentiel,
+//     `config_requise`) est un ASSOUPLISSEMENT : la correspondance normative du
+//     contrôle est abandonnée, et l'assouplissement apparaît dans le rendu
+//     terminal, dans l'assessment, dans les formats analysables et dans le
+//     bundle scellé. Une configuration qui n'apparaît pas dans la preuve est une
+//     porte dérobée vers le vert.
+//
+// # Comment la configuration atteint les règles
+//
+// Le moteur partagé (scankit/engine) n'expose PAS de document `data` : il ne
+// passe que l'`input`. La configuration résolue voyage donc DANS l'input, sous
+// la clé `config`, exactement comme `evaluated_at`. Ce n'est pas un pis-aller,
+// c'est la bonne place : la configuration est alors scellée dans l'input.json du
+// bundle, donc `verify --re-derive` rejoue le même verdict sous la même
+// politique, sans qu'on ait à la lui redonner.
+package policy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	yaml "go.yaml.in/yaml/v3"
+
+	"github.com/stephrobert/pepin/internal/exempt"
+	"github.com/stephrobert/pepin/internal/i18n"
+)
+
+// File est le contenu d'un fichier de politique, versionné et revu comme du code.
+//
+// Les sections sont des POINTEURS : « absente » et « présente mais vide » ne se
+// confondent pas. Une section absente laisse le profil par défaut intact ; une
+// section présente déclare que son auteur a pris une décision, et cette décision
+// est comparée au défaut.
+type File struct {
+	Controls *Controls `yaml:"controls" json:"controls,omitempty"`
+	// Exceptions porte les dérogations, dans le format INCHANGÉ du lot 2 : un
+	// fichier `--exceptions` existant est un fichier de politique valide.
+	Exceptions []exempt.Exemption `yaml:"exceptions" json:"exceptions,omitempty"`
+}
+
+// Controls porte les réglages des contrôles configurables.
+type Controls struct {
+	Tagging   *Tagging   `yaml:"tagging" json:"tagging,omitempty"`
+	Snapshots *Snapshots `yaml:"snapshots" json:"snapshots,omitempty"`
+	Secrets   *Secrets   `yaml:"secrets" json:"secrets,omitempty"`
+}
+
+// Tagging est la politique d'ÉTIQUETAGE, commune aux deux contrôles qui la lisent
+// (`governance_resource_required_tags` et `network_documented`). Une seule notion,
+// lue au même endroit : deux implémentations parallèles divergeraient.
+//
+// Les noms sont LOGIQUES (« owner »), pas littéraux : la comparaison est
+// insensible à la casse et aux séparateurs (`cost-center` ≡ `CostCenter`), et les
+// alias élargissent ce qu'un nom logique accepte (`owner` ≡ `team`).
+type Tagging struct {
+	// RequiredTags : les noms logiques exigés sur les ressources FACTURABLES.
+	RequiredTags []string `yaml:"required_tags" json:"required_tags,omitempty"`
+	// NetworkRequiredTags : les noms logiques exigés sur les RÉSEAUX (cartographie).
+	NetworkRequiredTags []string `yaml:"network_required_tags" json:"network_required_tags,omitempty"`
+	// Aliases : par nom logique, les autres écritures acceptées.
+	Aliases map[string][]string `yaml:"aliases" json:"aliases,omitempty"`
+	// ResourceTypes : les types de ressources normalisés sur lesquels l'étiquetage
+	// est exigé.
+	ResourceTypes []string `yaml:"resource_types" json:"resource_types,omitempty"`
+}
+
+// Snapshots règle le contrôle de FRAÎCHEUR des snapshots de volume.
+type Snapshots struct {
+	// MaxAgeDays : l'âge maximal d'une snapshot pour qu'elle compte. Pointeur :
+	// « non écrit » et « écrit à 7 » ne sont pas la même déclaration.
+	MaxAgeDays *int `yaml:"max_age_days" json:"max_age_days,omitempty"`
+	// AcceptedStates : les états NATIFS d'une snapshot réellement exploitable.
+	AcceptedStates []string `yaml:"accepted_states" json:"accepted_states,omitempty"`
+}
+
+// Secrets règle la DÉTECTION de secrets dans les données utilisateur.
+type Secrets struct {
+	// MinConfidence : le niveau de confiance minimal qu'une détection doit porter
+	// pour être signalée (`low` | `medium` | `high`). Monter ce seuil TAIT des
+	// détections : c'est un assouplissement.
+	MinConfidence string `yaml:"min_confidence" json:"min_confidence,omitempty"`
+}
+
+// Load lit un fichier de politique et VALIDE ses deux sections. Toutes les erreurs
+// sont rendues d'un coup : corriger un fichier une ligne par exécution est le genre
+// de friction qui fait abandonner le fichier — et revenir au contrôle désactivé.
+func Load(path string) (File, error) {
+	raw, err := os.ReadFile(path) // #nosec G304 -- fichier de politique choisi par l'opérateur en option CLI.
+	if err != nil {
+		return File{}, fmt.Errorf(i18n.T("lecture de la politique %s : %w", "reading the policy %s: %w"), path, err)
+	}
+	var f File
+	if uerr := yaml.Unmarshal(raw, &f); uerr != nil {
+		return File{}, fmt.Errorf(i18n.T("politique %s invalide : %w", "invalid policy %s: %w"), path, uerr)
+	}
+	if f.Controls == nil && len(f.Exceptions) == 0 {
+		return File{}, fmt.Errorf(i18n.T(
+			"politique %s : aucune entrée sous `controls:` ni sous `exceptions:`",
+			"policy %s: no entry under `controls:` nor under `exceptions:`"), path)
+	}
+	var problems []string
+	problems = append(problems, exempt.Problems(f.Exceptions)...)
+	problems = append(problems, f.Controls.problems()...)
+	if len(problems) > 0 {
+		return File{}, fmt.Errorf(i18n.T(
+			"politique %s : %d entrée(s) invalide(s) :\n%s",
+			"policy %s: %d invalid entry/entries —\n%s"),
+			path, len(problems), strings.Join(problems, "\n"))
+	}
+	return f, nil
+}
+
+// Exemptions rend la politique de dérogations portée par le fichier.
+func (f File) Exemptions() exempt.Policy { return exempt.Policy{Exemptions: f.Exceptions} }
+
+// problems valide la section `controls:`. Une valeur ininterprétable arrête le
+// scan ici : une politique à moitié comprise produirait un rapport dont personne
+// ne saurait dire sous quelle exigence il a été rendu.
+func (c *Controls) problems() []string {
+	if c == nil {
+		return nil
+	}
+	var out []string
+	if c.Tagging != nil {
+		for _, name := range c.Tagging.RequiredTags {
+			if strings.TrimSpace(name) == "" {
+				out = append(out, i18n.T("  controls.tagging.required_tags : nom d'étiquette vide",
+					"  controls.tagging.required_tags: empty tag name"))
+			}
+		}
+		for _, name := range c.Tagging.NetworkRequiredTags {
+			if strings.TrimSpace(name) == "" {
+				out = append(out, i18n.T("  controls.tagging.network_required_tags : nom d'étiquette vide",
+					"  controls.tagging.network_required_tags: empty tag name"))
+			}
+		}
+		for _, typ := range c.Tagging.ResourceTypes {
+			if strings.TrimSpace(typ) == "" {
+				out = append(out, i18n.T("  controls.tagging.resource_types : type de ressource vide",
+					"  controls.tagging.resource_types: empty resource type"))
+			}
+		}
+	}
+	if c.Snapshots != nil {
+		if c.Snapshots.MaxAgeDays != nil && *c.Snapshots.MaxAgeDays < 1 {
+			out = append(out, fmt.Sprintf(i18n.T(
+				"  controls.snapshots.max_age_days : %d — un délai de fraîcheur est un nombre de jours ≥ 1",
+				"  controls.snapshots.max_age_days: %d — a freshness window is a number of days ≥ 1"), *c.Snapshots.MaxAgeDays))
+		}
+		for _, st := range c.Snapshots.AcceptedStates {
+			if strings.TrimSpace(st) == "" {
+				out = append(out, i18n.T("  controls.snapshots.accepted_states : état vide",
+					"  controls.snapshots.accepted_states: empty state"))
+			}
+		}
+	}
+	if c.Secrets != nil && c.Secrets.MinConfidence != "" {
+		if rankOfConfidence(c.Secrets.MinConfidence) < 0 {
+			out = append(out, fmt.Sprintf(i18n.T(
+				"  controls.secrets.min_confidence : %q inconnu (valeurs : %s)",
+				"  controls.secrets.min_confidence: unknown %q (values: %s)"),
+				c.Secrets.MinConfidence, strings.Join(ConfidenceLevels, ", ")))
+		}
+	}
+	return out
+}
+
+// Digest empreinte la configuration RÉSOLUE (défauts compris), sous sa forme
+// canonique. Sert à prouver sous quelle politique un scan a été rendu,
+// indépendamment de la mise en forme du fichier YAML — et à distinguer deux
+// scans que seul un réglage sépare.
+func (r Resolved) Digest() string {
+	b, err := json.Marshal(r)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// normalizeTagKey rend la forme COMPARABLE d'un nom d'étiquette : minuscules, sans
+// séparateur. `CostCenter`, `cost-center`, `cost_center` et `Cost Center` s'y
+// réduisent tous à `costcenter`.
+//
+// Une convention d'écriture n'est pas une norme : imposer `CostCenter` à une
+// organisation qui écrit `cost-center` produit un FAUX POSITIF, et un outil qui
+// crie au loup sur une convention d'écriture finit désactivé.
+func normalizeTagKey(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		switch r {
+		case '-', '_', '.', ' ', '/', ':':
+			continue
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// sortedUnique rend la liste triée et dédoublonnée : la forme canonique dont
+// dépend l'empreinte de la configuration.
+func sortedUnique(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if v == "" || seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -1,0 +1,332 @@
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/pepin/referentiel"
+)
+
+// evaluable indique que le moteur sait lire ce réglage, sous l'une des trois
+// formes qu'une contrainte peut comparer : un ordinal, un ensemble, ou un jeu
+// d'exigences d'étiquetage.
+func evaluable(r Resolved, param string) bool {
+	if _, ok := ordinal(r, param); ok {
+		return true
+	}
+	if _, ok := members(r, param); ok {
+		return true
+	}
+	_, ok := requirements(r, param)
+	return ok
+}
+
+// write écrit un fichier de politique jetable et rend son chemin.
+func write(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "policy.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("écriture de la politique de test : %v", err)
+	}
+	return p
+}
+
+// TestEveryDeclaredParameterIsEvaluated est la garde ANTI-DÉRIVE entre les deux
+// moitiés de l'issue #65 : le référentiel DÉCLARE les réglages qu'une contrainte
+// peut nommer, le moteur les ÉVALUE. Un nom déclaré que le moteur ignore ne
+// protégerait rien — la contrainte serait écrite, jamais appliquée —, et un
+// réglage évalué que le référentiel ne nomme pas ne pourrait jamais faire tomber
+// une correspondance. Les deux listes doivent donc coïncider exactement.
+func TestEveryDeclaredParameterIsEvaluated(t *testing.T) {
+	def := Defaults()
+	for _, p := range referentiel.ConfigParameters {
+		if !evaluable(def, p) {
+			t.Errorf("le référentiel déclare le réglage %q, que le moteur de politique ne sait pas "+
+				"évaluer : la contrainte serait écrite et jamais appliquée. Ajouter le cas dans "+
+				"internal/policy/relaxation.go (ordinal ou members).", p)
+		}
+		if got := render(def, p); strings.Contains(got, "réglage inconnu") || strings.Contains(got, "unknown setting") {
+			t.Errorf("le réglage %q n'a pas de rendu lisible : le rapport ne pourrait pas dire "+
+				"ce qui a changé", p)
+		}
+	}
+}
+
+// TestNoEvaluatedParameterIsUndeclared est l'autre sens de la même garde.
+func TestNoEvaluatedParameterIsUndeclared(t *testing.T) {
+	declared := map[string]bool{}
+	for _, p := range referentiel.ConfigParameters {
+		declared[p] = true
+	}
+	// Les réglages que le moteur sait évaluer, énumérés à la main pour que l'ajout
+	// d'un cas dans ordinal/members sans sa déclaration au référentiel se voie ici.
+	evaluated := []string{
+		"tagging.required_tags",
+		"tagging.network_required_tags",
+		"tagging.resource_types",
+		"snapshots.max_age_days",
+		"snapshots.accepted_states",
+		"secrets.min_confidence",
+	}
+	def := Defaults()
+	for _, p := range evaluated {
+		if !evaluable(def, p) {
+			t.Fatalf("le test énumère %q comme évaluable alors que le moteur l'ignore", p)
+		}
+		if !declared[p] {
+			t.Errorf("le moteur évalue le réglage %q, qu'aucune `config_requise` ne peut nommer : "+
+				"le desserrer ne ferait tomber aucune correspondance normative. L'ajouter à "+
+				"referentiel.ConfigParameters et à la `config_requise` du contrôle qui le lit.", p)
+		}
+	}
+}
+
+// TestAnEmptyPolicyIsTheDefaultProfile : une section absente ne change rien. C'est
+// la propriété qui garantit qu'un fichier de politique partiel n'assouplit que ce
+// qu'il nomme.
+func TestAnEmptyPolicyIsTheDefaultProfile(t *testing.T) {
+	if got := Resolve(nil); !reflect.DeepEqual(got, Defaults()) {
+		t.Errorf("une politique absente doit rendre le profil par défaut\n  attendu : %+v\n  obtenu  : %+v", Defaults(), got)
+	}
+	if got := Resolve(&Controls{}); !reflect.DeepEqual(got, Defaults()) {
+		t.Errorf("une section `controls:` vide doit rendre le profil par défaut")
+	}
+}
+
+// TestAnExplicitDefaultPolicyRelaxesNothing : écrire les valeurs par défaut n'est
+// pas un assouplissement. Sans cette propriété, un utilisateur qui documente sa
+// configuration verrait son rapport perdre ses correspondances normatives pour
+// n'avoir rien changé.
+func TestAnExplicitDefaultPolicyRelaxesNothing(t *testing.T) {
+	seven := 7
+	res := Resolve(&Controls{
+		Tagging: &Tagging{
+			RequiredTags:        defaultBillableTags,
+			NetworkRequiredTags: defaultNetworkTags,
+			Aliases:             defaultTagAliases,
+			ResourceTypes:       defaultTaggedTypes,
+		},
+		Snapshots: &Snapshots{MaxAgeDays: &seven, AcceptedStates: defaultSnapshotStates},
+		Secrets:   &Secrets{MinConfidence: "low"},
+	})
+	if !reflect.DeepEqual(res, Defaults()) {
+		t.Fatalf("le profil par défaut écrit explicitement doit être identique au profil implicite\n  attendu : %+v\n  obtenu  : %+v", Defaults(), res)
+	}
+	if got := Relaxations(res, referentiel.ConfigConstraintsByControl(), nil); len(got) != 0 {
+		t.Errorf("le profil par défaut ne doit produire AUCUN assouplissement, obtenu : %+v", got)
+	}
+}
+
+// TestTighteningIsNotARelaxation : la contrainte ne dit pas « ne touche à rien »,
+// elle dit de quel côté du défaut la promesse survit. Durcir doit rester
+// silencieux, sinon la seule configuration confortable serait le défaut, et la
+// configurabilité n'aurait servi à personne.
+func TestTighteningIsNotARelaxation(t *testing.T) {
+	one := 1
+	res := Resolve(&Controls{
+		Tagging:   &Tagging{RequiredTags: append(append([]string{}, defaultBillableTags...), "data-classification")},
+		Snapshots: &Snapshots{MaxAgeDays: &one, AcceptedStates: []string{"completed"}},
+		Secrets:   &Secrets{MinConfidence: "low"},
+	})
+	if got := Relaxations(res, referentiel.ConfigConstraintsByControl(), nil); len(got) != 0 {
+		for code, rs := range got {
+			for _, r := range rs {
+				t.Errorf("durcissement signalé à tort : %s / %s (%s → %s)", code, r.Parameter, r.Default, r.Effective)
+			}
+		}
+	}
+}
+
+// TestAnotherWritingConventionIsNotARelaxation : le faux positif que l'issue #61
+// décrit, appliqué à la contrainte elle-même. Une organisation qui écrit
+// `cost-center, project, environment, owner` exige MOINS d'écritures que le profil
+// par défaut (qui accepte aussi `cc`, `app`, `env`, `team`…) : elle a resserré sa
+// convention, pas desserré son exigence. La signaler comme assouplie lui ferait
+// perdre sa correspondance normative pour avoir bien fait — le faux positif le plus
+// coûteux qui soit, puisqu'il punit le bon comportement.
+func TestAnotherWritingConventionIsNotARelaxation(t *testing.T) {
+	res := Resolve(&Controls{Tagging: &Tagging{
+		RequiredTags:        []string{"cost-center", "project", "environment", "owner"},
+		NetworkRequiredTags: []string{"owner", "project", "environment"},
+	}})
+	if got := Relaxations(res, referentiel.ConfigConstraintsByControl(), nil); len(got) != 0 {
+		for code, rs := range got {
+			for _, r := range rs {
+				t.Errorf("convention d'écriture signalée comme assouplissement : %s / %s (%s → %s)",
+					code, r.Parameter, r.Default, r.Effective)
+			}
+		}
+	}
+}
+
+// TestRelaxationsAreDetected éprouve chacun des sens de contrainte, un par un, sur
+// le réglage qui le porte réellement.
+func TestRelaxationsAreDetected(t *testing.T) {
+	thirty := 30
+	cases := []struct {
+		name    string
+		ctrl    *Controls
+		control string
+		param   string
+	}{
+		{
+			name:    "délai de fraîcheur allongé (au_plus_le_defaut)",
+			ctrl:    &Controls{Snapshots: &Snapshots{MaxAgeDays: &thirty}},
+			control: "blockstorage_volume_snapshots_exist",
+			param:   "snapshots.max_age_days",
+		},
+		{
+			name:    "états acceptés élargis (sous_ensemble_du_defaut)",
+			ctrl:    &Controls{Snapshots: &Snapshots{AcceptedStates: []string{"completed", "created", "creating"}}},
+			control: "blockstorage_volume_snapshots_exist",
+			param:   "snapshots.accepted_states",
+		},
+		{
+			name:    "étiquette retirée du profil (au_moins_aussi_strict_que_le_defaut)",
+			ctrl:    &Controls{Tagging: &Tagging{RequiredTags: []string{"Owner", "Project", "Env"}}},
+			control: "governance_resource_required_tags",
+			param:   "tagging.required_tags",
+		},
+		{
+			name:    "seuil de confiance monté (au_plus_le_defaut)",
+			ctrl:    &Controls{Secrets: &Secrets{MinConfidence: "high"}},
+			control: "compute_instance_no_secrets_in_user_data",
+			param:   "secrets.min_confidence",
+		},
+		{
+			name: "alias élargi (au_moins_aussi_strict_que_le_defaut)",
+			ctrl: &Controls{Tagging: &Tagging{Aliases: map[string][]string{
+				"CostCenter": {"CostCenter", "cost-center", "cc", "billing-code", "billing", "n-importe-quoi"},
+				"Project":    {"Project", "app", "application", "service"},
+				"Env":        {"Env", "environment", "stage"},
+				"Owner":      {"Owner", "team", "responsible", "contact"},
+			}}},
+			control: "governance_resource_required_tags",
+			param:   "tagging.required_tags",
+		},
+		{
+			name:    "périmètre de types rétréci (superset_du_defaut)",
+			ctrl:    &Controls{Tagging: &Tagging{ResourceTypes: []string{"compute_instance"}}},
+			control: "governance_resource_required_tags",
+			param:   "tagging.resource_types",
+		},
+	}
+	constraints := referentiel.ConfigConstraintsByControl()
+	refs := map[string][]string{
+		"blockstorage_volume_snapshots_exist":      {"scsl:CLD-STO-3"},
+		"governance_resource_required_tags":        {"scsl:CLD-GVN-1"},
+		"compute_instance_no_secrets_in_user_data": {"scsl:CLD-CMP-9"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Relaxations(Resolve(tc.ctrl), constraints, refs)
+			found := false
+			for _, r := range got[tc.control] {
+				if r.Parameter == tc.param {
+					found = true
+					if len(r.DroppedReferences) == 0 {
+						t.Errorf("l'assouplissement doit nommer les correspondances abandonnées")
+					}
+					if r.Default == r.Effective {
+						t.Errorf("l'assouplissement doit rendre deux valeurs distinctes, obtenu %q des deux côtés", r.Default)
+					}
+					if s := r.Sentence(); !strings.Contains(s, tc.param) {
+						t.Errorf("la phrase doit nommer le réglage : %q", s)
+					}
+				}
+			}
+			if !found {
+				t.Errorf("assouplissement non détecté sur %s / %s ; obtenu : %+v", tc.control, tc.param, got)
+			}
+		})
+	}
+}
+
+// TestTagComparisonIgnoresCaseAndSeparators : `cost-center` ≡ `CostCenter`
+// (critère d'acceptation de l'issue #61).
+func TestTagComparisonIgnoresCaseAndSeparators(t *testing.T) {
+	for _, form := range []string{"CostCenter", "cost-center", "cost_center", "Cost Center", "COST.CENTER"} {
+		if got := normalizeTagKey(form); got != "costcenter" {
+			t.Errorf("normalizeTagKey(%q) = %q, attendu \"costcenter\"", form, got)
+		}
+	}
+	// Et la normalisation ne fusionne pas deux noms réellement distincts.
+	if normalizeTagKey("owner") == normalizeTagKey("ownership") {
+		t.Error("la normalisation ne doit pas confondre deux noms distincts")
+	}
+}
+
+// TestLoadRefusesAnUnreadablePolicy : une valeur qu'on ne sait pas interpréter
+// arrête le scan, elle ne s'applique pas à moitié.
+func TestLoadRefusesAnUnreadablePolicy(t *testing.T) {
+	cases := []struct{ name, body, want string }{
+		{"fichier vide", "controls:\n", "exceptions"},
+		{"seuil inconnu", "controls:\n  secrets:\n    min_confidence: paranoid\n", "min_confidence"},
+		{"délai nul", "controls:\n  snapshots:\n    max_age_days: 0\n", "max_age_days"},
+		{"délai négatif", "controls:\n  snapshots:\n    max_age_days: -3\n", "max_age_days"},
+		{"étiquette vide", "controls:\n  tagging:\n    required_tags: [\"\"]\n", "required_tags"},
+		{"dérogation sans date", "exceptions:\n  - control: c\n    justification: j\n    owner: o\n    approved_by: a\n", "expires_at"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load(write(t, tc.body))
+			if err == nil {
+				t.Fatalf("politique invalide acceptée")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("le message doit nommer ce qui cloche (%q) ; obtenu : %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// TestLoadAcceptsAnExemptionsOnlyFile : un fichier `--exceptions` existant est un
+// fichier de politique valide. Sans cette propriété, le passage à un fichier
+// unique casserait toutes les invocations en place.
+func TestLoadAcceptsAnExemptionsOnlyFile(t *testing.T) {
+	f, err := Load(write(t, "exceptions:\n  - control: objectstorage_bucket_public_access\n"+
+		"    justification: bucket public assumé, contenu déjà public\n"+
+		"    expires_at: 2099-12-31\n    owner: sre\n    approved_by: rssi\n"))
+	if err != nil {
+		t.Fatalf("fichier de dérogations refusé : %v", err)
+	}
+	if len(f.Exemptions().Exemptions) != 1 {
+		t.Errorf("la dérogation doit être lue")
+	}
+	if !reflect.DeepEqual(Resolve(f.Controls), Defaults()) {
+		t.Errorf("un fichier sans section `controls:` doit laisser le profil par défaut intact")
+	}
+}
+
+// TestLoadReadsBothSections : les deux sections coexistent dans le même fichier.
+func TestLoadReadsBothSections(t *testing.T) {
+	f, err := Load(write(t, "controls:\n  snapshots:\n    max_age_days: 14\n"+
+		"exceptions:\n  - control: c\n    justification: j\n"+
+		"    expires_at: 2099-01-01\n    owner: o\n    approved_by: a\n"))
+	if err != nil {
+		t.Fatalf("politique à deux sections refusée : %v", err)
+	}
+	if len(f.Exemptions().Exemptions) != 1 {
+		t.Errorf("la section `exceptions:` doit être lue")
+	}
+	if got := Resolve(f.Controls).Snapshots.MaxAgeDays; got != 14 {
+		t.Errorf("la section `controls:` doit être lue, max_age_days = %d", got)
+	}
+}
+
+// TestDigestSeparatesTwoConfigurations : deux politiques différentes ne peuvent
+// pas porter la même empreinte sous le même résultat.
+func TestDigestSeparatesTwoConfigurations(t *testing.T) {
+	thirty := 30
+	a := Defaults().Digest()
+	b := Resolve(&Controls{Snapshots: &Snapshots{MaxAgeDays: &thirty}}).Digest()
+	if a == "" || a == b {
+		t.Errorf("deux configurations distinctes doivent avoir deux empreintes distinctes (%q vs %q)", a, b)
+	}
+	if a != Defaults().Digest() {
+		t.Error("l'empreinte doit être stable pour une même configuration")
+	}
+}

--- a/internal/policy/relaxation.go
+++ b/internal/policy/relaxation.go
@@ -1,0 +1,256 @@
+package policy
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/stephrobert/pepin/internal/i18n"
+	"github.com/stephrobert/pepin/referentiel"
+)
+
+// Relaxation est un ASSOUPLISSEMENT : un réglage qui s'écarte du défaut du
+// côté où la contrainte normative ne tient plus. Elle porte de quoi le juger
+// sans lire le code — le réglage, sa valeur par défaut, sa valeur effective, et
+// la phrase qui dit ce qui est perdu.
+type Relaxation struct {
+	// Control : le contrôle dont la correspondance normative tombe.
+	Control string `json:"control"`
+	// Parameter : le réglage en cause (`section.champ`).
+	Parameter string `json:"parameter"`
+	// Constraint : le sens de contrainte qui a été rompu.
+	Constraint string `json:"constraint"`
+	// Default / Effective : les deux valeurs, rendues lisibles.
+	Default   string `json:"default"`
+	Effective string `json:"effective"`
+	// DroppedReferences : les correspondances normatives ABANDONNÉES, sous leur
+	// forme `framework:id`. C'est ce que l'assouplissement fait perdre.
+	DroppedReferences []string `json:"dropped_references"`
+}
+
+// Sentence rend l'assouplissement en une phrase, dans la langue courante.
+func (r Relaxation) Sentence() string { return r.SentenceIn(i18n.Current()) }
+
+// SentenceIn est Sentence pour une langue explicite : la documentation bilingue
+// rend les deux versions dans une seule exécution.
+func (r Relaxation) SentenceIn(l i18n.Lang) string {
+	return fmt.Sprintf(i18n.TIn(l,
+		"%s : %s au lieu de %s (défaut) — %s",
+		"%s: %s instead of %s (default) — %s"),
+		r.Parameter, r.Effective, r.Default, constraintLossIn(l, r.Constraint))
+}
+
+// constraintLossIn dit CE QUI EST PERDU, par sens de contrainte. C'est la phrase
+// qui empêche de lire un assouplissement comme un simple réglage.
+func constraintLossIn(l i18n.Lang, kind string) string {
+	switch kind {
+	case referentiel.ConstraintAtMostDefault:
+		return i18n.TIn(l,
+			"une valeur au-delà du défaut tait ce que l'exigence demandait de voir",
+			"a value beyond the default silences what the requirement asked to see")
+	case referentiel.ConstraintSupersetOfDefault:
+		return i18n.TIn(l,
+			"retirer un membre du défaut, c'est cesser de vérifier ce que l'exigence demande",
+			"dropping a member of the default means no longer checking what the requirement asks")
+	case referentiel.ConstraintSubsetOfDefault:
+		return i18n.TIn(l,
+			"élargir au-delà du défaut, c'est accepter ce que l'exigence rejette",
+			"widening beyond the default means accepting what the requirement rejects")
+	case referentiel.ConstraintAtLeastAsStrict:
+		return i18n.TIn(l,
+			"une exigence du profil par défaut n'est plus tenue : elle a été retirée, ou ce qu'elle accepte a été élargi",
+			"a requirement of the default profile is no longer held: it was dropped, or what it accepts was widened")
+	default:
+		return i18n.TIn(l, "contrainte non tenue", "constraint not met")
+	}
+}
+
+// Relaxations rend, PAR CONTRÔLE, les assouplissements qui rompent ses
+// correspondances normatives. `refs` donne, par contrôle, les correspondances
+// qu'il perdrait — elles voyagent avec l'assouplissement pour que le rapport
+// puisse nommer ce qui est abandonné, et pas seulement dire qu'il abandonne.
+//
+// Un réglage DURCI (plus d'étiquettes exigées, un délai plus court, un ensemble
+// d'états acceptés plus étroit) n'est PAS un assouplissement : la correspondance
+// tient, et rien n'est signalé. La contrainte ne dit pas « ne touche à rien »,
+// elle dit de quel côté du défaut la promesse survit.
+func Relaxations(res Resolved, constraints map[string][]referentiel.ConfigConstraint, refs map[string][]string) map[string][]Relaxation {
+	def := Defaults()
+	out := map[string][]Relaxation{}
+	codes := make([]string, 0, len(constraints))
+	for code := range constraints {
+		codes = append(codes, code)
+	}
+	sort.Strings(codes)
+	for _, code := range codes {
+		for _, c := range constraints[code] {
+			if holds(res, def, c) {
+				continue
+			}
+			out[code] = append(out[code], Relaxation{
+				Control:           code,
+				Parameter:         c.Parametre,
+				Constraint:        c.Contrainte,
+				Default:           render(def, c.Parametre),
+				Effective:         render(res, c.Parametre),
+				DroppedReferences: refs[code],
+			})
+		}
+	}
+	return out
+}
+
+// holds évalue une contrainte : la valeur effective est-elle du bon côté du
+// défaut ? Un paramètre ou un sens de contrainte inconnu rend FAUX, donc
+// signale un assouplissement : entre taire une contrainte qu'on ne sait pas
+// évaluer et la signaler à tort, la seconde erreur est la seule réparable. Le
+// cas est de toute façon refusé en amont par `mise run validate`.
+func holds(res, def Resolved, c referentiel.ConfigConstraint) bool {
+	switch c.Contrainte {
+	case referentiel.ConstraintAtMostDefault:
+		got, ok1 := ordinal(res, c.Parametre)
+		want, ok2 := ordinal(def, c.Parametre)
+		return ok1 && ok2 && got <= want
+	case referentiel.ConstraintSupersetOfDefault:
+		got, ok1 := members(res, c.Parametre)
+		want, ok2 := members(def, c.Parametre)
+		return ok1 && ok2 && contains(got, want)
+	case referentiel.ConstraintSubsetOfDefault:
+		got, ok1 := members(res, c.Parametre)
+		want, ok2 := members(def, c.Parametre)
+		return ok1 && ok2 && contains(want, got)
+	case referentiel.ConstraintAtLeastAsStrict:
+		got, ok1 := requirements(res, c.Parametre)
+		want, ok2 := requirements(def, c.Parametre)
+		return ok1 && ok2 && atLeastAsStrict(got, want)
+	default:
+		return false
+	}
+}
+
+// atLeastAsStrict : pour CHAQUE exigence du profil par défaut, le profil effectif
+// en porte une dont les écritures acceptées sont non vides et incluses dans celles
+// du défaut. Tout ce qui satisfait l'exigence effective satisfait alors celle du
+// défaut — c'est la définition exacte de « au moins aussi strict ».
+func atLeastAsStrict(got, want []RequiredTag) bool {
+	for _, w := range want {
+		if !coveredBy(w, got) {
+			return false
+		}
+	}
+	return true
+}
+
+func coveredBy(want RequiredTag, got []RequiredTag) bool {
+	accepted := make(map[string]bool, len(want.Keys))
+	for _, k := range want.Keys {
+		accepted[k] = true
+	}
+	for _, g := range got {
+		if len(g.Keys) == 0 {
+			continue
+		}
+		included := true
+		for _, k := range g.Keys {
+			if !accepted[k] {
+				included = false
+				break
+			}
+		}
+		if included {
+			return true
+		}
+	}
+	return false
+}
+
+// requirements rend les EXIGENCES d'un réglage d'étiquetage (nom + écritures
+// acceptées), et si le paramètre en porte.
+func requirements(r Resolved, param string) ([]RequiredTag, bool) {
+	switch param {
+	case "tagging.required_tags":
+		return r.Tagging.Required, true
+	case "tagging.network_required_tags":
+		return r.Tagging.NetworkRequired, true
+	default:
+		return nil, false
+	}
+}
+
+// contains indique que `super` contient tous les membres de `sub`.
+func contains(super, sub map[string]bool) bool {
+	for k := range sub {
+		if !super[k] {
+			return false
+		}
+	}
+	return true
+}
+
+// ordinal rend la valeur ORDONNÉE d'un réglage scalaire (un délai, un rang de
+// seuil), et si le paramètre en porte une.
+func ordinal(r Resolved, param string) (int, bool) {
+	switch param {
+	case "snapshots.max_age_days":
+		return r.Snapshots.MaxAgeDays, true
+	case "secrets.min_confidence":
+		rank := rankOfConfidence(r.Secrets.MinConfidence)
+		return rank, rank >= 0
+	default:
+		return 0, false
+	}
+}
+
+// members rend l'ENSEMBLE des membres d'un réglage de type collection, et si le
+// paramètre en porte un.
+func members(r Resolved, param string) (map[string]bool, bool) {
+	set := func(vals []string) map[string]bool {
+		out := make(map[string]bool, len(vals))
+		for _, v := range vals {
+			out[v] = true
+		}
+		return out
+	}
+	switch param {
+	case "tagging.resource_types":
+		return set(r.Tagging.ResourceTypes), true
+	case "snapshots.accepted_states":
+		return set(r.Snapshots.AcceptedStates), true
+	default:
+		return nil, false
+	}
+}
+
+// render rend la valeur d'un réglage sous une forme lisible par un humain, celle
+// qui apparaît dans le rapport à côté du défaut.
+func render(r Resolved, param string) string {
+	if n, ok := ordinal(r, param); ok {
+		switch param {
+		case "snapshots.max_age_days":
+			return strconv.Itoa(n) + i18n.T(" jours", " days")
+		case "secrets.min_confidence":
+			return r.Secrets.MinConfidence
+		}
+	}
+	if reqs, ok := requirements(r, param); ok {
+		// Nom ET écritures acceptées : deux profils qui exigent les mêmes noms mais
+		// pas les mêmes écritures ne sont PAS la même exigence, et un rapport qui
+		// afficherait deux fois la même chaîne ne dirait pas ce qui a changé.
+		vals := make([]string, 0, len(reqs))
+		for _, t := range reqs {
+			vals = append(vals, t.Name+"{"+strings.Join(t.Keys, "|")+"}")
+		}
+		sort.Strings(vals)
+		return "[" + strings.Join(vals, ", ") + "]"
+	}
+	if m, ok := members(r, param); ok {
+		vals := make([]string, 0, len(m))
+		for k := range m {
+			vals = append(vals, k)
+		}
+		sort.Strings(vals)
+		return "[" + strings.Join(vals, ", ") + "]"
+	}
+	return i18n.T("(réglage inconnu)", "(unknown setting)")
+}

--- a/internal/policy/resolved.go
+++ b/internal/policy/resolved.go
@@ -1,0 +1,241 @@
+package policy
+
+import "strings"
+
+// Resolved est la configuration EFFECTIVE d'un scan : le profil par défaut, sur
+// lequel le fichier de politique a été appliqué. C'est elle que le scan injecte
+// dans l'input (clé `config`), donc elle qui est scellée dans l'input.json du
+// bundle et rejouée à l'identique par `verify --re-derive`.
+//
+// Sa forme est le CONTRAT que lisent les règles Rego : noms d'étiquettes déjà
+// normalisés et alias déjà résolus, pour que la règle n'ait qu'un test
+// d'appartenance à faire. La normalisation vit ici, en Go, en un seul endroit ;
+// la dupliquer dans chaque règle serait la faire diverger.
+type Resolved struct {
+	Tagging   ResolvedTagging   `json:"tagging"`
+	Snapshots ResolvedSnapshots `json:"snapshots"`
+	Secrets   ResolvedSecrets   `json:"secrets"`
+}
+
+// ResolvedTagging est la politique d'étiquetage effective.
+type ResolvedTagging struct {
+	// ResourceTypes : les types normalisés sur lesquels l'étiquetage est exigé.
+	ResourceTypes []string `json:"resource_types"`
+	// Required : les étiquettes exigées sur ces ressources.
+	Required []RequiredTag `json:"required"`
+	// NetworkRequired : les étiquettes exigées sur les réseaux (cartographie).
+	NetworkRequired []RequiredTag `json:"network_required"`
+}
+
+// RequiredTag est une étiquette exigée : son nom LOGIQUE (celui que lira un
+// humain dans le message du finding) et les écritures acceptées, normalisées.
+type RequiredTag struct {
+	Name string   `json:"name"`
+	Keys []string `json:"keys"`
+}
+
+// ResolvedSnapshots est la politique de fraîcheur effective.
+type ResolvedSnapshots struct {
+	MaxAgeDays     int      `json:"max_age_days"`
+	AcceptedStates []string `json:"accepted_states"`
+}
+
+// ResolvedSecrets est la politique de détection effective.
+type ResolvedSecrets struct {
+	MinConfidence string `json:"min_confidence"`
+}
+
+// ConfidenceLevels énumère les niveaux de confiance d'une détection de secret,
+// du plus faible au plus fort. L'ORDRE est signifiant : c'est lui qui décide
+// qu'un seuil plus haut est un assouplissement.
+var ConfidenceLevels = []string{"low", "medium", "high"}
+
+// rankOfConfidence rend le rang d'un niveau de confiance, -1 s'il est inconnu.
+func rankOfConfidence(level string) int {
+	for i, l := range ConfidenceLevels {
+		if strings.EqualFold(strings.TrimSpace(level), l) {
+			return i
+		}
+	}
+	return -1
+}
+
+// Le PROFIL PAR DÉFAUT. C'est une RECOMMANDATION, pas une norme : aucune
+// convention d'étiquetage ne fait autorité, et Pépin ne prétend pas le contraire.
+// Il est cependant ce à quoi les correspondances normatives du référentiel sont
+// adossées (`config_requise`) : s'en écarter dans le sens du relâchement fait
+// perdre la correspondance, et le rapport le dit.
+var (
+	// defaultBillableTags : les quatre étiquettes de gouvernance exigées sur une
+	// ressource facturable. Elles répondent à quatre questions qu'un inventaire
+	// doit savoir trancher : qui paye, pour quoi, à quel stade, et qui répond.
+	//
+	// Ce sont des noms d'AFFICHAGE, pas des littéraux à matcher : ce sont eux
+	// qu'un message de finding nomme, et ils gardent l'écriture historique pour
+	// qu'un rapport ne change pas de vocabulaire sous les yeux de ses lecteurs.
+	// La COMPARAISON, elle, est insensible à la casse et aux séparateurs et passe
+	// par les alias ci-dessous : `cost-center`, `costcenter` et `CostCenter` sont
+	// la même exigence. L'ORDRE est celui du message, donc il est signifiant et
+	// se conserve (voir resolveTags, qui ne trie pas).
+	defaultBillableTags = []string{"CostCenter", "Project", "Env", "Owner"}
+
+	// defaultNetworkTags : la cartographie réseau (CLD-NET-5) demande de savoir à
+	// QUI et à QUOI sert un réseau, et dans quel environnement. Le centre de coût
+	// n'en fait pas partie : un réseau n'est pas une ligne de facture.
+	defaultNetworkTags = []string{"Owner", "Project", "Env"}
+
+	// defaultTagAliases : les écritures acceptées pour chaque nom logique. La
+	// comparaison étant déjà insensible à la casse et aux séparateurs, ces alias
+	// ne couvrent que les SYNONYMES — `team` pour `Owner`, `environment` pour
+	// `Env` —, pas les variantes typographiques.
+	//
+	// C'est ici que se joue le faux positif de l'issue #61 : une organisation qui
+	// écrit `cost-center, application, environment, team` est gouvernée, et ne
+	// doit pas récolter un FAIL sur sa convention d'écriture.
+	defaultTagAliases = map[string][]string{
+		"CostCenter": {"CostCenter", "cost-center", "cc", "billing-code", "billing"},
+		"Project":    {"Project", "app", "application", "service"},
+		"Env":        {"Env", "environment", "stage"},
+		"Owner":      {"Owner", "team", "responsible", "contact"},
+	}
+
+	// defaultTaggedTypes : les types de ressources sur lesquels l'étiquetage est
+	// exigé, et POURQUOI chacun — le critère est « facturable et étiquetable » :
+	// une ressource qui coûte sans propriétaire connu est un coût orphelin autant
+	// qu'un risque orphelin.
+	//
+	//   compute_instance, blockstorage_volume, blockstorage_snapshot,
+	//   compute_image, load_balancer, object_storage_bucket, managed_database,
+	//   kubernetes_cluster
+	//
+	// Sont EXCLUS, et pour des raisons écrites : `network`, `subnet`,
+	// `network_peering`, `security_group*` (non facturés en propre ; le réseau a
+	// sa propre exigence de cartographie, CLD-NET-5), `iam_*`, `access_key`,
+	// `api_access_*` (ni facturés ni porteurs d'étiquettes), `governance_provider`
+	// (ressource synthétique, pas une ressource du tenant) et les `k8s_*`
+	// (portée INTRA-cluster, hors périmètre de la posture cloud).
+	defaultTaggedTypes = []string{
+		"compute_instance",
+		"blockstorage_volume",
+		"blockstorage_snapshot",
+		"compute_image",
+		"load_balancer",
+		"object_storage_bucket",
+		"managed_database",
+		"kubernetes_cluster",
+	}
+
+	// defaultMaxAgeDays : sept jours. Une semaine est la période de revue la plus
+	// courante, et c'est la valeur que le contrôle appliquait en dur avant d'être
+	// réglable — la rendre configurable ne devait déplacer aucun verdict.
+	defaultMaxAgeDays = 7
+
+	// defaultSnapshotStates : les états NATIFS d'une snapshot réellement
+	// exploitable, ANCRÉS sur le contrat de chaque API (jamais devinés) :
+	//   - Outscale, Snapshot.State ∈ in-queue | pending | completed | error |
+	//     deleting (osc-api/outscale.yaml, schéma Snapshot) → seul `completed`
+	//     désigne une snapshot terminée ;
+	//   - Exoscale, block-storage-snapshot.state ∈ partially-destroyed |
+	//     destroying | creating | created | promoting | error | destroyed |
+	//     allocated (openapi-v2.exoscale.com, schéma block-storage-snapshot) →
+	//     `created` désigne la snapshot terminée.
+	// Les autres états sont en cours, en erreur ou en suppression : une snapshot
+	// qui les porte ne restaure rien.
+	defaultSnapshotStates = []string{"completed", "created"}
+
+	// defaultMinConfidence : `low`, c'est-à-dire TOUT signaler. C'est le
+	// comportement d'avant ce lot, et c'est le seul défaut défendable pour un
+	// détecteur de secrets : taire par défaut ce qu'on ne sait pas confirmer,
+	// c'est choisir le faux négatif contre le faux positif, sur le seul sujet où
+	// le faux négatif se paye en fuite.
+	defaultMinConfidence = ConfidenceLevels[0]
+)
+
+// Defaults rend le profil par défaut résolu.
+func Defaults() Resolved {
+	return Resolved{
+		Tagging: ResolvedTagging{
+			ResourceTypes:   sortedUnique(defaultTaggedTypes),
+			Required:        resolveTags(defaultBillableTags, defaultTagAliases),
+			NetworkRequired: resolveTags(defaultNetworkTags, defaultTagAliases),
+		},
+		Snapshots: ResolvedSnapshots{
+			MaxAgeDays:     defaultMaxAgeDays,
+			AcceptedStates: sortedUnique(defaultSnapshotStates),
+		},
+		Secrets: ResolvedSecrets{MinConfidence: defaultMinConfidence},
+	}
+}
+
+// Resolve applique la section `controls:` au profil par défaut. Une section
+// absente laisse le défaut intact — c'est ce qui garantit qu'un scan sans
+// fichier de politique et un scan dont le fichier ne parle pas d'un contrôle
+// rendent le même verdict.
+func Resolve(c *Controls) Resolved {
+	out := Defaults()
+	if c == nil {
+		return out
+	}
+	if t := c.Tagging; t != nil {
+		aliases := defaultTagAliases
+		if t.Aliases != nil {
+			aliases = t.Aliases
+		}
+		names, netNames := defaultBillableTags, defaultNetworkTags
+		if t.RequiredTags != nil {
+			names = t.RequiredTags
+		}
+		if t.NetworkRequiredTags != nil {
+			netNames = t.NetworkRequiredTags
+		}
+		out.Tagging.Required = resolveTags(names, aliases)
+		out.Tagging.NetworkRequired = resolveTags(netNames, aliases)
+		if t.ResourceTypes != nil {
+			out.Tagging.ResourceTypes = sortedUnique(t.ResourceTypes)
+		}
+	}
+	if s := c.Snapshots; s != nil {
+		if s.MaxAgeDays != nil {
+			out.Snapshots.MaxAgeDays = *s.MaxAgeDays
+		}
+		if s.AcceptedStates != nil {
+			out.Snapshots.AcceptedStates = sortedUnique(s.AcceptedStates)
+		}
+	}
+	if s := c.Secrets; s != nil && s.MinConfidence != "" {
+		out.Secrets.MinConfidence = strings.ToLower(strings.TrimSpace(s.MinConfidence))
+	}
+	return out
+}
+
+// resolveTags projette des noms logiques et leurs alias en étiquettes exigées :
+// le nom tel qu'écrit (pour le message lu par un humain) et les écritures
+// acceptées, NORMALISÉES et triées. Le nom logique fait toujours partie de ses
+// propres écritures acceptées : déclarer `owner` sans alias exige `owner`.
+func resolveTags(names []string, aliases map[string][]string) []RequiredTag {
+	// Les alias sont indexés par nom NORMALISÉ : une politique qui exige `owner`
+	// doit hériter des alias déclarés sous `Owner`, et réciproquement. Sans cette
+	// indexation, la casse du nom logique déciderait silencieusement de la
+	// tolérance appliquée.
+	byName := make(map[string][]string, len(aliases))
+	for name, vals := range aliases {
+		byName[normalizeTagKey(name)] = vals
+	}
+	out := make([]RequiredTag, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		keys := []string{normalizeTagKey(name)}
+		for _, a := range byName[normalizeTagKey(name)] {
+			if k := normalizeTagKey(a); k != "" {
+				keys = append(keys, k)
+			}
+		}
+		out = append(out, RequiredTag{Name: name, Keys: sortedUnique(keys)})
+	}
+	// PAS de tri : l'ordre est celui que l'auteur de la politique a écrit, et
+	// c'est l'ordre dans lequel le message du finding énumère ce qui manque.
+	return out
+}

--- a/mise.toml
+++ b/mise.toml
@@ -24,13 +24,17 @@ run = "go test ./... -race"
 description = "Tests des politiques Rego (toutes communes)"
 run = "opa test internal/commonrules/rules -v"
 
+# `Config` sélectionne les gardes de l'issue #65 : une contrainte de configuration
+# ininterprétable (réglage inconnu, sens de contrainte inexistant) est refusée ici,
+# parce qu'une contrainte que personne n'évalue est pire qu'une contrainte absente —
+# elle donne l'impression que la correspondance normative est protégée.
 # `Finding` sélectionne TestEveryFindingCarriesRemediation, qui exige de chaque
 # règle sa remédiation ET ses deux labels de traduction (message_en,
 # remediation_en). C'est une vérification purement statique du texte des .rego :
 # elle a sa place dans la porte de cohérence, à côté de celle du référentiel.
 [tasks.validate]
 description = "Cohérence des référentiels (codes ↔ règles ↔ index SCSL gelé ↔ catalogue ↔ bilinguisme)"
-run = "go test ./referentiel/ -run 'Control|Rule|SCSL|Catalogue|Lookup|Coherent|Finding' -v"
+run = "go test ./referentiel/ -run 'Control|Rule|SCSL|Catalogue|Lookup|Coherent|Finding|Config' -v"
 
 # check-remediation est volontairement DÉCOUPLÉ de `validate` : la couverture est
 # aujourd'hui de 26/95 (exoscale 26/26, outscale 0/40, scaleway 0/25, kubernetes 0/4),

--- a/providers/exoscale.yaml
+++ b/providers/exoscale.yaml
@@ -223,6 +223,7 @@ collecte:
         snapshot_id: id
         volume_id: block-storage-volume.id
         creation_date: created-at
+        state: state
 
 mapping_terraform:
   # Mapping Terraform Exoscale → modèle normalisé commun, DÉCLARATIF (moteur
@@ -376,6 +377,11 @@ contrat:
         snapshot_id: id
         volume_id: block-storage-volume.id (ref vers le volume cible)
         creation_date: created-at (ISO 8601 → recence, CLD-STO-3)
+        state: 'state ∈ partially-destroyed | destroying | creating | created | promoting | error |
+          destroyed | allocated (schéma block-storage-snapshot, openapi-v2.exoscale.com). « created »
+          désigne la snapshot TERMINÉE, donc exploitable. Lu par blockstorage_volume_snapshots_exist
+          (CLD-STO-3), qui vérifie l''état et pas seulement la date.'
+
         global_permission: 'NON APPLICABLE : les snapshots block storage Exoscale ne sont ni exportables ni partageables publiquement
           (doc officielle storage/block-storage/operation/snapshot) → blockstorage_snapshot_not_public (CLD-STO-2) sans objet.'
     object_storage_bucket:

--- a/providers/outscale.yaml
+++ b/providers/outscale.yaml
@@ -342,6 +342,7 @@ collecte:
         snapshot_id: SnapshotId
         volume_id: VolumeId
         creation_date: CreationDate
+        state: State
         global_permission: PermissionsToCreateVolume.GlobalPermission
   
     # Politiques EIM : ReadPolicies puis ReadPolicyVersion (document JSON → statements).
@@ -601,6 +602,10 @@ contrat:
         snapshot_id: SnapshotId
         volume_id: VolumeId
         creation_date: CreationDate
+        state: 'State ∈ in-queue | pending | completed | error | deleting (schéma Snapshot de l''API
+          OUTSCALE, osc-api/outscale.yaml). Seul « completed » désigne une snapshot TERMINÉE, donc
+          exploitable : les autres sont en file, en cours, en erreur ou en suppression. Lu par
+          blockstorage_volume_snapshots_exist (CLD-STO-3), qui vérifie l''état et pas seulement la date.'
         global_permission: PermissionsToCreateVolume.GlobalPermission
     object_storage_bucket:
       etat: verifie

--- a/referentiel/config.go
+++ b/referentiel/config.go
@@ -1,0 +1,113 @@
+package referentiel
+
+// La CONFIGURATION d'un contrôle est liée à ses correspondances normatives.
+//
+// Une fois un contrôle réglable, rien n'empêche de le desserrer tout en
+// continuant d'afficher la même correspondance CIS ou SecNumCloud. Un contrôle
+// assoupli qui prétend couvrir la même exigence rend le rapport trompeur, et pour
+// un outil qui vend l'opposabilité, c'est le défaut le plus coûteux.
+//
+// Le référentiel porte donc, à côté de `scsl:` et `frameworks:`, la CONTRAINTE
+// sous laquelle ces correspondances valent :
+//
+//	config_requise:
+//	  - parametre: snapshots.max_age_days
+//	    contrainte: au_plus_le_defaut
+//
+// Elle se lit : « la correspondance CLD-STO-3 / CIS 11.2 / ISO A.8.13 ne vaut que
+// tant que le délai de fraîcheur ne dépasse pas le défaut ». Si la configuration
+// effective s'en écarte, la correspondance est ABANDONNÉE — le résultat reste
+// publié, avec ce qu'il mesure vraiment, mais sans prétendre couvrir l'exigence.
+//
+// Deux invariants, tenus par TestConfigConstraintsAreInterpretable :
+//   - le `parametre` est l'un de ceux que le moteur de politique sait évaluer ;
+//   - la `contrainte` est l'un des quatre sens définis ci-dessous.
+//
+// Une contrainte ininterprétable est refusée par `mise run validate` : une
+// contrainte que personne n'évalue est pire qu'une contrainte absente, parce
+// qu'elle donne l'impression d'être appliquée.
+
+// ConfigConstraint est une contrainte de configuration sous laquelle les
+// correspondances normatives d'un contrôle valent.
+type ConfigConstraint struct {
+	// Parametre : le chemin du réglage (`section.champ`), tel que le moteur de
+	// politique le nomme.
+	Parametre string `yaml:"parametre"`
+	// Contrainte : le SENS dans lequel le réglage peut s'écarter du défaut sans
+	// rompre la correspondance.
+	Contrainte string `yaml:"contrainte"`
+}
+
+// Les quatre sens de contrainte. Chacun désigne le côté du défaut où la
+// correspondance TIENT ENCORE ; s'en écarter de l'autre côté est un
+// assouplissement, et la correspondance tombe.
+const (
+	// ConstraintAtMostDefault : la valeur ne doit pas DÉPASSER le défaut. Pour un
+	// délai de fraîcheur ou un seuil de confiance : l'allonger ou le monter tait
+	// ce que l'exigence demandait de voir.
+	ConstraintAtMostDefault = "au_plus_le_defaut"
+	// ConstraintSupersetOfDefault : la valeur doit CONTENIR au moins le défaut.
+	// Pour un ensemble d'exigences (étiquettes obligatoires, types couverts) :
+	// en retirer un membre, c'est cesser de vérifier ce que l'exigence demande.
+	ConstraintSupersetOfDefault = "superset_du_defaut"
+	// ConstraintSubsetOfDefault : la valeur doit rester CONTENUE dans le défaut.
+	// Pour un ensemble de tolérances (états jugés exploitables) : l'élargir, c'est
+	// accepter ce que l'exigence rejette.
+	ConstraintSubsetOfDefault = "sous_ensemble_du_defaut"
+	// ConstraintAtLeastAsStrict : pour chaque EXIGENCE du profil par défaut, le
+	// profil effectif en porte une AU MOINS AUSSI STRICTE.
+	//
+	// Une comparaison par nom ne convient pas ici, et l'exemple qui l'a montré vaut
+	// d'être gardé : le profil par défaut exige « la question de l'environnement est
+	// répondue par l'une des écritures env | environment | stage ». Une organisation
+	// qui écrit `environment` n'assouplit rien — elle exige MOINS d'écritures, donc
+	// davantage. Comparer les noms l'aurait signalée comme assouplie, ce qui aurait
+	// fait perdre sa correspondance normative à quelqu'un qui a resserré sa
+	// convention : le faux positif le plus coûteux qui soit, puisqu'il punit le bon
+	// comportement.
+	//
+	// La règle exacte : une exigence par défaut D reste tenue s'il existe une
+	// exigence effective E dont les écritures acceptées sont NON VIDES et INCLUSES
+	// dans celles de D. Tout ce qui satisfait E satisfait alors D. Élargir les
+	// écritures d'un nom (un alias de plus) sort de l'inclusion, donc assouplit ;
+	// retirer une exigence la laisse sans candidat, donc assouplit ; en ajouter une
+	// nouvelle ne touche à aucune exigence par défaut, donc durcit.
+	ConstraintAtLeastAsStrict = "au_moins_aussi_strict_que_le_defaut"
+)
+
+// ConfigConstraintKinds énumère les sens de contrainte interprétables.
+var ConfigConstraintKinds = []string{
+	ConstraintAtMostDefault,
+	ConstraintSupersetOfDefault,
+	ConstraintSubsetOfDefault,
+	ConstraintAtLeastAsStrict,
+}
+
+// ConfigParameters énumère les réglages qu'une contrainte peut nommer. La liste
+// vit ICI, dans le référentiel, parce que c'est le référentiel qui déclare les
+// contraintes ; le moteur de politique (internal/policy) sait évaluer exactement
+// ces noms, et TestEveryDeclaredParameterIsEvaluated le vérifie dans les deux
+// sens — un nom que le moteur ignore ne protégerait rien, un réglage que le
+// référentiel ne nomme pas ne pourrait jamais rompre une correspondance.
+var ConfigParameters = []string{
+	"tagging.required_tags",
+	"tagging.network_required_tags",
+	"tagging.resource_types",
+	"snapshots.max_age_days",
+	"snapshots.accepted_states",
+	"secrets.min_confidence",
+}
+
+// ConfigConstraintsByControl rend, par code de contrôle, les contraintes de
+// configuration sous lesquelles ses correspondances normatives valent. Les
+// contrôles sans contrainte (la grande majorité : ils ne sont pas réglables) sont
+// absents de la carte.
+func ConfigConstraintsByControl() map[string][]ConfigConstraint {
+	out := map[string][]ConfigConstraint{}
+	for code, c := range byCode {
+		if len(c.ConfigRequise) > 0 {
+			out[code] = c.ConfigRequise
+		}
+	}
+	return out
+}

--- a/referentiel/config_test.go
+++ b/referentiel/config_test.go
@@ -1,0 +1,103 @@
+package referentiel
+
+import (
+	"testing"
+
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// TestConfigConstraintsAreInterpretable refuse une contrainte de configuration
+// que personne ne sait évaluer.
+//
+// C'est la porte de `mise run validate` pour l'issue #65. Une contrainte
+// ininterprétable est PIRE qu'une contrainte absente : elle donne l'impression
+// que la correspondance normative est protégée, alors que le moteur de politique
+// la traverse sans rien mesurer. Deux formes d'ininterprétabilité sont refusées —
+// un réglage que le moteur ne connaît pas, et un sens de contrainte qui n'existe
+// pas.
+func TestConfigConstraintsAreInterpretable(t *testing.T) {
+	params := map[string]bool{}
+	for _, p := range ConfigParameters {
+		params[p] = true
+	}
+	kinds := map[string]bool{}
+	for _, k := range ConfigConstraintKinds {
+		kinds[k] = true
+	}
+	for code, cs := range ConfigConstraintsByControl() {
+		for i, c := range cs {
+			if !params[c.Parametre] {
+				t.Errorf("%s config_requise[%d] : réglage %q inconnu du moteur de politique.\n"+
+					"Réglages évaluables : %v", code, i, c.Parametre, ConfigParameters)
+			}
+			if !kinds[c.Contrainte] {
+				t.Errorf("%s config_requise[%d] : contrainte %q ininterprétable.\n"+
+					"Sens définis : %v", code, i, c.Contrainte, ConfigConstraintKinds)
+			}
+		}
+	}
+}
+
+// TestConfigConstraintsAreNotDuplicated refuse deux contraintes sur le MÊME
+// réglage pour un même contrôle : la seconde ne peut qu'être un doublon ou une
+// contradiction, et les deux se règlent en relisant l'entrée, jamais en
+// évaluant les deux.
+func TestConfigConstraintsAreNotDuplicated(t *testing.T) {
+	for code, cs := range ConfigConstraintsByControl() {
+		seen := map[string]bool{}
+		for _, c := range cs {
+			if seen[c.Parametre] {
+				t.Errorf("%s : deux contraintes portent sur le réglage %q", code, c.Parametre)
+			}
+			seen[c.Parametre] = true
+		}
+	}
+}
+
+// TestEveryConfigurableControlDeclaresItsConstraint est la garde qui empêche
+// d'ajouter un réglage sans le lier à ce qu'il peut faire perdre.
+//
+// Le raisonnement : un réglage est une poignée qui permet de fabriquer du vert.
+// S'il n'est nommé par AUCUNE `config_requise`, aucune correspondance normative
+// ne tombe quand on le desserre — et le rapport continue d'afficher CIS ou
+// SecNumCloud sur un contrôle qu'on a soi-même abaissé. La liste des réglages
+// évaluables est donc la même que celle des réglages contraints, dans les deux
+// sens.
+func TestEveryConfigurableControlDeclaresItsConstraint(t *testing.T) {
+	constrained := map[string]bool{}
+	for _, cs := range ConfigConstraintsByControl() {
+		for _, c := range cs {
+			constrained[c.Parametre] = true
+		}
+	}
+	for _, p := range ConfigParameters {
+		if !constrained[p] {
+			t.Errorf("le réglage %q n'est contraint par aucun contrôle : le desserrer ne ferait "+
+				"tomber aucune correspondance normative, et le rapport continuerait d'afficher "+
+				"une conformité qu'il ne mesure plus. Ajouter sa `config_requise` au contrôle "+
+				"qui le lit, dans referentiel/controles.yaml.", p)
+		}
+	}
+}
+
+// TestConfigConstraintsParseFromYAML vérifie que le champ est réellement LU
+// depuis controles.yaml, et pas seulement déclaré en Go. Une structure qui ne se
+// désérialise pas rendrait la carte vide, donc tous les tests ci-dessus verts sur
+// rien du tout — le faux vert le plus discret qui soit.
+func TestConfigConstraintsParseFromYAML(t *testing.T) {
+	var c catalog
+	if err := yaml.Unmarshal(Raw(), &c); err != nil {
+		t.Fatalf("controles.yaml illisible : %v", err)
+	}
+	total := 0
+	for _, ctl := range c.Controles {
+		total += len(ctl.ConfigRequise)
+	}
+	if total == 0 {
+		t.Fatal("aucune `config_requise` lue depuis controles.yaml : le champ n'est pas désérialisé, " +
+			"et toutes les gardes de configuration mesurent le vide")
+	}
+	if got := len(ConfigConstraintsByControl()); got == 0 {
+		t.Fatalf("ConfigConstraintsByControl est vide alors que le YAML porte %d contrainte(s)", total)
+	}
+}

--- a/referentiel/controles.yaml
+++ b/referentiel/controles.yaml
@@ -1054,21 +1054,42 @@ controles:
 
   - code: blockstorage_volume_snapshots_exist
     famille: stockage
-    titre: Absence de sauvegarde récente
-    titre_en: No recent backup
+    titre: Absence de snapshot récente et terminée
+    titre_en: No recent, completed snapshot
     severite: high
     description: >
-      Un volume de données en usage n'a pas d'instantané/sauvegarde récent : la
-      restauration après incident n'est pas garantie.
+      CE QUI EST MESURÉ : un volume en usage a-t-il, dans la fenêtre configurée
+      (par défaut 7 jours, `controls.snapshots.max_age_days`), au moins une
+      snapshot dont l'état natif la dit TERMINÉE ? L'état est vérifié, pas
+      seulement la date : une snapshot en erreur ou en cours ne restaure rien.
+      CE QUE LE CONTRÔLE NE PROUVE PAS : ni que la snapshot soit restaurable
+      (aucune restauration n'est tentée), ni qu'elle soit complète au sens
+      applicatif, ni qu'une rétention soit respectée, ni qu'une politique de
+      sauvegarde existe. Un volume sauvegardé autrement (sauvegarde applicative,
+      réplication, service du fournisseur) sera signalé ici : c'est un faux
+      positif assumé, à traiter par une dérogation datée, jamais en désactivant
+      le contrôle. Ce contrôle ne participe donc pas à une affirmation
+      « sauvegarde conforme ».
     description_en: >
-      A data volume in use has no recent snapshot or backup: restoring after
-      an incident is not guaranteed.
+      WHAT IS MEASURED: does a volume in use have, within the configured window
+      (7 days by default, `controls.snapshots.max_age_days`), at least one
+      snapshot whose native state says it is COMPLETED? The state is checked, not
+      just the date: a failed or in-progress snapshot restores nothing.
+      WHAT THIS CONTROL DOES NOT PROVE: neither that the snapshot is restorable
+      (no restore is attempted), nor that it is complete in the application
+      sense, nor that a retention is honoured, nor that a backup policy exists. A
+      volume backed up by other means (application backup, replication, provider
+      service) will be reported here: an accepted false positive, to be handled
+      with a dated exemption rather than by disabling the control. This control
+      therefore takes no part in a "backup compliant" claim.
     remediation: >
-      Mettre en place une politique de sauvegarde régulière avec test de
-      restauration ; chiffrer et appliquer une rétention documentée.
+      Mettre en place un snapshot régulier automatisé et tester la restauration
+      périodiquement. Si le volume est sauvegardé autrement, poser une dérogation
+      datée et justifiée plutôt que de désactiver le contrôle.
     remediation_en: >
-      Set up a regular backup policy with restore testing; encrypt the backups
-      and apply a documented retention.
+      Set up an automated, regular snapshot schedule and test the restore
+      periodically. If the volume is backed up by other means, file a dated,
+      justified exemption rather than disabling the control.
     scsl: [CLD-STO-3]
     frameworks:
       secnumcloud_3_2: ["12.5"]

--- a/referentiel/controles.yaml
+++ b/referentiel/controles.yaml
@@ -611,6 +611,12 @@ controles:
       secnumcloud_3_2: ["13.1"]
       iso_27001_2022: ["A.5.9"]
     fournisseurs: [exoscale, outscale, scaleway]
+    # La cartographie exige de savoir à QUI et à QUOI sert un réseau. Retirer une
+    # de ces étiquettes du profil, ou élargir ce qu'un nom logique accepte, c'est
+    # cesser de mesurer ce que CLD-NET-5 demande.
+    config_requise:
+      - parametre: tagging.network_required_tags
+        contrainte: au_moins_aussi_strict_que_le_defaut
 
   - code: network_peering_cross_organization
     famille: reseau
@@ -710,6 +716,13 @@ controles:
     frameworks:
       secnumcloud_3_2: ["10.5"]
     fournisseurs: [outscale, exoscale, scaleway]
+    # Chaque détection porte son niveau de confiance (high | medium | low) et le
+    # seuil de signalement est réglable. Le monter TAIT des détections : « aucun
+    # secret en clair » (CLD-CMP-9) ne se prouve plus si l'on a choisi de ne pas
+    # regarder une partie de ce qui a été trouvé.
+    config_requise:
+      - parametre: secrets.min_confidence
+        contrainte: au_plus_le_defaut
 
   - code: k8s_rbac_no_cluster_admin_binding
     famille: compute
@@ -1052,6 +1065,14 @@ controles:
       cis_controls_v8: ["11.2"]
       iso_27001_2022: ["A.8.13"]
     fournisseurs: [outscale, exoscale]
+    # Allonger la fenêtre, ou compter des snapshots que leur état natif dit
+    # inachevées, c'est cesser de mesurer la fraîcheur que CLD-STO-3 / CIS 11.2
+    # demandent.
+    config_requise:
+      - parametre: snapshots.max_age_days
+        contrainte: au_plus_le_defaut
+      - parametre: snapshots.accepted_states
+        contrainte: sous_ensemble_du_defaut
 
   # ───────────────────────── Chiffrement & clés ──────────────────────
   - code: loadbalancer_ssl_listeners
@@ -1261,6 +1282,15 @@ controles:
       cis_controls_v8: ["1.1"]
       iso_27001_2022: ["A.5.9", "A.8.9"]
     fournisseurs: [outscale, scaleway, exoscale]
+    # Un inventaire tenu (CLD-GVN-1, CIS 1.1) suppose de savoir qui paye, pour
+    # quoi, à quel stade et qui répond, SUR TOUT ce qui est facturable. Retirer
+    # une étiquette du profil, élargir ce qu'un nom accepte, ou rétrécir le
+    # périmètre des types visés fait tomber la correspondance.
+    config_requise:
+      - parametre: tagging.required_tags
+        contrainte: au_moins_aussi_strict_que_le_defaut
+      - parametre: tagging.resource_types
+        contrainte: superset_du_defaut
 
   - code: governance_resource_region_in_eu
     famille: gouvernance

--- a/referentiel/controles.yaml
+++ b/referentiel/controles.yaml
@@ -1275,17 +1275,32 @@ controles:
     titre_en: Incomplete inventory and tagging
     severite: medium
     description: >
-      Des ressources n'ont pas les étiquettes de gouvernance (propriétaire,
-      projet, environnement) : l'inventaire et la responsabilité ne sont pas tenus.
+      CE QUI EST VÉRIFIÉ : une ressource facturable porte les étiquettes de
+      gouvernance exigées — par défaut centre de coût, projet, environnement et
+      propriétaire. Ce qui est exigé, ce sont les QUESTIONS auxquelles un
+      inventaire doit répondre (qui paye, pour quoi, à quel stade, qui répond),
+      jamais des mots précis : la comparaison est insensible à la casse et aux
+      séparateurs (`cost-center` ≡ `CostCenter`), et le profil, les alias et les
+      types de ressources visés sont configurables (`controls.tagging`). Le
+      profil livré est une RECOMMANDATION, pas une norme. Sans étiquettes
+      collectées, le contrôle rend « non évalué ».
     description_en: >
-      Some resources do not carry the governance tags (owner, project,
-      environment): the inventory and the accountability are not maintained.
+      WHAT IS CHECKED: a billable resource carries the required governance tags -
+      by default cost centre, project, environment and owner. What is required
+      are the QUESTIONS an inventory must answer (who pays, for what, at which
+      stage, who is accountable), never exact words: the comparison ignores case
+      and separators (`cost-center` = `CostCenter`), and the profile, its aliases
+      and the targeted resource types are configurable (`controls.tagging`). The
+      shipped profile is a RECOMMENDATION, not a standard. Without collected tags
+      the control returns "not evaluated".
     remediation: >
-      Imposer des étiquettes obligatoires (propriétaire, projet, environnement) ;
-      contrôler leur présence à la création.
+      Ajouter les étiquettes de gouvernance manquantes ; contrôler leur présence
+      à la création. Si votre convention diffère, la déclarer dans le fichier de
+      politique plutôt que de désactiver le contrôle.
     remediation_en: >
-      Enforce mandatory tags (owner, project, environment); check their
-      presence at creation time.
+      Add the missing governance tags; check their presence at creation time. If
+      your convention differs, declare it in the policy file rather than
+      disabling the control.
     scsl: [CLD-GVN-1]
     frameworks:
       secnumcloud_3_2: ["8.1"]

--- a/referentiel/controles.yaml
+++ b/referentiel/controles.yaml
@@ -589,22 +589,32 @@ controles:
 
   - code: network_documented
     famille: reseau
-    titre: Réseau non documenté (cartographie non tenue)
-    titre_en: Undocumented network (mapping not maintained)
+    titre: Réseau sans étiquettes de cartographie
+    titre_en: Network without mapping tags
     severite: low
     description: >
-      Un réseau (VPC / Net / réseau privé) n'a pas de nom ou d'étiquettes de
-      gouvernance : la cartographie réseau (inventaire, propriétaire, projet) n'est
-      pas tenue à jour, ce qui nuit à la revue et à la réponse aux incidents.
+      CE QUI EST VÉRIFIÉ : chaque réseau (VPC / Net / réseau privé) porte les
+      étiquettes de gouvernance qui le documentent — par défaut propriétaire,
+      projet et environnement. Une étiquette hors sujet ne documente rien : la
+      présence d'un tag quelconque ne suffit pas. La comparaison est insensible à
+      la casse et aux séparateurs, et le profil d'étiquetage est configurable
+      (`controls.tagging.network_required_tags`) ; le profil livré est une
+      recommandation, pas une norme. Sans étiquettes collectées, le contrôle rend
+      « non évalué » plutôt que de conclure.
     description_en: >
-      A network (VPC / Net / private network) has no name and no governance
-      tags: the network mapping (inventory, owner, project) is not kept up to
-      date, which hurts review and incident response.
+      WHAT IS CHECKED: every network (VPC / Net / private network) carries the
+      governance tags that document it - by default owner, project and
+      environment. An off-topic tag documents nothing: the mere presence of some
+      tag is not enough. The comparison ignores case and separators, and the
+      tagging profile is configurable (`controls.tagging.network_required_tags`);
+      the shipped profile is a recommendation, not a standard. Without collected
+      tags the control returns "not evaluated" rather than concluding.
     remediation: >
-      Nommer et étiqueter chaque réseau (propriétaire, projet, environnement) ;
-      tenir à jour la cartographie réseau et la réviser périodiquement.
+      Étiqueter chaque réseau avec son propriétaire, son projet et son
+      environnement ; tenir à jour la cartographie réseau et la réviser
+      périodiquement.
     remediation_en: >
-      Name and tag every network (owner, project, environment); keep the
+      Tag every network with its owner, project and environment; keep the
       network mapping up to date and review it periodically.
     scsl: [CLD-NET-5]
     frameworks:

--- a/referentiel/referentiel.go
+++ b/referentiel/referentiel.go
@@ -38,6 +38,12 @@ type Control struct {
 	Scsl          []string            `yaml:"scsl"`
 	Frameworks    map[string][]string `yaml:"frameworks"`
 	Fournisseurs  []string            `yaml:"fournisseurs"`
+	// ConfigRequise porte les contraintes de configuration sous lesquelles les
+	// correspondances ci-dessus (`Scsl`, `Frameworks`) VALENT. Vide pour un
+	// contrôle non réglable, ce qui est le cas de la grande majorité. Voir
+	// config.go : une configuration qui s'en écarte fait tomber la correspondance,
+	// et le rapport le dit plutôt que de continuer à l'afficher.
+	ConfigRequise []ConfigConstraint `yaml:"config_requise"`
 }
 
 type catalog struct {


### PR DESCRIPTION
Lot 3 de la vague 4 « Trustworthiness » : les cinq dernières issues P0 — #65, #47, #61, #49, #48. Basée sur `feat/wave4-trust-collection` (PR #86), donc ouverte contre elle ; GitHub la reciblera sur `main` à la fusion de #86.

> **La thèse.** Quatre de ces issues ajoutent des réglages à des contrôles. Chaque réglage est une poignée qui permet de fabriquer du vert : desserrer un seuil, retirer une étiquette exigée, allonger un délai — et continuer d'afficher la même correspondance CIS ou SecNumCloud. #65 n'est donc pas la cinquième tâche, c'est la clé de voûte : **vous pouvez abaisser la barre, vous ne pouvez pas l'abaisser et garder le badge.**

---

## 1. Ce que je n'ai pas pu faire ou vérifier

Mis en premier, parce que c'est ce qui se lit en premier.

- **Aucun scan live, aucun compte cloud.** Interdit par le brief. Tout ce qui suit est mesuré sur des fixtures du dépôt, des plans Terraform et des inventaires synthétiques. **Aucune ressource cloud provisionnée, donc rien à détruire.**
- **Les états natifs de snapshot ne sont pas mesurés, ils sont lus.** `completed` (Outscale) et `created` (Exoscale) viennent des spécifications OpenAPI officielles — `outscale/osc-api@master:outscale.yaml` (schéma `Snapshot`) et `openapi-v2.exoscale.com/source.json` (schéma `block-storage-snapshot`), toutes deux téléchargées et citées dans le contrat de chaque descripteur. Je n'ai **pas** observé une snapshot réelle dans chacun de ces états. Un scan live confirmerait que l'API renvoie bien ces valeurs telles quelles ; il reste dû.
- **Exoscale `allocated` et `promoting` sont hors du profil par défaut, sans certitude.** L'énumération les liste, la documentation ne dit pas clairement s'ils désignent une snapshot exploitable. J'ai choisi de ne PAS les accepter : refuser un état dont on ignore le sens produit un faux positif (bruyant, visible, corrigeable par un réglage), l'accepter produirait un faux vert (invisible). Un opérateur qui sait peut les ajouter — et le rapport dira que la correspondance CLD-STO-3 tombe.
- **Le profil d'alias par défaut est un jugement, pas une donnée.** `team ≡ Owner`, `app ≡ Project`, `stage ≡ Env` : c'est l'exemple donné par #61, pas une norme mesurée. La documentation le dit explicitement, et le retirer/élargir est traité comme un réglage à part entière.
- **Le contrôle de fraîcheur reste un faux positif assumé** sur un volume sauvegardé autrement (réplication, sauvegarde applicative, service du fournisseur). Je n'ai aucun moyen de le détecter ; la documentation dit de poser une dérogation datée, pas de désactiver le contrôle.
- **`labels.confidence` n'apparaît pas dans le rendu terminal.** Choix délibéré (voir §2), au prix qu'un humain qui trie dans un terminal ne voit pas le niveau sans passer par `--format json`.
- **`govulncheck` n'a pas pu tourner dans le bac à sable** (`unshare(CLONE_NEWUSER)` refusé) ; je l'ai lancé hors bac à sable : `0 vulnerabilities`. Tout le reste de `mise run audit` passe dans le bac à sable.

---

## 2. Les arbitrages, et pourquoi

### #65 — la contrainte normative, conçue d'abord

`referentiel/controles.yaml` porte désormais, à côté de `scsl:` et `frameworks:`, les contraintes sous lesquelles ces correspondances valent :

```yaml
config_requise:
  - parametre: snapshots.max_age_days
    contrainte: au_plus_le_defaut
  - parametre: snapshots.accepted_states
    contrainte: sous_ensemble_du_defaut
```

Quatre sens, chacun désignant **le côté du défaut où la promesse survit** : `au_plus_le_defaut`, `superset_du_defaut`, `sous_ensemble_du_defaut`, `au_moins_aussi_strict_que_le_defaut`. `mise run validate` refuse une contrainte qui nomme un réglage que le moteur ne sait pas évaluer, **et** un réglage qu'aucune contrainte ne nomme — une contrainte que personne n'évalue est pire qu'une contrainte absente, parce qu'elle donne l'impression d'être appliquée.

**Le statut ne change pas.** Un contrôle assoupli a bel et bien été évalué, contre une barre plus basse. On retire la seule chose qui a cessé d'être vraie — la correspondance — et on garde la mesure. Marquer `not-evaluated` aurait effacé une mesure réelle ; garder les `references` aurait menti.

**Le quatrième sens n'était pas prévu, la mesure l'a imposé.** Ma première version comparait les noms d'étiquettes. Le tableau §4 a alors signalé « convention d'écriture différente » (`cost-center, project, environment, owner`, l'exemple même de #61) comme un **assouplissement**. C'était faux : cette organisation accepte *moins* d'écritures que le profil par défaut, donc exige *davantage*. Le faux positif le plus coûteux qui soit, puisqu'il punit le bon comportement. D'où `au_moins_aussi_strict_que_le_defaut` : une exigence par défaut D reste tenue s'il existe une exigence effective E dont les écritures acceptées sont non vides et **incluses** dans celles de D.

### Combien de fichiers de configuration ? Un seul.

`--policy` lit **un** fichier à deux sections, `controls:` et `exceptions:`. `--exceptions` reste le nom historique du même fichier et lit le même schéma : une invocation existante et un fichier existant continuent de fonctionner, et un fichier de dérogations peut gagner une section `controls:` sans changer de ligne de commande. **Les deux drapeaux sont mutuellement exclusifs** : accepter deux fichiers différents, c'est garantir que l'un des deux dérivera. Le refus nomme les deux drapeaux.

### Comment la configuration atteint les règles

`scankit/engine.Evaluate` n'expose **pas** de document `data` : il ne passe que l'`input`. La configuration résolue voyage donc dans `input.config`, exactement comme `evaluated_at`. Ce n'est pas un pis-aller, c'est la bonne place : elle est alors scellée dans l'`input.json` du bundle, et `verify --re-derive` rejoue le même verdict sous la même politique sans qu'on la lui redonne. Un `input.json` rejoué garde sa propre `config` : le rejeu n'applique jamais la politique du jour à un dossier d'hier.

Corollaire : le profil par défaut existe **deux fois**, en Go (`internal/policy`) et en Rego (`lib.rego`, le repli pour `opa test` et pour un input sans `config`). Deux définitions divergent toujours, et cette divergence-là serait invisible. Elle est donc **mesurée** : `TestTheRegoFallbackProfileEqualsTheGoDefaultProfile` évalue onze inventaires par les deux chemins et exige des findings identiques, et `TestTheInjectedConfigurationIsActuallyRead` interdit que ce test soit vert pour la pire raison — des règles qui ignoreraient `input.config`.

### Renommer un code : non, deux fois

#49 demande `blockstorage_recent_snapshot_exists`, #47 évoque `network_has_tags`. **Je n'ai renommé ni l'un ni l'autre.** Un code voyage dans les `ruleId` SARIF des consommateurs, dans les assessments archivés et **dans les fichiers de dérogations** : un renommage transformerait du jour au lendemain une dérogation valide en dérogation orpheline, un opérateur verrait un avertissement apparaître et son écart réapparaître. Le lot 2 vient précisément de livrer la détection des dérogations orphelines ; la déclencher en masse une vague plus tard serait une régression de confiance.

Le critère de #47 dit « la règle exige les étiquettes qui documentent, **ou** le contrôle est renommé ». J'ai pris la première branche, qui est aussi celle que l'issue préfère : *rendre le contrôle conforme à sa promesse plutôt qu'abaisser la promesse au niveau du contrôle*. Ce sont donc le titre, la description, le message et la condition évaluée qui changent — dans les deux langues.

### #47 et #61 partagent une seule notion d'étiquetage

`tagging` est une section unique, lue au même endroit (`lib.rego`, helpers `required_tags_billable` / `required_tags_network` / `missing_required_tags`). #61 fournit le vocabulaire, #47 le consomme sur les réseaux. Aucune implémentation parallèle.

### #48 — le niveau voyage dans un label, pas dans le message

Le message d'un contrôle est une surface que des captures d'écran, des tickets et des annotations de forge recopient ; le déplacer d'un octet pour une information structurée se paye partout. Et un niveau est fait pour être **filtré** (`jq '.findings[] | select(.labels.confidence == "low")'`), pas lu au milieu d'une phrase. Résultat : le rendu par défaut n'a pas bougé d'un caractère, et `TestFrenchScanOutputHasNotMovedOneCharacter` — le gel de la sortie publiée du lot 1 — reste vert sans avoir été regénéré.

Coût assumé : un humain qui trie dans un terminal ne voit pas le niveau. C'est le seuil configurable qui traite l'irritation en CI, pas l'affichage.

### #61 — le nom d'affichage des étiquettes reste l'historique

`CostCenter, Project, Env, Owner` restent les noms **affichés** dans les messages ; la comparaison, elle, est normalisée et aliasée. Un rapport ne change donc pas de vocabulaire sous les yeux de ses lecteurs, et la remédiation est **dérivée de la politique effective** au lieu de citer quatre étiquettes figées qu'elle n'exige peut-être plus.

---

## 3. Propriété 1 — à configuration par défaut, aucun verdict ne bouge

Mesurée, pas affirmée. Campagne sur **les neuf cas exécutables du dépôt** (3 inventaires JSON, 6 plans Terraform, 3 fournisseurs), avant et après le lot, en comparant pour chaque contrôle le triplet `(statut, sujet, références normatives)` **plus** le code de sortie :

```
$ verdicts.sh /tmp/base    # binaire de cb76787 (tête du lot 2)
$ verdicts.sh /tmp/tip     # binaire de 4400521 (tête de cette PR)
$ diffverdicts.py /tmp/base /tmp/tip
--- 0 cas sur 9 ont bouge
```

**Zéro.** Ni un statut, ni une référence, ni un code de sortie. Et cela vaut aussi pour les corrections sémantiques de #47, #49 et #61, qui *pourraient* déplacer un verdict sur un autre tenant : sur les fixtures du dépôt, les ressources fautives n'ont aucune étiquette du tout et le réseau fautif n'en a aucune non plus, donc elles échouaient avant et échouent après, pour la raison correcte.

Deux gardes tiennent la propriété dans le temps :

| Garde | Ce qu'elle refuse |
|---|---|
| `TestAnExplicitDefaultPolicyMovesNoVerdict` (cmd) | un scan avec le profil par défaut **écrit à la main** dont la sortie ou le code diffère d'un scan sans fichier |
| `TestTheRegoFallbackProfileEqualsTheGoDefaultProfile` (commonrules) | un défaut Go qui s'écarte du repli Rego, sur 11 inventaires couvrant les 4 contrôles |

Où un verdict **peut** bouger sur un autre tenant, et c'est délibéré (chaque ligne a son entrée au CHANGELOG) :

| Changement | Sens | Effet |
|---|---|---|
| #47 : `network_documented` exige `Owner, Project, Env` | durcit | un réseau à tag hors sujet passait, il échoue |
| #47 : garde de capacité sur `tags` | assainit | sans tags collectés : `fail` → `not-evaluated` |
| #61 : comparaison insensible casse/séparateurs + alias | corrige un faux positif | `cost-center`/`team` passent désormais |
| #61 : 4 types facturables ajoutés au périmètre | corrige un faux négatif | snapshots, images, bases managées, clusters entrent |
| #49 : l'état natif de la snapshot est vérifié | durcit | une snapshot `error`/`pending` ne compte plus |

---

## 4. Propriété 2 — le tableau des configurations éprouvées

Douze configurations passées au binaire sur `examples/scaleway/terraform/plan.json` (non conforme) et `terraform-fixed/plan.json` (conforme, pour voir la porte stricte que le code 1 masquerait) :

| Configuration | findings | contrôles assouplis | correspondances abandonnées | code (normal / `--strict`) |
|---|---|---|---|---|
| aucun fichier | 10 | — | — | 1 / 1 |
| profil par défaut écrit explicitement | 10 | — | — | 1 / 1 |
| durcissement (étiquette de plus, fenêtre à 1 jour) | 10 | — | — | 1 / 1 |
| convention d'écriture différente (#61) | 10 | — | — | 1 / 1 |
| assouplissement : une étiquette retirée | 10 | `governance_resource_required_tags` | `scsl:CLD-GVN-1`, `cis-v8:1.1`, `iso-27001:A.5.9`, `iso-27001:A.8.9`, `secnumcloud-3.2:8.1` | 1 / 1 |
| assouplissement : périmètre de types rétréci | 10 | `governance_resource_required_tags` | idem | 1 / 1 |
| assouplissement : alias élargi | 10 | `governance_resource_required_tags`, `network_documented` | + `scsl:CLD-NET-5`, `secnumcloud-3.2:13.1` | 1 / 1 |
| assouplissement : fenêtre de snapshot à 90 j | 10 | `blockstorage_volume_snapshots_exist` | `scsl:CLD-STO-3`, `cis-v8:11.2`, `iso-27001:A.8.13`, `secnumcloud-3.2:12.5` | 1 / 1 |
| assouplissement : états de snapshot élargis | 10 | `blockstorage_volume_snapshots_exist` | idem | 1 / 1 |
| assouplissement : seuil de secrets à `medium` | **9** | `compute_instance_no_secrets_in_user_data` | `scsl:CLD-CMP-9`, `secnumcloud-3.2:10.5` | 1 / 1 |
| assouplissement : seuil de secrets à `high` | **9** | `compute_instance_no_secrets_in_user_data` | idem | 1 / 1 |
| **assouplissement sur une fixture CONFORME** | 0 | `blockstorage_volume_snapshots_exist` | `scsl:CLD-STO-3`, `cis-v8:11.2`, `iso-27001:A.8.13`, `secnumcloud-3.2:12.5` | **0 / 3** |

Les trois premières lignes tiennent la propriété 1 : l'empreinte de politique du cas 1 et du cas 2 est **identique** (`sha256:9ee02fa9…`), celle du durcissement diffère, et aucun des trois n'assouplit quoi que ce soit. La quatrième est le cas que la mesure a corrigé (§2).

Les deux dernières colonnes de la dernière ligne sont le cœur du sujet : **une configuration assouplie peut encore rendre 0**, mais elle rend 3 sous `--strict`, et elle est visible partout.

### Où l'assouplissement devient visible — les cinq endroits

| Endroit | Ce qui apparaît |
|---|---|
| **Terminal** | bloc `CONFIGURATION ASSOUPLIE : correspondances normatives NON TENUES`, une ligne par réglage (défaut → effectif, ce qui est perdu), puis les correspondances abandonnées ; et le bandeau de verdict devient `Verdict : SOUS CONFIGURATION ASSOUPLIE — n contrôle(s) évalué(s) sous une exigence abaissée` |
| **Assessment** (`--format assessment`, donc OSCAL et `assessment.json` scellé) | `references` **vidées** ; `labels.config_relaxed`, `labels.config_relaxed_detail`, `labels.references_dropped` ; et `evidence.observed` énonce l'assouplissement en toutes lettres |
| **Formats analysables** (`--format json`) | `config.policy_digest`, `config.effective` (**toujours**, défaut compris), `config.relaxations[]` et `config.dropped_references[]` |
| **Bundle scellé** | artefact `config.json` (empreinte + configuration effective + assouplissements + avertissement bilingue) et `manifest.config = {policy_digest, relaxed_controls, dropped_references}`, **tous deux couverts par `checksums.txt`** — l'empreinte du dossier dépend donc des réglages, et l'`input.json` porte la configuration effective |
| **Porte de CI** | `--strict` rend 3 |

---

## 5. Chaque invariant rougit quand on le casse

Méthode des lots 1 et 2, reprise : casser la propriété, lancer la garde, restaurer. Vingt et une propriétés, **vingt et un rouges**, arbre restauré et suite verte après coup.

| Ce qu'on casse | Garde | Verdict |
|---|---|---|
| une contrainte au sens ininterprétable (`a_peu_pres_le_defaut`) | `TestConfigConstraintsAreInterpretable` | 🔴 |
| une contrainte qui nomme un réglage inconnu | `TestConfigConstraintsAreInterpretable` | 🔴 |
| un réglage qu'aucune contrainte ne nomme | `TestEveryConfigurableControlDeclaresItsConstraint` | 🔴 |
| un réglage déclaré que le moteur n'évalue pas | `TestEveryDeclaredParameterIsEvaluated` | 🔴 |
| un `config_requise` non désérialisé (tag YAML faux) | `TestConfigConstraintsParseFromYAML` | 🔴 |
| un défaut Go qui s'écarte du repli Rego | `TestTheRegoFallbackProfileEqualsTheGoDefaultProfile` | 🔴 |
| un repli Rego qui s'écarte du défaut Go | idem | 🔴 |
| des règles qui **ignoreraient** `input.config` | `TestTheInjectedConfigurationIsActuallyRead` | 🔴 |
| un défaut qui déplace un verdict (`min_confidence: medium`) | `TestAnExplicitDefaultPolicyMovesNoVerdict` | 🔴 |
| un assouplissement qui garderait ses `references` | `TestARelaxedConfigurationIsVisibleEverywhere` | 🔴 |
| un assouplissement muet dans le terminal | idem / terminal | 🔴 |
| un assouplissement absent du JSON | idem | 🔴 |
| un assouplissement non scellé au bundle | idem | 🔴 |
| la `config` absente de l'`input.json` scellé | idem / bundle | 🔴 |
| un assouplissement qui passerait `--strict` | `TestARelaxedConfigurationFailsTheStrictGate` | 🔴 |
| deux fichiers de politique acceptés | `TestTwoPolicyFilesAreRefused` | 🔴 |
| un durcissement signalé comme assouplissement | `TestAnotherWritingConventionIsNotARelaxation` | 🔴 |
| un niveau de confiance absent des formats analysables | `TestASecretConfidenceTravelsInTheParsableFormats` | 🔴 |
| **un détecteur qui recopierait le secret dans son message** | `test_secret_value_never_leaks_{high,medium,low}` | 🔴 |
| un réseau validé par un tag unique et hors sujet | `test_network_single_irrelevant_tag_denied` | 🔴 |
| une snapshot en erreur comptée comme sauvegarde | `test_snapshot_in_error_does_not_count` | 🔴 |

---

## 6. Ce que le lot 2 impose, et ce que j'en ai fait

- **Registre de véracité** — `mise run veracity-update` lancé après chaque changement de contrôle. **Diff vide** : 178 chemins, 5 prouvés, 458 obligations, 445 restantes, inchangés. La raison tient en une phrase : `network_documented` lit `tags`, que les trois descripteurs projettent déjà, donc son verrou `requiredAttr` ne déplace aucune cellule de la matrice ; et `blockstorage_snapshot.state` n'est le verrou de `pass` d'aucun contrôle (celui de `blockstorage_volume_snapshots_exist` porte sur `blockstorage_volume.state`). Ce n'est pas un oubli, c'est le résultat.
- **Surfaces gelées** — trois bumps, chacun avec sa ligne de CHANGELOG bilingue : `cliSurfaceVersion` **3 → 4** (`--policy`), `assess.BundleFormat` **v2 → v3** (`config.json` + `manifest.config`), `model.InventoryFormat` **v3 → v4** (`blockstorage_snapshot.state`, et la note consigne la clé d'enveloppe `config`). `mise run frozen-update` lancé, diff relu.
- **Dérogations orphelines** — le piège nommé, évité en ne renommant aucun code (§2). `TestAnExceptionsFileStillWorksUnderItsHistoricName` mesure qu'un fichier `--exceptions` du lot 2 continue de rendre le code 4.

---

## 7. Documentation

`mise run gen-docs` lancé et committé à **chaque** commit (les cinq commits sont individuellement verts, `TestGeneratedDocsAreUpToDate` compris). Écrit à la main, dans les deux langues :

- **`docs/guides/control-configuration.md` / `.fr.md`** — page nouvelle, liée depuis les deux README : le fichier unique, le profil par défaut **présenté comme une recommandation** avec ses alias et ses types visés justifiés un par un, les quatre sens de contrainte, les cinq endroits où un assouplissement devient visible, **comment régler le seuil bloquant en CI** (#48) et **ce que le contrôle de snapshot ne prouve pas** (#49).
- `docs/reference/output-formats` — la clé `config`, toujours présente, et `labels.confidence`.
- `docs/reference/exit-codes` — `--strict` ajoute désormais deux comportements, pas un ; ordre de précédence mis à jour.
- `docs/guides/evidence-bundles` — section `config.json`, et pourquoi l'empreinte du bundle dépend des réglages.
- `docs/known-limitations` — trois sections : une snapshot récente n'est pas une politique de sauvegarde ; la détection de secrets a des niveaux, pas des certitudes ; un réglage assoupli retire la correspondance, pas la mesure.
- `docs/controls/*`, `docs/coverage`, `docs/concepts/assessment-model` — régénérés.

*Quelqu'un qui lit la documentation sans lire le code serait-il induit en erreur ?* Le point que j'ai vérifié en priorité : la page de configuration dit **ce qu'on perd**, pas seulement ce qu'on règle, et la description de chaque contrôle au référentiel commence par « CE QUI EST VÉRIFIÉ » / « CE QUE LE CONTRÔLE NE PROUVE PAS ».

---

## 8. Portes

`mise run validate` (gardes `Config` ajoutées à la tâche) · `mise run test` (`go test ./... -race` + `opa test`, 282 tests Rego) · `mise run audit` (vet, golangci-lint 0 issue, gosec, govulncheck, osv-scanner) — **tous verts**, à la réserve de `govulncheck` notée en §1.

Aucun `//nolint` ajouté, aucune exclusion gosec : les identifiants sensibles ont été **nommés** pour ne pas déclencher G101 (`defaultMinConfidence`, `rankOfConfidence`, `MinConfidence`).

## 9. Hors périmètre des cinq issues

- `chore(github): add the funding configuration` — `.github/FUNDING.yml` (`ko_fi: stephanerobert89902`), transplanté tel quel depuis un autre dépôt du mainteneur, à la demande de l'utilisateur. Ni preuve, ni test, ni documentation.

Closes #65, closes #47, closes #61, closes #49, closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)