### PR TITLE
fix(ci): pin the mise version, which resolved to a tag without a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Setup mise (outils + tâches)
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          # Épinglée, comme toute autre dépendance de la chaîne (ADR-0016). Sans
+          # `version`, l'action résout vers la DERNIÈRE étiquette — et une étiquette
+          # peut exister avant que ses binaires ne soient publiés : v2026.9.3 a rendu
+          # 404 sur cinq tentatives et cassé toutes les PR. Monter cette version est
+          # un geste délibéré, pas un effet de bord du calendrier de l'amont.
+          version: 2026.9.2
           experimental: true
 
       - name: Verify go.mod is tidy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Setup mise (outils + tâches)
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          # Épinglée, comme toute autre dépendance de la chaîne (ADR-0016). Sans
+          # `version`, l'action résout vers la DERNIÈRE étiquette — et une étiquette
+          # peut exister avant que ses binaires ne soient publiés : v2026.9.3 a rendu
+          # 404 sur cinq tentatives et cassé toutes les PR. Monter cette version est
+          # un geste délibéré, pas un effet de bord du calendrier de l'amont.
+          version: 2026.9.2
           experimental: true
 
       # Cohérence codes ↔ règles ↔ index SCSL gelé ↔ catalogue : un référentiel

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -58,6 +58,13 @@ jobs:
 
       - name: Setup mise (outils + tâches)
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          # Épinglée, comme toute autre dépendance de la chaîne (ADR-0016). Sans
+          # `version`, l'action résout vers la DERNIÈRE étiquette — et une étiquette
+          # peut exister avant que ses binaires ne soient publiés : v2026.9.3 a rendu
+          # 404 sur cinq tentatives et cassé toutes les PR. Monter cette version est
+          # un geste délibéré, pas un effet de bord du calendrier de l'amont.
+          version: 2026.9.2
 
       # Via mise plutôt que l'action gitleaks : la version est épinglée dans
       # mise.toml comme opa et terraform, et le scan reste identique en local.


### PR DESCRIPTION
Fixes every pull request failing at toolchain setup.

## What happened

`jdx/mise-action` was called without `version` in all three workflows, so it
resolved to the latest tag and downloaded:

```text
https://github.com/jdx/mise/releases/download/v2026.9.3/mise-v2026.9.3-linux-x64.tar.zst
curl: (22) The requested URL returned error: 404
```

Five retries, then the job died. Nothing in this repository changed.

## Measured, 8 September 2026

| what was measured | value |
|---|---|
| `https://mise.jdx.dev/VERSION` | `2026.9.3` |
| latest published release | `v2026.9.2` |
| `gh release view v2026.9.3` | `release not found` |
| git tag `v2026.9.3` | **exists**, `f12a7c9` |

Upstream pushes the tag before the release carries its artefacts. Anything
resolving "latest" therefore composes a URL to a file that is not published yet.

## The fix

The three call sites pin `2026.9.2`, which is what ADR-0016 already asks of
every other link in the chain. Moving that number becomes a deliberate act
rather than a side effect of upstream's calendar.

## What this does not fix, and it is worth saying

The number is now written in **three** places, and **Dependabot will not lift
it**. It tracks the action's SHA, because that is a dependency to it; `version:`
is an input, and nothing watches it. An unrefreshed pin ages until the first CVE.

A single declaration, in a composite action, plus a check that refuses a second
one, is the next step. It is not in this pull request because the CI is red now
and this makes it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)