### PR TITLE
fix(assessment): one resource can no longer vouch for its neighbour

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -745,18 +745,90 @@ func collected(v any) bool {
 
 func attrsByTypeOf(input any) map[string]map[string]bool {
 	out := map[string]map[string]bool{}
-	add := func(typ string, attrs map[string]any) {
+	// L'INTERSECTION, pas l'union. Un attribut ne compte comme collecté pour un type
+	// que si CHAQUE ressource de ce type le porte.
+	//
+	// L'union laissait une seule ressource porteuse ouvrir la porte du `pass` à
+	// toutes ses voisines : deux VMs, une seule avec `deletion_protection`, et le
+	// contrôle concluait sur la seconde sans avoir rien observé d'elle. Le fuzzing
+	// l'a trouvé de son côté, sur une liste vide voisine d'un nombre.
+	//
+	// Le coût est réel et voulu : un type dont une seule ressource manque l'attribut
+	// décisif ne rend plus `pass`, il rend `not-evaluated`. C'est ce que l'ADR-0006
+	// demande — on ne conclut pas sur ce qu'on n'a pas vu.
+	// La carte se construit en DEUX passes, et la seconde est ce qui la rend juste.
+	//
+	// Passe 1 — quels attributs le collecteur EXPOSE réellement sur ce type. Un
+	// attribut que personne n'expose n'a jamais été collecté : aucune provenance ne
+	// peut en faire une observation.
+	//
+	// Passe 2 — l'INTERSECTION sur les ressources, avec un secours. Un attribut
+	// absent des `attributes` mais présent en PROVENANCE a été cherché et non exposé
+	// par la source (ADR-0007) : c'est une observation — l'opérateur n'a rien
+	// déclaré — et non une lacune. Le secours n'est accordé QUE si la passe 1 a vu
+	// cet attribut exposé au moins une fois.
+	//
+	// Les trois cas que cette combinaison sépare, tous mesurés :
+	//
+	//   user_data       exposé sur 3 VM /5, cherché sur les 5   -> pass (rien à déclarer)
+	//   public_ip       exposé sur AUCUNE, cherché sur les 5    -> not-evaluated
+	//   disable_backup  exposé sur 1 base /2, cherché sur 1     -> not-evaluated
+	//
+	// Sans la passe 1, le deuxième cas devenait un `pass` — un faux vert bâti sur la
+	// seule intention de chercher.
+	type seenAttrs struct {
+		attrs map[string]any
+		prov  map[string]bool
+	}
+	perType := map[string][]seenAttrs{}
+	add := func(typ string, attrs map[string]any, prov map[string]bool) {
 		if typ == "" {
 			return
 		}
-		if out[typ] == nil {
-			out[typ] = map[string]bool{}
-		}
-		for k, v := range attrs {
-			if !collected(v) {
-				continue
+		perType[typ] = append(perType[typ], seenAttrs{attrs: attrs, prov: prov})
+	}
+	finish := func() {
+		for typ, rs := range perType {
+			exposed := map[string]bool{}
+			for _, r := range rs {
+				for k, v := range r.attrs {
+					if collected(v) {
+						exposed[k] = true
+					}
+				}
 			}
-			out[typ][k] = true
+			var inter map[string]bool
+			for i, r := range rs {
+				present := map[string]bool{}
+				for k, v := range r.attrs {
+					if collected(v) {
+						present[k] = true
+					}
+				}
+				for k := range r.prov {
+					if _, in := r.attrs[k]; !in && exposed[k] {
+						present[k] = true
+					}
+				}
+				if i == 0 {
+					inter = present
+					continue
+				}
+				for k := range inter {
+					if !present[k] {
+						delete(inter, k)
+					}
+				}
+			}
+			if inter == nil {
+				inter = map[string]bool{}
+			}
+			if out[typ] == nil {
+				out[typ] = map[string]bool{}
+			}
+			for k := range inter {
+				out[typ][k] = true
+			}
 		}
 	}
 	// La RÉGION est un champ de la ressource, pas un attribut : on l'enregistre sous la clé
@@ -779,7 +851,11 @@ func attrsByTypeOf(input any) map[string]map[string]bool {
 	switch rs := m["resources"].(type) {
 	case []model.Resource:
 		for _, r := range rs {
-			add(r.Type, r.Attributes)
+			prov := map[string]bool{}
+			for k := range r.Provenance {
+				prov[k] = true
+			}
+			add(r.Type, r.Attributes, prov)
 			addRegion(r.Region)
 		}
 	case []any:
@@ -787,12 +863,19 @@ func attrsByTypeOf(input any) map[string]map[string]bool {
 			if rm, ok := it.(map[string]any); ok {
 				t, _ := rm["type"].(string)
 				attrs, _ := rm["attributes"].(map[string]any)
-				add(t, attrs)
+				prov := map[string]bool{}
+				if pm, ok := rm["provenance"].(map[string]any); ok {
+					for k := range pm {
+						prov[k] = true
+					}
+				}
+				add(t, attrs, prov)
 				reg, _ := rm["region"].(string)
 				addRegion(reg)
 			}
 		}
 	}
+	finish()
 	return out
 }
 

--- a/cmd/testdata/fuzz/FuzzInventoryWalk/323e8db74b2187fc
+++ b/cmd/testdata/fuzz/FuzzInventoryWalk/323e8db74b2187fc
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"resources\":[{\"type\":\"0\",\"attributes\":{\"\":\"\",\"0\":[]}},{\"type\":\"0\",\"attributes\":{\"\":\"\",\"0\":\"\",\"0\":0}}]}")

--- a/docs/adr/0006-jamais-un-pass-non-prouve.md
+++ b/docs/adr/0006-jamais-un-pass-non-prouve.md
@@ -54,9 +54,16 @@ Une seule exception à « ce qui a été lu est gardé » : un **agrégat** n'es
 calculé sur une liste tronquée, parce qu'un compte faux est pire qu'un compte
 absent — une règle le compare à un seuil.
 
-**Dette connue** : le verrou raisonne aujourd'hui par *type* et en *any-of*, pas par
-ressource ni en *all-of*, et un contrôle ne déclare qu'un type. Voir #102 et #103 :
-c'est la limite actuelle de cette décision, pas une remise en cause de sa direction.
+**Dette, et ce qu'il en reste.** Le verrou raisonnait par *type* et en *any-of*
+implicite : une seule ressource porteuse de l'attribut ouvrait la porte du `pass` à
+toutes ses voisines. Corrigé (#102) — `attrsByType` se construit désormais par
+INTERSECTION, et la combinaison des attributs est explicite. Le défaut était vivant
+sur la fixture « conforme » du dépôt : quatre contrôles y déclaraient conforme une
+base de données dont la sauvegarde n'avait jamais été observée.
+
+Reste **#103** : un contrôle ne déclare qu'un seul type, donc l'incomplétude d'un
+second type qu'il lit ne le dégrade pas. C'est la limite actuelle de cette décision,
+pas une remise en cause de sa direction.
 
 ## Invariants
 

--- a/docs/getting-started/quickstart.fr.md
+++ b/docs/getting-started/quickstart.fr.md
@@ -208,7 +208,7 @@ sans le PermissionSet `IAMManager`, et les quatre étiquettes de gouvernance sur
 ──────────────────────────────────────────────────────────────────────────────
  Summary
 
- Verdict : conforme sur le périmètre déclaré (plan Terraform, état planifié) (aucune non-conformité détectée, 16 contrôles conformes)
+ Verdict : conforme sur le périmètre déclaré (plan Terraform, état planifié) (aucune non-conformité détectée, 12 contrôles conformes)
 
  🔴 CRITICAL 0   🟠 HIGH 0   🟡 MEDIUM 0   🔵 LOW 0
 ──────────────────────────────────────────────────────────────────────────────

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -205,7 +205,7 @@ without the `IAMManager` permission set, and the four governance tags on the ins
 ──────────────────────────────────────────────────────────────────────────────
  Summary
 
- Verdict: compliant on the declared scope (Terraform plan, planned state) (no deviation detected, 16 compliant controls)
+ Verdict: compliant on the declared scope (Terraform plan, planned state) (no deviation detected, 12 compliant controls)
 
  🔴 CRITICAL 0   🟠 HIGH 0   🟡 MEDIUM 0   🔵 LOW 0
 ──────────────────────────────────────────────────────────────────────────────

--- a/docs/reference/exit-codes.fr.md
+++ b/docs/reference/exit-codes.fr.md
@@ -54,7 +54,7 @@ $ ./pepin scan scaleway --terraform examples/scaleway/terraform-fixed/plan.json
 […]
  Summary
 
- Verdict : conforme sur le périmètre déclaré (plan Terraform, état planifié) (aucune non-conformité détectée, 16 contrôles conformes)
+ Verdict : conforme sur le périmètre déclaré (plan Terraform, état planifié) (aucune non-conformité détectée, 12 contrôles conformes)
 
  🔴 CRITICAL 0   🟠 HIGH 0   🟡 MEDIUM 0   🔵 LOW 0
 ──────────────────────────────────────────────────────────────────────────────

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -54,7 +54,7 @@ $ ./pepin scan scaleway --terraform examples/scaleway/terraform-fixed/plan.json
 […]
  Summary
 
- Verdict: compliant on the declared scope (Terraform plan, planned state) (no deviation detected, 16 compliant controls)
+ Verdict: compliant on the declared scope (Terraform plan, planned state) (no deviation detected, 12 compliant controls)
 
  🔴 CRITICAL 0   🟠 HIGH 0   🟡 MEDIUM 0   🔵 LOW 0
 ──────────────────────────────────────────────────────────────────────────────

--- a/internal/assess/assess.go
+++ b/internal/assess/assess.go
@@ -305,9 +305,37 @@ func Build(provider string, controls map[string]referentiel.Control, findings []
 // attrCollected indique que l'ATTRIBUT clé du contrôle (s'il en a un) est présent sur au moins
 // une ressource de son type. Sans attribut requis déclaré, true (le contrôle s'évalue par la
 // présence d'un finding). C'est le verrou par ATTRIBUT (pas seulement par type) du « pass ».
+// requireAll énumère les contrôles dont les attributs déclarés se combinent en ET,
+// et non en OU.
+//
+// Le défaut : `requiredAttr` portait une LISTE, et la boucle rendait vrai au premier
+// attribut trouvé — un `any-of` implicite que personne n'avait décidé. Pour la
+// plupart des contrôles c'est juste : plusieurs signaux alternatifs établissent le
+// même fait. Pour celui-ci, non.
+//
+// `network_peering_cross_organization` COMPARE les deux comptes. Avec un seul, il n'y
+// a rien à comparer, et le contrôle franchissait pourtant sa porte.
+var requireAll = map[string]bool{
+	"network_peering_cross_organization": true,
+}
+
+// attrCollected dit si la donnée qui DÉCIDE a été collectée pour ce contrôle.
+//
+// `attrsByType` est construit par INTERSECTION sur les ressources d'un type
+// (cf. attrsByTypeOf) : un attribut n'y figure que si CHAQUE ressource le porte.
+// C'est ce qui empêche une ressource voisine d'ouvrir la porte du `pass` à une
+// ressource dont on n'a rien observé.
 func attrCollected(code, typ string, attrsByType map[string]map[string]bool) bool {
 	attrs := requiredAttr[code]
 	if len(attrs) == 0 {
+		return true
+	}
+	if requireAll[code] {
+		for _, a := range attrs {
+			if !attrsByType[typ][a] {
+				return false
+			}
+		}
 		return true
 	}
 	for _, a := range attrs {

--- a/mise.toml
+++ b/mise.toml
@@ -287,7 +287,7 @@ go test ./cmd/ -run '^$' -fuzz 'FuzzInventoryWalk' -fuzztime="$t"
 
 [tasks.prepush]
 description = "Tout ce sur quoi une PR échouera, qui coûte des secondes et n'exige aucun compte"
-depends = ["validate", "test", "audit", "adr-drift", "secrets", "falsify:selftest"]
+depends = ["validate", "test", "audit", "adr-drift", "secrets", "falsify:selftest", "falsify:lint"]
 # Ce que c'est, et ce que ce n'est délibérément PAS.
 #
 # Chacune de ces portes est déterministe, hors ligne, et tient en quelques
@@ -300,3 +300,10 @@ depends = ["validate", "test", "audit", "adr-drift", "secrets", "falsify:selftes
 # fournisseur. Ces choses vivent en nocturne ou à la qualification de release,
 # précisément pour ne pas rendre ce chemin-ci trop lent pour être suivi.
 run = "echo 'prepush : toutes les portes locales sont vertes'"
+
+[tasks."falsify:lint"]
+description = "Les specs de falsification visent-elles encore du code qui existe"
+# Une spec dont le fragment a bougé ne mesure plus rien, et son silence ressemble
+# à s'y méprendre à une garde qui tient. Le cas s'est présenté dans l'heure qui a
+# suivi l'arrivée du harnais : le code a été réécrit, la spec est restée.
+run = "python3 tools/falsify/falsify.py --lint tools/falsify/specs"

--- a/tools/falsify/specs/one-resource-cannot-vouch-for-its-neighbour.json
+++ b/tools/falsify/specs/one-resource-cannot-vouch-for-its-neighbour.json
@@ -1,0 +1,12 @@
+{
+  "package": "./cmd/",
+  "mutations": [
+    {
+      "label": "l'intersection n'intersecte plus : la dernière ressource décide pour toutes",
+      "file": "cmd/scan.go",
+      "find": "\t\t\t\tif i == 0 {\n\t\t\t\t\tinter = present\n\t\t\t\t\tcontinue\n\t\t\t\t}",
+      "replace": "\t\t\t\tif i >= 0 {\n\t\t\t\t\tinter = present\n\t\t\t\t\tcontinue\n\t\t\t\t}",
+      "test": "FuzzInventoryWalk"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #102

## Impact ADR

- [x] **ADR-0006 étendu** — il nommait ce défaut comme sa dette connue : *« le verrou raisonne par type et en any-of… c'est la limite actuelle de cette décision, pas une remise en cause de sa direction »*. La décision ne change pas, son implémentation la rattrape. La section « Dette » est mise à jour, l'ADR n'est pas remplacé.
- [x] **ADR-0007 appliqué** — la provenance sert enfin à ce qu'elle documentait : distinguer un champ *cherché et non exposé* d'un champ jamais cherché.
- [x] ADR-0003, ADR-0014 respectés.

## Le défaut, et où il vivait

`attrsByTypeOf` faisait l'**union** des attributs sur les ressources d'un type. Une seule ressource porteuse ouvrait donc la porte du `pass` à toutes ses voisines.

Il était vivant sur la **fixture « conforme » du dépôt**. Son plan Terraform porte deux `managed_database` :

```
fr-par/1111…    → database_id, ip_filter
pepin-test-rdb  → database_id, disable_backup, encryption_at_rest
```

Quatre contrôles déclaraient ce tenant conforme sur une donnée jamais collectée pour la moitié d'entre lui.

## Deux passes, et la seconde est ce qui rend juste

**Passe 1** — quels attributs le collecteur **expose** réellement sur ce type. Un attribut que personne n'expose n'a jamais été collecté, et aucune provenance ne peut en faire une observation.

**Passe 2** — l'intersection sur les ressources, avec un **secours** : un attribut absent des `attributes` mais présent en **provenance** a été cherché et non exposé par la source, ce qu'ADR-0007 définit déjà comme une observation. Le secours n'est accordé que si la passe 1 a vu l'attribut exposé au moins une fois.

Les trois cas que cette combinaison sépare, tous mesurés sur des données réelles du dépôt :

| Attribut | Exposé | Cherché | Verdict |
|---|---|---|---|
| `user_data` | 3 VM sur 5 | les 5 | `pass` — rien à déclarer sur les 2 autres |
| `public_ip` | **aucune** | les 5 | `not-evaluated` |
| `disable_backup` | 1 base sur 2 | 1 seule | `not-evaluated` |

## L'erreur que j'ai commise, et ce qui l'a rattrapée

Ma première version accordait le secours **sur la seule présence en provenance**. Elle a produit **trois transitions `not-evaluated → pass`** — la direction interdite —, un faux vert bâti sur la seule intention de chercher.

Ce sont les **tenants de référence** (#58) qui l'ont attrapée, sur des configurations tierces inchangées, exactement le rôle pour lequel ils existent. La passe 1 est née de cette correction.

## Mesures

**Quatre transitions sur l'ensemble des fixtures et des tenants de référence, toutes `pass → not-evaluated`, aucune vers `pass`.**

La graine trouvée par le fuzzing rejoint le corpus versionné : le cas est désormais gardé pour toujours, et la spec de falsification prouve qu'il rougit quand l'intersection cesse d'intersecter (`compiled=yes`, le test mord, restauration verte).

## Rendu explicite au passage

`requiredAttr` combinait ses attributs en `any-of` **implicite**, que personne n'avait décidé. Pour `network_peering_cross_organization` c'était faux : la règle **compare** deux comptes, et un seul ne se compare pas. La combinaison est désormais déclarée.

## Ce que je n'ai pas fait

**#103 reste ouverte** : un contrôle ne déclare toujours qu'un seul type, donc l'incomplétude d'un second type qu'il lit ne le dégrade pas. C'est la dette qui subsiste, et ADR-0006 le dit maintenant explicitement.

`falsify:lint` rejoint `prepush` — une spec a cessé de s'appliquer **dans l'heure** qui a suivi l'arrivée du harnais, parce que j'ai réécrit le code sans la recibler. Son silence ressemblait à une garde qui tient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
