### PR TITLE
docs(adr): make architecture decisions the project's source of truth

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Ce que ça change
+
+<!-- Ce qu'un consommateur verra bouger. Pas le détail de l'implémentation. -->
+
+## Impact ADR
+
+<!--
+Obligatoire dès que la PR touche : modèle de données, architecture, réseau, API,
+workflow, format de sortie, persistance, sécurité, génération, orchestration ou
+comportement public. Une faute de frappe ou un test manquant : « aucun » suffit.
+
+Voir docs/adr/README.md.
+-->
+
+- [ ] aucun — la modification ne touche aucune décision d'architecture
+- [ ] ADR-XXXX respecté
+- [ ] ADR-XXXX étendu
+- [ ] ADR-XXXX à remplacer — un nouvel ADR est proposé dans cette PR
+- [ ] un nouvel ADR est nécessaire
+
+**Invariants concernés** :
+
+<!--
+Lister les invariants des ADR applicables, et dire comment la PR les préserve.
+Si la PR réintroduit une alternative écartée par un ADR, le dire ICI et expliquer
+pourquoi la raison du rejet a cessé d'être vraie.
+-->
+
+## Ce que je n'ai pas pu faire ou vérifier
+
+<!--
+La section la plus lue. Ce qui n'est pas mesuré se dit : un lot qui prétend tout
+avoir vérifié sans compte cloud ment.
+-->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,48 @@ dans **`internal/commonrules/`** et s'évaluent sur le **modèle normalisé comm
 > collecteur/mapper vers le modèle commun, puis on écrit **une** règle commune —
 > jamais une règle par provider.
 
+## 0.1 Revue ADR — AVANT toute implémentation
+
+Le code décrit l'état actuel. Les **ADR** (`docs/adr/`) expliquent pourquoi cet
+état existe et quelles décisions ne se rouvrent pas sans décision explicite.
+
+> **Une issue décrit ce que nous voulons changer. Un ADR décrit les décisions déjà
+> prises. Une issue ne peut pas annuler un ADR en silence.**
+>
+> **Une solution techniquement correcte mais contraire à une décision existante est
+> INCORRECTE tant que cette décision n'a pas été explicitement révisée.**
+
+Avant de modifier du code qui touche au modèle de données, à l'architecture, au
+réseau, à une API, à un workflow, à un format de sortie, à la persistance, à la
+sécurité, à la génération, à l'orchestration ou au **comportement public** :
+
+1. Lire `docs/adr/README.md`.
+2. Identifier les ADR applicables — table de portée, ou champ `scope:`. **Ne pas
+   lire tout le registre pour un petit changement** ; le parcourir entièrement
+   pour un changement transverse.
+3. Lire ces ADR EN ENTIER, pas leur titre.
+4. Relever leurs invariants.
+5. Vérifier que la solution envisagée ne réintroduit pas une **alternative écartée**.
+   C'est le piège propre à un agent : reproposer, vite et de bonne foi, une solution
+   plausible que quelqu'un a déjà rejetée pour des raisons écrites.
+6. **En cas de conflit : ne pas implémenter.** Signaler :
+
+   ```
+   Cette évolution entre en conflit avec ADR-XXXX : <résumé>.
+   Elle exige soit de respecter l'ADR, soit une nouvelle décision explicite.
+   ```
+
+   Si la décision doit changer, créer un ADR qui remplace (`ADR-0023 supersedes
+   ADR-0007`) et passer l'ancien en `Status: Superseded by ADR-0023`. Jamais de
+   réécriture silencieuse : l'historique est ce qui empêche de refaire le tour.
+7. Après implémentation, vérifier que les invariants tiennent toujours.
+
+Déclarer le résultat dans la PR sous **Impact ADR**. Une faute de frappe ou un test
+manquant n'exige rien de cela.
+
+`mise run adr-drift` signale la dérive de FORME. Il ne dit pas qu'un ADR est devenu
+faux.
+
 ## 1. Build, test, audit — toujours via `mise`
 
 Le projet est piloté par **mise** (`mise.toml`, plus de Makefile) : `mise run <tâche>`

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -39,6 +39,34 @@ Ne proposez pas de changement si `mise run test` ou `mise run audit` échoue.
 6. **Aucun secret en dur** (clés, mots de passe) : options CLI / environnement /
    `random_password` dans les fixtures.
 
+## Revue ADR — avant de toucher au code
+
+Le code décrit l'état actuel. Un **ADR** (`docs/adr/`) explique pourquoi cet état
+existe, et quelles décisions ne se rouvrent pas sans décision explicite.
+
+> **Une issue décrit ce que nous voulons changer. Un ADR décrit les décisions déjà
+> prises. Une issue ne peut pas annuler un ADR en silence.**
+
+Avant d'implémenter quoi que ce soit qui touche au modèle de données, à
+l'architecture, au réseau, à une API, à un workflow, à un format de sortie, à la
+persistance, à la sécurité, à la génération, à l'orchestration ou au
+**comportement public** :
+
+1. Identifier les composants touchés.
+2. Trouver les ADR applicables — table de portée dans
+   [`docs/adr/README.md`](docs/adr/README.md), ou champ `scope:` de chaque ADR.
+3. Les lire en entier, et relever leurs invariants.
+4. Vérifier que le changement ne réintroduit pas une alternative qu'un ADR a écartée.
+5. En cas de conflit, **s'arrêter** : proposer d'abord un ADR qui remplace, jamais
+   une réécriture silencieuse de l'ancien.
+
+Une faute de frappe ou un test manquant n'exige rien de tout cela. Déclarer le
+résultat dans la PR, sous **Impact ADR**.
+
+`mise run adr-drift` signale la dérive de forme — un chemin disparu, une garde
+qui n'existe plus. Il ne sait pas dire qu'un ADR est devenu faux ; cela demande
+encore de lire.
+
 ## Ajouter un provider
 
 Un provider = un fichier `providers/<nom>.yaml` : identité, auth, résolution des

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,32 @@ Do not submit a change if `mise run test` or `mise run audit` fails. `opa test`,
 6. **No hardcoded secrets** (keys, passwords): CLI options / environment /
    `random_password` in fixtures.
 
+## ADR review — before touching the code
+
+Code describes the current state. An **ADR** (`docs/adr/`) explains why that state
+exists, and which decisions cannot be reopened without an explicit new decision.
+
+> **An issue describes what we want to change. An ADR describes decisions already
+> taken. An issue cannot silently overturn an ADR.**
+
+Before implementing anything that touches the data model, the architecture, the
+network, an API, a workflow, an output format, persistence, security, generation,
+orchestration or **public behaviour**:
+
+1. Identify the components touched.
+2. Find the applicable ADRs — scope table in [`docs/adr/README.md`](docs/adr/README.md),
+   or each ADR's `scope:` field.
+3. Read them in full, and list their invariants.
+4. Check that the change does not reintroduce an alternative an ADR rejected.
+5. If it conflicts with an ADR, **stop**: propose a superseding ADR first, never a
+   silent rewrite of the old one.
+
+A typo or a missing test needs none of this. Declare the outcome in the PR under
+**ADR impact**.
+
+`mise run adr-drift` reports stale form — a vanished path, a guard that no longer
+exists. It cannot tell you an ADR has become false; that still takes reading.
+
 ## Adding a provider
 
 A provider is one `providers/<name>.yaml` file: identity, auth, credential

