### PR TITLE
test(rules): a dedicated corpus, and the rules it finally lets us measure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,25 @@ jobs:
         with:
           args: -quiet ./...
 
+      # La version de Go vient de go.mod, et il faut la passer par `go-version-input`.
+      # `go-version-file` seul était IGNORÉ : l'action porte un `go-version-input`
+      # défaut « stable » qu'elle transmet à setup-go, lequel avertit « only
+      # go-version will be used ». govulncheck analysait donc le code sous une
+      # version que le projet ne cible pas — ce qui compte, l'applicabilité d'une
+      # vulnérabilité de la bibliothèque standard dépendant de cette version.
+      #
+      # `cache: false` parce que setup-go a DÉJÀ restauré le cache Go plus haut :
+      # deux restaurations dans le même job déballent l'une sur l'autre, d'où les
+      # « Cannot open: File exists » et l'échec de tar en fin de job.
+      - name: Version de Go du projet
+        id: gomod
+        run: echo "version=$(sed -n 's/^go //p' go.mod)" >> "$GITHUB_OUTPUT"
+
       - name: Vulnérabilités appelées (govulncheck)
         uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
         with:
-          go-version-file: go.mod
+          go-version-input: ${{ steps.gomod.outputs.version }}
+          cache: false
           repo-checkout: false
 
   lint:

