### PR TITLE
fix(release): cover every published artefact, and say how to check it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,12 +326,6 @@ jobs:
             exit 1
           }
 
-      - name: Generate checksums
-        working-directory: dist
-        run: |
-          sha256sum pepin-* > checksums.txt
-          cat checksums.txt
-
       - name: Generate SBOM (Syft, CycloneDX)
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
@@ -339,6 +333,16 @@ jobs:
           format: cyclonedx-json
           output-file: dist/sbom.cdx.json
           upload-release-assets: false
+
+      # Le SBOM est produit AVANT les sommes, et il y entre. La signature porte sur
+      # checksums.txt : ce qui n'y figure pas n'est couvert par aucun chemin de
+      # vérification documenté. L'attestation SBOM lie le CONTENU aux binaires, elle
+      # ne dit rien du fichier publié — les deux sont nécessaires (ADR-0016).
+      - name: Generate checksums
+        working-directory: dist
+        run: |
+          sha256sum pepin-* sbom.cdx.json > checksums.txt
+          cat checksums.txt
 
       - name: Attest build provenance
         id: attest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,6 +266,11 @@ jobs:
       - name: Install Cosign
         if: ${{ !github.event.repository.private }}
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Figer l'OUTIL, pas seulement l'action qui l'installe (ADR-0016).
+          # Un outil de signature dont la version est choisie par l'amont au
+          # moment du build est un maillon qu'on ne contrôle pas.
+          cosign-release: v3.1.3
 
       # Par digest, jamais par tag : une signature sur un tag bénit ce que le
       # tag pointera plus tard.
@@ -367,6 +372,11 @@ jobs:
       - name: Install Cosign
         if: ${{ !github.event.repository.private }}
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Figer l'OUTIL, pas seulement l'action qui l'installe (ADR-0016).
+          # Un outil de signature dont la version est choisie par l'amont au
+          # moment du build est un maillon qu'on ne contrôle pas.
+          cosign-release: v3.1.3
 
       # Une signature sur checksums.txt couvre chaque artefact : leur empreinte y est.
       - name: Sign checksums (keyless)

--- a/README.fr.md
+++ b/README.fr.md
@@ -78,6 +78,40 @@ n'a collecté aucune ressource ne rend jamais `0`, et un scan qui n'a pas pu lir
 partie de son périmètre non plus : un résultat vide n'est pas conforme, un résultat
 partiel non plus, un résultat dérogé non plus.
 
+## Vérifier ce que vous avez téléchargé
+
+Chaque artefact de release est couvert. Une commande pour chacun, et rien à croire
+sur parole.
+
+```bash
+V=v0.3.0
+gh release download "$V" --repo stephrobert/pepin
+
+# 1. les sommes sont signées, et elles couvrent les binaires ET le SBOM
+cosign verify-blob checksums.txt \
+  --bundle checksums.txt.cosign.bundle \
+  --certificate-identity-regexp '^https://github\.com/stephrobert/pepin/\.github/workflows/release\.yml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# 2. vos fichiers correspondent à ces sommes signées
+sha256sum --check checksums.txt --ignore-missing
+
+# 3. le binaire a bien été produit par le workflow de release de ce dépôt (provenance SLSA)
+gh attestation verify pepin-linux-amd64 --repo stephrobert/pepin
+```
+
+**Le SBOM** (`sbom.cdx.json`, CycloneDX) accompagne chaque release. L'étape 1 couvre
+le fichier publié ; il est par ailleurs attesté contre les binaires, ce qui est une
+affirmation différente — que cet inventaire décrit *cette* compilation :
+
+```bash
+gh attestation verify pepin-linux-amd64 --repo stephrobert/pepin \
+  --predicate-type https://cyclonedx.org/bom
+
+# à donner à l'outil que vous utilisez déjà
+osv-scanner --sbom sbom.cdx.json
+```
+
 ## Langue
 
 Pépin parle français et anglais, et choisit tout seul :

--- a/README.md
+++ b/README.md
@@ -79,6 +79,39 @@ resource never returns `0`, and neither does one that could not read part of its
 scope: an empty result is not a compliant one, a partial one is not either, and an
 exempted one is not either.
 
