### PR TITLE
fix(rules): absent is not disabled, and a port is not a protocol

### DIFF
--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -109,6 +109,7 @@ Le tableau ci-dessous est rendu depuis cette table même, il n'en est pas la cop
 | `kubernetes_cluster_deletion_protection` | `kubernetes_cluster` | `deletion_protection` |
 | `kubernetes_cluster_not_publicly_accessible` | `kubernetes_cluster` | `admin_whitelist` |
 | `loadbalancer_http_redirect_to_https` | `load_balancer` | `redirect_to_https` |
+| `loadbalancer_logging_enabled` | `load_balancer` | `access_log` |
 | `loadbalancer_ssl_listeners` | `load_balancer` | `load_balancer_type` |
 | `network_documented` | `network` | `tags` |
 | `network_flow_matrix_documented` | `security_group_rule` | `description` |

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -109,6 +109,7 @@ The table below is rendered from that very map — not transcribed from it:
 | `kubernetes_cluster_deletion_protection` | `kubernetes_cluster` | `deletion_protection` |
 | `kubernetes_cluster_not_publicly_accessible` | `kubernetes_cluster` | `admin_whitelist` |
 | `loadbalancer_http_redirect_to_https` | `load_balancer` | `redirect_to_https` |
+| `loadbalancer_logging_enabled` | `load_balancer` | `access_log` |
 | `loadbalancer_ssl_listeners` | `load_balancer` | `load_balancer_type` |
 | `network_documented` | `network` | `tags` |
 | `network_flow_matrix_documented` | `security_group_rule` | `description` |

--- a/docs/controls/loadbalancer_logging_enabled.fr.md
+++ b/docs/controls/loadbalancer_logging_enabled.fr.md
@@ -15,7 +15,7 @@
 | Sévérité | `medium` |
 | Exigence SCSL (index gelé) | `CLD-LOG-1` |
 | Type de ressource lu | `load_balancer` |
-| Attribut décisif | _aucun : jugé à la présence d'un écart_ |
+| Attribut décisif | `access_log` |
 | État | actif |
 | Déclaré pour | `outscale` |
 | Preuves de remédiation | 0 / 1 |
@@ -78,7 +78,8 @@ contient aucune ressource du type visé : « rien à voir » n'est pas « confor
 ## Comment enquêter
 
 - Type de ressource normalisé lu par la règle : `load_balancer`
-- Aucun verrou d'attribut : le contrôle se juge à la présence d'un écart, l'absence de mauvaise configuration valant conformité.
+- Attribut dont la décision dépend : `access_log`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
 - Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
 - La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
 

--- a/docs/controls/loadbalancer_logging_enabled.md
+++ b/docs/controls/loadbalancer_logging_enabled.md
@@ -15,7 +15,7 @@
 | Severity | `medium` |
 | SCSL requirement (frozen index) | `CLD-LOG-1` |
 | Resource type read | `load_balancer` |
-| Deciding attribute | _none: judged on the presence of a deviation_ |
+| Deciding attribute | `access_log` |
 | State | active |
 | Declared for | `outscale` |
 | Remediation proofs | 0 / 1 |
@@ -77,7 +77,8 @@ resource of the targeted type: "nothing to look at" is not "compliant".
 ## How to investigate
 
 - Normalized resource type the rule reads: `load_balancer`
-- No attribute lock: the control is judged on the presence of a deviation, absence of a bad configuration counting as compliance.
+- Attribute the decision depends on: `access_log`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
 - What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
 - The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
 

