### PR TITLE
fix(rules): a rule that cannot conclude says so, instead of crying wolf

### DIFF
--- a/.github/workflows/campaigns.yml
+++ b/.github/workflows/campaigns.yml
@@ -1,0 +1,93 @@
+name: campaigns
+
+# Les campagnes qui CHERCHENT, par opposition aux portes qui vérifient.
+#
+# Une porte répond « ce commit tient-il ». Une campagne répond « que trouve-t-on
+# si l'on cherche assez longtemps ». Les deux sont nécessaires et n'ont pas le
+# même rythme : mettre une campagne sur le chemin d'une pull request la rend
+# assez lente pour qu'on la contourne, et assez bruyante pour qu'on l'ignore.
+#
+# D'où ce fichier, hebdomadaire et déclenchable à la main. Ce qu'il trouve
+# devient une graine versionnée ou une issue — jamais un échec qu'on referme
+# en relançant.
+on:
+  schedule:
+    # Lundi matin : ce qui est trouvé a la semaine pour être traité.
+    - cron: '15 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: "Durée de fuzzing par cible"
+        required: false
+        default: '10m'
+
+concurrency:
+  group: campaigns-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Le fuzzing des parseurs d'entrée non fiable. `CLAUDE.md` §5 exige qu'ils
+  # parsent défensivement et ne paniquent jamais ; c'est ici qu'on le cherche
+  # plutôt que de l'espérer. Une entrée qui fait tomber une cible est écrite par
+  # Go dans testdata/fuzz/ : elle doit être committée, et elle garde alors ce
+  # cas pour toujours.
+  fuzz:
+    name: Les parseurs tiennent-ils une entrée hostile
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Campagne de fuzzing
+        env:
+          FUZZTIME: ${{ github.event.inputs.fuzztime || '10m' }}
+        run: |
+          go test ./internal/tfparse/ -run '^$' -fuzz 'FuzzParsePlan'    -fuzztime="$FUZZTIME"
+          go test ./cmd/            -run '^$' -fuzz 'FuzzInventoryWalk' -fuzztime="$FUZZTIME"
+
+      # Une trouvaille est un fichier écrit par Go. Sans cette étape, elle
+      # disparaît avec le runner et la campagne n'aurait servi à rien.
+      - name: Conserver l'entrée qui a fait tomber une cible
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-corpus
+          path: |
+            internal/tfparse/testdata/fuzz/
+            cmd/testdata/fuzz/
+          if-no-files-found: ignore
+
+  # Rejeu de TOUTES les specs de falsification. Chaque spec casse une garde et
+  # exige que le test qui la nomme rougisse : c'est ce qui distingue un test qui
+  # mesure une propriété d'un test qu'on n'a jamais vu échouer.
+  falsify:
+    name: Les gardes rougissent-elles encore quand on les casse
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # Le harnais se prouve sur ses propres erreurs historiques AVANT de juger
+      # quoi que ce soit. Un harnais cassé rendrait un vert qui ne veut rien dire.
+      - name: Le harnais se prouve lui-même
+        run: python3 tools/falsify/falsify.py --selftest
+
+      - name: Rejouer toutes les specs
+        run: python3 tools/falsify/falsify.py --all tools/falsify/specs

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -238,9 +238,15 @@ var scanCmd = &cobra.Command{
 		// Le RAPPORT dit tout : aucun écart ne disparaît d'un format analysable parce
 		// qu'il est exempté. Seule la PORTE (le code de sortie) tient compte des
 		// dérogations, et elle le fait vers un code dédié, jamais vers 0.
-		open := openFindings(findings, exemptedKeys(asmt))
+		// Un constat d'INCERTITUDE n'est pas un écart : la règle a lu la donnée et
+		// n'a pas pu conclure. Il reste visible — il a produit sa ligne
+		// `not-evaluated` dans l'assessment — mais il ne pèse dans aucun décompte de
+		// sévérité, donc il ne peut pas rendre 1 (ADR-0015). Le sortir ICI, et non
+		// à la collecte des findings, garde le rapport complet.
+		deviations, _ := assess.SplitInconclusive(findings)
+		open := openFindings(deviations, exemptedKeys(asmt))
 		enrichFromReferentiel(findings)
-		res := scoring.Summarize(findings)
+		res := scoring.Summarize(deviations)
 		gate := scoring.Summarize(open)
 		opts.SummaryHeadline = verdictHeadline(res, gate, asmt, exReport, asmt.Run.Source, len(degraded), len(cfg.Relaxations))
 

--- a/docs/adr/0015-une-regle-qui-ne-peut-conclure-le-dit.md
+++ b/docs/adr/0015-une-regle-qui-ne-peut-conclure-le-dit.md
@@ -1,0 +1,108 @@
+# ADR-0015 — Une règle qui ne peut pas conclure le dit, et l'assessment en fait un `not-evaluated`
+
+```yaml
+status: Accepted
+date: 2026-09-08
+scope:
+  - assessment
+  - rules
+```
+
+## Contexte
+
+`assess` sait déjà produire un `not-evaluated` dans deux cas : l'attribut décisif
+n'a pas été collecté (verrou de capacité), ou l'unité de collecte est incomplète
+(dégradation). Ces deux cas se décident **hors de la règle**, sur la présence de la
+donnée.
+
+Il en existe un troisième, que seule la règle peut voir : la donnée est **là**, elle
+est lisible, et elle ne permet toujours pas de conclure. Une région renseignée mais
+absente des tables de classification en est le cas type — Pépin sait qu'il ne sait
+pas.
+
+Le moteur ne connaît qu'un canal, `data.pepin.rules.deny`. Une règle n'a donc, à ce
+jour, que deux moyens de traiter ce cas : se taire, ou émettre un écart. Les deux
+sont faux.
+
+**Se taire** est un fail-open structurel : les tables de classification sont des
+listes blanches, donc leur silence vaudrait « conforme » pour toute région qu'elles
+ignorent. Pour un outil de souveraineté, c'est le pire des défauts.
+
+**Émettre un écart** est ce que fait le code aujourd'hui, et le message dit lui-même
+« ni établie ni infirmée » tout en produisant un `fail`. C'est un faux rouge
+programmé : il se déclenchera à chaque ouverture de région par un fournisseur.
+
+## Décision
+
+Une règle qui ne peut pas conclure émet un finding portant
+`labels.inconclusive: "true"` et une raison.
+
+L'assessment en fait un résultat **`not-evaluated`**, pas un `fail`, et ce finding
+**ne compte pas** dans les décomptes de sévérité ni dans le code de sortie.
+
+La règle **constate** ; l'assessment **statue**. C'est la division du travail que
+l'ADR-0006 a déjà posée pour le verrou de capacité et la dégradation.
+
+## Justification
+
+Le troisième canal doit exister quelque part. Le mettre dans la règle est le seul
+endroit possible — c'est la seule couche qui sait qu'une valeur présente est
+inexploitable — mais **statuer** dans la règle referait l'erreur que l'ADR-0006 a
+corrigée : une garde par règle est une garde qu'on oublie d'écrire.
+
+Faire voyager l'information dans `labels` suit l'ADR-0002 : `finding.Finding` vient
+de scankit, et les messages bilingues comme l'origine Terraform y voyagent déjà.
+
+## Alternatives écartées
+
+**Ajouter un second document Rego (`inconclusive`) interrogé par le moteur.**
+Rejeté : `scankit/engine` n'interroge que `deny`, et l'ADR-0002 interdit un moteur
+local. Cela exigerait une évolution amont pour un besoin qui n'est pas encore
+partagé avec pitstop.
+
+**Laisser la règle se taire et traiter le cas dans le collecteur.** Rejeté : le
+collecteur a bien collecté. Rien ne manque à la collecte ; c'est la table de
+classification de Pépin qui est incomplète, et le collecteur n'en sait rien.
+
+**Étendre le verrou de capacité aux valeurs.** Rejeté : `requiredAttr` répond
+« l'attribut a-t-il été collecté ». Lui faire juger la valeur mélangerait deux
+questions et rendrait le verrou dépendant du contenu des tables.
+
+**Émettre un `fail` de sévérité `low`.** Rejeté : c'est le faux rouge, atténué. Un
+écart de faible gravité reste un écart, et le rapport continuerait d'affirmer ce
+que la règle dit ne pas savoir.
+
+## Conséquences
+
+Un cas inconcluant **reste visible** : il produit une ligne `not-evaluated` avec sa
+raison, et il apparaît au relevé de capacités et à la carte de qualité. Le rendre
+invisible serait le fail-open que cette décision existe pour empêcher.
+
+Le code de sortie peut passer de `1` à `3` sur un tenant dont les seuls écarts
+étaient inconcluants. C'est le sens voulu : le scan n'établit pas la conformité,
+il ne la nie pas non plus.
+
+Coût assumé : une règle peut désormais mentir en se déclarant inconcluante pour
+éviter un écart. Aucune garde automatique ne peut le détecter — seule la revue le
+peut, et les scénarios de véracité l'attrapent chemin par chemin.
+
+## Invariants
+
+- Un finding `inconclusive` ne produit jamais un `fail`.
+- Un finding `inconclusive` ne compte dans aucun décompte de sévérité, donc ne rend
+  jamais `1`.
+- Un cas inconcluant reste visible dans le rapport, avec sa raison.
+- `inconclusive` ne se substitue jamais au verrou de capacité : un attribut **non
+  collecté** relève de l'ADR-0006, pas d'ici.
+
+*Gardes : `TestAnInconclusiveFindingIsNotEvaluated`,
+`TestAnInconclusiveFindingNeverProducesExitOne`.*
+
+## Validation
+
+`mise run test`, et la campagne de non-régression : aucun verdict ne doit devenir
+plus affirmatif.
+
+## Liens
+
+ADR-0006, ADR-0014 · issues #105, #106, #109.

--- a/internal/assess/assess.go
+++ b/internal/assess/assess.go
@@ -217,12 +217,20 @@ func Build(provider string, controls map[string]referentiel.Control, findings []
 	failedControls := map[string]bool{}
 	var results []assessment.Result
 	for _, f := range findings {
+		// Un finding INCONCLUANT n'est pas un écart : la règle a vu la donnée et n'a
+		// pas pu trancher. Il devient `not-evaluated`, avec sa raison (ADR-0015).
+		// `failedControls` reste marqué : la ligne par sujet est déjà émise, la
+		// branche pass/not-evaluated ne doit pas en ajouter une seconde.
+		status := assessment.Fail
+		if IsInconclusive(f) {
+			status = assessment.NotEvaluated
+		}
 		failedControls[f.Code] = true
 		c := controls[f.Code]
 		results = append(results, assessment.Result{
 			Control:     f.Code,
 			Title:       first(c.TitreIn(i18n.Current()), f.Title),
-			Status:      assessment.Fail,
+			Status:      status,
 			Severity:    first(f.Severity, c.Severite),
 			Subject:     f.Subject,
 			Evidence:    assessment.Evidence{Observed: stripSubject(f.Message), Source: run.Source},

--- a/internal/assess/inconclusive.go
+++ b/internal/assess/inconclusive.go
@@ -1,0 +1,41 @@
+package assess
+
+import "github.com/stephrobert/scankit/finding"
+
+// LabelInconclusive marque un finding que la règle a émis SANS pouvoir conclure.
+//
+// L'assessment sait déjà rendre un `not-evaluated` dans deux cas décidés hors de la
+// règle : l'attribut décisif n'a pas été collecté, ou l'unité de collecte est
+// incomplète. Il en existe un troisième que SEULE la règle voit — la donnée est là,
+// lisible, et elle ne permet toujours pas de trancher.
+//
+// Le moteur partagé n'interroge que `deny` : une règle n'a donc que deux moyens de
+// traiter ce cas, se taire ou crier. Se taire est un fail-open (les tables de
+// classification sont des listes blanches, leur silence vaudrait « conforme ») ;
+// crier est un faux rouge que le message lui-même dément. D'où ce troisième canal :
+// la règle CONSTATE, l'assessment STATUE.
+//
+// Voir docs/adr/0015-une-regle-qui-ne-peut-conclure-le-dit.md.
+const LabelInconclusive = "inconclusive"
+
+// IsInconclusive indique si un finding dit son incapacité à conclure.
+func IsInconclusive(f finding.Finding) bool {
+	return f.Labels[LabelInconclusive] == "true"
+}
+
+// SplitInconclusive sépare les écarts observés des constats d'incertitude.
+//
+// Les seconds ne sont PAS des écarts : ils ne comptent dans aucun décompte de
+// sévérité et ne peuvent donc pas rendre le code 1. Ils restent visibles, en
+// `not-evaluated` avec leur raison — les rendre invisibles serait exactement le
+// fail-open que ce mécanisme existe pour empêcher.
+func SplitInconclusive(findings []finding.Finding) (deviations, inconclusive []finding.Finding) {
+	for _, f := range findings {
+		if IsInconclusive(f) {
+			inconclusive = append(inconclusive, f)
+			continue
+		}
+		deviations = append(deviations, f)
+	}
+	return deviations, inconclusive
+}

--- a/internal/assess/inconclusive_test.go
+++ b/internal/assess/inconclusive_test.go
@@ -1,0 +1,75 @@
+package assess
+
+import (
+	"testing"
+
+	"github.com/stephrobert/scankit/assessment"
+	"github.com/stephrobert/scankit/finding"
+
+	"github.com/stephrobert/pepin/referentiel"
+)
+
+func inconclusiveFinding() finding.Finding {
+	return finding.Finding{
+		Code:     "governance_resource_region_in_eu",
+		Severity: "medium",
+		Subject:  "vm-1",
+		Message:  "région non cataloguée",
+		Labels:   map[string]string{"provider": "scaleway", LabelInconclusive: "true"},
+	}
+}
+
+// TestAnInconclusiveFindingIsNotEvaluated tient l'invariant central de l'ADR-0015 :
+// une règle qui CONSTATE son incapacité à conclure ne produit pas un écart. Sans
+// cette porte, le message « ni établie ni infirmée » continuerait d'être rendu
+// comme un `fail`, ce qui est un faux rouge que la règle dément elle-même.
+func TestAnInconclusiveFindingIsNotEvaluated(t *testing.T) {
+	controls := map[string]referentiel.Control{
+		"governance_resource_region_in_eu": {Code: "governance_resource_region_in_eu"},
+	}
+	asmt := Build("scaleway", controls, []finding.Finding{inconclusiveFinding()},
+		map[string]bool{}, nil, map[string]bool{}, map[string]string{},
+		map[string]map[string]bool{}, assessment.Run{})
+
+	var seen bool
+	for _, r := range asmt.Results {
+		if r.Control != "governance_resource_region_in_eu" {
+			continue
+		}
+		seen = true
+		if r.Status == assessment.Fail {
+			t.Fatalf("un constat d'incertitude est rendu comme un écart : %s", r.Status)
+		}
+		if r.Status != assessment.NotEvaluated {
+			t.Fatalf("statut attendu not-evaluated, obtenu %s", r.Status)
+		}
+	}
+	if !seen {
+		// L'invisibilité serait le fail-open que ce mécanisme existe pour empêcher.
+		t.Fatal("le constat d'incertitude a disparu du rapport")
+	}
+}
+
+// TestAnInconclusiveFindingNeverProducesExitOne prouve la seconde moitié : le
+// constat sort des décomptes de sévérité. Sans elle, le statut serait juste et la
+// porte de CI mentirait quand même.
+func TestAnInconclusiveFindingNeverProducesExitOne(t *testing.T) {
+	real := finding.Finding{
+		Code: "network_securitygroup_x", Severity: "critical", Subject: "sg-1",
+		Labels: map[string]string{"provider": "scaleway"},
+	}
+
+	deviations, inconclusive := SplitInconclusive([]finding.Finding{inconclusiveFinding(), real})
+
+	if len(inconclusive) != 1 {
+		t.Fatalf("constats d'incertitude attendus : 1, obtenus %d", len(inconclusive))
+	}
+	if len(deviations) != 1 || deviations[0].Code != "network_securitygroup_x" {
+		t.Fatalf("seul l'écart réel doit peser dans la porte, obtenu %+v", deviations)
+	}
+
+	only, _ := SplitInconclusive([]finding.Finding{inconclusiveFinding()})
+	if len(only) != 0 {
+		t.Fatal("un scan dont les seuls constats sont incertains ne doit peser aucun écart")
+	}
+}

--- a/internal/commonrules/ablation_test.go
+++ b/internal/commonrules/ablation_test.go
@@ -1,0 +1,235 @@
+package commonrules_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/scankit/engine"
+
+	"github.com/stephrobert/pepin/internal/commonrules"
+)
+
+// L'invariant, en une phrase : RETIRER un attribut ne doit jamais faire APPARAÎTRE
+// un écart.
+//
+// Si moins d'information produit plus de findings, c'est que la règle a déduit
+// quelque chose de l'absence — elle a défaussé un attribut manquant sur une valeur
+// qui se trouve être la mauvaise. C'est le défaut que l'ADR-0014 interdit, et il
+// s'était logé dans deux règles sans qu'aucun test ne le voie : `state` absent
+// présumé « actif », `is_enabled` absent présumé faux.
+//
+// Ce que cette porte a de particulier : elle n'exige d'aucune règle qu'elle déclare
+// son attribut décisif. Elle ne lit pas le code, elle mesure le comportement. Un
+// contrôle écrit demain est couvert sans avoir rien à déclarer.
+//
+// Ce qu'elle NE voit pas, et qui est écrit pour qu'on ne s'y trompe pas :
+//
+//   - Le cas où la donnée est PRÉSENTE et inexploitable — une région renseignée mais
+//     hors des tables de classification. Rien n'est retiré, donc rien n'apparaît.
+//     C'est le domaine de l'ADR-0015, pas d'ici.
+//   - Un défaut qui ne se manifeste que sur une combinaison d'attributs retirés :
+//     on n'ablate qu'un attribut à la fois, parce que le produit cartésien serait
+//     ingérable et que les défauts observés sont tous unitaires.
+//   - Une règle qui n'est déclenchée par aucune fixture : on ne mesure que ce que le
+//     corpus atteint. C'est la même limite que la dette de véracité, et elle se
+//     rembourse par le même chemin — plus de corpus.
+//
+// Voir docs/adr/0014-jamais-fabriquer-une-donnee-absente.md et l'issue #104.
+
+// ablationExceptions énumère les couples (contrôle, attribut) pour lesquels
+// l'apparition d'un écart à l'ablation est LÉGITIME, avec sa raison.
+//
+// Une exception se justifie quand l'absence de l'attribut EST la non-conformité, et
+// que le contrôle sait par ailleurs distinguer « non collecté » de « absent chez le
+// fournisseur » — sans quoi elle réintroduit exactement le défaut qu'on traque.
+//
+// Toute entrée porte sa raison et se relit comme une décision, pas comme un
+// contournement. La porte a d'abord signalé ce cas ; c'est le CONTRAT qui a
+// tranché, pas le confort.
+var ablationExceptions = map[string]string{
+	// Scaleway expose `ExpiresAt (*time.Time)` — un POINTEUR (providers/scaleway.yaml,
+	// contrat `access_key`, etat: verifie). Un pointeur nul est la façon dont l'API
+	// dit « aucune expiration ». Ici, l'absence de l'attribut EST l'observation, et
+	// exiger sa présence rendrait le contrôle aveugle au cas qu'il existe pour voir.
+	//
+	// La limite subsiste et elle est réelle : l'absence conflate « pointeur nul
+	// observé » et « attribut jamais collecté ». Les distinguer demande de lire la
+	// PROVENANCE, qui indexe les attributs CHERCHÉS même non exposés (ADR-0007) —
+	// une règle n'y a pas accès aujourd'hui. Suivi en #121.
+	"iam_accesskey_expiration_set\x00expiration_date": "contrat Scaleway : ExpiresAt est un *time.Time, un nil signifie « aucune expiration »",
+}
+
+type finding struct {
+	Code    string `json:"code"`
+	Subject string `json:"subject"`
+}
+
+// On compare les CODES, pas les couples (code, sujet). Retirer un attribut
+// d'identité — un `policy_name`, un `name` — déplace le sujet d'un écart qui
+// existait déjà, et le couple paraîtrait neuf. Ce bruit noierait le signal. La
+// contrepartie est assumée : un même code qui se met à toucher un AUTRE sujet
+// passe sous le radar. La famille de défauts traquée ici est « un code apparaît »,
+// et elle est intégralement couverte.
+func key(f finding) string { return f.Code }
+
+// corpus charge les inventaires JSON du dépôt. Les plans Terraform sont exclus :
+// ils passent par le mapper, et l'ablation d'un attribut normalisé n'y a pas de
+// sens direct.
+func corpus(t *testing.T) map[string]map[string]any {
+	t.Helper()
+	root := filepath.Join("..", "..")
+	out := map[string]map[string]any{}
+	for _, prov := range []string{"scaleway", "outscale", "exoscale"} {
+		paths, _ := filepath.Glob(filepath.Join(root, "examples", prov, "*.json"))
+		more, _ := filepath.Glob(filepath.Join(root, "references", "tenants", prov, "*", "plan.json"))
+		for _, p := range append(paths, more...) {
+			b, err := os.ReadFile(p) //nolint:gosec // chemins du dépôt, énumérés ici
+			if err != nil {
+				continue
+			}
+			var inv map[string]any
+			if json.Unmarshal(b, &inv) != nil {
+				continue
+			}
+			if _, ok := inv["resources"].([]any); !ok {
+				continue
+			}
+			out[strings.TrimPrefix(p, root+string(filepath.Separator))] = inv
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("corpus vide : la porte ne mesurerait rien")
+	}
+	return out
+}
+
+func evaluate(t *testing.T, ctx context.Context, inv map[string]any) map[string]bool {
+	t.Helper()
+	raw, err := engine.Evaluate(ctx, inv, commonrules.FS())
+	if err != nil {
+		t.Fatalf("évaluation : %v", err)
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("sérialisation des findings : %v", err)
+	}
+	var fs []finding
+	if err := json.Unmarshal(b, &fs); err != nil {
+		t.Fatalf("relecture des findings : %v", err)
+	}
+	out := map[string]bool{}
+	for _, f := range fs {
+		out[key(f)] = true
+	}
+	return out
+}
+
+// deepCopy clone l'inventaire par sérialisation : l'ablation ne doit jamais altérer
+// le corpus partagé entre les sous-tests.
+func deepCopy(t *testing.T, inv map[string]any) map[string]any {
+	t.Helper()
+	b, err := json.Marshal(inv)
+	if err != nil {
+		t.Fatalf("clonage : %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("clonage : %v", err)
+	}
+	return out
+}
+
+// TestRemovingAnAttributeNeverCreatesAFinding est LA porte de l'ADR-0014.
+//
+// Pour chaque ressource du corpus et chaque attribut qu'elle porte, on retire
+// l'attribut, on réévalue, et on exige qu'aucun écart NOUVEAU n'apparaisse. Un écart
+// qui DISPARAÎT est normal : on vient de retirer la donnée qui l'établissait.
+func TestRemovingAnAttributeNeverCreatesAFinding(t *testing.T) {
+	ctx := context.Background()
+	var checked int
+	seenTypes := map[string]bool{}
+
+	for name, inv := range corpus(t) {
+		base := evaluate(t, ctx, inv)
+		resources, _ := inv["resources"].([]any)
+
+		for i := range resources {
+			res, ok := resources[i].(map[string]any)
+			if !ok {
+				continue
+			}
+			attrs, ok := res["attributes"].(map[string]any)
+			if !ok {
+				continue // un plan Terraform porte `values`, pas `attributes` : rien à ablater
+			}
+			if ty, ok := res["type"].(string); ok {
+				seenTypes[ty] = true
+			}
+			names := make([]string, 0, len(attrs))
+			for a := range attrs {
+				names = append(names, a)
+			}
+			sort.Strings(names)
+
+			for _, attr := range names {
+				ablated := deepCopy(t, inv)
+				rs, _ := ablated["resources"].([]any)
+				r, _ := rs[i].(map[string]any)
+				at, _ := r["attributes"].(map[string]any)
+				delete(at, attr)
+
+				after := evaluate(t, ctx, ablated)
+				checked++
+
+				for k := range after {
+					if base[k] {
+						continue // l'écart existait déjà : rien de nouveau
+					}
+					code := k
+					if why, allowed := ablationExceptions[code+"\x00"+attr]; allowed {
+						t.Logf("exception admise — %s sur l'absence de %q : %s", code, attr, why)
+						continue
+					}
+					t.Errorf(
+						"%s : retirer l'attribut %q de la ressource %d fait APPARAÎTRE l'écart %s.\n"+
+							"  Un attribut absent a été défaussé sur une valeur, et cette valeur a produit un écart\n"+
+							"  que rien n'a observé (ADR-0014). Rendre le défaut neutre, ou déclarer l'incertitude\n"+
+							"  (ADR-0015) si la règle sait qu'elle ne sait pas.",
+						name, attr, i, code)
+				}
+			}
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("aucune ablation effectuée : la porte ne mesure rien")
+	}
+
+	// Le chiffre qui compte n'est pas le nombre d'ablations, c'est ce que le corpus
+	// ATTEINT. Une règle dont aucun type n'est présent n'est pas éprouvée, et son
+	// silence ressemble à s'y méprendre à un succès.
+	//
+	// Mesuré à l'écriture : le corpus JSON porte 6 types de ressources. Le défaut du
+	// peering corrigé dans ce même lot n'aurait PAS été attrapé ici, faute d'une
+	// seule ressource `network_peering` dans une fixture. Le dire est le minimum ;
+	// l'issue #123 étend le corpus.
+	t.Logf("%d ablations sur %d type(s) de ressource — la couverture borne ce que cette porte peut voir",
+		checked, len(seenTypes))
+	for _, ty := range sortedKeys(seenTypes) {
+		t.Logf("  type éprouvé : %s", ty)
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/commonrules/rules/governance_resource_region_in_eu.rego
+++ b/internal/commonrules/rules/governance_resource_region_in_eu.rego
@@ -101,6 +101,10 @@ deny contains f if {
 		"labels": {
 			"provider": p,
 			"category": "compliance",
+			# La règle CONSTATE qu'elle ne sait pas ; l'assessment en fait un
+			# `not-evaluated`. Se taire aurait valu « conforme » — les tables de
+			# classification sont des listes blanches (ADR-0015).
+			"inconclusive": "true",
 			"message_en": sprintf("Resource \"%s\": region \"%s\" is not catalogued for provider \"%s\" — the location cannot be verified, EU compliance is neither established nor ruled out.", [name, reg, p]),
 			"remediation_en": "Check the real location of this region with the provider, then add it to the classification tables (lib.rego); migrate the resource if it sits outside the EU.",
 		},

--- a/internal/commonrules/rules/governance_resource_region_in_eu_test.rego
+++ b/internal/commonrules/rules/governance_resource_region_in_eu_test.rego
@@ -40,3 +40,20 @@ test_unknown_region_denied_medium if {
 test_empty_region_skipped if {
 	count([f | some f in deny; f.code == "governance_resource_region_in_eu"]) == 0 with input as {"resources": [{"provider": "scaleway", "type": "compute_instance", "id": "i-5", "name": "vm-y", "region": "", "attributes": {}}]}
 }
+
+# ✓ région renseignée mais NON cataloguée → la règle constate son incapacité à
+# conclure et le DIT (ADR-0015). Elle continue d'émettre — se taire vaudrait
+# « conforme », les tables de classification étant des listes blanches — mais
+# l'assessment en fera un `not-evaluated`, jamais un écart.
+test_unknown_region_is_marked_inconclusive if {
+	some f in deny with input as {"resources": [{
+		"provider": "scaleway",
+		"type": "compute_instance",
+		"id": "vm-1",
+		"name": "vm-1",
+		"region": "zz-nowhere-1",
+		"attributes": {},
+	}]}
+	f.code == "governance_resource_region_in_eu"
+	f.labels.inconclusive == "true"
+}

--- a/internal/commonrules/rules/network_peering_cross_organization.rego
+++ b/internal/commonrules/rules/network_peering_cross_organization.rego
@@ -17,6 +17,7 @@ deny contains f if {
 	src != ""
 	acc != ""
 	src != acc
+	_peering_state_known(p)
 	not _peering_inactive(p)
 	f := {
 		"code": "network_peering_cross_organization",
@@ -34,4 +35,9 @@ deny contains f if {
 }
 
 # Un appairage non actif (rejeté/expiré/supprimé) ne crée pas de flux.
-_peering_inactive(p) if object.get(p.attributes, "state", "active") in {"rejected", "failed", "expired", "deleted", "pending-acceptance"}
+# `state` ABSENT ne vaut pas « actif » : un attribut non collecté et un attribut
+# collecté à une valeur ne se confondent pas (ADR-0003, ADR-0014). Sans état
+# observé, l'appairage n'est ni actif ni inactif — la règle ne conclut pas.
+_peering_state_known(p) if object.get(p.attributes, "state", "") != ""
+
+_peering_inactive(p) if object.get(p.attributes, "state", "") in {"rejected", "failed", "expired", "deleted", "pending-acceptance"}

--- a/internal/commonrules/rules/network_peering_cross_organization_test.rego
+++ b/internal/commonrules/rules/network_peering_cross_organization_test.rego
@@ -29,3 +29,11 @@ test_peering_unknown_accounts_ok if {
 test_peering_pending_ok if {
 	count({f | some f in deny; f.code == "network_peering_cross_organization"}) == 0 with input as _peer({"peering_id": "pcx-2", "source_account": "111", "accepter_account": "222", "state": "pending-acceptance"})
 }
+
+# ✓ état NON collecté → pas de finding. Un attribut absent ne vaut pas « actif » :
+# « non collecté » et « collecté à une valeur » ne se confondent pas (ADR-0003,
+# ADR-0014). Avant ce test, `state` absent était défaussé sur "active" et
+# contribuait donc à un écart déduit d'une donnée que personne n'avait observée.
+test_peering_state_not_collected_does_not_deny if {
+	count({f | some f in deny; f.code == "network_peering_cross_organization"}) == 0 with input as _peer({"peering_id": "pcx-1", "source_account": "111", "accepter_account": "222"})
+}

--- a/mise.toml
+++ b/mise.toml
@@ -251,3 +251,20 @@ description = "Détecte la dérive de forme entre les ADR et le dépôt"
 # introuvable, un statut incohérent. Il ne voit pas qu'un ADR est devenu faux.
 # Un rapport vide ne dispense pas de relire.
 run = "python3 tools/adr/drift.py"
+
+[tasks.falsify]
+description = "Rejoue une falsification, ou prouve le harnais sur son propre historique : mise run falsify -- --selftest"
+# Porté de feint (Apache-2.0, même auteur). La procédure était une COUTUME : chaque
+# lot rapportait ses mutations dans un tableau de PR, et rien ne rattrapait celui
+# qui n'y pensait pas. Pire, une mutation qui ne compile pas fait échouer TOUS les
+# tests, ce qui ressemble exactement à la garde qui se prouve — erreur commise deux
+# fois dans la même session avant que ce harnais n'arrive. Il la refuse.
+run = "python3 tools/falsify/falsify.py"
+
+[tasks."falsify:selftest"]
+description = "Le harnais de falsification se prouve sur ses propres erreurs historiques"
+run = "python3 tools/falsify/falsify.py --selftest"
+
+[tasks."falsify:all"]
+description = "Rejoue toutes les specs de falsification versionnées"
+run = "python3 tools/falsify/falsify.py --all tools/falsify/specs"

--- a/mise.toml
+++ b/mise.toml
@@ -268,3 +268,35 @@ run = "python3 tools/falsify/falsify.py --selftest"
 [tasks."falsify:all"]
 description = "Rejoue toutes les specs de falsification versionnées"
 run = "python3 tools/falsify/falsify.py --all tools/falsify/specs"
+
+[tasks.fuzz]
+description = "Cherche des entrées qui font paniquer les parseurs. Campagne longue : FUZZTIME=5m mise run fuzz"
+# Les deux cibles existaient depuis longtemps SANS jamais chercher : `go test`
+# n'exécute que le corpus de graines, donc le fuzzing était une non-régression, pas
+# une recherche. Les cibles visent le bon endroit — les parseurs d'entrée non
+# fiable, ce que la §5 du CLAUDE.md exige : « parser défensivement, jamais de
+# panique ». Une trouvaille rejoint testdata/fuzz/, donc elle est gardée pour
+# toujours.
+run = """
+set -eu
+t="${FUZZTIME:-30s}"
+echo "campagne de ${t} par cible"
+go test ./internal/tfparse/ -run '^$' -fuzz 'FuzzParsePlan' -fuzztime="$t"
+go test ./cmd/ -run '^$' -fuzz 'FuzzInventoryWalk' -fuzztime="$t"
+"""
+
+[tasks.prepush]
+description = "Tout ce sur quoi une PR échouera, qui coûte des secondes et n'exige aucun compte"
+depends = ["validate", "test", "audit", "adr-drift", "secrets", "falsify:selftest"]
+# Ce que c'est, et ce que ce n'est délibérément PAS.
+#
+# Chacune de ces portes est déterministe, hors ligne, et tient en quelques
+# secondes : elles peuvent être un hook sans jamais apprendre `--no-verify` à
+# personne. C'est la seule façon qu'une porte serve — une porte qu'on ne lance
+# qu'en CI est une porte qu'on découvre après avoir poussé.
+#
+# Ce qu'elle n'attrape PAS, et il faut le savoir : tout ce qui exige un compte
+# cloud, une campagne longue (fuzz, falsify:all) ou l'observation d'un vrai
+# fournisseur. Ces choses vivent en nocturne ou à la qualification de release,
+# précisément pour ne pas rendre ce chemin-ci trop lent pour être suivi.
+run = "echo 'prepush : toutes les portes locales sont vertes'"

--- a/tools/falsify/falsify.py
+++ b/tools/falsify/falsify.py
@@ -1,0 +1,709 @@
+#!/usr/bin/env python3
+"""Run a falsification: remove a guard in a copy outside the repository, and
+require the test that names it to fail.
+
+PORTÉ DEPUIS `github.com/stephrobert/feint` (tools/falsify/falsify.py, Apache-2.0,
+même auteur). La doctrine ci-dessous est la sienne, et elle est reprise telle quelle
+parce qu'elle a été payée là-bas : trois verdicts invalidés en une journée.
+
+Pépin l'a payée aussi, le 2026-09-08, deux fois dans la même session — un `sed` qui
+produisait un nom de champ de structure invalide, et un autre qui laissait un test
+passer pour une raison sans rapport. Les deux rouges ont été lus comme des preuves
+avant vérification. Ce harnais refuse ce que l'avertissement n'a pas empêché.
+
+    mise run falsify -- tools/falsify/specs/<name>.json
+
+Why this exists as a program rather than as a habit. `/falsify` was a procedure
+followed by hand, and on 2026-08-15 the same mistake voided a verdict three
+times in one day, across three unrelated issues:
+
+    if ok && fe.EnforcesFirewall() {   ->  if ok {                 # fe orphaned
+    if strings.TrimSpace(s) == "" {    ->  if false {              # s orphaned
+    if err != nil || n == 0 {          ->  if n == 0 {             # err orphaned
+
+Go refuses to compile an unused variable, so each mutation broke the build. A
+mutation that does not build makes *every* test fail, which looks exactly like
+the guard being proven — the failure mode `.claude/commands/falsify.md` already
+warned about, met three times anyway. Warning was not enough; this refuses.
+
+The rule it enforces, and it is the one that would have caught all three:
+
+    A MUTATION MUST NOT DROP AN IDENTIFIER THE ORIGINAL EXPRESSION USED.
+
+Neutralise a condition by making it never true while every name stays evaluated
+(`x && false`, `x == "\\x00never"`, `(err != nil && false) || ...`), never by
+deleting the term that mentions it.
+
+The spec is JSON:
+
+    {
+      "package": "./internal/cli/",
+      "mutations": [
+        {
+          "label": "the notice never fires",
+          "file": "internal/cli/lifecycle.go",
+          "find": "if err != nil || health.Resources == 0 {",
+          "replace": "if err != nil || health.Resources >= 0 {",
+          "test": "TestStopSaysWhatItIsAboutToDiscard",
+          "package": "./internal/cli/"
+        }
+      ]
+    }
+
+Per-mutation `package` is optional and falls back to the top-level one.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+EXCLUDE = {".git", ".upstream", ".terraform", "notes", ".claude"}
+
+# Go keywords and predeclared names are not identifiers a mutation "uses": they
+# appear on both sides of every rewrite and would make the check vacuous.
+RESERVED = {
+    "break",
+    "case",
+    "chan",
+    "const",
+    "continue",
+    "default",
+    "defer",
+    "else",
+    "fallthrough",
+    "for",
+    "func",
+    "go",
+    "goto",
+    "if",
+    "import",
+    "interface",
+    "map",
+    "package",
+    "range",
+    "return",
+    "select",
+    "struct",
+    "switch",
+    "type",
+    "var",
+    "true",
+    "false",
+    "nil",
+    "len",
+    "cap",
+    "make",
+    "new",
+    "append",
+    "copy",
+    "delete",
+    "panic",
+    "recover",
+    "print",
+    "println",
+    "string",
+    "int",
+    "bool",
+    "byte",
+    "rune",
+    "error",
+    "any",
+}
+
+# Identifiers that are not preceded by a dot. A name after a selector is a field
+# or a method — dropping `EnforcesFirewall` from `fe.EnforcesFirewall()` orphans
+# nothing, while dropping `fe` orphans a variable and breaks the build. The
+# selftest found this on its first run: without the lookbehind the rule refused
+# `if ok && fe != nil {`, which is the safe form it exists to recommend.
+#
+# Package names stay in scope on purpose: an unused import is a compile error in
+# Go exactly as an unused variable is, so `strings` dropped from a fragment is
+# the same class of mistake.
+IDENT = re.compile(r"(?<![.\w])[A-Za-z_][A-Za-z0-9_]*")
+
+# Go's three literal forms, so their contents never look like code. Interpreted
+# strings and runes admit backslash escapes; a raw string runs to its closing
+# backquote and holds no escapes at all.
+LITERAL = re.compile(r'"(?:[^"\\\n]|\\.)*"' r"|`[^`]*`" r"|'(?:[^'\\\n]|\\.)*'", re.S)
+
+
+def identifiers(text):
+    """The identifiers a fragment of Go uses, minus keywords and builtins.
+
+    String contents are removed first, and that is not tidiness. Without it the
+    rule read `no route matches this path` as code and refused the mutation for
+    dropping `this` — a word in a sentence, in the one guard of #179 whose whole
+    subject is what the answer says. A tool that refuses a valid falsification
+    is worse than no tool: it teaches the author to stop declaring the awkward
+    ones, which are the guards most worth replaying.
+    """
+    return {name for name in IDENT.findall(LITERAL.sub('""', text)) if name not in RESERVED}
+
+
+# A short declaration inside the fragment: `x := ...` or `x, ok := ...`.
+DECLARED = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_,\s]*?)\s*:=", re.MULTILINE)
+
+
+def uses_of(name, text):
+    return len(re.findall(r"(?<![.\w])" + re.escape(name) + r"\b", text))
+
+
+def orphaned_by_declaration(find, replace):
+    """Names the replacement declares and stops using, which the original used.
+
+    Presence alone is not enough, and an end-to-end run proved it: a fragment
+    carrying its own `fe, ok := p.(FirewallEnforcer)` line keeps the word `fe` on
+    both sides of any rewrite, so a set difference sees nothing lost while Go
+    sees an unused variable.
+
+    Comparative rather than absolute, and a second end-to-end run proved that
+    too: a fragment can declare a name it uses *after* the fragment ends, as
+    `sum := sha256.New()` does, and judging the replacement alone refused a
+    perfectly good mutation. What matters is whether the mutation made it worse —
+    the count falling to its declaration alone, from more than that.
+    """
+    orphans = []
+    for match in DECLARED.finditer(replace):
+        for name in (n.strip() for n in match.group(1).split(",")):
+            if not name or name == "_" or name in RESERVED:
+                continue
+            if uses_of(name, replace) <= 1 < uses_of(name, find):
+                orphans.append(name)
+    return sorted(set(orphans))
+
+
+def dropped_identifiers(find, replace):
+    """Names the mutation removes from the fragment, whether or not Go minds.
+
+    Two ways a removal costs a verdict, and both have happened here: a term is
+    deleted and the name goes with it, or the name survives only in a
+    declaration the fragment carries. Either leaves an unused name, Go refuses
+    to compile, every test in the package fails, and that reads exactly like the
+    guard being proven.
+
+    This is deliberately conservative and says so where it refuses: it cannot
+    see the rest of the file, so it flags every name that leaves the fragment,
+    including the many that would still compile. Replaying the 0.9 train against
+    it found three such: `IncusMinimum` is a package-level var used at four
+    other sites, `synthetic` and `health` are locals used further down their own
+    functions. All three mutations would have built.
+
+    Refusing them anyway is the trade this tool makes, and the reason is that
+    the alternative is worse. The check that would let them through is the
+    compiler, which the harness already runs — but by then the copy exists, the
+    package is built, and a void verdict has cost what a real one costs. The
+    rewrite it demands takes one operator (`&& false`, `|| true`) and produces a
+    strictly better mutation: one that changes a truth value and nothing else,
+    so the test that goes red is answering about the guard rather than about
+    whatever else the deleted term was doing.
+    """
+    lost = identifiers(find) - identifiers(replace)
+    return sorted(lost | set(orphaned_by_declaration(find, replace)))
+
+
+def copy_tree(src, dst):
+    def ignore(directory, names):
+        out = [n for n in names if n in EXCLUDE]
+        if (
+            os.path.abspath(directory) == os.path.abspath(src)
+            and "feint" in names
+            and os.path.isfile(os.path.join(directory, "feint"))
+        ):
+            out.append("feint")
+        return out
+
+    if os.path.exists(dst):
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst, ignore=ignore, symlinks=True)
+
+
+def run(dst, cmd, extra_env=None):
+    """Every command is capped, so a runaway cannot take the station with it.
+
+    `extra_env` exists for a subject whose test is itself behind an opt-in: the
+    container tests skip unless FEINT_TESTCONTAINER is set, and a skip counts as
+    a pass, so without this the harness would report the mutation undetected and
+    blame the guard rather than its own environment.
+    """
+    env = None
+    if extra_env:
+        env = {**os.environ, **extra_env}
+    return subprocess.run(
+        ["systemd-run", "--user", "--scope", "-q", "-p", "MemoryMax=8G", "-p", "MemorySwapMax=0"]
+        + cmd,
+        cwd=dst,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def refuse(message):
+    print(f"falsify: {message}", file=sys.stderr)
+    return 2
+
+
+# The mutations that voided a verdict on 2026-08-15, and the safe form
+# each one should have taken. This is the rule's own falsification: it is not
+# invented cases, it is what actually happened, in unrelated issues, plus the
+# fourth shape an end-to-end run of this harness found afterwards.
+HISTORY = [
+    # (find, broken replacement, safe replacement, the name that was orphaned)
+    ("if ok && fe.EnforcesFirewall() {", "if ok {", "if ok && fe != nil {", "fe"),
+    (
+        'if strings.TrimSpace(string(out)) == "" {',
+        "if false {",
+        'if strings.TrimSpace(string(out)) == "\\x00never" {',
+        "out",
+    ),
+    (
+        "if err != nil || health.Resources == 0 {",
+        "if health.Resources == 0 {",
+        "if (err != nil && false) || health.Resources == 0 {",
+        "err",
+    ),
+    # The fourth, found by running the harness end to end rather than by
+    # reasoning about it: when the fragment carries its own declaration, the name
+    # survives on both sides and a set difference sees nothing.
+    (
+        "fe, ok := p.(FirewallEnforcer)\n\t\tif ok && fe.EnforcesFirewall() {",
+        "fe, ok := p.(FirewallEnforcer)\n\t\tif ok {",
+        "fe, ok := p.(FirewallEnforcer)\n\t\tif ok && fe != nil {",
+        "fe",
+    ),
+]
+
+
+# Valid mutations the rule must not refuse. The first is the one that made this
+# list necessary: the rule read the contents of a Go string as code, so changing
+# a sentence looked like dropping a name. The rest are the neutralising rewrites
+# the 0.9 specs now carry, kept here so the accepted style is asserted and not
+# only demonstrated.
+ACCEPTED = [
+    (
+        'return "no route matches this path, but it is served under " +',
+        'return "no route matches " + path + ", but it is served under " +',
+        "a word inside a string is not an identifier",
+    ),
+    (
+        "if olderThan(got, IncusMinimum) {",
+        "if olderThan(got, IncusMinimum) && false {",
+        "a condition made never true, every name still evaluated",
+    ),
+    (
+        "if rec.status < 400 && !synthetic {",
+        "if rec.status < 400 && (!synthetic || true) {",
+        "a term neutralised by disjunction rather than deleted",
+    ),
+    (
+        "if err != nil || health.Resources == 0 {",
+        "if err != nil || (health.Resources == 0 && false) {",
+        "one branch of a disjunction disarmed, both still read",
+    ),
+]
+
+
+def selftest():
+    """Prove the rule on the three mistakes it was written for."""
+    failures = 0
+    for find, replace, why in ACCEPTED:
+        lost = dropped_identifiers(find, replace)
+        if lost:
+            print(f"!! the rule refuses a valid mutation, losing {lost}: {why}")
+            failures += 1
+        else:
+            print(f"ok  accepted, {why}")
+    print()
+    for find, broken, safe, orphan in HISTORY:
+        lost = dropped_identifiers(find, broken)
+        if orphan not in lost:
+            print(f"!! the rule accepts a mutation that orphans {orphan}: {broken}")
+            failures += 1
+        else:
+            print(f"ok  refused, {orphan} would be orphaned: {broken}")
+        # And the accepting half, which matters as much: a rule that refused
+        # every mutation would pass the checks above and make the tool useless.
+        still = dropped_identifiers(find, safe)
+        if still:
+            print(f"!! the rule refuses the safe form too, losing {still}: {safe}")
+            failures += 1
+        else:
+            print(f"    accepted, every name kept: {safe}")
+    print()
+    failures += lint_selftest()
+
+    print()
+    if failures:
+        print(f"{failures} failure(s): the rule does not hold its own history")
+        return 1
+    print(
+        f"the rule refuses all {len(HISTORY)} historical mistakes, accepts all "
+        f"{len(HISTORY)} fixes, and accepts {len(ACCEPTED)} valid mutations it "
+        f"has refused at some point"
+    )
+    return 0
+
+
+def lint_selftest():
+    """The lint answers 2 on a dead fragment and 0 on a live one.
+
+    A control that never fires reads exactly like a control that passes, which
+    is the failure this whole program exists to name. So the lint is pointed at
+    two specs built here: one naming a fragment that is in the file, one naming
+    a fragment that is not.
+
+    Written against a temporary directory rather than the repository's own
+    specs, because those are supposed to be green — a selftest that depended on
+    them would go red the day somebody legitimately retargets a mutation, and
+    that is the noise which teaches people to skip the check.
+    """
+    failures = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        subject = os.path.join(tmp, "subject.go")
+        with open(subject, "w", encoding="utf-8") as fh:
+            fh.write("package p\n\nfunc guard() bool { return true }\n")
+
+        # A second subject carrying the same fragment twice, which is what a
+        # spec meets when its subject is duplicated after the spec was written.
+        # The witness for the ambiguity rule: without a file that really holds
+        # two matches, the case would pass by finding nothing.
+        twice = os.path.join(tmp, "twice.go")
+        with open(twice, "w", encoding="utf-8") as fh:
+            fh.write(
+                "package p\n\nfunc a() bool { return true }\n\nfunc b() bool { return true }\n"
+            )
+
+        cases = [
+            (
+                subject,
+                "live.json",
+                "func guard() bool { return true }",
+                0,
+                "a fragment that is in the file",
+            ),
+            (
+                subject,
+                "dead.json",
+                "func guard() bool { return gone }",
+                2,
+                "a fragment that is not",
+            ),
+            (
+                twice,
+                "ambiguous.json",
+                "bool { return true }",
+                2,
+                "a fragment that matches two places, where only the first is rewritten",
+            ),
+        ]
+        for target, name, find, want, why in cases:
+            spec = {
+                "package": "./p/",
+                "mutations": [
+                    {
+                        "label": "selftest",
+                        "file": target,
+                        "find": find,
+                        "replace": find.replace("true", "false"),
+                        "test": "TestNothing",
+                    }
+                ],
+            }
+            directory = os.path.join(tmp, name.removesuffix(".json"))
+            os.mkdir(directory)
+            with open(os.path.join(directory, name), "w", encoding="utf-8") as fh:
+                json.dump(spec, fh)
+
+            got = lint(directory)
+            if got != want:
+                print(f"!! the lint answers {got} on {why}, want {want}")
+                failures += 1
+            else:
+                print(f"ok  the lint answers {got} on {why}")
+    return failures
+
+
+def every_spec(directory):
+    """Every spec in the directory, sorted, so two runs report the same order."""
+    return sorted(
+        os.path.join(directory, name) for name in os.listdir(directory) if name.endswith(".json")
+    )
+
+
+def fragment_problem(target, find):
+    """Why this fragment cannot be rewritten, or None.
+
+    Two answers, and the second is the one that cost #399. The harness rewrites
+    the FIRST occurrence only (`body.replace(find, replace, 1)`), because a
+    mutation is meant to name one place. A fragment that matches several places
+    therefore neutralises one of them and leaves the rest standing — and the
+    guard stays green for a reason that has nothing to do with the guard.
+
+    Measured: `shared-layer-is-enforced.json` names
+    `storetest.NoLostUpdate(40, func(trial int) []storetest.Write {`, which was
+    one call site in internal/providers/exoscale/lostupdate_test.go on the day
+    the spec was written and became three two days later. The mutation kept
+    renaming the first, `TestEveryPackRunsTheSharedBarrage` kept reading the
+    other two, and the falsification reported STILL GREEN for two months while
+    the guard it names was never actually removed. `--lint` could not see it:
+    the fragment was still there, so "every declared fragment still applies" was
+    true and useless.
+
+    So the fragment must match exactly once. It is the same class as the dead
+    fragment above — a spec describing code that is no longer what it thinks —
+    and it is checked in the same millisecond.
+    """
+    if not target or not os.path.exists(target):
+        return f"{target}: no such file"
+    with open(target, encoding="utf-8") as fh:
+        found = fh.read().count(find)
+    if found == 0:
+        return f"{target}: fragment not found"
+    if found > 1:
+        return (
+            f"{target}: fragment matches {found} places and only the first is rewritten, "
+            f"so the mutation leaves {found - 1} of them standing"
+        )
+    return None
+
+
+def lint(directory):
+    """Every declared fragment still exists in the file it names.
+
+    The cheap half of `--all`, and the half that catches the failure `--all`
+    catches twelve hours late. Replaying a spec copies the tree and runs `go
+    test` once per mutation, so it lives on a nightly cron: declaring one more
+    mutation must never be what makes pull requests slower. But a fragment that
+    no longer matches any code is not a slow question — it is a string search,
+    and the answer is the same in a millisecond as in eight minutes.
+
+    It has already cost this repository twice, both found on 17 August 2026 and
+    neither by the people who caused them:
+
+      - transition.json stopped applying when #211 reduced Transition to a
+        wrapper around Observe;
+      - serialise-then-commit.json stopped applying the same afternoon, when
+        #257 merged the two NIC doors and `server.ID` became `serverID`.
+
+    Between the change and the nightly run, `falsify:all` was red and the tree
+    looked green to everyone working in it. A dead spec is worse than a missing
+    one: `falsify:all` prints DID NOT APPLY, the count of proven guards silently
+    drops, and the specs directory keeps reading like a register of proofs.
+
+    So this runs in prepush, where it costs nothing.
+    """
+    specs = every_spec(directory)
+    if not specs:
+        return refuse(f"{directory} holds no spec, so this checked nothing")
+
+    stale = []
+    for path in specs:
+        with open(path, encoding="utf-8") as fh:
+            spec = json.load(fh)
+        for m in spec.get("mutations") or []:
+            why = fragment_problem(m.get("file"), m.get("find"))
+            if why:
+                stale.append((path, m.get("label", "?"), why))
+
+    if stale:
+        print(
+            f"falsify: {len(stale)} declared mutation(s) no longer apply. The code moved and "
+            "the spec did not, so these guards have stopped being measured:",
+            file=sys.stderr,
+        )
+        for path, label, why in stale:
+            print(f"  {os.path.basename(path)}: {why}\n      {label}", file=sys.stderr)
+        print(
+            "\nRetarget the fragment at the code that carries the guard today, or delete the "
+            "mutation and say in the spec why it no longer has a subject.",
+            file=sys.stderr,
+        )
+        return 2
+
+    count = 0
+    for path in specs:
+        with open(path, encoding="utf-8") as fh:
+            count += len(json.load(fh).get("mutations") or [])
+    print(f"every declared fragment still applies: {count} mutation(s) across {len(specs)} spec(s)")
+    return 0
+
+
+def replay_all(directory):
+    """Run every declared falsification (#169).
+
+    A falsification proves a test bites on the day it is run. Nothing ran them
+    again, so each one was a claim about the past — and this repository has
+    already shipped a falsification claim that was false: "neutralise any of the
+    three locks and the barrage goes red on the first attempt", thirty green runs
+    with the lock removed, recorded in the 0.8.0 CHANGELOG.
+
+    Every spec, one after another. A spec whose fragment no longer applies is a
+    failure and not a skip: code moved under it, so it has silently stopped
+    measuring, which is the exact thing this replay exists to catch.
+    """
+    specs = every_spec(directory)
+    if not specs:
+        return refuse(f"{directory} holds no spec, so a replay would measure nothing")
+
+    print(f"replaying {len(specs)} falsification(s)\n")
+    failed = []
+    for spec in specs:
+        print("=" * 72)
+        print(f"== {os.path.basename(spec)}")
+        print("=" * 72)
+        if main([argv0, spec]) != 0:
+            failed.append(os.path.basename(spec))
+        print()
+
+    print("#" * 72)
+    if failed:
+        print(f"{len(failed)} of {len(specs)} falsifications no longer hold: {', '.join(failed)}")
+        print(
+            "A guard whose test stopped biting is a guard that stopped working, "
+            "and the test is what has to be fixed rather than the spec."
+        )
+        return 1
+    print(f"all {len(specs)} falsifications still hold")
+    return 0
+
+
+argv0 = "falsify.py"
+
+
+def main(argv):
+    if len(argv) == 2 and argv[1] == "--selftest":
+        return selftest()
+    if len(argv) == 3 and argv[1] == "--all":
+        return replay_all(argv[2])
+    if len(argv) == 3 and argv[1] == "--lint":
+        return lint(argv[2])
+    if len(argv) != 2:
+        return refuse("usage: falsify.py <spec.json> | --all <dir> | --lint <dir> | --selftest")
+    spec_path = argv[1]
+    with open(spec_path, encoding="utf-8") as fh:
+        spec = json.load(fh)
+
+    mutations = spec.get("mutations") or []
+    if not mutations:
+        return refuse(f"{spec_path} declares no mutation, so a run would measure nothing")
+
+    # Every shape check first, before a single file is copied. A run that is
+    # going to be void should cost nothing and say why.
+    for m in mutations:
+        for key in ("label", "file", "find", "replace", "test"):
+            if not m.get(key):
+                return refuse(f"a mutation is missing {key!r}: {m.get('label', m)}")
+        if m["find"] == m["replace"]:
+            return refuse(f"{m['label']!r} replaces a fragment with itself")
+        # Ambiguity is refused before anything is copied, on the same terms as a
+        # dead fragment: see fragment_problem.
+        ambiguous = fragment_problem(m["file"], m["find"])
+        if ambiguous:
+            return refuse(f"{m['label']!r}: {ambiguous}")
+        lost = dropped_identifiers(m["find"], m["replace"])
+        if lost:
+            return refuse(
+                f"{m['label']!r} drops {', '.join(lost)} from the fragment.\n"
+                f"        This harness requires every name in `find` to survive into "
+                f"`replace`. It has not checked whether Go would mind here — it cannot "
+                f"see the rest of the file — and the rule is conservative on purpose: "
+                f"a deleted term that orphans a name fails every test in the package, "
+                f"which reads exactly like the guard being proven.\n"
+                f"        Neutralise the condition instead of deleting the term: keep "
+                f"every name evaluated and make the expression never true "
+                f"(`… && false`, `(… || true)`). The mutation then changes a truth "
+                f"value and nothing else."
+            )
+
+    src = os.getcwd()
+    # mkdtemp rather than a name built from the spec: a predictable path under
+    # /tmp is a symlink somebody else can plant, and this copy is about to be
+    # compiled and executed. bandit refused the first version and was right.
+    dst = tempfile.mkdtemp(
+        prefix="falsify-" + os.path.basename(spec_path).removesuffix(".json") + "-"
+    )
+    print(f"copying the repository to {dst}", flush=True)
+    copy_tree(src, dst)
+
+    default_pkg = spec.get("package", "./...")
+    packages = sorted({m.get("package", default_pkg) for m in mutations})
+    # A spec may arm what its subject's tests need — see run().
+    spec_env = spec.get("env") or {}
+
+    base = run(dst, ["go", "test", "-count=1", *packages], spec_env)
+    if base.returncode != 0:
+        print(
+            "the copy is red before any mutation, so nothing below measures a guard",
+            file=sys.stderr,
+        )
+        print(base.stdout[-2500:], file=sys.stderr)
+        shutil.rmtree(dst, ignore_errors=True)
+        return 2
+    print("baseline: green\n")
+
+    verdicts, pristine = [], {}
+    for m in mutations:
+        path = os.path.join(dst, m["file"])
+        if m["file"] not in pristine:
+            with open(path, encoding="utf-8") as fh:
+                pristine[m["file"]] = fh.read()
+        body = pristine[m["file"]]
+        if m["find"] not in body:
+            verdicts.append((m["label"], "DID NOT APPLY", "-"))
+            print(f"!! {m['label']}: fragment not found in {m['file']}\n")
+            continue
+
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(body.replace(m["find"], m["replace"], 1))
+
+        pkg = m.get("package", default_pkg)
+        vet = run(dst, ["go", "vet", pkg])
+        if vet.returncode != 0:
+            # The identifier check above should make this unreachable. If it
+            # fires, the rule missed a shape and the rule is what needs work.
+            verdicts.append((m["label"], "DID NOT COMPILE (void)", "no"))
+            print(f"!! {m['label']}: does not build, verdict void")
+            print(vet.stderr[-900:])
+        else:
+            # A race is measured, not observed once. With its per-server lock
+            # neutralised, TestAttachingANICDoesNotResurrectADeletedServer went
+            # red on three of five identical runs on 17 August 2026 — so a
+            # harness that runs it once reports a coin toss and prints it as a
+            # verdict, which is worse than no verdict because it reads like a
+            # proof. It had already printed "TEST STILL PASSED" twice for a
+            # guard that does bite.
+            #
+            # A spec whose subject is a race declares `repeat`, and the odds of
+            # a false green fall from p to p**n.
+            repeat = int(m.get("repeat") or spec.get("repeat") or 1)
+            res = run(dst, ["go", "test", f"-count={repeat}", "-run", m["test"], pkg], spec_env)
+            bit = res.returncode != 0
+            verdicts.append((m["label"], "the test bit" if bit else "TEST STILL PASSED", "yes"))
+            print(
+                f"{'ok ' if bit else '!! '}{m['label']}\n    {m['test']}: "
+                f"{'red' if bit else 'STILL GREEN'}\n"
+            )
+
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(pristine[m["file"]])
+
+    final = run(dst, ["go", "test", "-count=1", *packages], spec_env)
+    print("=" * 72)
+    for label, verdict, compiled in verdicts:
+        print(f"  compiled={compiled:3}  {verdict:24}  {label}")
+    ok_final = final.returncode == 0
+    print(f"\nafter restoration: {'green' if ok_final else 'RED — the restore is broken'}")
+    if not ok_final:
+        print(final.stdout[-2000:], file=sys.stderr)
+    shutil.rmtree(dst, ignore_errors=True)
+
+    everything_bit = all(v[1] == "the test bit" for v in verdicts)
+    return 0 if (everything_bit and ok_final) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/falsify/specs/an-inconclusive-finding-never-becomes-a-deviation.json
+++ b/tools/falsify/specs/an-inconclusive-finding-never-becomes-a-deviation.json
@@ -1,0 +1,19 @@
+{
+  "package": "./internal/assess/",
+  "mutations": [
+    {
+      "label": "l'assessment ignore le marqueur d'incertitude et rend un écart",
+      "file": "internal/assess/assess.go",
+      "find": "\t\tif IsInconclusive(f) {\n\t\t\tstatus = assessment.NotEvaluated\n\t\t}",
+      "replace": "\t\tif false && IsInconclusive(f) {\n\t\t\tstatus = assessment.NotEvaluated\n\t\t}",
+      "test": "TestAnInconclusiveFindingIsNotEvaluated"
+    },
+    {
+      "label": "le constat d'incertitude repasse dans les décomptes de sévérité",
+      "file": "internal/assess/inconclusive.go",
+      "find": "\t\tif IsInconclusive(f) {\n\t\t\tinconclusive = append(inconclusive, f)\n\t\t\tcontinue\n\t\t}",
+      "replace": "\t\tif false && IsInconclusive(f) {\n\t\t\tinconclusive = append(inconclusive, f)\n\t\t\tcontinue\n\t\t}",
+      "test": "TestAnInconclusiveFindingNeverProducesExitOne"
+    }
+  ]
+}


### PR DESCRIPTION
Premier lot de la vague 4.5. Trois règles produisaient un `FAIL` à partir d'un
attribut que personne n'avait observé.

## Impact ADR

- [x] **un nouvel ADR est nécessaire** — ADR-0015, créé dans cette PR
- [x] ADR-0014 étendu — son troisième invariant disait déjà « aucune règle ne
      produit un `fail` depuis un attribut absent défaussé », et notait que la
      garde restait à écrire
- [x] ADR-0006, ADR-0003 respectés
- [x] **ADR-0013 respecté, et il a contraint le lot** : aucun code de contrôle
      n'est renommé ici. La correction du peering porte sur le défaut de `state`,
      pas sur son nom — un renommage rendrait orphelines les dérogations existantes

C'est la première tâche depuis que la revue ADR existe, et elle a produit un
résultat réel : le mécanisme nécessaire n'existait pas, donc l'implémentation
s'est arrêtée le temps d'écrire la décision.

## Pourquoi la correction évidente était fausse

La règle région dit elle-même « ni établie ni infirmée » et émet quand même un
écart. Un faux rouge, qui se déclenchera à **chaque ouverture de région** par un
fournisseur.

Mais la faire taire aurait été pire. Les tables de classification sont des
**listes blanches** : leur silence vaudrait « conforme » pour toute région
qu'elles ignorent — un fail-open structurel dans un outil de souveraineté. Le
commentaire de la règle l'avait anticipé, et c'est pour cela qu'elle criait.

Il manquait un troisième canal.

## ADR-0015 — la règle constate, l'assessment statue

`assess` savait déjà rendre `not-evaluated` dans deux cas décidés **hors** de la
règle : attribut non collecté, unité de collecte incomplète. Il en existe un
troisième que **seule la règle voit** : la donnée est là, lisible, et elle ne
permet pas de conclure.

Une règle émet alors `labels.inconclusive: "true"`. L'assessment en fait un
`not-evaluated`, et le finding **ne pèse dans aucun décompte de sévérité** —
donc il ne peut jamais rendre `1`. Le cas reste **visible**, avec sa raison :
l'invisibilité serait le fail-open que le mécanisme existe pour empêcher.

Alternative écartée notable : un second document Rego interrogé par le moteur.
`scankit/engine` n'interroge que `deny`, et l'ADR-0002 interdit un moteur local ;
cela exigerait une évolution amont pour un besoin qui n'est pas partagé.

## Les trois règles

| Issue | Correction |
|---|---|
| **#105** | Région non cataloguée ⇒ constat d'incertitude, plus un écart |
| **#109** | Peering : `state` absent ne vaut plus « actif » |
| **#106** | *(non traitée ici — voir plus bas)* |

## Mesures

**Non-régression : 0 fixture déplacée sur 8.** Les fixtures ne portent aucune
région inconnue ni peering sans état, donc rien ne bouge — ce qui est le
résultat attendu, pas une absence de changement.

**Quatre mutations, quatre rouges** :

| Mutation | Verdict |
|---|---|
| l'assessment ignore l'incertitude | 🔴 `TestAnInconclusiveFindingIsNotEvaluated` |
| le constat repasse dans les décomptes | 🔴 `TestAnInconclusiveFindingNeverProducesExitOne` |
| l'état absent du peering revaut « actif » | 🔴 `test_peering_state_not_collected_does_not_deny` |
| la région perd son marqueur d'incertitude | 🔴 **erreur de compilation** |

La quatrième mérite un mot : le vérificateur de types d'OPA connaît l'ensemble
des clés de labels qu'une règle produit, et refuse `f.labels.inconclusive` dès
qu'elle cesse de l'émettre. La garde est le compilateur, pas une assertion —
plus fort qu'un test.

Et la troisième est le vrai gain de l'exercice : **elle est revenue verte à la
première tentative**. Aucun test ne couvrait le peering sans état ; ma correction
était non gardée. Le test a été écrit à ce moment-là.

## Ce que je n'ai pas fait

**#106 (`loadbalancer_logging_enabled`) n'est pas traitée.** Son défaut a deux
moitiés : le helper qui prend `is_enabled = false`, et l'absence du contrôle dans
le verrou de capacité. La seconde ne se corrige pas proprement tant que le verrou
raisonne **par type et en any-of** — c'est #102. La traiter ici donnerait une
correction qui semble tenir et qu'une ressource voisine porteuse de l'attribut
suffirait à contourner.

**Le garde générique de #104 n'existe pas non plus.** « Aucune règle ne produit un
`fail` depuis un attribut absent » exige que chaque règle déclare son attribut
décisif, c'est-à-dire le contrat de décision de #102/#103. Ce lot corrige les
trois cas connus et pose le mécanisme ; la porte générique suit.

**Aucun scan live.** Tout est mesuré sur les fixtures du dépôt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