--- a/internal/commonrules/ablation_test.go
+++ b/internal/commonrules/ablation_test.go
@@ -62,6 +62,17 @@ var ablationExceptions = map[string]string{
 	// PROVENANCE, qui indexe les attributs CHERCHÉS même non exposés (ADR-0007) —
 	// une règle n'y a pas accès aujourd'hui. Suivi en #121.
 	"iam_accesskey_expiration_set\x00expiration_date": "contrat Scaleway : ExpiresAt est un *time.Time, un nil signifie « aucune expiration »",
+
+	// Une snapshot sans `volume_id` n'est attribuable à AUCUN volume : le lien est
+	// ce qui la fait compter. Son absence n'est donc pas un repli défavorable mais
+	// une donnée structurellement inexploitable.
+	//
+	// La bonne réponse à long terme n'est pas ici mais au verrou de capacité : si
+	// `volume_id` n'est pas collecté sur les snapshots, AUCUNE ne peut être
+	// attribuée et tous les volumes paraissent non sauvegardés — un faux positif
+	// de masse. Exprimer cela demande un verrou par TYPE au sein d'un contrôle
+	// multi-types, que le contrat de décision ne porte pas encore. Suivi en #133.
+	"blockstorage_volume_snapshots_exist\x00volume_id": "le lien vers le volume est structurel : sans lui la snapshot n'est attribuable à rien",
 }
 
 type finding struct {
@@ -84,10 +95,27 @@ func corpus(t *testing.T) map[string]map[string]any {
 	t.Helper()
 	root := filepath.Join("..", "..")
 	out := map[string]map[string]any{}
+	// Le corpus DÉDIÉ (testdata/corpus) complète les fixtures d'exemple. Il vit ici et
+	// non dans examples/ parce qu'il ne sert qu'à cette porte : le mettre dans
+	// examples/ ferait dériver la documentation générée à chaque ajout, ce qui
+	// dissuaderait d'en ajouter — exactement l'effet inverse de celui recherché.
+	//
+	// Chaque tenant y est CONFORME : l'ablation part d'une base silencieuse, sans quoi
+	// l'écart y serait déjà présent et son apparition ne se verrait pas.
+	groups := [][]string{{filepath.Join("testdata", "corpus", "*.json")}}
 	for _, prov := range []string{"scaleway", "outscale", "exoscale"} {
-		paths, _ := filepath.Glob(filepath.Join(root, "examples", prov, "*.json"))
-		more, _ := filepath.Glob(filepath.Join(root, "references", "tenants", prov, "*", "plan.json"))
-		for _, p := range append(paths, more...) {
+		groups = append(groups, []string{
+			filepath.Join(root, "examples", prov, "*.json"),
+			filepath.Join(root, "references", "tenants", prov, "*", "plan.json"),
+		})
+	}
+	for _, patterns := range groups {
+		var all []string
+		for _, pat := range patterns {
+			m, _ := filepath.Glob(pat)
+			all = append(all, m...)
+		}
+		for _, p := range all {
 			b, err := os.ReadFile(p) //nolint:gosec // chemins du dépôt, énumérés ici
 			if err != nil {
 				continue

--- a/internal/commonrules/rules/blockstorage_volume_snapshots_exist.rego
+++ b/internal/commonrules/rules/blockstorage_volume_snapshots_exist.rego
@@ -65,10 +65,31 @@ _has_recent_snapshot(vid) if {
 	some s in resources_of_type("blockstorage_snapshot")
 	object.get(s.attributes, "volume_id", "") == vid
 	_snapshot_usable(s)
+	_snapshot_fresh(s)
+}
+
+# _snapshot_fresh — la date est DANS la fenêtre, ou n'a pas été collectée.
+#
+# Le second cas suit exactement le précédent que `_snapshot_usable` a posé pour
+# l'état : quand le collecteur n'a pas projeté `creation_date`, on ne SAIT pas
+# quand la snapshot a été prise. La traiter comme périmée inventait « trop
+# ancienne » à partir d'une absence, et rendait un volume réellement sauvegardé
+# non conforme (ADR-0014). Trouvé par la porte d'ablation, sur le corpus dédié
+# ajouté pour couvrir ce type — aucune fixture ne l'exerçait auparavant.
+_snapshot_fresh(s) if {
 	date := object.get(s.attributes, "creation_date", "")
 	is_string(date)
 	date != ""
 	_eval_now_ns - time.parse_rfc3339_ns(date) <= snapshot_max_age_ns
+}
+
+_snapshot_fresh(s) if not _snapshot_date_collected(s)
+
+_snapshot_date_collected(s) if {
+	"creation_date" in object.keys(s.attributes)
+	d := object.get(s.attributes, "creation_date", "")
+	is_string(d)
+	d != ""
 }
 
 # _snapshot_usable — l'état de la snapshot est ACCEPTÉ. Deux cas, et le second

--- a/internal/commonrules/rules/compute_instance_deletion_protection.rego
+++ b/internal/commonrules/rules/compute_instance_deletion_protection.rego
@@ -14,6 +14,13 @@ import rego.v1
 
 deny contains f if {
 	some r in resources_of_type("compute_instance")
+
+	# PRODUCTION seulement. Le commentaire de ce contrôle visait « les ressources de
+	# calcul portant un service en production » ; sa condition, elle, exigeait la
+	# protection de TOUTE instance. Une VM de développement, de CI ou de laboratoire
+	# produisait donc le même écart qu'un serveur de production — un faux positif
+	# contextuel, et le genre qui use la confiance sans rien apprendre.
+	is_production(r.attributes)
 	not truthy(object.get(r.attributes, "deletion_protection", true))
 	id := object.get(r.attributes, "vm_id", r.id)
 	f := {
@@ -27,6 +34,33 @@ deny contains f if {
 			"category": "compliance",
 			"message_en": sprintf("Instance \"%s\" has no deletion protection — an accidental or malicious action destroys it.", [id]),
 			"remediation_en": "Enable deletion protection on the instances carrying a production service.",
+		},
+	}
+}
+
+# ── indéterminé : l'environnement n'est pas lisible ───────────────────────────
+#
+# Sans étiquette d'environnement, on ne SAIT pas si cette instance porte un service
+# de production. Se taire vaudrait « conforme » et laisserait passer un vrai serveur
+# non protégé ; crier ferait le faux positif qu'on vient de retirer. La règle
+# constate, l'assessment statue (ADR-0015).
+deny contains f if {
+	some r in resources_of_type("compute_instance")
+	not environment_known(r.attributes)
+	not truthy(object.get(r.attributes, "deletion_protection", true))
+	id := object.get(r.attributes, "vm_id", r.id)
+	f := {
+		"code": "compute_instance_deletion_protection",
+		"severity": "medium",
+		"subject": id,
+		"message": sprintf("VM « %s » sans protection contre la suppression, et sans étiquette d'environnement — impossible de dire si elle porte un service de production.", [id]),
+		"remediation": "Étiqueter l'environnement (Env / environment / stage) pour que ce contrôle sache s'il s'applique ; activer la protection sur les instances de production.",
+		"labels": {
+			"provider": provider_of(r),
+			"category": "compliance",
+			"inconclusive": "true",
+			"message_en": sprintf("VM \"%s\" has no deletion protection and no environment tag — whether it carries a production service cannot be told.", [id]),
+			"remediation_en": "Tag the environment (Env / environment / stage) so this control knows whether it applies; enable protection on production instances.",
 		},
 	}
 }

--- a/internal/commonrules/rules/compute_instance_deletion_protection_test.rego
+++ b/internal/commonrules/rules/compute_instance_deletion_protection_test.rego
@@ -1,0 +1,42 @@
+package pepin.rules
+
+import rego.v1
+
+_dp_vm(attrs) := {"resources": [{"provider": "outscale", "type": "compute_instance", "id": "i-9", "attributes": attrs}]}
+
+_dp_code := "compute_instance_deletion_protection"
+
+# ✗ Production sans protection → écart, et il est CONCLUANT.
+test_production_without_protection_denied if {
+	some f in deny with input as _dp_vm({"vm_id": "i-9", "deletion_protection": false, "tags": [{"key": "Env", "value": "production"}]})
+	f.code == _dp_code
+	not f.labels.inconclusive
+}
+
+# ✓ LE CONTRE-EXEMPLE. Une VM de développement, éphémère par construction, ne doit
+# pas produire le même écart qu'un serveur de production. Ce faux positif contextuel
+# use la confiance sans rien apprendre.
+test_development_without_protection_is_not_a_deviation if {
+	count({f | some f in deny; f.code == _dp_code}) == 0 with input as _dp_vm({"vm_id": "i-9", "deletion_protection": false, "tags": [{"key": "environment", "value": "dev"}]})
+}
+
+# ✓ Production AVEC protection → rien.
+test_production_with_protection_ok if {
+	count({f | some f in deny; f.code == _dp_code}) == 0 with input as _dp_vm({"vm_id": "i-9", "deletion_protection": true, "tags": [{"key": "Env", "value": "prod"}]})
+}
+
+# ✗→? Sans étiquette d'environnement, on ne SAIT pas. Se taire vaudrait « conforme »
+# et laisserait passer un vrai serveur non protégé (ADR-0015).
+test_unknown_environment_is_inconclusive if {
+	some f in deny with input as _dp_vm({"vm_id": "i-9", "deletion_protection": false})
+	f.code == _dp_code
+	f.labels.inconclusive == "true"
+}
+
+# ✓ L'écriture de l'environnement est insensible à la casse et aux séparateurs,
+# comme celle des noms d'étiquettes : « PROD » vaut « prod ».
+test_production_value_is_case_insensitive if {
+	some f in deny with input as _dp_vm({"vm_id": "i-9", "deletion_protection": false, "tags": [{"key": "stage", "value": "PROD"}]})
+	f.code == _dp_code
+	not f.labels.inconclusive
+}

--- a/internal/commonrules/rules/lib.rego
+++ b/internal/commonrules/rules/lib.rego
@@ -396,3 +396,33 @@ _default_snapshot_max_age_days := 7
 _default_snapshot_states := ["completed", "created"]
 
 _default_min_confidence := "low"
+
+# ── L'ENVIRONNEMENT d'une ressource, et ce qu'il autorise à conclure ──────────
+#
+# Certains contrôles ne visent que les services EN PRODUCTION : leur commentaire
+# le disait déjà, leur condition ne le vérifiait pas. Une VM de laboratoire, par
+# construction éphémère, produisait le même écart qu'un serveur de production.
+#
+# Les valeurs qui désignent la production sont CONFIGURABLES : imposer « prod »
+# serait la convention arbitraire que l'issue #61 dénonçait. La comparaison est
+# insensible à la casse, comme celle des noms d'étiquettes.
+
+production_values := object.get(_config_tagging, "production_values", _default_production_values)
+
+_default_production_values := ["live", "prd", "prod", "production"]
+
+# environment_of — la valeur de l'étiquette d'environnement, ou undefined si
+# aucune n'est lisible. Les écritures acceptées viennent du même profil que le
+# reste : `Env`, `environment`, `stage`, et ce qu'une organisation y ajoute.
+environment_of(attrs) := lower(v) if {
+	some t in object.get(attrs, "tags", [])
+	some req in required_tags_billable
+	req.name == "Env"
+	normalize_tag_key(object.get(t, "key", "")) in req.keys
+	v := object.get(t, "value", "")
+	v != ""
+}
+
+is_production(attrs) if environment_of(attrs) in production_values
+
+environment_known(attrs) if environment_of(attrs)

--- a/internal/commonrules/testdata/corpus/blockstorage.json
+++ b/internal/commonrules/testdata/corpus/blockstorage.json
@@ -1,0 +1,50 @@
+{
+  "provider": "outscale",
+  "resources": [
+    {
+      "provider": "outscale",
+      "type": "blockstorage_volume",
+      "id": "vol-1",
+      "name": "vol-1",
+      "region": "eu-west-2",
+      "attributes": {
+        "volume_id": "vol-1",
+        "state": "in-use",
+        "encrypted": true,
+        "tags": [
+          {
+            "key": "CostCenter",
+            "value": "cc-1"
+          },
+          {
+            "key": "Project",
+            "value": "p"
+          },
+          {
+            "key": "Env",
+            "value": "prod"
+          },
+          {
+            "key": "Owner",
+            "value": "team"
+          }
+        ]
+      }
+    },
+    {
+      "provider": "outscale",
+      "type": "blockstorage_snapshot",
+      "id": "snap-1",
+      "name": "snap-1",
+      "region": "eu-west-2",
+      "attributes": {
+        "snapshot_id": "snap-1",
+        "volume_id": "vol-1",
+        "state": "completed",
+        "creation_date": "2099-01-01T00:00:00Z",
+        "account_ids": [],
+        "global_permission": false
+      }
+    }
+  ]
+}

--- a/internal/commonrules/testdata/corpus/load-balancer.json
+++ b/internal/commonrules/testdata/corpus/load-balancer.json
@@ -1,0 +1,45 @@
+{
+  "provider": "outscale",
+  "resources": [
+    {
+      "provider": "outscale",
+      "type": "load_balancer",
+      "id": "lb-1",
+      "name": "lb-1",
+      "region": "eu-west-2",
+      "attributes": {
+        "load_balancer_name": "lb-1",
+        "load_balancer_type": "internal",
+        "listeners": [
+          {
+            "load_balancer_protocol": "HTTPS",
+            "load_balancer_port": 443
+          }
+        ],
+        "access_log": {
+          "is_enabled": true,
+          "osu_bucket_name": "logs"
+        },
+        "redirect_to_https": true,
+        "tags": [
+          {
+            "key": "CostCenter",
+            "value": "cc-1"
+          },
+          {
+            "key": "Project",
+            "value": "p"
+          },
+          {
+            "key": "Env",
+            "value": "prod"
+          },
+          {
+            "key": "Owner",
+            "value": "team"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/internal/commonrules/testdata/corpus/network-peering.json
+++ b/internal/commonrules/testdata/corpus/network-peering.json
@@ -1,0 +1,31 @@
+{
+  "provider": "outscale",
+  "resources": [
+    {
+      "provider": "outscale",
+      "type": "network_peering",
+      "id": "pcx-1",
+      "name": "pcx-1",
+      "region": "eu-west-2",
+      "attributes": {
+        "peering_id": "pcx-1",
+        "source_account": "111111111111",
+        "accepter_account": "111111111111",
+        "state": "active"
+      }
+    },
+    {
+      "provider": "outscale",
+      "type": "network_peering",
+      "id": "pcx-2",
+      "name": "pcx-2",
+      "region": "eu-west-2",
+      "attributes": {
+        "peering_id": "pcx-2",
+        "source_account": "111111111111",
+        "accepter_account": "222222222222",
+        "state": "expired"
+      }
+    }
+  ]
+}

--- a/internal/commonrules/testdata/corpus/network.json
+++ b/internal/commonrules/testdata/corpus/network.json
@@ -1,0 +1,45 @@
+{
+  "provider": "outscale",
+  "resources": [
+    {
+      "provider": "outscale",
+      "type": "network",
+      "id": "vpc-1",
+      "name": "vpc-1",
+      "region": "eu-west-2",
+      "attributes": {
+        "net_id": "vpc-1",
+        "tags": [
+          {
+            "key": "Owner",
+            "value": "team"
+          },
+          {
+            "key": "Project",
+            "value": "p"
+          },
+          {
+            "key": "Env",
+            "value": "prod"
+          },
+          {
+            "key": "CostCenter",
+            "value": "cc"
+          }
+        ]
+      }
+    },
+    {
+      "provider": "outscale",
+      "type": "subnet",
+      "id": "sub-1",
+      "name": "sub-1",
+      "region": "eu-west-2",
+      "attributes": {
+        "subnet_id": "sub-1",
+        "net_id": "vpc-1",
+        "map_public_ip_on_launch": false
+      }
+    }
+  ]
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -99,6 +99,14 @@ type Tagging struct {
 	// ResourceTypes : les types de ressources normalisés sur lesquels l'étiquetage
 	// est exigé.
 	ResourceTypes []string `yaml:"resource_types" json:"resource_types,omitempty"`
+	// ProductionValues : les valeurs de l'étiquette d'environnement qui désignent la
+	// PRODUCTION. Elles décident du périmètre des contrôles réservés aux services en
+	// production — la protection contre la suppression, notamment.
+	//
+	// Configurable parce qu'imposer « prod » serait la même convention arbitraire que
+	// #61 dénonçait : une organisation qui écrit « live » ou « prd » n'est pas moins
+	// gouvernée. La comparaison est insensible à la casse.
+	ProductionValues []string `yaml:"production_values" json:"production_values,omitempty"`
 }
 
 // Snapshots règle le contrôle de FRAÎCHEUR des snapshots de volume.

--- a/internal/policy/relaxation.go
+++ b/internal/policy/relaxation.go
@@ -215,6 +215,13 @@ func members(r Resolved, param string) (map[string]bool, bool) {
 	switch param {
 	case "tagging.resource_types":
 		return set(r.Tagging.ResourceTypes), true
+	case "tagging.production_values":
+		// Le sens compte, et il est l'INVERSE de celui des états de snapshot.
+		// Élargir cet ensemble fait entrer PLUS d'instances dans le périmètre du
+		// contrôle : c'est un durcissement. Le RÉTRÉCIR en sort des instances, donc
+		// cesse de les regarder — c'est cela qui assouplit. La correspondance ne
+		// tient donc que si l'ensemble effectif est un SURENSEMBLE du défaut.
+		return set(r.Tagging.ProductionValues), true
 	case "snapshots.accepted_states":
 		return set(r.Snapshots.AcceptedStates), true
 	default:

--- a/internal/policy/resolved.go
+++ b/internal/policy/resolved.go
@@ -25,6 +25,10 @@ type ResolvedTagging struct {
 	Required []RequiredTag `json:"required"`
 	// NetworkRequired : les étiquettes exigées sur les réseaux (cartographie).
 	NetworkRequired []RequiredTag `json:"network_required"`
+	// ProductionValues : les valeurs d'environnement qui désignent la production,
+	// en minuscules. Elles décident du périmètre des contrôles qui ne visent que
+	// les services en production.
+	ProductionValues []string `json:"production_values"`
 }
 
 // RequiredTag est une étiquette exigée : son nom LOGIQUE (celui que lira un
@@ -78,6 +82,10 @@ var (
 	// la même exigence. L'ORDRE est celui du message, donc il est signifiant et
 	// se conserve (voir resolveTags, qui ne trie pas).
 	defaultBillableTags = []string{"CostCenter", "Project", "Env", "Owner"}
+
+	// Les écritures courantes de « production », en minuscules. Recommandation,
+	// pas norme : une organisation qui écrit autrement le déclare.
+	defaultProductionValues = []string{"prod", "production", "prd", "live"}
 
 	// defaultNetworkTags : la cartographie réseau (CLD-NET-5) demande de savoir à
 	// QUI et à QUOI sert un réseau, et dans quel environnement. Le centre de coût
@@ -155,9 +163,10 @@ var (
 func Defaults() Resolved {
 	return Resolved{
 		Tagging: ResolvedTagging{
-			ResourceTypes:   sortedUnique(defaultTaggedTypes),
-			Required:        resolveTags(defaultBillableTags, defaultTagAliases),
-			NetworkRequired: resolveTags(defaultNetworkTags, defaultTagAliases),
+			ResourceTypes:    sortedUnique(defaultTaggedTypes),
+			Required:         resolveTags(defaultBillableTags, defaultTagAliases),
+			NetworkRequired:  resolveTags(defaultNetworkTags, defaultTagAliases),
+			ProductionValues: sortedUnique(defaultProductionValues),
 		},
 		Snapshots: ResolvedSnapshots{
 			MaxAgeDays:     defaultMaxAgeDays,
@@ -190,6 +199,13 @@ func Resolve(c *Controls) Resolved {
 		}
 		out.Tagging.Required = resolveTags(names, aliases)
 		out.Tagging.NetworkRequired = resolveTags(netNames, aliases)
+		if t.ProductionValues != nil {
+			lower := make([]string, 0, len(t.ProductionValues))
+			for _, v := range t.ProductionValues {
+				lower = append(lower, strings.ToLower(strings.TrimSpace(v)))
+			}
+			out.Tagging.ProductionValues = sortedUnique(lower)
+		}
 		if t.ResourceTypes != nil {
 			out.Tagging.ResourceTypes = sortedUnique(t.ResourceTypes)
 		}

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -283,6 +283,7 @@
       ],
       "rego_tests": [
         "internal/commonrules/rules/compute_blockstorage_test.rego",
+        "internal/commonrules/rules/compute_instance_deletion_protection_test.rego",
         "internal/commonrules/rules/zz_boolean_as_string_test.rego"
       ]
     },

--- a/referentiel/config.go
+++ b/referentiel/config.go
@@ -93,6 +93,7 @@ var ConfigParameters = []string{
 	"tagging.required_tags",
 	"tagging.network_required_tags",
 	"tagging.resource_types",
+	"tagging.production_values",
 	"snapshots.max_age_days",
 	"snapshots.accepted_states",
 	"secrets.min_confidence",

--- a/referentiel/controles.yaml
+++ b/referentiel/controles.yaml
@@ -929,6 +929,13 @@ controles:
     scsl: [CLD-CMP-10]
     frameworks:
     fournisseurs: [outscale]
+    # RÉTRÉCIR les valeurs qui désignent la production sort des instances du
+    # périmètre : le contrôle cesse de les regarder, et la correspondance ne vaut
+    # plus. Élargir, au contraire, durcit. Le périmètre doit donc rester au moins
+    # aussi large que le défaut.
+    config_requise:
+      - parametre: tagging.production_values
+        contrainte: superset_du_defaut
 
   - code: kubernetes_cluster_deletion_protection
     famille: compute


### PR DESCRIPTION
Closes #123 · Closes #113

Deux sujets, réunis parce qu'ils se répondent : le corpus est ce qui permet de mesurer une règle, et la règle corrigée ici est de celles qu'aucune fixture n'exerçait.

---

# 1. Le corpus dédié (#123)


## Impact ADR — corpus

- [x] ADR-0014 outillé, ADR-0010 servi — le corpus est ce qui rembourse la dette de véracité
- [x] Aucune décision d'architecture touchée

## Pourquoi maintenant

Quatre lots consécutifs ont corrigé six règles qu'**aucune fixture n'exerçait** :

| Lot | Règles | Corpus |
|---|---|---|
| #120 | région, peering | aucun |
| #129 | VM publique | aucun |
| #130 | journalisation, TLS | aucun |
| #131 | corrélation multi-types | aucun |

Leurs preuves étaient des cas que j'écris moi-même — l'auto-confirmation que #58 dénonçait, déplacée de la fixture vers le test.

## Ce que ça change

**6 types de ressource → 12. 65 ablations → 94.** Quatre tenants conformes couvrant l'appairage, le load balancer, le stockage bloc et le réseau — précisément les familles que ce jalon a corrigées sans pouvoir les mesurer.

## Pourquoi `testdata/corpus` et pas `examples/`

Une fixture dans `examples/` déplace la **documentation générée** : chaque ajout coûte une régénération et un diff à relire. Cette friction est exactement ce qui dissuade d'en ajouter — l'effet inverse de celui recherché. Ici, le coût d'un tenant est un fichier.

Chaque tenant est **conforme**, parce que l'ablation part d'une base silencieuse : sur un tenant fautif, l'écart est déjà là et son apparition ne se voit pas.

## Le défaut trouvé en quelques minutes

`blockstorage_volume_snapshots_exist` traitait une snapshot dont `creation_date` n'avait pas été collectée comme **périmée**. Un volume réellement sauvegardé sortait donc non conforme.

La correction suit un **précédent que la règle portait déjà** : `_snapshot_usable` traite un `state` non collecté comme exploitable, et son commentaire dit pourquoi — *« inventer inexploitable ferait un faux positif sur une sauvegarde réelle »*. La fraîcheur fait désormais de même. La règle était cohérente avec elle-même sur l'état, et ne l'était pas sur la date.

## Une exception, avec sa raison et son suivi

Une snapshot sans `volume_id` n'est reliée à rien : son absence n'est pas un repli défavorable mais une donnée **structurellement inexploitable**.

La vraie réponse est un cran plus haut. Si `volume_id` n'est pas collecté, **aucune** snapshot n'est attribuable et **tous** les volumes paraissent non sauvegardés — un faux positif de masse sur un contrôle `high`. L'exprimer demande un verrou de capacité par **type**, que le contrat de décision de #103 ne porte pas encore : déposé en **#133**.

## Mesures

**Aucun verdict ne bouge** sur les fixtures existantes ni sur les tenants de référence. Rego 292/292. `prepush` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# 2. La protection contre la suppression, réduite à la production (#113)


## Impact ADR — protection

- [x] **ADR-0009 respecté** — la configurabilité ajoutée porte sa contrainte normative
- [x] **ADR-0015 appliqué** — un environnement illisible ne se devine pas
- [x] ADR-0014 respecté

## Le faux positif contextuel

Le commentaire du contrôle visait « les ressources de calcul portant un service en production ». Sa condition, elle, l'exigeait de **toute** instance. Une VM de développement, de CI ou de laboratoire — éphémère par construction — produisait le même écart qu'un serveur de production.

C'est le genre de faux positif qui use la confiance sans rien apprendre.

## L'environnement se lit avec la machinerie qui existe

Les alias (`Env`, `environment`, `stage`) et la comparaison insensible à la casse viennent du profil d'étiquetage livré en vague 4 lot 3. Rien de nouveau à maintenir.

**Les valeurs qui désignent la production sont configurables**, parce qu'imposer `prod` serait la convention arbitraire que #61 dénonçait : une organisation qui écrit `live` ou `prd` n'est pas moins gouvernée.

## Sans étiquette, la règle ne devine pas

Se taire vaudrait « conforme » et laisserait passer un vrai serveur non protégé. Crier restaurerait le faux positif qu'on vient de retirer. La règle constate, l'assessment rend `not-evaluated`.

## L'erreur que la rédaction du commentaire a rattrapée

**J'avais déclaré la contrainte à l'envers.** J'ai écrit `sous_ensemble_du_defaut`, puis mon propre commentaire s'est auto-corrigé en cours de phrase — signe qu'il fallait s'arrêter.

Élargir les valeurs de production fait entrer **plus** d'instances dans le périmètre : c'est un **durcissement**. Le rétrécir sort des instances du regard du contrôle, et **c'est cela qui assouplit**. La correspondance ne tient donc que si l'ensemble effectif est un **surensemble** du défaut.

C'est le sens inverse de celui des états de snapshot, et cette asymétrie est écrite dans le code pour que personne ne la redéduise.

## Mesures

**Vérifié en exécution** : rétrécir le périmètre à `[prod]` est détecté comme un assouplissement, et la correspondance normative tombe.

Cinq scénarios Rego, dont le contre-exemple — une VM de développement sans protection ne produit plus d'écart. Retirer la restriction à la production le fait rougir.

**Aucun verdict ne bouge** sur les fixtures. Rego 297/297, `prepush` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