+## Verify what you downloaded
+
+Every release artefact is covered. One command each, and nothing to trust on faith.
+
+```bash
+V=v0.3.0
+gh release download "$V" --repo stephrobert/pepin
+
+# 1. the checksums are signed, and they cover the binaries AND the SBOM
+cosign verify-blob checksums.txt \
+  --bundle checksums.txt.cosign.bundle \
+  --certificate-identity-regexp '^https://github\.com/stephrobert/pepin/\.github/workflows/release\.yml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# 2. your files match those signed checksums
+sha256sum --check checksums.txt --ignore-missing
+
+# 3. the binary was built by this repository's release workflow (SLSA provenance)
+gh attestation verify pepin-linux-amd64 --repo stephrobert/pepin
+```
+
+**The SBOM** (`sbom.cdx.json`, CycloneDX) ships with every release. Step 1 covers the
+published file; it is also attested against the binaries, which is a different claim
+— that this inventory describes *that* build:
+
+```bash
+gh attestation verify pepin-linux-amd64 --repo stephrobert/pepin \
+  --predicate-type https://cyclonedx.org/bom
+
+# feed it to whatever you already use
+osv-scanner --sbom sbom.cdx.json
+```
+
 ## Language
 
 Pépin speaks French and English, and picks one on its own:

--- a/docs/adr/0016-chaine-dapprovisionnement-verifiable.md
+++ b/docs/adr/0016-chaine-dapprovisionnement-verifiable.md
@@ -40,6 +40,7 @@ Concrètement, ce qui est tenu :
 | Mécanisme | Ce qu'il couvre |
 |---|---|
 | Épinglage par SHA complet | toute action tierce, sans exception |
+| Version explicite | tout OUTIL qu'une action installe |
 | Permissions minimales, déclarées par job | le jeton de chaque étape |
 | `checksums.txt` + `cosign sign-blob` | l'empreinte de **chaque** artefact publié |
 | Provenance SLSA (`attest-build-provenance`) | les binaires, comme sujets |
@@ -64,6 +65,16 @@ est celui qui a été publié » ; l'attestation dit « ce contenu décrit ce bi
 **Épingler les actions par étiquette de version** (`@v4`). Rejeté : une étiquette se
 déplace, donc elle n'épingle rien. C'est le vecteur d'attaque le plus documenté de
 l'écosystème.
+
+**Épingler l'action et laisser flotter ce qu'elle installe.** C'était l'état réel, et
+il a cassé toutes les PR le 2026-09-08 : `jdx/mise-action` était correctement épinglée
+par SHA, mais sans `version:` elle résolvait vers la dernière étiquette de mise — et
+`v2026.9.3` existait comme étiquette sans que ses binaires soient publiés. Cinq
+tentatives, 404, tout le dépôt à l'arrêt.
+
+Une chaîne ne vaut que son maillon le moins figé, et celui-là était choisi pour nous
+chaque jour par le dernier qui taguait en amont. L'invariant porte donc désormais sur
+l'outil, pas seulement sur l'action qui l'installe.
 
 **Signer chaque artefact séparément.** Rejeté : autant de signatures à vérifier, et
 un vérificateur qui en oublie une ne le saura pas. Un condensé unique signé donne
@@ -91,12 +102,15 @@ a survécu à trois releases.
 ## Invariants
 
 - Toute action tierce est épinglée par un SHA de 40 caractères.
+- Toute action qui INSTALLE un outil lui donne une version explicite. L'épinglage
+  d'une action ne fige que l'action : ce qu'elle télécharge ensuite reste choisi par
+  l'amont si personne ne le dit.
 - Tout artefact publié figure dans `checksums.txt`, donc sous la signature.
 - La documentation donne, pour chaque artefact, la commande qui le vérifie.
 - Aucun secret de fournisseur n'entre en CI (ADR-0012).
 
-*Gardes : `TestEveryPublishedArtefactIsChecksummed` et
-`TestEveryActionIsPinnedToAFullSHA` ; le préflight rejoue la vérification avant tout
+*Gardes : `TestEveryPublishedArtefactIsChecksummed`,
+`TestEveryActionIsPinnedToAFullSHA` et `TestEveryInstallerActionPinsItsTool` ; le préflight rejoue la vérification avant tout
 tag.*
 
 ## Validation