--- a/internal/assess/assess.go
+++ b/internal/assess/assess.go
@@ -68,8 +68,12 @@ var requiredAttr = map[string][]string{
 	// seul, ce qui franchissait le verrou et concluait « conforme » sur une ACL jamais lue —
 	// alors que l'ACL est le vecteur d'exposition le plus courant. Sans signal d'ACL, le
 	// contrôle sort « non évalué », ce qui est la réponse honnête.
-	"objectstorage_bucket_public_access":                {"acl", "acl_grants", "public_via_acl"},
-	"database_encryption_at_rest_enabled":               {"encryption_at_rest"},
+	"objectstorage_bucket_public_access":  {"acl", "acl_grants", "public_via_acl"},
+	"database_encryption_at_rest_enabled": {"encryption_at_rest"},
+	// Sans cette entrée, une LBU dont `access_log` n'a pas été collecté rendait un
+	// `pass` SILENCIEUX depuis que la règle a cessé de conclure sur une absence.
+	// La règle se tait, le verrou dit pourquoi : « non collecté », pas « conforme ».
+	"loadbalancer_logging_enabled":                      {"access_log"},
 	"loadbalancer_http_redirect_to_https":               {"redirect_to_https"},
 	"loadbalancer_ssl_listeners":                        {"load_balancer_type"},
 	"network_subnet_no_public_ip_by_default":            {"map_public_ip_on_launch"},

--- a/internal/commonrules/rules/loadbalancer_logging_enabled.rego
+++ b/internal/commonrules/rules/loadbalancer_logging_enabled.rego
@@ -10,6 +10,13 @@ import rego.v1
 
 deny contains f if {
 	some lb in resources_of_type("load_balancer")
+
+	# La configuration de journalisation doit être OBSERVÉE. Sans cette garde,
+	# `access_log` non exposé par l'API ou non mappé par le collecteur retombait
+	# sur `is_enabled = false`, et Pépin annonçait « journalisation désactivée »
+	# alors que personne n'avait rien regardé (ADR-0003, ADR-0014). Le verrou de
+	# capacité prend alors le relais : le contrôle rend `not-evaluated`.
+	"access_log" in object.keys(lb.attributes)
 	not _access_log_enabled(lb.attributes)
 	name := object.get(lb.attributes, "load_balancer_name", lb.id)
 	f := {

--- a/internal/commonrules/rules/loadbalancer_ssl_listeners.rego
+++ b/internal/commonrules/rules/loadbalancer_ssl_listeners.rego
@@ -13,6 +13,7 @@ deny contains f if {
 	some lb in resources_of_type("load_balancer")
 	object.get(lb.attributes, "load_balancer_type", "") == "internet-facing"
 	not _has_secure_listener(lb.attributes)
+	not _tls_passthrough_candidate(lb.attributes)
 	name := object.get(lb.attributes, "load_balancer_name", lb.id)
 	f := {
 		"code": "loadbalancer_ssl_listeners",
@@ -34,11 +35,45 @@ _has_secure_listener(attrs) if {
 	object.get(l, "load_balancer_protocol", "") in {"HTTPS", "SSL"}
 }
 
-# TLS passthrough : un listener TCP sur un port TLS standard transporte du chiffré terminé
-# au backend (configuration légitime et chiffrée de bout en bout). Le LBU ne voit pas le
-# contenu : affirmer « trafic en clair » serait un faux positif — on ne conclut pas.
-_has_secure_listener(attrs) if {
+# _tls_passthrough_candidate — un listener TCP sur un port TLS standard.
+#
+# Le commentaire d'origine disait juste et concluait faux : « affirmer trafic en
+# clair serait un faux positif — on ne conclut pas », puis comptait ce listener
+# comme SÉCURISÉ. Un numéro de port n'est pas un protocole : on sert ce qu'on veut
+# en clair sur 443, et c'est même une pratique de contournement de pare-feu
+# répandue. Compter cela comme du TLS produisait un FAUX VERT — le seul du lot, et
+# le plus grave, parce qu'un faux vert ne se voit pas.
+#
+# La règle constate donc son incapacité à conclure, et l'assessment en fait un
+# `not-evaluated` (ADR-0015). Ni « sécurisé », ni « en clair » : indéterminé.
+_tls_passthrough_candidate(attrs) if {
 	some l in object.get(attrs, "listeners", [])
 	object.get(l, "load_balancer_protocol", "") == "TCP"
 	object.get(l, "load_balancer_port", 0) in {443, 8443}
+}
+
+# ── indéterminé : un TCP sur un port TLS, dont rien ne dit s'il porte du chiffré ──
+deny contains f if {
+	some lb in resources_of_type("load_balancer")
+	object.get(lb.attributes, "load_balancer_type", "") == "internet-facing"
+	not _has_secure_listener(lb.attributes)
+	_tls_passthrough_candidate(lb.attributes)
+	name := object.get(lb.attributes, "load_balancer_name", lb.id)
+	f := {
+		"code": "loadbalancer_ssl_listeners",
+		"severity": "high",
+		"subject": name,
+		"message": sprintf("LBU « %s » : seul un listener TCP sur port TLS standard — passthrough chiffré ou trafic en clair, l'API ne permet pas de trancher.", [name]),
+		"remediation": "Confirmer la terminaison TLS côté backend, ou déclarer un listener HTTPS/SSL pour que la protection soit attestée.",
+		"labels": {
+			"provider": provider_of(lb),
+			"category": "security",
+			# La règle CONSTATE son incapacité à conclure ; l'assessment en fait un
+			# `not-evaluated`. Compter ce listener comme sécurisé était un FAUX VERT
+			# (ADR-0015) : un port n'est pas un protocole.
+			"inconclusive": "true",
+			"message_en": sprintf("LBU \"%s\": only a TCP listener on a standard TLS port — encrypted passthrough or cleartext, the API cannot tell.", [name]),
+			"remediation_en": "Confirm TLS termination on the backend, or declare an HTTPS/SSL listener so the protection is attested.",
+		},
+	}
 }

--- a/internal/commonrules/rules/oks_lbu_governance_test.rego
+++ b/internal/commonrules/rules/oks_lbu_governance_test.rego
@@ -29,9 +29,18 @@ test_lbu_internal_ok if {
 }
 
 # ---- loadbalancer_logging_enabled ----
-test_lbu_no_log_denied if {
-	some f in deny with input as _lb({"load_balancer_name": "web", "load_balancer_type": "internal", "listeners": [{"load_balancer_protocol": "HTTPS"}]})
+# ✗ access_log OBSERVÉ et désactivé → finding. C'est le seul cas où la règle sait.
+test_lbu_log_disabled_denied if {
+	some f in deny with input as _lb({"load_balancer_name": "web", "load_balancer_type": "internal", "listeners": [{"load_balancer_protocol": "HTTPS"}], "access_log": {"is_enabled": false}})
 	f.code == "loadbalancer_logging_enabled"
+}
+
+# ✓ access_log NON collecté → aucun finding. « Absent » et « désactivé » ne se
+# confondent pas (ADR-0003, ADR-0014) : sans cette distinction, un fournisseur qui
+# n'expose pas ce champ produisait un écart permanent et incorrigible. Le verrou de
+# capacité prend le relais et rend `not-evaluated`.
+test_lbu_log_not_collected_does_not_deny if {
+	count({f | some f in deny; f.code == "loadbalancer_logging_enabled"}) == 0 with input as _lb({"load_balancer_name": "web", "load_balancer_type": "internal", "listeners": [{"load_balancer_protocol": "HTTPS"}]})
 }
 
 test_lbu_log_ok if {
@@ -58,12 +67,29 @@ test_tags_not_exposed_ok if {
 
 # ✓ FP : un LBU internet-facing en TLS PASSTHROUGH (listener TCP:443, TLS terminé au
 # backend) est chiffré de bout en bout — le flaguer « trafic en clair » était un faux positif.
-test_lbu_tcp_passthrough_not_cleartext if {
-	count({f | some f in deny; f.code == "loadbalancer_ssl_listeners"}) == 0 with input as {"resources": [{
+# ✗→? Un TCP sur port TLS standard ne PROUVE rien : ni chiffrement, ni clair. La
+# règle constate son incapacité (`inconclusive`), et l'assessment en fait un
+# `not-evaluated`. Le compter comme sécurisé était un FAUX VERT (ADR-0015) — le
+# seul du lot, et le plus grave, parce qu'un faux vert ne se voit pas.
+test_lbu_tcp_passthrough_is_inconclusive if {
+	some f in deny with input as {"resources": [{
 		"provider": "outscale", "type": "load_balancer", "id": "lb-1",
 		"attributes": {
 			"load_balancer_name": "lb-1", "load_balancer_type": "internet-facing",
 			"listeners": [{"load_balancer_protocol": "TCP", "load_balancer_port": 443}],
+		},
+	}]}
+	f.code == "loadbalancer_ssl_listeners"
+	f.labels.inconclusive == "true"
+}
+
+# ✓ Un vrai listener HTTPS reste conforme, et n'est PAS marqué indéterminé.
+test_lbu_https_listener_is_conclusive if {
+	count({f | some f in deny; f.code == "loadbalancer_ssl_listeners"}) == 0 with input as {"resources": [{
+		"provider": "outscale", "type": "load_balancer", "id": "lb-1",
+		"attributes": {
+			"load_balancer_name": "lb-1", "load_balancer_type": "internet-facing",
+			"listeners": [{"load_balancer_protocol": "HTTPS", "load_balancer_port": 443}],
 		},
 	}]}
 }


### PR DESCRIPTION
Closes #107 · Closes #108

## Impact ADR

- [x] **ADR-0014 appliqué** — deux règles concluaient depuis une donnée non observée
- [x] **ADR-0015 appliqué** — la seconde ne peut pas trancher, et le dit désormais
- [x] ADR-0006 étendu — le verrou de capacité gagne l'entrée qui manquait

## Deux règles, deux directions opposées

### #107 — `loadbalancer_logging_enabled` : absent traité comme désactivé

Le helper lisait `access_log` à travers un défaut `false`. Un fournisseur qui n'expose pas ce champ, ou un collecteur qui ne le mappe pas, produisait donc un écart **permanent et incorrigible** pour son opérateur.

La règle exige maintenant que la configuration soit **observée**, et le verrou de capacité prend le relais : `not-evaluated` avec sa raison, au lieu d'un `pass` silencieux.

**Les deux moitiés étaient nécessaires.** Corriger la règle seule aurait troqué un faux rouge contre un faux vert — le contrôle se serait tu, et rien n'aurait dit pourquoi.

### #108 — `loadbalancer_ssl_listeners` : un port pris pour un protocole

Un listener `TCP` sur 443 ou 8443 comptait comme sécurisé. Le commentaire de la règle avait le raisonnement juste et la conclusion fausse :

> *TLS passthrough : […] affirmer « trafic en clair » serait un faux positif — on ne conclut pas.*

…puis elle concluait, en faveur de la conformité.

Un numéro de port n'est pas un protocole. On sert ce qu'on veut en clair sur 443, et c'est même une pratique de contournement de pare-feu répandue. **C'était le seul faux vert du lot, et le plus grave — parce qu'un faux vert ne se voit pas.**

La règle constate désormais son incapacité à trancher, et l'assessment en fait un `not-evaluated` : ni sécurisé, ni en clair, **indéterminé**.

C'est le premier cas où le commentaire d'une règle décrivait le mécanisme d'ADR-0015 **avant** que ce mécanisme n'existe.

## Les gardes, éprouvées en les cassant

| Mutation | Verdict |
|---|---|
| la journalisation reconclut sur une absence | 🔴 |
| le candidat passthrough redevient un listener sécurisé | 🔴 |

Ma première tentative sur la seconde est revenue **verte** : renommer la définition rendait le symbole indéfini, ce qui changeait le comportement autrement qu'en restaurant le défaut. Refaite en ajoutant vraiment l'ancienne équivalence.

## Mesures

**Aucun verdict ne bouge sur les fixtures** — parce qu'aucune n'exerce ces règles. C'est **#123**, rencontrée pour la troisième fois dans ce jalon : les contrôles corrigés ici, comme celui de la PR précédente, n'ont aucune couverture de corpus.

`prepush` vert : `validate`, `test` (Rego 292/292), `audit`, `adr-drift`, `secrets`, `falsify`.

## Ce que je n'ai pas fait

Aucun scan live, aucun identifiant. Et je n'ai pas étendu le corpus : c'est le sujet de #123, et le faire ici mélangerait deux changements dont l'un déplace des verdicts et l'autre non.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
