### PR TITLE
fix(assessment): a control degrades on every type it reads, not only the one its code names

### DIFF
--- a/docs/adr/0006-jamais-un-pass-non-prouve.md
+++ b/docs/adr/0006-jamais-un-pass-non-prouve.md
@@ -61,9 +61,12 @@ INTERSECTION, et la combinaison des attributs est explicite. Le défaut était v
 sur la fixture « conforme » du dépôt : quatre contrôles y déclaraient conforme une
 base de données dont la sauvegarde n'avait jamais été observée.
 
-Reste **#103** : un contrôle ne déclare qu'un seul type, donc l'incomplétude d'un
-second type qu'il lit ne le dégrade pas. C'est la limite actuelle de cette décision,
-pas une remise en cause de sa direction.
+Corrigé aussi (#103) : un contrôle déclare désormais TOUS les types qu'il lit, et
+l'incomplétude de n'importe lequel le dégrade. Six règles corrèlent plusieurs types,
+et l'incomplétude du second passait inaperçue — « VMs collectées, règles SG en 403 »
+laissait conclure sur une exposition dont la donnée n'était jamais arrivée. La
+déclaration est gardée par sa dérivation : `TestControlTypesMatchTheRules` la
+confronte à ce que les règles lisent, dans les deux sens.
 
 ## Invariants
 

--- a/docs/reference/exit-codes.fr.md
+++ b/docs/reference/exit-codes.fr.md
@@ -269,7 +269,8 @@ Relevé de capacités du collecteur
   ✗ security_group_rule — privilège insuffisant du compte de scan
     droit requis : InstancesReadOnly (Project scope)
     HTTP 403 - GET https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups - insufficient permissions
-Résultat : 6 contrôle(s) ne pourront pas être évalués sur ce périmètre.
+Résultat : 7 contrôle(s) ne pourront pas être évalués sur ce périmètre.
+  · compute_instance_public_ip_with_open_securitygroup
   · network_securitygroup_allow_ingress_from_internet_to_all_ports
   · network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports
   · network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports
@@ -288,7 +289,7 @@ $ ./pepin scan scaleway partial-inventory.json
 […]
  Summary
 
- Verdict : INCOMPLET — 6 contrôle(s) non évaluables faute d'une collecte complète, 0 écart(s) medium/low sur ce qui a pu être lu
+ Verdict : INCOMPLET — 7 contrôle(s) non évaluables faute d'une collecte complète, 0 écart(s) medium/low sur ce qui a pu être lu
 
  🔴 CRITICAL 0   🟠 HIGH 0   🟡 MEDIUM 0   🔵 LOW 0
 ──────────────────────────────────────────────────────────────────────────────

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -267,7 +267,8 @@ Collector capability report
   ✗ security_group_rule — insufficient privilege on the scanning account
     required grant: InstancesReadOnly (Project scope)
     HTTP 403 - GET https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups - insufficient permissions
-Result: 6 control(s) cannot be evaluated on this scope.
+Result: 7 control(s) cannot be evaluated on this scope.
+  · compute_instance_public_ip_with_open_securitygroup
   · network_securitygroup_allow_ingress_from_internet_to_all_ports
   · network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports
   · network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports
@@ -286,7 +287,7 @@ $ ./pepin scan scaleway partial-inventory.json
 […]
  Summary
 
- Verdict: INCOMPLETE — 6 control(s) are not evaluable because the collection is incomplete, 0 medium/low deviation(s) on what could be read
+ Verdict: INCOMPLETE — 7 control(s) are not evaluable because the collection is incomplete, 0 medium/low deviation(s) on what could be read
 
  🔴 CRITICAL 0   🟠 HIGH 0   🟡 MEDIUM 0   🔵 LOW 0
 ──────────────────────────────────────────────────────────────────────────────

--- a/internal/assess/collection.go
+++ b/internal/assess/collection.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/stephrobert/pepin/internal/genprovider"
 	"github.com/stephrobert/pepin/internal/i18n"
 	"github.com/stephrobert/pepin/internal/model"
 	"github.com/stephrobert/scankit/assessment"
@@ -58,15 +59,25 @@ func DegradedControls(coll model.Collection, controlType map[string]string, scop
 		if !scope[code] {
 			continue
 		}
-		typ := controlType[code]
-		if typ == "" {
-			// Un contrôle transverse (gouvernance) ne lit pas un type précis : aucune
-			// unité ne le porte, donc aucune ne peut prouver qu'il est dégradé. Ne pas
-			// le compter est l'énoncé prudent — l'affirmer serait inventer un lien.
+		// TOUS les types que le contrôle lit, pas seulement celui dont son code
+		// porte le préfixe. Six règles corrèlent plusieurs types, et l'incomplétude
+		// du SECOND passait inaperçue : « VMs collectées, règles SG en 403 » laissait
+		// conclure sur une exposition dont la donnée n'était jamais arrivée.
+		// L'incomplétude de n'importe lequel dégrade (ADR-0006).
+		types := genprovider.ControlTypes(code)
+		if len(types) == 0 {
+			// Un contrôle transverse qui ne lit AUCUN type : aucune unité ne le porte,
+			// donc aucune ne peut prouver qu'il est dégradé. Ne pas le compter est
+			// l'énoncé prudent — l'affirmer serait inventer un lien.
 			continue
 		}
-		if unit, ok := incomplete[typ]; ok {
+		for _, typ := range types {
+			unit, ok := incomplete[typ]
+			if !ok {
+				continue
+			}
 			out[code] = unit
+			break // une unité incomplète suffit ; la première nommée est la raison
 		}
 	}
 	return out

--- a/internal/assess/multitype_test.go
+++ b/internal/assess/multitype_test.go
@@ -1,0 +1,57 @@
+package assess
+
+import (
+	"testing"
+
+	"github.com/stephrobert/pepin/internal/model"
+)
+
+// TestAnIncompleteSecondTypeDegradesTheControl ferme le faux vert de l'ADR-0006.
+//
+// Six règles CORRÈLENT plusieurs types. Tant qu'un contrôle ne déclarait que celui
+// dont son code porte le préfixe, l'incomplétude du second passait inaperçue :
+//
+//	Collecte des VMs        -> OK
+//	Collecte des règles SG  -> 403
+//
+// et `compute_instance_public_ip_with_open_securitygroup` rendait `pass` — « aucune
+// non-conformité détectée sur les ressources de type compute_instance » — alors que
+// la donnée qui ÉTABLIT l'exposition n'était jamais arrivée. Mesuré avant/après :
+// le verdict passe désormais à `not-evaluated`, en nommant l'unité fautive.
+func TestAnIncompleteSecondTypeDegradesTheControl(t *testing.T) {
+	coll := model.Collection{Units: []model.CollectionUnit{{
+		Unit:      "security_group_rule",
+		Types:     []string{"security_group_rule"},
+		Attempted: true,
+		Complete:  false,
+		Error:     model.OutcomePermissionDenied,
+	}}}
+	scope := map[string]bool{"compute_instance_public_ip_with_open_securitygroup": true}
+
+	got := DegradedControls(coll, nil, scope)
+	unit, ok := got["compute_instance_public_ip_with_open_securitygroup"]
+	if !ok {
+		t.Fatal("un contrôle qui corrèle security_group_rule n'est pas dégradé quand cette " +
+			"collecte est incomplète : il conclura sur une donnée jamais arrivée")
+	}
+	if unit.Unit != "security_group_rule" {
+		t.Fatalf("l'unité nommée doit être celle qui a échoué, obtenu %q", unit.Unit)
+	}
+}
+
+// TestOnlyTheTypesAControlReadsDegradeIt est le contre-test. Dégrader trop large
+// serait un faux `not-evaluated` : moins grave qu'un faux `pass`, et tout aussi faux.
+func TestOnlyTheTypesAControlReadsDegradeIt(t *testing.T) {
+	coll := model.Collection{Units: []model.CollectionUnit{{
+		Unit:      "object_storage_bucket",
+		Types:     []string{"object_storage_bucket"},
+		Attempted: true,
+		Complete:  false,
+		Error:     model.OutcomePermissionDenied,
+	}}}
+	scope := map[string]bool{"compute_instance_public_ip_with_open_securitygroup": true}
+
+	if got := DegradedControls(coll, nil, scope); len(got) != 0 {
+		t.Fatalf("un contrôle qui ne lit pas ce type ne doit pas être dégradé, obtenu %v", got)
+	}
+}

--- a/internal/genprovider/controltypes.go
+++ b/internal/genprovider/controltypes.go
@@ -1,0 +1,57 @@
+package genprovider
+
+// extraControlTypes — les types SECONDAIRES qu'un contrôle lit, en plus de celui
+// que `ControlType` déduit de son code.
+//
+// Pourquoi cette table existe. `ControlType` rend UN type, déduit du préfixe de
+// service : c'est ce qui décide de l'applicabilité, et c'est suffisant pour la
+// majorité des contrôles. Mais six règles CORRÈLENT plusieurs types, et une
+// collecte incomplète sur le second passait alors inaperçue :
+//
+//	Collecte des VMs             -> OK
+//	Collecte des règles SG       -> 403
+//
+// Le contrôle rattaché à `compute_instance` concluait sans que la donnée qui
+// établit l'exposition soit jamais arrivée. C'est la dette que l'ADR-0006 nommait.
+//
+// Pourquoi elle est DÉCLARÉE et pas dérivée à l'exécution. Lire le Rego au moment
+// du scan ferait dépendre un verdict d'une analyse textuelle, ce qui est fragile.
+// La table est donc écrite, et `TestControlTypesMatchTheRules` la confronte à ce
+// que les règles lisent RÉELLEMENT : une divergence casse la CI, dans les deux
+// sens. Deux tables qu'on maintient à la main divergent ; une table gardée par sa
+// dérivation, non.
+var extraControlTypes = map[string][]string{
+	"blockstorage_volume_snapshots_exist":                {"blockstorage_snapshot"},
+	"compute_instance_public_ip_with_open_securitygroup": {"security_group_rule"},
+	"iam_apiaccesspolicy_max_key_expiration":             {"api_access_rule", "api_access_summary"},
+	"iam_apiaccessrule_defined":                          {"api_access_policy", "api_access_rule", "api_access_summary"},
+	"iam_apiaccessrule_no_public_cidr":                   {"api_access_policy", "api_access_summary"},
+	"iam_policy_no_privilege_escalation":                 {"iam_role"},
+
+	// Contrôle transverse : `ControlType` rend "" pour la gouvernance, mais celui-ci
+	// lit bien un type — la ressource synthétique que le descripteur publie. Sans
+	// cette entrée, une collecte incomplète de cette ressource ne le dégradait pas.
+	"governance_provider_sovereignty": {"governance_provider"},
+}
+
+// ControlTypes rend TOUS les types normalisés qu'un contrôle lit : celui qui décide
+// de son applicabilité, puis ceux qu'il corrèle.
+//
+// L'incomplétude de N'IMPORTE LEQUEL doit dégrader le contrôle : conclure sur une
+// corrélation dont un côté n'a pas été lu, c'est conclure sur ce qu'on n'a pas vu.
+func ControlTypes(code string) []string {
+	primary := ControlType(code)
+	extra := extraControlTypes[code]
+	if primary == "" {
+		return append([]string(nil), extra...)
+	}
+	out := make([]string, 0, 1+len(extra))
+	out = append(out, primary)
+	for _, t := range extra {
+		if t == primary {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}

--- a/internal/genprovider/controltypes_test.go
+++ b/internal/genprovider/controltypes_test.go
@@ -1,0 +1,124 @@
+package genprovider_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/pepin/internal/genprovider"
+)
+
+var (
+	reReadsType = regexp.MustCompile(`resources_of_type\("([a-z_]+)"\)`)
+	reEmitsCode = regexp.MustCompile(`"code":\s*"([a-z0-9_]+)"`)
+)
+
+// TestControlTypesMatchTheRules confronte la table déclarée à ce que les règles
+// LISENT réellement.
+//
+// Sans cette porte, `extraControlTypes` serait une seconde table à maintenir à la
+// main, et deux tables divergent — celle qui diverge étant toujours celle qu'on
+// lit. Ici la source de vérité reste le Rego : la table le déclare, ce test le
+// vérifie, et la CI casse dans les deux sens.
+//
+// Ce qu'il ne peut PAS voir : un type lu à travers un helper de lib.rego plutôt que
+// par un `resources_of_type` littéral. Aucune règle ne le fait aujourd'hui ; si
+// l'une venait à le faire, ce test la déclarerait conforme à tort. C'est la limite
+// d'une analyse textuelle, et elle est écrite plutôt que tue.
+func TestControlTypesMatchTheRules(t *testing.T) {
+	dir := filepath.Join("..", "commonrules", "rules")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("lecture des règles : %v", err)
+	}
+
+	var checked int
+	for _, e := range entries {
+		n := e.Name()
+		if !strings.HasSuffix(n, ".rego") || strings.HasSuffix(n, "_test.rego") || n == "lib.rego" {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, n)) //nolint:gosec // chemin du dépôt
+		if err != nil {
+			t.Fatalf("lecture de %s : %v", n, err)
+		}
+		text := string(b)
+
+		read := map[string]bool{}
+		for _, m := range reReadsType.FindAllStringSubmatch(text, -1) {
+			read[m[1]] = true
+		}
+		if len(read) == 0 {
+			continue
+		}
+		codes := map[string]bool{}
+		for _, m := range reEmitsCode.FindAllStringSubmatch(text, -1) {
+			codes[m[1]] = true
+		}
+
+		for code := range codes {
+			declared := map[string]bool{}
+			for _, ty := range genprovider.ControlTypes(code) {
+				declared[ty] = true
+			}
+			checked++
+
+			for ty := range read {
+				if !declared[ty] {
+					t.Errorf("%s : le contrôle %q lit le type %q sans le déclarer.\n"+
+						"  Une collecte incomplète sur ce type ne le dégraderait donc pas, et il\n"+
+						"  conclurait sur une donnée jamais arrivée (ADR-0006). Ajouter le type à\n"+
+						"  extraControlTypes.", n, code, ty)
+				}
+			}
+			for ty := range declared {
+				if !read[ty] {
+					t.Errorf("%s : le contrôle %q déclare le type %q qu'il ne lit pas.\n"+
+						"  Un type déclaré en trop dégrade le contrôle sans raison : c'est un faux\n"+
+						"  `not-evaluated`, moins grave qu'un faux `pass` mais tout aussi faux.",
+						n, code, ty)
+				}
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("aucun contrôle vérifié : la porte ne mesure rien")
+	}
+	t.Logf("%d couple(s) contrôle/règle vérifié(s)", checked)
+}
+
+// TestEveryMultiTypeControlIsDeclared est le contre-test : il énumère les règles qui
+// lisent PLUSIEURS types et exige que chacune ait sa déclaration. Le test précédent
+// pourrait passer sur une table vide si aucune règle ne lisait rien ; celui-ci
+// interdit ce vert-là.
+func TestEveryMultiTypeControlIsDeclared(t *testing.T) {
+	dir := filepath.Join("..", "commonrules", "rules")
+	entries, _ := os.ReadDir(dir)
+	var multi []string
+	for _, e := range entries {
+		n := e.Name()
+		if !strings.HasSuffix(n, ".rego") || strings.HasSuffix(n, "_test.rego") || n == "lib.rego" {
+			continue
+		}
+		b, _ := os.ReadFile(filepath.Join(dir, n)) //nolint:gosec // chemin du dépôt
+		read := map[string]bool{}
+		for _, m := range reReadsType.FindAllStringSubmatch(string(b), -1) {
+			read[m[1]] = true
+		}
+		if len(read) < 2 {
+			continue
+		}
+		for _, m := range reEmitsCode.FindAllStringSubmatch(string(b), -1) {
+			if len(genprovider.ControlTypes(m[1])) < 2 {
+				multi = append(multi, m[1])
+			}
+		}
+	}
+	sort.Strings(multi)
+	if len(multi) > 0 {
+		t.Errorf("contrôle(s) lisant plusieurs types sans les déclarer : %v", multi)
+	}
+}

--- a/tools/falsify/specs/an-incomplete-second-type-degrades-the-control.json
+++ b/tools/falsify/specs/an-incomplete-second-type-degrades-the-control.json
@@ -1,0 +1,12 @@
+{
+  "package": "./internal/assess/",
+  "mutations": [
+    {
+      "label": "seul le type principal dégrade, comme avant",
+      "file": "internal/assess/collection.go",
+      "find": "\t\ttypes := genprovider.ControlTypes(code)",
+      "replace": "\t\ttypes := genprovider.ControlTypes(code)[:1]",
+      "test": "TestAnIncompleteSecondTypeDegradesTheControl"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #103

## Impact ADR

- [x] **ADR-0006 étendu — sa dette est soldée.** L'ADR nommait ce défaut : *« un contrôle ne déclare qu'un seul type, donc l'incomplétude d'un second type qu'il lit ne le dégrade pas »*. La décision ne change pas ; son implémentation la rattrape enfin.

## Le faux vert, reproduit puis fermé

Six règles corrèlent plusieurs types de ressources. Un contrôle ne déclarait que celui dont son code porte le préfixe.

```
Collecte des VMs             → OK
Collecte des règles SG       → 403
```

| | Verdict de `compute_instance_public_ip_with_open_securitygroup` |
|---|---|
| **Avant** | `pass` — *« aucune non-conformité détectée sur les ressources de type compute_instance »* |
| **Après** | `not-evaluated` — *« collecte incomplète de security_group_rule : privilège insuffisant du compte »* |

Le contrôle concluait sur une exposition dont **la donnée qui l'établit n'était jamais arrivée**. Mesuré sur ce cas exact, avant et après.

## Déclaré, mais gardé par sa dérivation

Les types secondaires sont **déclarés** plutôt qu'inférés à l'exécution : faire dépendre un verdict d'une analyse textuelle du Rego serait fragile.

Mais une seconde table maintenue à la main diverge, et celle qui diverge est toujours celle qu'on lit. `TestControlTypesMatchTheRules` confronte donc la déclaration à ce que les règles lisent **réellement**, et casse **dans les deux sens** :

- un type **lu et non déclaré** → le contrôle conclurait sur une donnée qu'une collecte incomplète n'aurait pas fournie ;
- un type **déclaré et non lu** → le contrôle se dégraderait sans raison, ce qui est un faux `not-evaluated` : moins grave qu'un faux `pass`, et tout aussi faux.

**Cette garde a trouvé deux manques dans ma propre table dès sa première exécution** : `iam_apiaccessrule_defined` lisait un type que j'avais omis, et `governance_provider_sovereignty` lit la ressource synthétique du descripteur, pour laquelle `ControlType` rend `""`.

Son propre angle mort est écrit dans le test : un type atteint par un helper de `lib.rego` plutôt que par un `resources_of_type` littéral serait déclaré conforme à tort. Aucune règle ne le fait aujourd'hui.

## Mesures

**Aucun verdict ne bouge sur les fixtures du dépôt** — aucune ne porte d'état de collecte, donc rien n'y dégrade. C'est attendu : le mouvement n'existe que là où une collecte est incomplète, d'où la construction du cas.

La falsification confirme la garde : `compiled=yes`, le test mord quand on limite la dégradation au seul type principal, restauration verte.

`prepush` vert, `adr-drift` vert, 16 ADR contrôlés.

## Ce qui reste

**#104** — la porte générique « aucune règle ne produit un FAIL depuis un attribut absent ». Elle exigeait ce contrat de décision ; il existe désormais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