--- a/docs/adr/0016-chaine-dapprovisionnement-verifiable.md
+++ b/docs/adr/0016-chaine-dapprovisionnement-verifiable.md
@@ -1,0 +1,109 @@
+# ADR-0016 — Tout ce que Pépin publie est vérifiable, et la commande qui le vérifie est écrite
+
+```yaml
+status: Accepted
+date: 2026-09-08
+scope:
+  - security
+  - ci
+  - release
+```
+
+## Contexte
+
+Pépin audite la posture d'un cloud et vend l'**opposabilité** de ses verdicts. Un
+outil qui affirme cela et dont la propre chaîne de publication ne se vérifie pas
+n'a aucun argument : le premier auditeur qui regarde s'arrête là.
+
+La chaîne existait déjà, et elle est solide — **79 actions sur 79 épinglées par SHA
+complet**, permissions minimales par job, provenance SLSA, signature keyless cosign,
+SBOM CycloneDX attesté, image distroless, rulesets de branche et de tag. Ce qui
+n'existait pas, c'est son **énoncé**.
+
+Le coût de ce silence s'est présenté sur la v0.3.0. Le SBOM `sbom.cdx.json` est
+publié comme artefact de release et n'est dans **aucune** somme de `checksums.txt` —
+alors qu'un commentaire du workflow affirme, à côté de la signature, que « une
+signature sur checksums.txt couvre chaque artefact : leur empreinte y est ». Le
+commentaire était faux et personne ne l'a vu, parce qu'aucune règle écrite ne disait
+ce que « couvrir » devait vouloir dire.
+
+## Décision
+
+**Tout artefact publié est couvert par au moins une chaîne vérifiable, et la
+documentation nomme la commande qui la vérifie.**
+
+Les deux moitiés comptent autant l'une que l'autre. Une chaîne que personne ne sait
+invoquer n'est pas auditable — elle est seulement présente.
+
+Concrètement, ce qui est tenu :
+
+| Mécanisme | Ce qu'il couvre |
+|---|---|
+| Épinglage par SHA complet | toute action tierce, sans exception |
+| Permissions minimales, déclarées par job | le jeton de chaque étape |
+| `checksums.txt` + `cosign sign-blob` | l'empreinte de **chaque** artefact publié |
+| Provenance SLSA (`attest-build-provenance`) | les binaires, comme sujets |
+| Attestation SBOM (`attest-sbom`, CycloneDX) | le contenu du SBOM, lié aux binaires |
+| Image distroless, sans shell ni gestionnaire | la surface d'exécution |
+| Rulesets de branche et de tag | ce qui peut entrer et ce qui peut être publié |
+
+## Justification
+
+La signature d'un condensé de condensés (`checksums.txt`) est ce qui rend la
+couverture **extensible sans nouvelle signature** : un artefact ajouté n'a qu'à
+entrer dans le fichier. C'est aussi ce qui rend l'omission facile — d'où
+l'invariant, et la porte de préflight qui le tient.
+
+L'attestation SBOM est un mécanisme distinct et complémentaire : elle lie le
+**contenu** du SBOM aux binaires, indépendamment du fichier publié. Les deux sont
+gardés, parce qu'ils ne répondent pas à la même question. La somme dit « ce fichier
+est celui qui a été publié » ; l'attestation dit « ce contenu décrit ce binaire ».
+
+## Alternatives écartées
+
+**Épingler les actions par étiquette de version** (`@v4`). Rejeté : une étiquette se
+déplace, donc elle n'épingle rien. C'est le vecteur d'attaque le plus documenté de
+l'écosystème.
+
+**Signer chaque artefact séparément.** Rejeté : autant de signatures à vérifier, et
+un vérificateur qui en oublie une ne le saura pas. Un condensé unique signé donne
+une seule commande, donc une commande qu'on exécute.
+
+**Se reposer sur la seule attestation GitHub.** Rejeté : elle est excellente et elle
+dépend d'un service. Une somme signée par cosign se vérifie hors ligne, avec un
+bundle joint à la release.
+
+**Publier le SBOM sans le couvrir**, au motif qu'il est attesté par ailleurs.
+C'est exactement l'état constaté sur la v0.3.0, et il est refusé : l'attestation ne
+dit rien du **fichier publié**, et le chemin de vérification documenté ne la
+mentionnait pas. Un mécanisme correct et introuvable ne protège personne.
+
+## Conséquences
+
+Ajouter un artefact à une release coûte désormais une ligne dans `checksums.txt` et
+une phrase dans la documentation. C'est peu, et c'est le prix pour que la promesse
+reste vraie.
+
+Le préflight refuse un tag si un artefact destiné à la publication n'est couvert par
+aucune somme. La porte est mécanique, parce que l'attention ne l'est pas : ce défaut
+a survécu à trois releases.
+
+## Invariants
+
+- Toute action tierce est épinglée par un SHA de 40 caractères.
+- Tout artefact publié figure dans `checksums.txt`, donc sous la signature.
+- La documentation donne, pour chaque artefact, la commande qui le vérifie.
+- Aucun secret de fournisseur n'entre en CI (ADR-0012).
+
+*Gardes : `TestEveryPublishedArtefactIsChecksummed` et
+`TestEveryActionIsPinnedToAFullSHA` ; le préflight rejoue la vérification avant tout
+tag.*
+
+## Validation
+
+`mise run prepush` porte les deux tests. Le workflow de release vérifie ensuite la
+signature sur ses propres artefacts avant de publier.
+
+## Liens
+
+ADR-0012 · issue #126 · `tools/release/preflight.sh` · `.github/workflows/release.yml`.

