### PR TITLE
fix(rules): what is exposed decides the severity, not the mere existence of an ingress

### DIFF
--- a/internal/commonrules/rules/compute_instance_public_ip_with_open_securitygroup.rego
+++ b/internal/commonrules/rules/compute_instance_public_ip_with_open_securitygroup.rego
@@ -1,6 +1,17 @@
 # compute_instance_public_ip_with_open_securitygroup
 #   VM avec une IP publique ET un security group acceptant du trafic entrant
-#   depuis Internet (0.0.0.0/0 ou ::/0) — vecteur d'intrusion direct.
+#   depuis Internet sur un port qui le rend dangereux.
+#
+#   CE QUI EST VÉRIFIÉ : ce qui est RÉELLEMENT exposé, pas la seule existence d'un
+#   ingress Internet. Une VM publique servant 443/tcp depuis 0.0.0.0/0 est un
+#   serveur web, pas un incident — et la signaler en `critical` était le finding le
+#   plus coûteux du dépôt, celui qu'une personne rencontre dans ses cinq premières
+#   minutes et qui fait douter de tous les autres.
+#
+#   CE QUE LE CONTRÔLE NE PROUVE PAS : qu'un service exposé sur un port sensible est
+#   effectivement vulnérable, ni qu'un port anodin ne l'est pas. Il mesure la
+#   surface, pas l'exploitabilité.
+#
 # Origine : osc-policy OSC-VM-014. SCSL : CLD-NET-3.
 # Contrat : type normalisé agnostique `compute_instance` (attributs natifs
 #   osc-sdk-go Vm). Champs : vm_id, public_ip (string), security_group_ids
@@ -10,32 +21,81 @@ package pepin.rules
 
 import rego.v1
 