--- a/docs/adr/0001-regles-communes-providers-collecteurs.md
+++ b/docs/adr/0001-regles-communes-providers-collecteurs.md
@@ -1,0 +1,72 @@
+# ADR-0001 — Un seul jeu de règles commun, les providers ne sont que des collecteurs
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - rules
+  - providers
+```
+
+## Contexte
+
+Pépin est né de la généralisation d'`osc-policy`, écrit pour un seul cloud. La
+question posée à la généralisation était : duplique-t-on les règles par
+fournisseur, ou les mutualise-t-on sur un modèle commun ?
+
+## Décision
+
+**Toutes** les règles de posture sont communes et vivent dans
+`internal/commonrules/rules/`. Elles s'évaluent sur un modèle normalisé agnostique.
+Un provider est un **collecteur** : son seul rôle est de projeter sa source vers
+ce modèle. Il ne porte aucune règle.
+
+Le `code` d'un contrôle est agnostique (`network_securitygroup_…`,
+`objectstorage_bucket_…`), jamais préfixé par un fournisseur.
+
+## Justification
+
+La duplication par fournisseur ne divise pas le travail, elle le multiplie : à
+chaque correction de règle il faut retrouver ses N copies, et celle qu'on oublie
+devient un faux verdict silencieux. Un modèle commun déplace le coût là où il est
+irréductible — la différence entre les API — et l'y confine.
+
+## Alternatives écartées
+
+**Un paquet de règles par fournisseur.** Rejeté : N copies d'une même logique
+divergent, et la divergence ne se voit qu'au moment où un verdict est faux.
+
+**Des règles communes avec des exceptions par fournisseur dans la règle.** Rejeté :
+c'est la duplication en pire, parce qu'elle est invisible dans l'arborescence.
+`labels.provider` se tire de la ressource via `provider_of(r)`, jamais en dur.
+
+## Conséquences
+
+Ajouter un fournisseur, c'est un contrat plus un collecteur, et **zéro règle**.
+
+En retour, tout écart d'API doit être absorbé par la normalisation, ce qui rend le
+collecteur plus riche et le modèle commun plus contraint. Une règle ne se déclenche
+que si des ressources du type visé existent, donc un fournisseur qui n'a pas ce
+type ne produit pas de faux positif.
+
+## Invariants
+
+- Aucun fichier `.rego` de posture hors de `internal/commonrules/rules/`.
+- Aucun code de contrôle ne nomme un fournisseur.
+- `labels.provider` vient de la ressource, jamais d'une constante.
+
+*Gardes : `TestActiveControlsHaveRule` (tout contrôle actif a une règle),
+`TestRuleCodesAreControlled` (tout code émis est catalogué), `TestCatalogueCoherent`.*
+
+*Le troisième invariant — `labels.provider` tiré de la ressource — n'a pas de garde :
+une constante mise en dur produirait un rapport plausible que rien ne distingue.
+Il tient par la revue et par le helper `provider_of`, qui est le seul chemin écrit.*
+
+## Validation
+
+`mise run validate` et `mise run test-rego`. Un contrôle actif sans règle, ou un
+code émis hors catalogue, casse la validation.
+
+## Liens
+
+`CLAUDE.md` §0 et §3 · skills `nouvelle-regle`, `nouveau-provider`.

--- a/docs/adr/0002-moteur-partage-scankit.md
+++ b/docs/adr/0002-moteur-partage-scankit.md
@@ -1,0 +1,76 @@
+# ADR-0002 — Le moteur, le modèle de finding et le rendu viennent de scankit
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - engine
+  - output
+```
+
+## Contexte
+
+Pépin et **pitstop** évaluent des politiques et rendent des résultats. Écrits
+séparément, ils auraient deux moteurs OPA, deux modèles de finding et deux rendus
+qui divergeraient sans que personne ne le décide.
+
+## Décision
+
+Le moteur OPA, `finding.Finding`, le rendu (terminal, SARIF), le scoring et
+l'assessment viennent du module publié
+**`github.com/stephrobert/scankit`**, épinglé par version dans `go.mod`, consommé
+en ligne — **sans `replace` local**.
+
+Reste dans Pépin : les règles, les collecteurs, le référentiel, la marque et le
+verdict.
+
+## Justification
+
+Une évolution de moteur ou de rendu profite alors aux deux outils, et le rendu
+terminal reste identique entre eux — ce qui est une propriété visible par
+l'utilisateur, pas un détail interne.
+
+## Alternatives écartées
+
+**Un moteur local à Pépin.** Rejeté : deux implémentations d'un même verdict
+divergent, et la divergence se découvre par un rapport faux.
+
+**Un `replace` local vers un clone de scankit.** Rejeté : il rend le dépôt
+non reproductible pour quiconque n'a pas ce clone, et masque la version
+réellement utilisée.
+
+## Conséquences
+
+Une évolution du modèle de finding ou du rendu se fait **en amont**. Ce coût est
+réel : la vague 4 a dû faire voyager les traductions, l'origine Terraform et la
+confiance dans `labels` plutôt que dans des champs de premier rang, parce que
+`finding.Finding` ne se modifie pas depuis ici.
+
+`labels` est donc la voie normale d'extension tant qu'un besoin n'est pas partagé
+avec pitstop.
+
+## Invariants
+
+- Aucun moteur, rendu ou scoring local dans Pépin.
+- Aucun `replace` vers scankit dans `go.mod`.
+- Toute donnée propre à Pépin voyage dans `labels`, pas dans un champ de scankit.
+
+*Non automatisable : on ne sait pas écrire un test qui distingue « du code qui
+évalue une politique » de « du code qui fait autre chose ». Un moteur local
+réintroduit se voit à la revue et à l'arborescence. L'absence de `replace` se lit
+en une ligne de `go.mod`. C'est une limite assumée : cette décision repose sur la
+revue.*
+
+## Validation
+
+*Aucune garde automatique.* Un moteur local réintroduit se verrait à la revue et à
+l'arborescence, pas par un test : on ne sait pas écrire un test qui distingue « du code
+qui évalue une politique » de « du code qui fait autre chose ». `go.mod` se relit,
+et l'absence de `replace` y est visible en une ligne.
+
+C'est une limite assumée de cette décision : elle repose sur la revue.
+
+## Liens
+
+`CLAUDE.md` §9 · limitation connue : SARIF ne sait pas exprimer une suppression
+(issue #94), qui se règle en amont.

--- a/docs/adr/0003-inventaire-contrat-gele.md
+++ b/docs/adr/0003-inventaire-contrat-gele.md
@@ -1,0 +1,63 @@
+# ADR-0003 — L'inventaire normalisé est un contrat gelé et versionné
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - model
+```
+
+## Contexte
+
+L'inventaire est le point de passage de tout : la collecte y projette, les règles
+s'y évaluent, l'assessment en dérive, le bundle le scelle. Chaque nouvel usage le
+figeait un peu plus **par accident**, et une évolution du modèle cassait alors un
+consommateur en silence.
+
+## Décision
+
+Le schéma est un contrat nommé, versionné (`model.InventoryFormat`) et gelé dans
+`cmd/testdata/frozen/inventory.json`. Ce qui est garanti et ce qui ne l'est pas
+sont écrits ; un changement de forme exige un bump, une entrée d'historique et une
+ligne de CHANGELOG.
+
+## Justification
+
+Un contrat implicite est un contrat qu'on casse sans le savoir. Le nommer coûte un
+`frozen-update` par changement ; ne pas le nommer coûte un consommateur cassé sans
+avertissement.
+
+## Alternatives écartées
+
+**Laisser le schéma implicite et documenter les usages.** Rejeté : la
+documentation dérive, le gel ne dérive pas.
+
+**Versionner sans geler.** Rejeté : sans fixture, rien ne détecte le changement au
+moment où il est fait.
+
+## Conséquences
+
+Ajouter un attribut à un descripteur rend la fixture rouge et coûte un
+`frozen-update`. **C'est le but** : l'inventaire cesse d'être un détail
+d'implémentation.
+
+## Invariants
+
+- Un attribut **absent** n'est jamais forcé à une valeur : « non collecté » et
+  « collecté à faux » ne se confondent pas. *C'est l'invariant dont tout le modèle
+  de confiance dépend.*
+- `attributes` est une carte plate, en snake_case, agnostique du fournisseur.
+- `evaluated_at` et `config` sont écrits **une fois** : un `input.json` rejoué
+  garde les siens.
+- L'ordre des ressources et l'exhaustivité de l'inventaire ne sont **pas** garantis.
+
+*Garde : `TestTheFrozenSurfacesStillMatchTheirFixture`.*
+
+## Validation
+
+`mise run test` inclut le gel. `mise run frozen-update` régénère, et le diff se
+relit — la porte attrape l'oubli, pas la négligence.
+
+## Liens
+
+`internal/model/schema.go` · ADR-0006, ADR-0007.

--- a/docs/adr/0004-index-scsl-gele.md
+++ b/docs/adr/0004-index-scsl-gele.md
@@ -1,0 +1,56 @@
+# ADR-0004 — L'index SCSL est gelé : on mappe, on n'invente jamais
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - referentiel
+```
+
+## Contexte
+
+Pépin s'ancre sur SCSL, dont les exigences `CLD-*` sont publiées par un référentiel
+externe. La tentation, en couvrant un contrôle nouveau, est de « créer l'exigence
+qui manque ».
+
+## Décision
+
+L'index SCSL est **gelé**. Un contrôle se mappe sur une exigence `CLD-*`
+**existante**. Si aucune ne couvre le besoin, le contrôle reste au catalogue en
+`statut: a_trier` — hors périmètre tant que SCSL ne l'a pas figé.
+
+## Justification
+
+Un référentiel dont on invente les exigences ne vaut plus rien comme référentiel.
+L'opposabilité que Pépin revendique repose entièrement sur le fait que la
+correspondance renvoie à un texte que Pépin n'a pas écrit.
+
+## Alternatives écartées
+
+**Créer des exigences locales en attendant.** Rejeté : elles deviendraient
+indiscernables des vraies dans un rapport lu par un auditeur.
+
+**Mapper sur l'exigence « la plus proche ».** Rejeté : c'est la même invention,
+avec un air de rigueur.
+
+## Conséquences
+
+Des contrôles utiles restent au catalogue sans être actifs. C'est le prix, et il
+est assumé : un contrôle sans ancrage normatif reste mesurable, il n'est
+simplement pas opposable.
+
+## Invariants
+
+- Tout `scsl:` d'un contrôle actif existe dans l'index gelé.
+- Aucune exigence n'est créée depuis ce dépôt.
+
+*Gardes : `TestSCSLReferencesExist` (tout `scsl:` existe dans l'index gelé),
+`TestSCSLCoherence`, `TestFrameworkReferencesExist`.*
+
+## Validation
+
+`mise run validate`, et `scsl-drift` au préflight de release.
+
+## Liens
+
+`CLAUDE.md` §3 et §10 · ADR-0009 pour ce qu'un assouplissement fait perdre.

--- a/docs/adr/0005-codes-de-sortie.md
+++ b/docs/adr/0005-codes-de-sortie.md
@@ -1,0 +1,69 @@
+# ADR-0005 — Sémantique des codes de sortie, et pourquoi il n'y en a pas un cinquième
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - cli
+  - ci
+```
+
+## Contexte
+
+Les codes de sortie sont la **porte de CI** : ce sont eux, et non le rapport, qui
+décident si une chaîne passe. Chaque code ajouté coûte à tous les consommateurs une
+relecture de leur `case $?`.
+
+## Décision
+
+`0` conforme · `1` non-conformité (≥ 1 écart critical/high) · `2` erreur technique ·
+`3` **le scan n'établit pas la conformité** — rien de mesuré, collecte incomplète,
+ou écarts medium/low avec `--strict` · `4` tout écart critical/high est couvert par
+une dérogation valide.
+
+Ordre de précédence : `2` > `1` > `3` (rien de mesuré) > `4` > `3` (`--strict`).
+
+**Ni `3` ni `4` ne valent conformité.**
+
+## Justification
+
+Un cinquième code pour l'incomplétude a été envisagé puis rejeté : il ne pourrait
+**jamais** primer sur `1` — masquer un écart critique réel parce que le reste
+manquait serait exactement le faux vert que le modèle de confiance combat —, donc
+il ne se déclencherait que là où `3` se déclenche déjà. Deux codes pour une même
+position dans l'ordre de précédence sont un doublon, pas une distinction.
+
+Ce qui distingue les cas est **lisible ailleurs** : relevé de capacités, motif de
+chaque `not-evaluated`, clé `collection` de `--format json`.
+
+## Alternatives écartées
+
+**Un code dédié à l'incomplétude.** Rejeté, cf. ci-dessus.
+
+**Rendre `0` sur une collecte partielle.** Rejeté : c'est la définition du faux vert.
+
+**Rendre `1` sur une dérogation valide.** Rejeté : une équipe qui ne peut pas
+déroger supprime le contrôle à la place.
+
+## Conséquences
+
+Un changement de cette sémantique touche **cinq lieux qui doivent bouger ensemble** :
+`README.md`, `README.fr.md`, `CLAUDE.md` §6, et `docs/reference/exit-codes.{md,fr.md}`
+qui est généré. L'oubli du résumé de page d'accueil s'est déjà produit.
+
+## Invariants
+
+- Un scan qui n'a rien collecté ne rend jamais `0`.
+- Une dérogation ne rend jamais `0`.
+- L'incomplétude n'efface jamais un écart observé : `1` prime sur `3`.
+
+*Gardes : `TestAnExemptionNeverProducesAZeroExitCode`, et le préflight vérifie que
+les codes répondent ce que le README promet.*
+
+## Validation
+
+`tools/release/preflight.sh` exécute les quatre cas nominaux avant tout tag.
+
+## Liens
+
+`CLAUDE.md` §6 · ADR-0008.

--- a/docs/adr/0006-jamais-un-pass-non-prouve.md
+++ b/docs/adr/0006-jamais-un-pass-non-prouve.md
@@ -1,0 +1,77 @@
+# ADR-0006 — Un PASS non prouvé est un défaut : verrou de capacité et dégradation
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - assessment
+```
+
+## Contexte
+
+L'incident fondateur : une policy EIM inline `Action: "*"` échappait à **tous** les
+contrôles `iam_policy_*`. La règle Rego était juste. **La donnée n'arrivait jamais
+jusqu'à elle.** Un test Rego parfait serait resté vert pendant que le scanner
+produisait un faux vert.
+
+## Décision
+
+Deux mécanismes, tenus par l'assessment et non par les règles :
+
+**Le verrou de capacité** (`requiredAttr`) — un contrôle ne peut pas rendre `pass`
+si l'attribut qui décide n'a pas été collecté.
+
+**La dégradation** (`assess.Degrade`) — une unité de collecte incomplète fait
+passer les contrôles qui en dépendent de `pass` à `not-evaluated`, avec la raison.
+
+La transition est **strictement directionnelle** et n'en produit qu'une :
+`pass → not-evaluated`.
+
+## Justification
+
+Confier cette garde aux règles serait la confier à la mémoire de celui qui écrira
+la cinquantième. L'assessment la tire une fois, pour toutes les règles présentes
+et à venir.
+
+Un `fail` est **conservé** : l'écart a été *vu*, la donnée qui l'établit est
+arrivée, et l'effacer supprimerait une non-conformité vraie. Un `not-applicable`
+est conservé : il vient du contrat du fournisseur, et rien de ce qu'un scan lit ou
+ne lit pas ne peut le contredire.
+
+## Alternatives écartées
+
+**Une garde par règle.** Rejeté : c'est une garde qu'on oublie d'écrire.
+
+**Avorter le scan sur un endpoint refusé.** Rejeté : sûr en apparence, mais cela
+pousse l'opérateur à **élargir les droits** du compte qui exécute le CSPM. Un outil
+qui incite à donner plus de privilèges travaille contre son propre objet.
+
+**Dégrader aussi les `fail`.** Rejeté : cf. justification.
+
+## Conséquences
+
+Une seule exception à « ce qui a été lu est gardé » : un **agrégat** n'est jamais
+calculé sur une liste tronquée, parce qu'un compte faux est pire qu'un compte
+absent — une règle le compare à un seuil.
+
+**Dette connue** : le verrou raisonne aujourd'hui par *type* et en *any-of*, pas par
+ressource ni en *all-of*, et un contrôle ne déclare qu'un type. Voir #102 et #103 :
+c'est la limite actuelle de cette décision, pas une remise en cause de sa direction.
+
+## Invariants
+
+- Aucun `pass` sans l'attribut qui décide.
+- La dégradation ne produit que `pass → not-evaluated`.
+- Un agrégat n'est jamais calculé sur une liste tronquée.
+
+*Gardes : `TestAnIncompleteCollectionWithdrawsThePassAndOnlyThePass`,
+`TestAnAggregateIsNotComputedOnATruncatedList`.*
+
+## Validation
+
+Campagne binaire avant/après sur les fixtures et le corpus à chaque évolution :
+**aucun verdict ne doit devenir plus affirmatif**.
+
+## Liens
+
+`CLAUDE.md` §10 · ADR-0010 · issues #102, #103, #104.

--- a/docs/adr/0007-provenance-index-parallele.md
+++ b/docs/adr/0007-provenance-index-parallele.md
@@ -1,0 +1,71 @@
+# ADR-0007 — La provenance est un index parallèle, pas une enveloppe autour de chaque valeur
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - model
+  - assessment
+```
+
+## Contexte
+
+Pour dire ce que Pépin a **observé** plutôt que ce qu'il suppose, chaque attribut
+devait porter son origine : appel d'API servi, littéral de descripteur, valeur
+dérivée.
+
+## Décision
+
+`model.Resource` gagne une carte `provenance`, indexée par les **mêmes** noms
+d'attributs, sœur de `attributes` — jamais imbriquée dans une valeur.
+
+Une source `api` nomme **la requête réellement servie**, lue sur la requête après
+une réponse valide, jamais celle que la spec déclare.
+
+## Justification
+
+Envelopper chaque valeur (`{"value": false, "observed": true, …}`) aurait imposé de
+réécrire les 59 règles, et **une règle réécrite est une règle qui peut changer de
+verdict**. Avec un index parallèle, l'entrée des règles est identique octet pour
+octet : la non-régression devient structurelle au lieu d'être espérée.
+
+Une provenance qui désigne un appel qui n'a pas eu lieu donnerait l'**apparence** de
+la traçabilité, ce qui est pire que son absence.
+
+## Alternatives écartées
+
+**Envelopper chaque valeur.** Rejeté : réécriture des 59 règles.
+
+**Dériver la provenance de la spec YAML.** Rejeté : elle nommerait un appel non
+émis.
+
+**Rendre la provenance optionnelle derrière un drapeau.** Rejeté : un dossier de
+preuve dont la provenance est optionnelle est un dossier qu'on peut produire sans
+elle.
+
+## Conséquences
+
+L'`input.json` d'un bundle grossit d'une entrée par attribut mappé. Coût assumé :
+si la taille devient un problème, la correction honnête est une **compaction** de
+l'attestation, pas sa désactivation.
+
+La provenance **ne déplace aucun verdict**. Elle rend visible qu'un contrôle
+franchit son verrou grâce à un littéral de descripteur plutôt qu'à une mesure —
+l'écart devient *détectable*, ce qui est tout l'objet.
+
+## Invariants
+
+- La provenance ne modifie jamais un statut.
+- Une source `api` nomme un appel réellement servi.
+- Une origine absente n'est jamais fabriquée.
+
+*Gardes : `TestProvenanceNeverMovesAVerdict`,
+`TestProvenanceNamesTheCallThatActuallyHappened`.*
+
+## Validation
+
+Comparaison des verdicts avant/après sur toutes les fixtures, dans les deux langues.
+
+## Liens
+
+ADR-0003, ADR-0014.

--- a/docs/adr/0008-derogation-nest-pas-conformite.md
+++ b/docs/adr/0008-derogation-nest-pas-conformite.md
@@ -1,0 +1,72 @@
+# ADR-0008 — Une dérogation écarte un écart, elle ne le déclare jamais conforme
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - assessment
+  - ci
+```
+
+## Contexte
+
+Une équipe qui ne peut pas déroger à un contrôle **supprime le contrôle**. Il
+fallait donc un mécanisme de dérogation — sans qu'il devienne une porte vers le vert.
+
+## Décision
+
+Un cinquième statut, `exempted`, et un code de sortie dédié, `4`. Une dérogation
+porte une justification, une échéance, un propriétaire et un approbateur.
+
+L'écart dérogé **reste** dans `--format json`, dans le SARIF et dans les décomptes
+de sévérité ; `summary.conforme` reste faux. Seule la **porte** bouge.
+
+## Justification
+
+`0` ferait de la dérogation un faux vert silencieux, exactement ce que le statut
+existe pour empêcher. `1` la rendrait inutile. `4` est non nul — rien ne passe en
+silence — et distinct, donc une chaîne qui l'accepte doit écrire le nombre, donc
+savoir qu'il existe.
+
+L'échéance s'évalue contre `evaluated_at`, pas contre l'horloge : un bundle rejoué
+rend le même verdict, et une dérogation valide ne « périme » pas entre le scan et
+la vérification.
+
+## Alternatives écartées
+
+**Rendre `0`.** Rejeté : faux vert.
+
+**Rendre `1`.** Rejeté : mécanisme inutilisable, donc contrôle supprimé.
+
+**Retirer l'écart dérogé du SARIF.** Rejeté : c'est le format le plus souvent
+branché sur une porte de fusion. L'en retirer serait le faux vert que cette vague
+combat. Le coût est réel et documenté (issue #94).
+
+## Conséquences
+
+`exemptions.json` est un artefact du bundle, sous `checksums.txt`, donc **sous
+signature** : un dossier ne peut pas perdre ses dérogations sans échouer à sa
+propre vérification.
+
+Une dérogation **périmée** cesse de s'appliquer et le dit ; une dérogation
+**orpheline** est signalée. Sous `--strict`, les deux font échouer la porte.
+
+## Invariants
+
+- `exempted` n'est jamais compté comme `pass`.
+- Un scan avec dérogation ne rend jamais `0`.
+- Seul un `fail` peut être dérogé.
+- Une dérogation expirée ne s'applique plus.
+
+*Gardes : `TestAnExemptionNeverTurnsAFailIntoAPass`,
+`TestAnExemptionNeverProducesAZeroExitCode`,
+`TestAnExpiredExemptionStopsApplyingAndSaysSo`, `TestOnlyAFailCanBeExempted`.*
+
+## Validation
+
+`mise run test`, plus la vérification qu'un bundle scellé avec dérogations se
+re-dérive fidèlement.
+
+## Liens
+
+ADR-0005 · issue #94.

--- a/docs/adr/0009-configuration-lie-mapping.md
+++ b/docs/adr/0009-configuration-lie-mapping.md
@@ -1,0 +1,80 @@
+# ADR-0009 — Un contrôle assoupli perd ses correspondances normatives
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - referentiel
+  - controls
+```
+
+## Contexte
+
+Rendre des contrôles configurables — étiquettes exigées, fraîcheur des snapshots,
+seuil de confiance — donne à l'utilisateur une **poignée qui fabrique du vert** :
+desserrer le seuil, puis continuer d'afficher la même correspondance CIS ou
+SecNumCloud.
+
+## Décision
+
+`referentiel/controles.yaml` porte, à côté de `scsl:` et `frameworks:`, les
+contraintes sous lesquelles ces correspondances valent (`config_requise`), en
+quatre sens : `au_plus_le_defaut`, `superset_du_defaut`, `sous_ensemble_du_defaut`,
+`au_moins_aussi_strict_que_le_defaut`.
+
+Quand la configuration effective sort de la contrainte, le contrôle **perd ses
+`references`** mais **garde son statut**, et l'assouplissement devient visible en
+cinq endroits : terminal, assessment, `--format json`, bundle scellé, et `--strict`
+qui rend `3`.
+
+## Justification
+
+Le statut ne change pas parce que le contrôle **a bien été évalué**, contre une
+barre plus basse. On retire la seule chose qui a cessé d'être vraie — la
+correspondance — et on garde la mesure. Marquer `not-evaluated` effacerait une
+mesure réelle ; garder les `references` mentirait.
+
+Vous pouvez abaisser la barre. Vous ne pouvez pas l'abaisser **et** garder le badge.
+
+## Alternatives écartées
+
+**Refuser la configurabilité.** Rejeté : une politique d'étiquetage figée produit
+des faux positifs sur toute organisation qui n'a pas choisi la même convention.
+
+**Configurer sans lier au mapping.** Rejeté : c'est la poignée à vert.
+
+**Passer un contrôle assoupli en `not-evaluated`.** Rejeté : il a été mesuré.
+
+Le quatrième sens de contrainte n'était pas prévu : la mesure a signalé qu'une
+convention d'écriture différente — l'exemple même de l'issue d'origine — était
+comptée comme un assouplissement alors qu'elle **durcit**. Un faux positif qui
+punit le bon comportement.
+
+## Conséquences
+
+Un fichier de politique unique (`--policy`), dont `--exceptions` est le nom
+historique ; les deux drapeaux sont mutuellement exclusifs, parce que deux fichiers
+divergent.
+
+La configuration voyage dans `input.config`, donc elle est **scellée** et le rejeu
+n'applique jamais la politique du jour à un dossier d'hier.
+
+## Invariants
+
+- À configuration par défaut, aucun verdict ne bouge.
+- Un contrôle assoupli n'affiche plus ses correspondances normatives.
+- Un assouplissement est visible dans les cinq surfaces, bundle compris.
+- Un durcissement n'est jamais signalé comme un assouplissement.
+
+*Gardes : `TestAnExplicitDefaultPolicyMovesNoVerdict`,
+`TestARelaxedConfigurationIsVisibleEverywhere`,
+`TestAnotherWritingConventionIsNotARelaxation`.*
+
+## Validation
+
+Campagne de configurations éprouvées, avec ce que chacune déclenche et où elle
+devient visible.
+
+## Liens
+
+ADR-0004, ADR-0005.

--- a/docs/adr/0010-dette-de-veracite-comptee.md
+++ b/docs/adr/0010-dette-de-veracite-comptee.md
@@ -1,0 +1,73 @@
+# ADR-0010 — Le contrat de véracité publie une dette comptée, jamais une matrice verte
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - testing
+  - quality
+```
+
+## Contexte
+
+L'unité de test qui compte pour un CSPM n'est pas `fixture → Rego → FAIL`, mais la
+chaîne entière : `réponse d'API → collecteur → normalisation → verrou → Rego →
+assessment → verdict`. L'incident EIM inline l'a démontré : la règle était juste,
+la donnée n'arrivait jamais.
+
+## Décision
+
+`internal/veracity` dérive, pour chaque chemin contrôle × fournisseur × source, les
+verdicts qu'il peut **réellement atteindre**, les compare aux scénarios versionnés
+qui s'exécutent **contre le binaire**, et exige que la différence soit inscrite dans
+un registre de dette.
+
+Le registre est une porte **dans les deux sens** : effacer une dette sans preuve
+échoue, en inventer une échoue, ajouter un contrôle sans scénarios échoue.
+
+## Justification
+
+178 chemins × quatre verdicts font environ sept cents cas. Personne ne peut
+*éprouver* sept cents cas — les casser un par un pour vérifier qu'ils rougissent —
+et une matrice engendrée par gabarit serait exactement le faux vert que tout le
+reste combat.
+
+Et « quatre verdicts partout » est faux : exiger un `not-applicable` d'un chemin où
+le mécanisme existe demande d'inventer une non-applicabilité.
+
+**Un compteur de dette honnête vaut mieux qu'une matrice verte.**
+
+## Alternatives écartées
+
+**Une matrice complète engendrée.** Rejeté : verte parce que creuse.
+
+**Masquer la dette.** Rejeté : le chiffre laid est l'information.
+
+**Compter un scénario par sa seule présence.** Rejeté : un filtre écarte le crédit
+obtenu par simple absence d'un type de ressource.
+
+## Conséquences
+
+Les chiffres publiés sont laids et ils sont justes. La carte de qualité les affiche,
+y compris « validé en live : 0 % », dont le zéro est **dérivé** et non écrit.
+
+Un scénario `live` dont le type est produit par la spec de collecte entre par `api:`
+— des réponses servies au collecteur **réel** —, jamais par `inventory:` : c'est le
+collecteur qui a laissé passer l'incident fondateur.
+
+## Invariants
+
+- Aucun chiffre publié ne peut dépasser ce que le registre autorise.
+- Un contrôle ajouté sans ses scénarios casse la CI.
+- Une dette effacée sans preuve casse la CI.
+
+*Gardes : `TestTheVeracityDebtLedgerIsExact`, `TestTheMapNeverExceedsTheLedger`,
+`TestNoPublishedFigureFlattersTheMeasure`.*
+
+## Validation
+
+`mise run veracity-update` régénère le registre ; le diff se relit.
+
+## Liens
+
+`CLAUDE.md` §10 étape 6 · ADR-0006 · issue #115 (contre-exemples).

--- a/docs/adr/0011-bilinguisme-francais-normatif.md
+++ b/docs/adr/0011-bilinguisme-francais-normatif.md
@@ -1,0 +1,72 @@
+# ADR-0011 — Bilinguisme : l'anglais est primaire, le français fait foi pour le normatif
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - docs
+  - cli
+  - referentiel
+```
+
+## Contexte
+
+Pépin vise l'écosystème souverain francophone **et** une audience internationale.
+Un outil de conformité dont le contenu normatif est traduit approximativement perd
+sa valeur d'opposabilité.
+
+## Décision
+
+**L'anglais est la langue primaire du dépôt** : `README.md`, `SECURITY.md`,
+`CONTRIBUTING.md`, avec leur contrepartie `*.fr.md`.
+
+**Le français est la langue de référence du contenu normatif** : c'est lui qui fait
+foi, l'anglais en est la traduction maintenue en parallèle.
+
+La langue de la CLI est détectée : `--lang` → `PEPIN_LANG` → `LC_ALL` → `LANG` →
+repli `en`. Elle vaut pour tout ce que l'outil imprime, formats parsables compris.
+
+Le **code et les commentaires** restent en français ; les **commits** en anglais.
+
+## Justification
+
+Le contenu normatif est adossé à des textes français (SCSL, SecNumCloud). En faire
+la référence évite qu'une nuance juridique se perde dans un aller-retour de
+traduction.
+
+## Alternatives écartées
+
+**Tout en anglais.** Rejeté : perte de précision sur le normatif, et le public
+premier est francophone.
+
+**Tout en français.** Rejeté : ferme l'outil à l'international.
+
+**Traduire à la volée.** Rejeté : une traduction non relue d'un texte normatif est
+une affirmation que personne n'a validée.
+
+## Conséquences
+
+Tout texte utilisateur s'écrit **deux fois, côte à côte** : `i18n.T(fr, en)` en Go,
+`message`/`labels.message_en` en Rego, `titre`/`titre_en` au référentiel,
+`reason`/`reason_en` dans les contrats.
+
+Les traductions voyagent dans `labels` parce que scankit ne se modifie pas depuis
+ici (ADR-0002).
+
+## Invariants
+
+- Aucune traduction manquante.
+- Une sortie `LANG=en` ne porte aucun mot accenté qui ne vienne de l'inventaire scanné.
+- La sortie française publiée n'a pas bougé d'un octet sans décision.
+
+*Gardes : `TestEveryControlIsBilingual`, `TestEveryFindingCarriesRemediation`,
+`TestEveryContractJustificationIsBilingual`,
+`TestFrenchScanOutputHasNotMovedOneCharacter`.*
+
+## Validation
+
+Les quatre portes sont dans `mise run validate` et `mise run test`.
+
+## Liens
+
+`CLAUDE.md` §1.2.

--- a/docs/adr/0012-aucun-identifiant-en-ci.md
+++ b/docs/adr/0012-aucun-identifiant-en-ci.md
@@ -1,0 +1,75 @@
+# ADR-0012 — Aucun identifiant cloud en CI ; l'émulateur est la surface de mesure
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - testing
+  - security
+```
+
+## Contexte
+
+Valider un chemin de collecte « live » demande une API réelle. Mettre des
+identifiants cloud en CI les expose à toute la chaîne d'approvisionnement du dépôt
+— actions tierces comprises.
+
+## Décision
+
+**Aucun identifiant cloud n'entre en CI.** Un scan live est un geste de mainteneur,
+lancé localement, dont le résultat est **consigné et daté** ; le préflight peut
+juger ce relevé périmé **sans jamais détenir de secret**.
+
+La surface de mesure automatisable est l'**émulateur local** des trois clouds
+souverains, atteint par un proxy d'enregistrement, plus les **plans Terraform**, qui
+ne provisionnent rien.
+
+## Justification
+
+Un CSPM dont la CI porte les clés d'un tenant réel est une cible : il concentre en
+un point ce qu'il est censé protéger.
+
+Et le non-provisionnement est préférable au provisionnement encadré : un plan
+Terraform suffit à valider un mapping, sans coût, sans surface d'exposition, sans
+rien à détruire.
+
+## Alternatives écartées
+
+**Des identifiants à droits réduits en CI.** Rejeté : « réduits » n'est pas
+« inoffensifs », et la réduction dérive.
+
+**Un endpoint de collecte surchargeable** pour rediriger les appels. Rejeté :
+chaque requête de collecte porte une clé en en-tête ; un endpoint configurable est
+un moyen d'envoyer les clés du tenant vers un hôte arbitraire. L'audit de livraison
+l'avait identifié comme tel. Le proxy obtient le même résultat **sans créer cette
+surface**, parce que le client honore déjà `HTTPS_PROXY`.
+
+## Conséquences
+
+Ce qui n'est pas mesuré contre une API réelle est **déclaré comme tel** : la colonne
+« live » de `docs/coverage.md`, les permissions minimales en `a_verifier`, la
+classification d'un vrai `403`.
+
+**Un émulateur prouve ce que Pépin fait, pas ce que le cloud répond.** Confondre les
+deux fabriquerait la fausse confiance que tout le reste combat.
+
+Corollaire de sécurité : toute ressource provisionnée pour un test **doit** être
+détruite, et l'enregistrement d'une session porte l'inventaire réel d'un tenant —
+aucun n'entre au dépôt sans relecture et assainissement, par **liste blanche** de ce
+qui est conservé. Une liste noire a été éprouvée et a échoué.
+
+## Invariants
+
+- Aucun secret dans un fichier versionné.
+- Aucune ressource cloud laissée derrière un test.
+- Ce qui n'est pas observé est déclaré non observé.
+
+*Gardes : `gitleaks` et `trufflehog` en CI ; le préflight juge la fraîcheur du relevé.*
+
+## Validation
+
+`mise run secrets` sur l'historique complet.
+
+## Liens
+
+`CLAUDE.md` §1.1 · skill `tracer-api` · ADR-0010.

--- a/docs/adr/0013-un-code-de-controle-ne-se-renomme-pas.md
+++ b/docs/adr/0013-un-code-de-controle-ne-se-renomme-pas.md
@@ -1,0 +1,62 @@
+# ADR-0013 — Un code de contrôle ne se renomme pas sans migration
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - controls
+  - compatibility
+```
+
+## Contexte
+
+Plusieurs contrôles portent un nom qui promet plus que ce qu'ils mesurent. La
+correction évidente est de les renommer.
+
+## Décision
+
+Un code de contrôle est une **surface de consommateur**. Il ne se renomme pas sans
+migration documentée. Quand la promesse est fausse, on corrige d'abord le titre, la
+description, le message et **la condition évaluée** — dans les deux langues.
+
+## Justification
+
+Un code voyage dans les `ruleId` SARIF des consommateurs, dans les assessments
+archivés, et **dans les fichiers de dérogations**. Un renommage transforme du jour
+au lendemain une dérogation valide en dérogation **orpheline** : l'opérateur voit
+un avertissement apparaître et son écart réapparaître, sans avoir rien changé.
+
+Déclencher en masse la détection d'orphelines qu'on vient soi-même de livrer serait
+une régression de confiance.
+
+## Alternatives écartées
+
+**Renommer et laisser les consommateurs suivre.** Rejeté : ils ne le sauront qu'en
+voyant leur porte de CI changer d'avis.
+
+**Renommer avec un alias permanent.** Recevable, mais non retenu par défaut : deux
+noms pour un contrôle sont deux noms qui divergeront dans les rapports.
+
+## Conséquences
+
+Certains noms restent imparfaits plus longtemps que leur contenu. Quand le **nom
+lui-même** est ce qui ment — `cross_organization` pour ce qui mesure
+`cross_account` —, le renommage redevient la bonne réponse, mais il se paie d'une
+migration explicite et d'une ligne de CHANGELOG.
+
+## Invariants
+
+- Aucun renommage de code sans migration écrite.
+- Un renommage retenu déclare son effet sur les dérogations existantes.
+
+*Non automatisable : aucune garde ne peut savoir qu'un renommage était justifié.
+C'est une décision de revue, pas de test.*
+
+## Validation
+
+Revue de PR. La détection des dérogations orphelines rend l'effet visible en
+exécution.
+
+## Liens
+
+ADR-0008 · issue #109.

--- a/docs/adr/0014-jamais-fabriquer-une-donnee-absente.md
+++ b/docs/adr/0014-jamais-fabriquer-une-donnee-absente.md
@@ -1,0 +1,77 @@
+# ADR-0014 — Une donnée absente ne se fabrique jamais, elle se déclare
+
+```yaml
+status: Accepted
+date: 2026-08-23
+scope:
+  - assessment
+  - collectors
+  - output
+```
+
+## Contexte
+
+Trois fois, la même tentation s'est présentée sous trois formes : donner une valeur
+plausible à ce qu'on n'a pas observé, parce que l'absence est inconfortable à
+afficher.
+
+## Décision
+
+Ce qui n'a pas été observé est **déclaré absent**, jamais estimé, jamais approché.
+
+**Origine Terraform** : `terraform show -json` ne porte ni fichier ni ligne — vérifié
+dans la source de Terraform. Le module se **lit** sur l'adresse, le fichier et la
+ligne se **mesurent** dans les `.tf` à côté du plan. Sources absentes, module
+distant, ou en-tête trouvé deux fois ⇒ **aucune origine**.
+
+**Relevé de capacités** : il est dérivé de la collecte **réellement effectuée**,
+jamais d'une sonde préalable.
+
+**Permissions minimales** : chaque ligne dit `verifie` ou `a_verifier`.
+
+## Justification
+
+Une ligne fausse envoie quelqu'un corriger au mauvais endroit, **et elle est crue**.
+Une sonde qui réussit là où l'appel réel échoue produit un relevé **qui ment** —
+c'est la règle de provenance appliquée aux capacités.
+
+Aucun drapeau ne pointe vers un autre arbre de sources : résoudre une origine contre
+un arbre dont le plan ne vient pas donne une ligne **plausible et fausse**, ce qui
+est le pire des deux.
+
+## Alternatives écartées
+
+**Approcher la ligne au plus proche.** Rejeté : plausible et faux.
+
+**Sonder les endpoints avant le scan.** Rejeté : le relevé mentirait, et il
+doublerait les appels contre les limites de débit qui causent l'incomplétude.
+
+**Déduire les permissions de la documentation sans le dire.** Rejeté : chaque ligne
+porte son état de vérification.
+
+## Conséquences
+
+Une origine manque plus souvent qu'elle ne pourrait. C'est le mode d'échec voulu.
+
+**Dette connue** : plusieurs règles violent encore cette décision en défaussant un
+attribut absent sur une valeur défavorable — `state` présumé actif, `is_enabled`
+présumé faux, région inconnue traitée comme un écart. Voir #104, #106, #107, #109.
+Ce sont des violations à corriger, pas des exceptions.
+
+## Invariants
+
+- Une origine absente n'est jamais fabriquée.
+- Le relevé de capacités ne nomme que des appels réellement émis.
+- Aucune règle ne produit un `fail` depuis un attribut absent défaussé.
+
+*Gardes : `TestALiveOrExportedInventoryCarriesNoFabricatedOrigin`,
+`TestAnAmbiguousBlockYieldsNoOrigin`, `TestTheRecordedCollectionStillHappens`. Le
+troisième invariant n'a pas encore sa garde : c'est l'objet de #104.*
+
+## Validation
+
+`mise run test`, et la garde de rejeu des endpoints enregistrés.
+
+## Liens
+
+ADR-0003, ADR-0006, ADR-0007 · issues #104, #106, #107, #109.

--- a/docs/adr/README.en.md
+++ b/docs/adr/README.en.md
@@ -1,0 +1,94 @@
+# Architecture decision records
+
+> 🇬🇧 English · [🇫🇷 Français](README.md)
+
+Code describes **the current state**. An ADR explains **why that state exists**,
+and which decisions cannot be reopened without an explicit new decision.
+
+The rule that governs this registry:
+
+> **An issue describes what we want to change. An ADR describes decisions already
+> taken. An issue cannot silently overturn an ADR.**
+
+## Why this registry exists
+
+This project has replayed the same debates more than once. A rejected solution
+comes back under another name, a local fix contradicts a global decision, an aged
+comment turns false, and two parts of the code drift into different rules without
+anyone deciding so.
+
+The risk is sharper with an agent: it produces, quickly, a solution that is
+technically plausible **and already rejected**, because nothing tells it so.
+
+## When to write one
+
+A change to any of these surfaces calls for one:
+
+data model · architecture · network · API · workflow · output format ·
+persistence · security · generation · orchestration · **public behaviour**.
+
+A typo, a missing test, a local rename: **no**.
+
+## When not to
+
+- To explain what a piece of code does — that is a comment's job.
+- To record a style preference — that is `CONTRIBUTING.md`'s job.
+- To state a live count of the repository. An ADR says "every generated module has
+  a test", never "the 43 modules have a test". Live figures come from generated
+  reports (`docs/detection-quality.md`, `docs/coverage.md`).
+
+## The review contract, before any change
+
+1. Identify the components touched.
+2. Find the applicable ADRs — through the scope table, or each ADR's `scope:` field.
+3. **Read them in full**, not just their titles.
+4. List their invariants.
+5. Check whether the change respects, extends, contradicts or reopens a decision.
+
+Do not read the whole registry for every fix. A cross-cutting or architectural
+change, on the other hand, warrants reading all of it.
+
+## If the change contradicts an ADR
+
+**Do not modify the code.** Say so first:
+
+```
+This change conflicts with ADR-XXXX: <summary of the decision>.
+
+It therefore requires either honouring the ADR, or taking an explicit new
+architectural decision.
+```
+
+If the decision genuinely must change, **do not rewrite the old ADR**. Write one
+that supersedes it (`ADR-0023 supersedes ADR-0007`) and set the old one to
+`Status: Superseded by ADR-0023`. The history stays visible: that is what stops
+the third round of the same debate.
+
+## If the proposed solution was already rejected
+
+**Alternatives écartées** is not decoration. If an implementation matches an
+explicitly rejected alternative, **stop** and say so:
+
+```
+ADR-0014 rejected X for reasons A, B and C.
+The proposed solution reintroduces X.
+Before implementing, establish that A, B and C have ceased to hold.
+```
+
+## Scope table
+
+The scope table and the ADR list live in the French [`README.md`](README.md),
+which is the maintained index. Each ADR also carries a `scope:` field so the
+lookup can be automated.
+
+The ADRs themselves are written in French, like the code comments they replace
+(`CLAUDE.md` §1.2: code and comments in French, commits in English). This page and
+its French counterpart carry the process, which contributors read first.
+
+## Drift between ADRs and code
+
+`mise run adr-drift` produces a report: ADRs citing a vanished file, `Accepted`
+ADRs whose invariant no longer names a test, superseded ADRs left unmarked.
+
+That check is **partial by construction**: it catches stale form, not contradicted
+substance. An empty report does not prove an ADR still tells the truth.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,116 @@
+# Registre des décisions d'architecture
+
+> 🇫🇷 Français · [🇬🇧 English](README.en.md)
+
+Le code décrit **l'état actuel**. Un ADR explique **pourquoi cet état existe** et
+quelles décisions ne se remettent pas en cause sans décision explicite.
+
+La règle qui gouverne ce registre :
+
+> **Une issue décrit ce que nous voulons changer. Un ADR décrit les décisions
+> déjà prises. Une issue ne peut pas annuler un ADR en silence.**
+
+## Pourquoi ce registre existe
+
+Ce projet a rejoué plusieurs fois les mêmes débats. Une solution écartée revient
+sous un autre nom, un correctif local contredit une décision globale, un
+commentaire vieilli devient faux, et deux parties du code appliquent des règles
+divergentes sans que personne ne l'ait décidé.
+
+Le risque est plus grand encore avec un agent : il produit vite une solution
+techniquement plausible **et déjà rejetée**, parce que rien ne lui dit qu'elle
+l'a été.
+
+## Quand créer un ADR
+
+Une modification de l'une de ces surfaces en demande un :
+
+modèle de données · architecture · réseau · API · workflow · format de sortie ·
+persistance · sécurité · génération · orchestration · **comportement public**.
+
+Une correction de faute, un test manquant, un renommage local : **non**.
+
+## Quand ne pas en créer
+
+- Pour expliquer ce que fait une portion de code — c'est le rôle d'un commentaire.
+- Pour consigner une préférence de style — c'est le rôle de `CONTRIBUTING.md`.
+- Pour décrire un état chiffré du dépôt. Un ADR dit « tout module généré a un
+  test », jamais « les 43 modules ont un test ». Les chiffres vivants viennent
+  des rapports générés (`docs/detection-quality.md`, `docs/coverage.md`).
+
+## Le contrat de revue, avant toute modification
+
+1. Identifier les composants touchés.
+2. Trouver les ADR applicables — par la table de portée ci-dessous, ou par le
+   champ `scope:` de chaque ADR.
+3. **Les lire en entier**, pas seulement leur titre.
+4. Relever leurs invariants.
+5. Vérifier si le changement respecte, étend, contredit ou rouvre une décision.
+
+Ne pas lire tout le registre à chaque correctif. En revanche, un changement
+transverse ou architectural justifie de le parcourir entièrement.
+
+## Si le changement contredit un ADR
+
+**Ne pas modifier le code.** Signaler d'abord :
+
+```
+Cette évolution entre en conflit avec ADR-XXXX : <résumé de la décision>.
+
+Elle exige donc soit de respecter l'ADR, soit de prendre explicitement une
+nouvelle décision d'architecture.
+```
+
+Si la décision doit vraiment changer, **ne pas réécrire l'ancien ADR**. En créer
+un nouveau qui le remplace :
+
+```
+ADR-0023 supersedes ADR-0007
+```
+
+et passer l'ancien en `Status: Superseded by ADR-0023`. L'historique reste
+visible : c'est lui qui empêche de refaire le tour trois fois.
+
+## Si la solution proposée a déjà été rejetée
+
+La section **Alternatives écartées** n'est pas décorative. Si une implémentation
+correspond à une alternative explicitement rejetée, **s'arrêter** et le dire :
+
+```
+ADR-0014 a rejeté X pour les raisons A, B et C.
+La solution proposée réintroduit X.
+Avant d'implémenter, établir si A, B et C ont cessé d'être vraies.
+```
+
+## Table de portée
+
+| Domaine | ADR |
+|---|---|
+| Architecture des règles, providers | [0001](0001-regles-communes-providers-collecteurs.md) |
+| Moteur, findings, rendu, scoring | [0002](0002-moteur-partage-scankit.md) |
+| Modèle de données, inventaire | [0003](0003-inventaire-contrat-gele.md), [0007](0007-provenance-index-parallele.md) |
+| Référentiel, frameworks normatifs | [0004](0004-index-scsl-gele.md), [0009](0009-configuration-lie-mapping.md) |
+| Codes de sortie, portes de CI | [0005](0005-codes-de-sortie.md), [0008](0008-derogation-nest-pas-conformite.md) |
+| Assessment, verdicts, dégradation | [0006](0006-jamais-un-pass-non-prouve.md), [0014](0014-jamais-fabriquer-une-donnee-absente.md) |
+| Tests, preuve, véracité | [0010](0010-dette-de-veracite-comptee.md) |
+| Langue, documentation | [0011](0011-bilinguisme-francais-normatif.md) |
+| Sécurité de la mesure, identifiants | [0012](0012-aucun-identifiant-en-ci.md) |
+| Compatibilité des consommateurs | [0013](0013-un-code-de-controle-ne-se-renomme-pas.md) |
+
+Chaque ADR porte aussi un `scope:` en tête, pour que cette identification soit
+automatisable.
+
+## Dérive entre les ADR et le code
+
+`mise run adr-drift` produit un rapport : ADR citant un fichier disparu, ADR
+`Accepted` dont l'invariant n'a plus de test, ADR remplacé mais non marqué.
+
+Ce contrôle est **partiel par construction** : il détecte l'obsolescence de
+forme, pas la contradiction de fond. Un rapport vide ne prouve pas qu'un ADR dit
+encore la vérité.
+
+## Format
+
+Le gabarit est dans [`TEMPLATE.md`](TEMPLATE.md). La section **Invariants** est
+obligatoire pour tout ADR structurant, et chaque invariant automatisable doit
+nommer le test qui le garde. Quand il ne l'est pas, l'ADR dit pourquoi.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,48 @@
+# ADR-XXXX — Titre
+
+```yaml
+status: Proposed | Accepted | Superseded by ADR-YYYY | Deprecated
+date: AAAA-MM-JJ
+scope:
+  - domaine
+```
+
+## Contexte
+
+Quel problème résout-on ? Quelles contraintes existent ? Ce qui a rendu la
+décision nécessaire, pas l'histoire du projet.
+
+## Décision
+
+Ce qui est retenu. Une ou deux phrases, à l'affirmative.
+
+## Justification
+
+Pourquoi celle-ci. L'argument qui tranche, pas la liste des avantages.
+
+## Alternatives écartées
+
+Chaque alternative sérieusement envisagée, et **pourquoi elle a été rejetée**.
+Cette section est ce qui empêche de rejouer le débat : si une proposition future
+correspond à l'une d'elles, il faut d'abord établir que la raison du rejet a
+cessé d'être vraie.
+
+## Conséquences
+
+Ce que la décision apporte, et ce qu'elle coûte. Une décision sans coût n'a
+probablement pas été comprise.
+
+## Invariants
+
+Les règles qui doivent rester vraies dans le code. Chacune nommant le test qui la
+garde, ou disant pourquoi elle n'est pas automatisable.
+
+- Invariant énoncé à l'impératif — *garde : `TestNomDuTest`*
+
+## Validation
+
+Comment on vérifie que la décision tient encore.
+
+## Liens
+
+Issues, PR, ADR, composants.

--- a/mise.toml
+++ b/mise.toml
@@ -244,3 +244,10 @@ run = [
   "go install golang.org/x/vuln/cmd/govulncheck@v1.7.0",
   "go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.5.1",
 ]
+
+[tasks.adr-drift]
+description = "Détecte la dérive de forme entre les ADR et le dépôt"
+# Partiel par construction : ce contrôle voit un chemin disparu, une garde
+# introuvable, un statut incohérent. Il ne voit pas qu'un ADR est devenu faux.
+# Un rapport vide ne dispense pas de relire.
+run = "python3 tools/adr/drift.py"

--- a/tools/adr/drift.py
+++ b/tools/adr/drift.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Détecte la dérive de FORME entre les ADR et le dépôt.
+
+Ce contrôle est délibérément partiel. Il attrape ce qu'une machine peut voir —
+un chemin disparu, une garde qui n'existe plus, un statut incohérent — et rien
+de ce qui demande de lire. Un rapport vide ne prouve pas qu'un ADR dit encore la
+vérité : il prouve seulement qu'il ne cite rien de manifestement mort.
+
+Code de sortie : 0 rien à signaler, 1 dérive détectée, 2 erreur technique.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ADR = ROOT / "docs" / "adr"
+
+# Un chemin cité : `internal/assess/assess.go`, `cmd/scan.go`, `docs/coverage.md`.
+PATH = re.compile(r"`((?:internal|cmd|providers|referentiel|docs|tools|scripts)/[\w./-]+)`")
+# Une garde citée : `TestQuelqueChose` ou `test_quelque_chose` (Rego).
+GUARD = re.compile(r"`(Test[A-Z]\w+|test_[a-z0-9_]+)`")
+STATUS = re.compile(r"^status:\s*(.+)$", re.M)
+SUPERSEDES = re.compile(r"ADR-(\d{4})\s+supersedes\s+ADR-(\d{4})", re.I)
+
+
+def go_symbols() -> set[str]:
+    """Noms de tests Go et Rego présents dans le dépôt."""
+    out: set[str] = set()
+    for p in ROOT.rglob("*_test.go"):
+        if ".git" in p.parts:
+            continue
+        out.update(re.findall(r"^func (Test\w+)", p.read_text(encoding="utf-8", errors="replace"), re.M))
+    for p in ROOT.rglob("*_test.rego"):
+        if ".git" in p.parts:
+            continue
+        out.update(re.findall(r"^(test_[a-z0-9_]+)", p.read_text(encoding="utf-8", errors="replace"), re.M))
+    return out
+
+
+def main() -> int:
+    if not ADR.is_dir():
+        print(f"pas de registre ADR en {ADR}", file=sys.stderr)
+        return 2
+
+    adrs = sorted(p for p in ADR.glob("0*.md"))
+    if not adrs:
+        print("registre vide : rien à contrôler", file=sys.stderr)
+        return 2
+
+    known = go_symbols()
+    findings: list[str] = []
+    superseded_by: dict[str, str] = {}
+
+    for p in adrs:
+        text = p.read_text(encoding="utf-8")
+        num = p.name[:4]
+
+        st = STATUS.search(text)
+        status = st.group(1).strip() if st else ""
+        if not status:
+            findings.append(f"{p.name} : aucun `status:`")
+
+        for m in SUPERSEDES.finditer(text):
+            superseded_by[f"{int(m.group(2)):04d}"] = f"{int(m.group(1)):04d}"
+
+        for cited in set(PATH.findall(text)):
+            # Un chemin peut désigner un répertoire ou un fichier.
+            if not (ROOT / cited).exists():
+                findings.append(f"{p.name} : chemin cité inexistant — {cited}")
+
+        guards = set(GUARD.findall(text))
+        for g in guards:
+            if g not in known:
+                findings.append(f"{p.name} : garde citée introuvable — {g}")
+
+        if status.startswith("Accepted") and "## Invariants" in text and not guards:
+            if "automatisable" not in text and "automatable" not in text:
+                findings.append(
+                    f"{p.name} : Accepted, des invariants, aucune garde citée "
+                    "et aucune raison écrite de ne pas en avoir"
+                )
+
+    for old, new in superseded_by.items():
+        match = [p for p in adrs if p.name.startswith(old)]
+        if not match:
+            findings.append(f"ADR-{new} remplace ADR-{old}, qui n'existe pas")
+            continue
+        text = match[0].read_text(encoding="utf-8")
+        if f"Superseded by ADR-{new}" not in text:
+            findings.append(
+                f"{match[0].name} : remplacé par ADR-{new} mais son statut ne le dit pas"
+            )
+
+    print(f"adr-drift : {len(adrs)} ADR contrôlés")
+    if not findings:
+        print("  rien à signaler — de forme ; la substance se relit")
+        return 0
+    for f in findings:
+        print(f"  ✘ {f}")
+    print(f"\n{len(findings)} dérive(s). Ce contrôle ne voit que la forme.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Le raisonnement de ce dépôt vivait dans des commentaires, des corps de PR et la
mémoire de celui qui avait touché le fichier en dernier. C'est ainsi qu'une
solution écartée revient sous un autre nom, qu'un correctif local contredit une
décision globale, et qu'un commentaire vieilli devient faux sans que personne
ne le voie.

## Ce que contient le registre

**14 ADR**, tirés des décisions qui ont réellement façonné l'outil — pas des
documents écrits pour remplir un dossier :

| ADR | Décision |
|---|---|
| 0001 | Un seul jeu de règles commun, les providers ne sont que des collecteurs |
| 0002 | Le moteur, le finding et le rendu viennent de scankit |
| 0003 | L'inventaire normalisé est un contrat gelé et versionné |
| 0004 | L'index SCSL est gelé : on mappe, on n'invente jamais |
| 0005 | Codes de sortie, et pourquoi il n'y en a pas un cinquième |
| 0006 | Un PASS non prouvé est un défaut : verrou de capacité et dégradation |
| 0007 | La provenance est un index parallèle, pas une enveloppe |
| 0008 | Une dérogation écarte, elle ne déclare jamais conforme |
| 0009 | Un contrôle assoupli perd ses correspondances normatives |
| 0010 | Une dette de véracité comptée, jamais une matrice verte |
| 0011 | Bilinguisme : anglais primaire, français normatif |
| 0012 | Aucun identifiant cloud en CI ; l'émulateur est la surface de mesure |
| 0013 | Un code de contrôle ne se renomme pas sans migration |
| 0014 | Une donnée absente ne se fabrique jamais, elle se déclare |

## La section qui compte

**Alternatives écartées.** C'est elle qui empêche de rejouer le débat, et c'est
le piège propre à un agent : reproposer, vite et de bonne foi, une solution
plausible que quelqu'un a déjà rejetée pour des raisons écrites.

Quelques-unes, telles qu'elles ont réellement été tranchées : envelopper chaque
valeur de sa provenance (aurait réécrit les 59 règles, et une règle réécrite
peut changer de verdict) ; un cinquième code de sortie pour l'incomplétude (ne
pourrait jamais primer sur `1`, donc doublon de `3`) ; avorter le scan sur un
endpoint refusé (pousse l'opérateur à élargir les droits du compte de scan) ;
un endpoint de collecte surchargeable (chaque requête porte une clé, c'est une
surface d'exfiltration) ; retirer un écart dérogé du SARIF (le format le plus
souvent branché sur une porte de fusion).

## Les invariants sont reliés à leurs gardes

Chaque invariant nomme le test qui le garde, ou dit pourquoi il n'est pas
automatisable. **Les 17 gardes citées ont été vérifiées présentes** avant d'être
écrites.

Écrire ces ADR a immédiatement trouvé trois de mes propres manques : 0001, 0002
et 0004 citaient une tâche `mise` au lieu d'un test. `adr-drift` les a signalés
avant que ce commit n'existe, ce qui est le meilleur argument pour son
existence.

Deux invariants sont déclarés **non automatisables**, avec leur raison : on ne
sait pas écrire un test qui distingue « du code qui évalue une politique » de
« du code qui fait autre chose », ni un test qui sache qu'un renommage était
justifié.

## Le contrat de revue

Dans `CONTRIBUTING.md` et `CONTRIBUTING.fr.md`, dans `CLAUDE.md` en section 0.1,
et dans le template de PR sous **Impact ADR**. Une faute de frappe n'en a pas
besoin — la revue se déclenche sur le modèle de données, l'architecture, le
réseau, une API, un workflow, un format, la persistance, la sécurité, la
génération, l'orchestration ou le comportement public.

En cas de conflit : **ne pas implémenter**, signaler, et créer un ADR qui
remplace plutôt que de réécrire l'ancien. L'historique est ce qui empêche de
refaire le tour.

## La dette, écrite plutôt que tue

Trois ADR consignent que le code les viole encore aujourd'hui, en renvoyant aux
issues de la vague 4.5 : le verrou de capacité raisonne par type et en any-of
(#102, #103), et plusieurs règles produisent un `fail` depuis un attribut absent
défaussé (#104, #106, #107, #109). Un ADR qui tairait cela serait pire qu'absent.

## Ce que ce contrôle ne fait pas

`mise run adr-drift` voit un chemin disparu, une garde introuvable, un statut
incohérent. **Il ne sait pas dire qu'un ADR est devenu faux.** Un rapport vide
ne dispense pas de relire, et c'est écrit dans le registre.

## Portes

`mise run adr-drift`, `mise run validate`, `mise run test` (Rego 282/282, Go
avec `-race`), `mise run audit` (lint 0 issue), `mise run secrets` — vertes.
`mise run gen-docs` ne régénère rien.

## Impact ADR

- [x] un nouvel ADR est nécessaire — cette PR crée le registre lui-même

🤖 Generated with [Claude Code](https://claude.com/claude-code)