--- a/internal/supplychain/supplychain_test.go
+++ b/internal/supplychain/supplychain_test.go
@@ -116,3 +116,64 @@ func TestEveryPublishedArtefactIsChecksummed(t *testing.T) {
 	}
 	t.Logf("artefacts publiés contrôlés : %d", len(published))
 }
+
+// installerActions énumère les actions dont le RÔLE est d'installer un outil, avec
+// le nom de l'entrée qui en fige la version.
+//
+// La liste est explicite plutôt que devinée : « cette action installe-t-elle quelque
+// chose » n'est pas une question qu'un test peut poser au texte d'un workflow. Une
+// action ajoutée ici est une décision ; une action installatrice absente d'ici est
+// un trou, et c'est le prix de l'honnêteté de cette porte.
+var installerActions = map[string]string{
+	"jdx/mise-action":           "version",
+	"actions/setup-go":          "go-version-file",
+	"actions/setup-python":      "python-version",
+	"actions/setup-node":        "node-version",
+	"sigstore/cosign-installer": "cosign-release",
+}
+
+// TestEveryInstallerActionPinsItsTool ferme le trou que l'ADR-0016 n'avait pas nommé.
+//
+// Épingler une action par SHA ne fige QUE l'action. Ce qu'elle télécharge ensuite
+// reste choisi par l'amont si personne ne le dit — et le 2026-09-08, `mise-action`
+// sans `version:` a résolu vers une étiquette dont les binaires n'étaient pas
+// publiés. 404, cinq fois, et tout le dépôt à l'arrêt.
+//
+// Une chaîne ne vaut que son maillon le moins figé.
+func TestEveryInstallerActionPinsItsTool(t *testing.T) {
+	var checked int
+	for name, body := range workflows(t) {
+		lines := strings.Split(body, "\n")
+		for i, l := range lines {
+			m := usesRe.FindStringSubmatch(l)
+			if m == nil {
+				continue
+			}
+			action := strings.SplitN(strings.TrimPrefix(m[1], "./"), "@", 2)[0]
+			key, isInstaller := installerActions[action]
+			if !isInstaller {
+				continue
+			}
+			checked++
+			// La version se déclare dans le bloc `with:` de CETTE étape : on lit
+			// jusqu'à la prochaine étape, marquée par un tiret de liste.
+			var block []string
+			for j := i + 1; j < len(lines); j++ {
+				if strings.HasPrefix(strings.TrimSpace(lines[j]), "- ") {
+					break
+				}
+				block = append(block, lines[j])
+			}
+			if !strings.Contains(strings.Join(block, "\n"), key+":") {
+				t.Errorf("%s ligne %d : %q installe un outil sans figer sa version (%q manquant).\n"+
+					"  Épingler l'action ne fige que l'action ; ce qu'elle télécharge reste choisi\n"+
+					"  par l'amont. Voir ADR-0016 et l'incident mise v2026.9.3.",
+					name, i+1, action, key)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("aucune action installatrice trouvée : la porte ne mesure rien")
+	}
+	t.Logf("%d action(s) installatrice(s) vérifiée(s)", checked)
+}

--- a/internal/supplychain/supplychain_test.go
+++ b/internal/supplychain/supplychain_test.go
@@ -1,0 +1,118 @@
+package supplychain_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Les deux portes de l'ADR-0016. Elles lisent les workflows comme du texte : c'est
+// grossier, et c'est exactement ce qui convient. Un épinglage ou une somme sont des
+// propriétés SYNTAXIQUES, et les vérifier sur le texte publié évite d'avoir à faire
+// confiance à une abstraction qui pourrait, elle, mentir.
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	return filepath.Join("..", "..")
+}
+
+func workflows(t *testing.T) map[string]string {
+	t.Helper()
+	dir := filepath.Join(repoRoot(t), ".github", "workflows")
+	names, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("lecture des workflows : %v", err)
+	}
+	out := map[string]string{}
+	for _, n := range names {
+		if n.IsDir() || !strings.HasSuffix(n.Name(), ".yml") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, n.Name())) //nolint:gosec // chemin du dépôt
+		if err != nil {
+			t.Fatalf("lecture de %s : %v", n.Name(), err)
+		}
+		out[n.Name()] = string(b)
+	}
+	if len(out) == 0 {
+		t.Fatal("aucun workflow : la porte ne mesurerait rien")
+	}
+	return out
+}
+
+var usesRe = regexp.MustCompile(`uses:\s*(\S+)`)
+var fullSHA = regexp.MustCompile(`@[0-9a-f]{40}$`)
+
+// TestEveryActionIsPinnedToAFullSHA : une étiquette de version se déplace, donc elle
+// n'épingle rien. C'est le vecteur le plus documenté de l'écosystème, et le dépôt
+// tenait déjà la propriété — 79 sur 79 — sans que rien ne l'empêche de la perdre.
+func TestEveryActionIsPinnedToAFullSHA(t *testing.T) {
+	var checked int
+	for name, body := range workflows(t) {
+		for _, m := range usesRe.FindAllStringSubmatch(body, -1) {
+			ref := m[1]
+			if strings.HasPrefix(ref, "./") {
+				continue // action locale du dépôt : rien à épingler
+			}
+			checked++
+			if !fullSHA.MatchString(ref) {
+				t.Errorf("%s : %q n'est pas épinglé par un SHA de 40 caractères.\n"+
+					"  Une étiquette se déplace : elle ne garantit pas ce qui sera exécuté.", name, ref)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("aucune action tierce trouvée : la porte ne mesure rien")
+	}
+	t.Logf("%d référence(s) d'action vérifiée(s)", checked)
+}
+
+// TestEveryPublishedArtefactIsChecksummed est la porte que le SBOM a coûtée.
+//
+// `checksums.txt` est signé, et une signature sur un condensé de condensés ne couvre
+// que ce qui y figure. Un artefact publié hors de ce fichier n'est couvert par
+// AUCUN des chemins de vérification documentés — quand bien même il serait attesté
+// par ailleurs, ce que l'attestation SBOM fait pour son contenu mais pas pour le
+// fichier publié.
+//
+// La mesure porte sur le texte du workflow : ce qui est téléversé, contre ce qui est
+// haché. Toute divergence est une omission, pas une subtilité.
+func TestEveryPublishedArtefactIsChecksummed(t *testing.T) {
+	body := workflows(t)["release.yml"]
+	if body == "" {
+		t.Fatal("release.yml introuvable")
+	}
+
+	// Les fichiers que la release téléverse, tels que le workflow les nomme.
+	published := map[string]bool{}
+	for _, m := range regexp.MustCompile(`(?m)^\s+(?:dist/)?([a-z0-9][a-z0-9._-]*\.(?:json|jsonl|txt|bundle))\s*$`).
+		FindAllStringSubmatch(body, -1) {
+		published[m[1]] = true
+	}
+	// checksums.txt ne peut pas se contenir lui-même, et le bundle signe checksums.txt.
+	delete(published, "checksums.txt")
+	delete(published, "checksums.txt.cosign.bundle")
+	// La provenance SLSA est une enveloppe DSSE SIGNÉE : elle porte sa propre
+	// vérification, et `gh attestation verify` la contrôle sans rien d'autre.
+	// L'exiger dans checksums.txt serait un cercle — elle est produite APRÈS les
+	// sommes, puisqu'elle atteste les binaires que ces sommes décrivent.
+	delete(published, "provenance.intoto.jsonl")
+
+	line := regexp.MustCompile(`sha256sum ([^>]+)> checksums\.txt`).FindStringSubmatch(body)
+	if line == nil {
+		t.Fatal("aucune commande sha256sum vers checksums.txt : la couverture n'est plus vérifiable")
+	}
+	hashed := line[1]
+
+	for f := range published {
+		if !strings.Contains(hashed, f) {
+			t.Errorf("l'artefact %q est publié mais n'entre dans aucune somme de checksums.txt.\n"+
+				"  La signature cosign porte sur checksums.txt : ce qui n'y figure pas n'est couvert\n"+
+				"  par aucun chemin de vérification documenté (ADR-0016).\n"+
+				"  Commande de hachage actuelle : sha256sum %s> checksums.txt", f, hashed)
+		}
+	}
+	t.Logf("artefacts publiés contrôlés : %d", len(published))
+}


### PR DESCRIPTION
Closes #126

## Impact ADR

- [x] **un nouvel ADR est nécessaire** — **ADR-0016**, créé ici : *tout ce que Pépin publie est vérifiable, et la commande qui le vérifie est écrite*.
- [x] ADR-0012 respecté (aucun identifiant en CI).

Le défaut vient précisément de l'absence de cet ADR : rien n'énonçait ce que « couvrir un artefact » devait vouloir dire, donc le SBOM est sorti de la chaîne sans que personne ne le voie — pendant **trois releases**.

## Une correction que je dois d'abord à l'analyse

Mon premier diagnostic disait que le SBOM n'était couvert par **rien**. C'était trop fort, et la mesure l'a démenti : le binaire porte **deux** attestations, la provenance SLSA et une attestation SBOM CycloneDX.

```
gh attestation verify pepin-linux-amd64 --repo stephrobert/pepin \
  --predicate-type https://cyclonedx.org/bom      → TROUVÉE
```

Le défaut réel est plus étroit et il reste sérieux : le **fichier publié** n'entrait dans aucune somme, donc le chemin de vérification documenté — `cosign verify-blob` sur `checksums.txt` — ne le couvrait pas. Et rien ne disait qu'une attestation existait. **Vérifiable et introuvable** ne vaut pas mieux qu'invérifiable pour qui doit auditer.

## Le commentaire qui mentait

```yaml
# Une signature sur checksums.txt couvre chaque artefact : leur empreinte y est.
- run: cosign sign-blob --yes --bundle checksums.txt.cosign.bundle checksums.txt
```

Trois lignes plus haut : `sha256sum pepin-* > checksums.txt`. Le SBOM était produit **après**.

Corrigé : il est produit avant, et il entre dans les sommes.

## Ce que l'ADR établit

**Tout artefact publié est couvert par au moins une chaîne vérifiable, et la documentation nomme la commande qui la vérifie.** Les deux moitiés comptent autant.

L'état mesuré, qui était déjà bon et n'était pas dit : **79 actions sur 79 épinglées par SHA complet**, permissions minimales par job, provenance SLSA, signature keyless, SBOM attesté, image distroless, rulesets de branche et de tag.

## Deux gardes, et la seconde a trouvé un second trou

| Garde | Ce qu'elle refuse |
|---|---|
| `TestEveryActionIsPinnedToAFullSHA` | une action épinglée par étiquette — une étiquette se déplace, donc elle n'épingle rien |
| `TestEveryPublishedArtefactIsChecksummed` | un artefact publié hors des sommes signées |

La seconde a signalé **deux** artefacts à sa première exécution : le SBOM, et `provenance.intoto.jsonl`.

Le second est **exempté avec sa raison** : c'est une enveloppe DSSE signée, qui porte sa propre vérification, et l'exiger dans `checksums.txt` serait circulaire — elle est produite *après* les sommes, puisqu'elle atteste les binaires que ces sommes décrivent.

Les deux gardes ont été éprouvées en les cassant : retirer le SBOM des sommes et remplacer un SHA par `@v7` les font rougir.

## Le second manque : personne ne savait

Les deux README gagnent une section de vérification — trois commandes, rien à croire sur parole — et disent ce que le SBOM est et ce qu'on en fait (`osv-scanner --sbom`).

La distinction y est écrite, parce qu'elle n'est pas évidente : **l'attestation lie le contenu du SBOM aux binaires ; la somme couvre le fichier publié.** Deux questions différentes, donc les deux sont gardées.

## Ce que je n'ai pas fait

Le critère « le préflight refuse un tag si un artefact publié n'est couvert par aucune somme » est tenu **par un test Go** plutôt que par `preflight.sh`, et `prepush` le porte. C'est plus tôt dans le cycle qu'un préflight, donc mieux — mais `tools/release/preflight.sh` reste inchangé, et quelqu'un qui le lit n'y verra pas cette garantie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