-# _exposed_sg_ids — security groups avec ≥ 1 règle entrante ouverte sur Internet
-# (schéma SG commun : direction/action/cidrs).
-_exposed_sg_ids contains sg_id if {
+# _sg_all_ports — la règle n'a AUCUNE borne de port, ou porte la sentinelle -1 que
+# plusieurs API emploient pour « toute la plage ». Tout est exposé, y compris ce que
+# personne n'a voulu exposer.
+_sg_all_ports(attrs) if {
+	not _port_bound(attrs, "port_from")
+	not _port_bound(attrs, "port_to")
+}
+
+_sg_all_ports(attrs) if _port_bound(attrs, "port_from") == -1
+
+_sg_all_ports(attrs) if _port_bound(attrs, "port_to") == -1
+
+# _sg_ids_any_port — security groups ouverts sur Internet SANS restriction de port.
+_sg_ids_any_port contains sg_id if {
 	some r in resources_of_type("security_group_rule")
 	sg_inbound_from_internet(r.attributes)
+	_sg_all_ports(r.attributes)
 	sg_id := object.get(r.attributes, "security_group_id", "")
 	sg_id != ""
 }
 
+# _sg_sensitive[sg_id] — ports sensibles qu'un security group expose à Internet.
+# `sensitive_ports` est la table partagée (lib.rego), sourcée sur les benchmarks CIS.
+_sg_sensitive[sg_id] contains port if {
+	some r in resources_of_type("security_group_rule")
+	sg_inbound_from_internet(r.attributes)
+	not _sg_all_ports(r.attributes)
+	some port in sensitive_ports
+	covers_port(r.attributes, port)
+	sg_id := object.get(r.attributes, "security_group_id", "")
+	sg_id != ""
+}
+
+# ── critical : tous les ports ouverts sur Internet ────────────────────────────────
 deny contains f if {
 	some vm in resources_of_type("compute_instance")
 	_vm_has_public_ip(vm)
 	some sg_id in object.get(vm.attributes, "security_group_ids", [])
-	sg_id in _exposed_sg_ids
+	sg_id in _sg_ids_any_port
 	id := object.get(vm.attributes, "vm_id", vm.id)
 	f := {
 		"code": "compute_instance_public_ip_with_open_securitygroup",
 		"severity": "critical",
 		"subject": id,
-		"message": sprintf("VM « %s » exposée publiquement via le security group %s (règle entrante ouverte sur Internet).", [id, sg_id]),
-		"remediation": "Retirer la règle entrante 0.0.0.0/0 du security group, ou détacher l'IP publique et passer par un LBU / NAT.",
+		"message": sprintf("VM « %s » exposée publiquement : le security group %s ouvre TOUS les ports sur Internet.", [id, sg_id]),
+		"remediation": "Restreindre la règle entrante aux seuls ports servis, ou détacher l'IP publique et passer par un LBU / NAT.",
 		"labels": {
 			"provider": provider_of(vm),
 			"category": "security",
-			"message_en": sprintf("VM \"%s\" publicly exposed through security group %s (inbound rule open to the internet).", [id, sg_id]),
-			"remediation_en": "Remove the 0.0.0.0/0 inbound rule from the security group, or detach the public IP and go through an LBU / NAT.",
+			"message_en": sprintf("VM \"%s\" publicly exposed: security group %s opens EVERY port to the internet.", [id, sg_id]),
+			"remediation_en": "Restrict the inbound rule to the ports actually served, or detach the public IP and go through an LBU / NAT.",
+		},
+	}
+}
+
+# ── high : un port sensible ouvert sur Internet ───────────────────────────────────
+deny contains f if {
+	some vm in resources_of_type("compute_instance")
+	_vm_has_public_ip(vm)
+	some sg_id in object.get(vm.attributes, "security_group_ids", [])
+	not sg_id in _sg_ids_any_port
+	ports := sort([p | some p in _sg_sensitive[sg_id]])
+	count(ports) > 0
+	id := object.get(vm.attributes, "vm_id", vm.id)
+	f := {
+		"code": "compute_instance_public_ip_with_open_securitygroup",
+		"severity": "high",
+		"subject": id,
+		"message": sprintf("VM « %s » exposée publiquement : le security group %s ouvre sur Internet le(s) port(s) sensible(s) %v.", [id, sg_id, ports]),
+		"remediation": "Restreindre ces ports aux réseaux d'administration, ou passer par un bastion / VPN ; ne laisser ouverts que les ports du service rendu.",
+		"labels": {
+			"provider": provider_of(vm),
+			"category": "security",
+			"message_en": sprintf("VM \"%s\" publicly exposed: security group %s opens sensitive port(s) %v to the internet.", [id, sg_id, ports]),
+			"remediation_en": "Restrict those ports to administration networks, or go through a bastion / VPN; leave open only the ports the service actually needs.",
 		},
 	}
 }

--- a/internal/commonrules/rules/compute_instance_public_ip_with_open_securitygroup_test.rego
+++ b/internal/commonrules/rules/compute_instance_public_ip_with_open_securitygroup_test.rego
@@ -31,3 +31,63 @@ test_private_vm_open_sg_ok if {
 	input_doc := {"resources": [_open_rule, _vm({"vm_id": "i-1", "security_group_ids": ["sg-1"]})]}
 	count({f | some f in deny; f.code == _vm_code}) == 0 with input as input_doc
 }
+
+# _sg — règle entrante depuis Internet, sur une plage de ports donnée.
+_sg_range(id, from, to) := {
+	"provider": "outscale", "type": "security_group_rule", "id": sprintf("%s-in", [id]),
+	"attributes": {
+		"direction": "inbound", "action": "accept", "security_group_id": id,
+		"cidrs": ["0.0.0.0/0"], "protocol": "tcp", "port_from": from, "port_to": to,
+	},
+}
+
+_public_vm(sg) := _vm({"vm_id": "i-1", "public_ip": "203.0.113.1", "security_group_ids": [sg]})
+
+# ✓ LE CONTRE-EXEMPLE. Une VM publique servant 443/tcp depuis Internet est un serveur
+# web, pas un incident. La signaler en `critical` était le finding le plus coûteux du
+# dépôt : celui qu'une personne rencontre en cinq minutes, et qui fait douter de tous
+# les autres. Ce test est ce qui empêche son retour.
+test_public_vm_serving_https_only_is_not_a_deviation if {
+	doc := {"resources": [_sg_range("sg-web", 443, 443), _public_vm("sg-web")]}
+	count({f | some f in deny; f.code == _vm_code}) == 0 with input as doc
+}
+
+# ✓ Le même en HTTP, qui redirige en pratique vers HTTPS → pas davantage un écart.
+test_public_vm_serving_http_only_is_not_a_deviation if {
+	doc := {"resources": [_sg_range("sg-web", 80, 80), _public_vm("sg-web")]}
+	count({f | some f in deny; f.code == _vm_code}) == 0 with input as doc
+}
+
+# ✗ SSH ouvert sur Internet → high, et le message NOMME le port.
+test_public_vm_ssh_open_is_high if {
+	doc := {"resources": [_sg_range("sg-adm", 22, 22), _public_vm("sg-adm")]}
+	some f in deny with input as doc
+	f.code == _vm_code
+	f.severity == "high"
+	contains(f.message, "22")
+}
+
+# ✗ RDP ouvert sur Internet → high également.
+test_public_vm_rdp_open_is_high if {
+	doc := {"resources": [_sg_range("sg-adm", 3389, 3389), _public_vm("sg-adm")]}
+	some f in deny with input as doc
+	f.code == _vm_code
+	f.severity == "high"
+}
+
+# ✗ Une plage large qui ENGLOBE un port sensible reste un écart : la largeur ne dilue
+# pas l'exposition, elle l'aggrave.
+test_public_vm_wide_range_covering_ssh_is_high if {
+	doc := {"resources": [_sg_range("sg-large", 1, 1024), _public_vm("sg-large")]}
+	some f in deny with input as doc
+	f.code == _vm_code
+	f.severity == "high"
+}
+
+# ✗ Sentinelle « tous les ports » (-1/-1, encodage Outscale OAPI) → critical.
+test_public_vm_all_ports_sentinel_is_critical if {
+	doc := {"resources": [_sg_range("sg-any", -1, -1), _public_vm("sg-any")]}
+	some f in deny with input as doc
+	f.code == _vm_code
+	f.severity == "critical"
+}

--- a/scripts/trace-collector-inner.sh
+++ b/scripts/trace-collector-inner.sh
@@ -1,82 +1,103 @@
 #!/usr/bin/env bash
 #
-# Second étage de scripts/trace-collector.sh : exécuté DANS l'espace de noms
-# (user, mount et net). Ne s'appelle pas seul : il suppose une pile réseau privée
-# et un /etc/hosts qu'il a le droit de remplacer.
-set -uo pipefail
+# Étage unique. Appelé par trace-collector.sh, qui a préparé $OUT/hosts.txt.
+#
+# ─── POURQUOI CE SCRIPT A MAIGRI ─────────────────────────────────────────────
+#
+# Il tenait 89 lignes et exigeait un espace de noms utilisateur, un /etc/hosts de
+# remplacement et le port 443 privilégié. La raison était écrite dans son propre
+# en-tête : feint 0.10.0 REFUSAIT --forward et --upstream ensemble, parce que le
+# premier envoie chaque requête à l'hôte que le CLIENT a demandé, le second à
+# l'hôte qu'on a CHOISI. Il fallait donc un second étage pour que « l'hôte
+# demandé » devienne l'émulateur, et un /etc/hosts privé pour l'y résoudre.
+#
+# feint ≥ 0.12 accepte `host=target` dans --forward : l'hôte demandé est
+# conservé dans la transcription, seule la socket va ailleurs. Le second étage,
+# l'espace de noms et le port privilégié disparaissent tous les trois.
+#
+# Ce que cela débloque concrètement : la procédure tourne désormais sur un hôte
+# portant apparmor_restrict_unprivileged_userns=1, où `unshare` échoue — c'est
+# le cas de la machine de développement, et c'était l'objet de l'issue #92.
+#
+#   Pépin ──HTTPS_PROXY, CONNECT──▶ feint proxy --forward api.x=http://…:PORT
+#                                        │ enregistre, puis redial
+#                                        ▼
+#                                   feint serve (l'émulateur)
+#
+# Aucune ligne de Pépin n'est modifiée, donc aucune surface d'exfiltration n'est
+# créée : un endpoint de collecte surchargeable serait un moyen d'envoyer la clé
+# secrète d'un tenant vers un hôte arbitraire (ADR-0012).
+set -euo pipefail
 
-OUT="${PEPIN_TRACE_OUT:?}"
-PROVIDER="${PEPIN_TRACE_PROVIDER:?}"
+PROVIDER=${1:?provider}
+OUT=${2:?répertoire de sortie}
 HOSTS=$(paste -sd, "$OUT/hosts.txt")
-PEPIN="${PEPIN_BIN:-./pepin}"
 
-# Un proxy d'entreprise hérité de l'environnement se glisserait dans la mesure et
-# la rendrait fausse. Il n'y a pas de mesure sans maîtrise de ce qui la traverse.
-unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy
-unset GRPC_PROXY grpc_proxy FTP_PROXY ftp_proxy NO_PROXY no_proxy
+# Les PORTS sont configurables, et ils doivent l'être : feint tourne souvent en
+# parallèle pour d'autres projets sur la même machine, et un port figé transforme
+# une collision en échec incompréhensible.
+FEINT_PORT="${FEINT_PORT:-4599}"
+PROXY_PORT="${PROXY_PORT:-4600}"
 
-ip link set lo up
-mount --bind "$OUT/hosts" /etc/hosts
+# Refuser tôt : un port déjà pris donne sinon un timeout de 30 s sans raison lisible.
+for p in "$FEINT_PORT" "$PROXY_PORT"; do
+  if ss -ltn 2>/dev/null | grep -qE "[:.]${p}\b"; then
+    echo "port $p déjà occupé — feint tourne peut-être pour un autre projet." >&2
+    echo "Relancer avec FEINT_PORT / PROXY_PORT sur des ports libres." >&2
+    exit 2
+  fi
+done
 
+# `feint stop` ne connaît que les instances lancées par `feint start`, qui les
+# enregistre ; un `feint serve &` lui est invisible — il répond « nothing recorded »
+# et laisse le processus vivant. On garde donc les PID et on les tue. Vérifié en
+# exécution : sans cela, l'émulateur survivait au script et gardait son port.
 cleanup() {
-  # CLAUDE.md §1.1 : rien de ce qui a été lancé ne survit à la mesure. Le SIGTERM
-  # laisse aux proxys le temps de vider leur file d'écriture ; un SIGKILL perdrait
-  # les derniers échanges, c'est-à-dire précisément ceux de la fin de collecte.
-  for pid in "${UP:-}" "${DOWN:-}" "${SERVE:-}"; do
-    [ -n "$pid" ] && kill -TERM "$pid" 2>/dev/null && wait "$pid" 2>/dev/null
+  for pid in "${PROXY_PID:-}" "${SERVE_PID:-}"; do
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
   done
+  wait 2>/dev/null || true
 }
-trap cleanup EXIT
+trap cleanup EXIT INT TERM
 
-# 1. l'émulateur. --vm off : aucun conteneur ne démarre avec vos privilèges.
-feint serve --addr 127.0.0.1:4599 --vm off --state "$OUT/feint-state.json" \
-  > "$OUT/serve.log" 2>&1 &
-SERVE=$!
-feint wait --addr 127.0.0.1:4599 --timeout 30s || { cat "$OUT/serve.log"; exit 1; }
+# 1. l'émulateur. --vm off : aucun conteneur n'est démarré avec les privilèges de
+#    l'utilisateur, et il n'y a donc rien à détruire ensuite (CLAUDE.md §1.1).
+feint serve --addr "127.0.0.1:$FEINT_PORT" --vm off --state "$OUT/feint-state.json" \
+  >"$OUT/serve.log" 2>&1 &
+SERVE_PID=$!
+feint wait --addr "127.0.0.1:$FEINT_PORT" --timeout 30s || { cat "$OUT/serve.log"; exit 1; }
 
-waitCA() { # rend le chemin de l'autorité éphémère qu'un proxy vient de frapper
-  local log=$1
+# 2. le proxy direct, qui termine le TLS et renvoie chaque hôte vers l'émulateur.
+FORWARD=$(tr ',' '\n' <<<"$HOSTS" | sed "s|\$|=http://127.0.0.1:$FEINT_PORT|" | paste -sd,)
+feint proxy --addr "127.0.0.1:$PROXY_PORT" --forward "$FORWARD" \
+  --record "$OUT/$PROVIDER.jsonl" >"$OUT/proxy-$PROVIDER.log" 2>&1 &
+PROXY_PID=$!
+
+waitCA() { # rend le chemin de l'autorité éphémère que le proxy vient de frapper
   for _ in $(seq 1 100); do
-    grep -q "CA written to" "$log" 2>/dev/null && break
+    grep -q "CA written to" "$OUT/proxy-$PROVIDER.log" 2>/dev/null && break
     sleep 0.2
   done
-  sed -n 's/.*CA written to \([^ ]*\).*/\1/p' "$log" | head -1
+  sed -n 's/.*CA written to \([^ ]*\).*/\1/p' "$OUT/proxy-$PROVIDER.log" | head -1
 }
+CA=$(waitCA)
+[ -s "$CA" ] || { echo "le proxy n'a frappé aucune autorité :" >&2; cat "$OUT/proxy-$PROVIDER.log" >&2; exit 1; }
 
-# 2. étage AVAL : sert le TLS des hôtes figés, renvoie à l'émulateur.
-feint proxy --addr 127.0.0.1:443 --intercept "$HOSTS" \
-  --upstream http://127.0.0.1:4599 --record "$OUT/aval-$PROVIDER.jsonl" \
-  > "$OUT/aval-$PROVIDER.log" 2>&1 &
-DOWN=$!
-CA_DOWN=$(waitCA "$OUT/aval-$PROVIDER.log")
-[ -s "$CA_DOWN" ] || { echo "étage aval : pas d'autorité"; cat "$OUT/aval-$PROVIDER.log"; exit 1; }
+# 3. le scan. Les identifiants sont SYNTHÉTIQUES : l'émulateur accepte tout, et
+#    aucun secret réel n'entre donc dans la procédure ni dans l'enregistrement.
+SSL_CERT_FILE="$CA" \
+HTTPS_PROXY="http://127.0.0.1:$PROXY_PORT" \
+HTTP_PROXY="http://127.0.0.1:$PROXY_PORT" \
+SCW_ACCESS_KEY=SCWXXXXXXXXXXXXXXXXX \
+SCW_SECRET_KEY=11111111-1111-1111-1111-111111111111 \
+SCW_DEFAULT_ORGANIZATION_ID=11111111-1111-1111-1111-111111111111 \
+SCW_DEFAULT_PROJECT_ID=11111111-1111-1111-1111-111111111111 \
+SCW_DEFAULT_REGION=fr-par \
+OSC_ACCESS_KEY=SCWXXXXXXXXXXXXXXXXX \
+OSC_SECRET_KEY=11111111-1111-1111-1111-111111111111 \
+OSC_REGION=eu-west-2 \
+EXOSCALE_API_KEY=EXOxxxxxxxxxxxxxxxxxxxx \
+EXOSCALE_API_SECRET=11111111-1111-1111-1111-111111111111 \
+  ./pepin scan "$PROVIDER" --live --format json >"$OUT/$PROVIDER-scan.json" 2>"$OUT/$PROVIDER-scan.log" || true
 
-# 3. étage AMONT : accepte le CONNECT, déchiffre, ENREGISTRE. Sa transcription
-#    est celle qui fait foi, car elle voit exactement ce que Pépin a émis.
-SSL_CERT_FILE="$CA_DOWN" feint proxy --addr 127.0.0.1:4600 --forward "$HOSTS" \
-  --record "$OUT/$PROVIDER.jsonl" > "$OUT/amont-$PROVIDER.log" 2>&1 &
-UP=$!
-CA_UP=$(waitCA "$OUT/amont-$PROVIDER.log")
-[ -s "$CA_UP" ] || { echo "étage amont : pas d'autorité"; cat "$OUT/amont-$PROVIDER.log"; exit 1; }
-
-# 4. Pépin, INCHANGÉ. Les identifiants sont ceux de l'émulateur, qui les accepte
-#    tous : aucun secret réel ne traverse quoi que ce soit.
-eval "$(feint env "$PROVIDER" 2>/dev/null)"
-# L'émulateur publie SCW_API_URL / OSC_ENDPOINT_API / EXOSCALE_API_ENDPOINT.
-# Pépin ne les lit PAS : ses base_url sont figées, et c'est la raison d'être de
-# toute cette plomberie. On les retire pour que rien ne puisse le prétendre.
-unset SCW_API_URL OSC_ENDPOINT_API OSC_PROTOCOL EXOSCALE_API_ENDPOINT SCW_INSECURE
-export HTTPS_PROXY=http://127.0.0.1:4600
-export SSL_CERT_FILE="$CA_UP"
-
-"$PEPIN" scan "$PROVIDER" --live --format json \
-  > "$OUT/scan-$PROVIDER.json" 2> "$OUT/scan-$PROVIDER.err"
-echo "pepin scan $PROVIDER --live → code $?"
-
-cleanup; trap - EXIT
-echo
-echo "transcription : $OUT/$PROVIDER.jsonl"
-echo "état de collecte : $OUT/scan-$PROVIDER.json (clé \"collection\")"
-echo
-echo "AVANT de committer : relire la transcription VALEUR PAR VALEUR."
-echo "Les corps sont conservés : contre un vrai tenant ils portent son inventaire."
+echo "enregistrement : $OUT/$PROVIDER.jsonl ($(wc -l <"$OUT/$PROVIDER.jsonl" 2>/dev/null || echo 0) échanges)"

--- a/scripts/trace-collector.sh
+++ b/scripts/trace-collector.sh
@@ -21,30 +21,26 @@
 #
 # Aucune base_url de collecte n'est redirigeable (seul --s3-endpoint l'est). Le
 # client de collecte, lui, n'installe pas de Transport : il hérite de
-# http.DefaultTransport, DONC il honore HTTPS_PROXY. Deux étages suffisent alors,
-# et ils ne demandent aucune modification de Pépin, donc aucune surface
+# http.DefaultTransport, DONC il honore HTTPS_PROXY. Un seul étage suffit alors,
+# et il ne demande aucune modification de Pépin, donc aucune surface
 # d'exfiltration : un endpoint de collecte surchargeable serait un moyen
-# d'envoyer la clé secrète d'un tenant vers un hôte arbitraire.
+# d'envoyer la clé secrète d'un tenant vers un hôte arbitraire (ADR-0012).
 #
-#   Pépin ──HTTPS_PROXY, CONNECT──▶ proxy AMONT (--forward, enregistre)
-#                                        │ redial vers l'hôte demandé
-#                                        ▼  (résolu sur 127.0.0.1 par /etc/hosts)
-#                                   proxy AVAL (--intercept, sert le TLS)
-#                                        │ --upstream
+#   Pépin ──HTTPS_PROXY, CONNECT──▶ feint proxy --forward api.x=http://…:PORT
+#                                        │ enregistre, puis redial
 #                                        ▼
 #                                   feint serve (l'émulateur)
 #
-# feint 0.10.0 REFUSE --forward et --upstream ensemble : --forward envoie chaque
-# requête à l'hôte que le client a demandé, --upstream à l'hôte qu'on a choisi.
-# Le second étage est ce qui fait que « l'hôte demandé » est l'émulateur.
+# Cette procédure exigeait naguère un espace de noms utilisateur, un /etc/hosts
+# de remplacement et le port 443 privilégié, parce que feint 0.10.0 refusait
+# --forward et --upstream ensemble. feint ≥ 0.12 accepte `host=target` : l'hôte
+# demandé reste dans la transcription, seule la socket va ailleurs. Les trois
+# contraintes tombent, et la procédure tourne désormais là où
+# apparmor_restrict_unprivileged_userns=1 interdit `unshare` (issue #92).
 #
-# ─── CE QUE CE SCRIPT NE TOUCHE PAS ──────────────────────────────────────────
-#
-# Tout tourne dans un espace de noms (user + mount + net) : le /etc/hosts modifié
-# est celui de CET espace, jamais le vôtre, et le port 443 lié l'est dans une
-# pile réseau privée qui disparaît avec le dernier processus. Rien n'écoute hors
-# de la boucle locale. --vm off interdit à l'émulateur de démarrer le moindre
-# conteneur avec vos privilèges.
+# Rien n'écoute hors de la boucle locale. --vm off interdit à l'émulateur de
+# démarrer le moindre conteneur avec vos privilèges, donc rien n'est provisionné
+# et rien n'est à détruire (CLAUDE.md §1.1).
 #
 # ─── LA PRÉCAUTION QUI NE SE NÉGOCIE PAS ─────────────────────────────────────
 #
@@ -61,7 +57,6 @@ OUT="${2:-$(mktemp -d)}"
 mkdir -p "$OUT"
 
 command -v feint >/dev/null || { echo "feint absent du PATH (https://github.com/…/feint)"; exit 2; }
-command -v unshare >/dev/null || { echo "unshare absent : util-linux requis"; exit 2; }
 
 # Les hôtes que les descripteurs figent. Un hôte non nommé ici voit son CONNECT
 # REFUSÉ par le proxy amont, qui le signale à l'arrêt. C'est ainsi que l'API
@@ -78,12 +73,4 @@ sos-ch-dk-2.exo.io
 sos-ch-gva-2.exo.io
 EOF
 
-{
-  echo "127.0.0.1 localhost"
-  echo "::1 localhost"
-  while read -r h; do [ -n "$h" ] && echo "127.0.0.1 $h"; done < "$OUT/hosts.txt"
-} > "$OUT/hosts"
-
-export PEPIN_TRACE_OUT="$OUT"
-export PEPIN_TRACE_PROVIDER="$PROVIDER"
-exec unshare --map-root-user --mount --net -- "$(dirname "$0")/trace-collector-inner.sh"
+exec "$(dirname "$0")/trace-collector-inner.sh" "$PROVIDER" "$OUT"


### PR DESCRIPTION
Closes #105 · Closes #92

## Impact ADR

- [x] ADR-0001, ADR-0015 respectés
- [x] **ADR-0013 respecté** — aucun renommage de code : la promesse est corrigée, l'identifiant reste
- [x] **ADR-0012 appliqué** — la chaîne de traçage ne modifie toujours aucune ligne de Pépin, donc ne crée aucune surface d'exfiltration

## Le finding qui coûtait le plus cher

Une VM publique servant `443/tcp` depuis `0.0.0.0/0` rendait **CRITICAL**. C'est un serveur web, et c'est la configuration que fait tourner l'essentiel d'Internet.

C'était aussi le premier résultat qu'une personne rencontre en essayant Pépin. Il ne coûtait donc pas un faux positif : il coûtait la crédibilité de **tous** les autres findings du rapport.

## L'échelle, sur ce qui est réellement joignable

| Exposition | Verdict |
|---|---|
| Aucune borne de port, ou sentinelle `-1` (plage complète) | `critical` — tout est ouvert, y compris ce que personne n'a voulu ouvrir |
| Un port de la table `sensitive_ports` (sourcée CIS) | `high`, et le message **nomme les ports** |
| `80` ou `443` seuls | aucun écart |

Le référentiel garde `critical`, la sévérité **maximale** que la règle émet — `governance_resource_region_in_eu` avait posé ce précédent, et la porte `TestRegoSeverityMatchesReferentiel` le documente.

## Les contre-exemples que l'issue demandait

Six scénarios, dont deux qui prouvent ce sur quoi la règle **refuse** de se déclencher : HTTPS seul et HTTP seul. Réintroduire l'ancien comportement en fait rougir **cinq**.

## Et #92, parce que le traçage était nécessaire pour vérifier cette règle

Aucune fixture du dépôt n'exerce ce contrôle — la maigreur du corpus (#123). J'ai donc voulu le tracer contre l'émulateur, et la procédure ne tournait pas : elle exigeait un espace de noms utilisateur, un `/etc/hosts` de remplacement et le port 443 privilégié, pour une raison écrite dans son propre en-tête — *feint 0.10.0 refusait `--forward` et `--upstream` ensemble*.

**feint 0.12 accepte `host=target`.** Un seul étage fait ce que deux faisaient :

```
Pépin ──HTTPS_PROXY, CONNECT──▶ feint proxy --forward api.x=http://…:PORT
                                     │ enregistre, puis redial
                                     ▼
                                feint serve
```

**Mesuré** : la procédure tourne désormais sur cet hôte, où `apparmor_restrict_unprivileged_userns=1` fait échouer `unshare`. Six échanges réels enregistrés, dont la jointure parent→enfant sur les security groups.

## Deux détails d'intendance qui ont demandé de vérifier plutôt que de supposer

**Les ports sont configurables.** feint tourne souvent en parallèle pour d'autres projets, et un port figé transforme une collision en timeout illisible. Le script refuse tôt, avec le message qui dit quoi faire.

**Le nettoyage tue les PID.** `feint stop` ne connaît que les instances lancées par `feint start` : il a répondu « nothing recorded » et laissé l'émulateur tenir son port. Trouvé en regardant après coup, pas en le supposant. Vérifié depuis : zéro processus, zéro port laissé ouvert.

## Ce que je n'ai pas fait

**Aucun scan live**, aucun identifiant réel — l'émulateur accepte des identifiants synthétiques, et rien de secret n'entre dans l'enregistrement.

**Aucun verdict ne bouge sur les fixtures**, parce qu'aucune ne déclenche ce contrôle. C'est #123, et cette PR en donne une illustration de plus : la règle la plus visible du produit n'avait aucune couverture de corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
