### PR TITLE
fix(rules): every public listener is judged, not the existence of one good one

### DIFF
--- a/internal/commonrules/rules/loadbalancer_http_redirect.rego
+++ b/internal/commonrules/rules/loadbalancer_http_redirect.rego
@@ -16,7 +16,12 @@ deny contains f if {
 	some lb in resources_of_type("load_balancer")
 	some l in object.get(lb.attributes, "listeners", [])
 	object.get(l, "load_balancer_protocol", "") == "HTTP"
-	object.get(l, "load_balancer_port", 0) == 80
+
+	# TOUT listener HTTP, quel que soit son port. Ne viser que le 80 laissait passer
+	# un HTTP sur 8080, 8000 ou 8888 — des ports d'application courants, servis en
+	# clair tout autant. C'est le miroir du défaut de `loadbalancer_ssl_listeners` :
+	# là un port était pris pour un protocole, ici un port restreignait un protocole
+	# pourtant connu. Le protocole est ce que l'API déclare ; le port n'en dit rien.
 	"redirect_to_https" in object.keys(l) # garde de capacité : état de redirection réellement collecté
 	not truthy(object.get(l, "redirect_to_https", true))
 	name := object.get(lb.attributes, "load_balancer_name", lb.id)
@@ -24,12 +29,12 @@ deny contains f if {
 		"code": "loadbalancer_http_redirect_to_https",
 		"severity": "medium",
 		"subject": name,
-		"message": sprintf("LBU « %s » : listener HTTP:80 sans redirection vers HTTPS — trafic en clair possible.", [name]),
+		"message": sprintf("LBU « %s » : listener HTTP (port %d) sans redirection vers HTTPS — trafic en clair possible.", [name, object.get(l, "load_balancer_port", 0)]),
 		"remediation": "Mettre en place une redirection 301 du listener HTTP:80 vers HTTPS.",
 		"labels": {
 			"provider": provider_of(lb),
 			"category": "security",
-			"message_en": sprintf("LBU \"%s\": HTTP:80 listener with no redirect to HTTPS — cleartext traffic is possible.", [name]),
+			"message_en": sprintf("LBU \"%s\": HTTP listener (port %d) with no redirect to HTTPS — cleartext traffic is possible.", [name, object.get(l, "load_balancer_port", 0)]),
 			"remediation_en": "Set up a 301 redirect from the HTTP:80 listener to HTTPS.",
 		},
 	}

--- a/internal/commonrules/rules/loadbalancer_ssl_listeners.rego
+++ b/internal/commonrules/rules/loadbalancer_ssl_listeners.rego
@@ -77,3 +77,41 @@ deny contains f if {
 		},
 	}
 }
+
+# ── CHAQUE listener public, pas seulement l'existence d'un bon ────────────────
+#
+# La règle d'origine demandait « le LBU a-t-il AU MOINS UN listener sécurisé ». Un
+# répartiteur offrant HTTPS:443 ET HTTP:8080 la satisfaisait donc, tout en servant
+# du clair — un quantificateur existentiel là où il fallait un universel. C'est la
+# même erreur que le verrou de capacité par type corrigé en #102, sur un autre objet.
+#
+# Ce `deny` porte sur le LISTENER fautif et le NOMME, parce qu'un rapport qui dit
+# « ce LBU a un problème » sans dire lequel oblige à le chercher.
+deny contains f if {
+	some lb in resources_of_type("load_balancer")
+	object.get(lb.attributes, "load_balancer_type", "") == "internet-facing"
+	_has_secure_listener(lb.attributes)
+	some l in object.get(lb.attributes, "listeners", [])
+	_listener_is_cleartext(l)
+	name := object.get(lb.attributes, "load_balancer_name", lb.id)
+	port := object.get(l, "load_balancer_port", 0)
+	f := {
+		"code": "loadbalancer_ssl_listeners",
+		"severity": "high",
+		"subject": name,
+		"message": sprintf("LBU « %s » : le listener %s:%d sert en clair, alors qu'un autre listener est chiffré — la protection n'est pas celle qu'on croit.", [name, object.get(l, "load_balancer_protocol", ""), port]),
+		"remediation": "Chiffrer ou retirer ce listener : la présence d'un listener HTTPS ailleurs ne protège pas le trafic qui passe par celui-ci.",
+		"labels": {
+			"provider": provider_of(lb),
+			"category": "security",
+			"message_en": sprintf("LBU \"%s\": listener %s:%d serves cleartext while another listener is encrypted — the protection is not what it looks like.", [name, object.get(l, "load_balancer_protocol", ""), port]),
+			"remediation_en": "Encrypt or remove that listener: an HTTPS listener elsewhere does not protect the traffic going through this one.",
+		},
+	}
+}
+
+# _listener_is_cleartext — un listener dont le protocole DÉCLARÉ transporte du clair.
+# On ne juge que ce que l'API affirme : `HTTP`. Un `TCP` peut porter du chiffré, et
+# c'est précisément ce que la règle ne sait pas trancher (voir la branche
+# indéterminée ci-dessus) — l'inclure ici referait le faux positif qu'on évite.
+_listener_is_cleartext(l) if object.get(l, "load_balancer_protocol", "") == "HTTP"

--- a/internal/commonrules/rules/oks_lbu_governance_test.rego
+++ b/internal/commonrules/rules/oks_lbu_governance_test.rego
@@ -105,3 +105,51 @@ test_lbu_tcp_port80_denied if {
 	}]}
 	f.code == "loadbalancer_ssl_listeners"
 }
+
+_lbu(listeners, extra) := {"resources": [{
+	"provider": "outscale", "type": "load_balancer", "id": "lb-x",
+	"attributes": object.union(
+		{"load_balancer_name": "lb-x", "load_balancer_type": "internet-facing", "listeners": listeners},
+		extra,
+	),
+}]}
+
+# ✗ HTTPS:443 ET HTTP:8080 → écart. Un listener chiffré ailleurs ne protège pas le
+# trafic qui passe par celui-ci. La règle demandait « au moins un bon listener »,
+# un existentiel là où il fallait un universel.
+test_mixed_listeners_are_a_deviation if {
+	some f in deny with input as _lbu(
+		[
+			{"load_balancer_protocol": "HTTPS", "load_balancer_port": 443},
+			{"load_balancer_protocol": "HTTP", "load_balancer_port": 8080},
+		],
+		{},
+	)
+	f.code == "loadbalancer_ssl_listeners"
+	contains(f.message, "8080")
+}
+
+# ✓ Tout en HTTPS → rien.
+test_all_https_listeners_ok if {
+	count({f | some f in deny; f.code == "loadbalancer_ssl_listeners"}) == 0 with input as _lbu(
+		[
+			{"load_balancer_protocol": "HTTPS", "load_balancer_port": 443},
+			{"load_balancer_protocol": "HTTPS", "load_balancer_port": 8443},
+		],
+		{},
+	)
+}
+
+# ✗ HTTP sur un port ALTERNATIF sans redirection → écart. Ne viser que le 80
+# laissait passer 8080, 8000, 8888 : des ports d'application servis en clair tout
+# autant.
+test_http_on_alternative_port_needs_redirect if {
+	some f in deny with input as _lbu([{"load_balancer_protocol": "HTTP", "load_balancer_port": 8080, "redirect_to_https": false}], {})
+	f.code == "loadbalancer_http_redirect_to_https"
+	contains(f.message, "8080")
+}
+
+# ✓ Le même avec redirection → rien.
+test_http_on_alternative_port_with_redirect_ok if {
+	count({f | some f in deny; f.code == "loadbalancer_http_redirect_to_https"}) == 0 with input as _lbu([{"load_balancer_protocol": "HTTP", "load_balancer_port": 8080, "redirect_to_https": true}], {})
+}

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -1480,7 +1480,8 @@
         "outscale/ztiac-vpc-nat"
       ],
       "rego_tests": [
-        "internal/commonrules/rules/loadbalancer_http_redirect_test.rego"
+        "internal/commonrules/rules/loadbalancer_http_redirect_test.rego",
+        "internal/commonrules/rules/oks_lbu_governance_test.rego"
       ]
     },
     "loadbalancer_logging_enabled": {


### PR DESCRIPTION
Closes #114

## Impact ADR

- [x] ADR-0014, ADR-0015 respectés — la branche indéterminée de #108 est préservée
- [x] Aucune décision d'architecture touchée

## Un quantificateur existentiel là où il fallait un universel

`loadbalancer_ssl_listeners` demandait si le LBU avait **au moins un** listener sécurisé. Un répartiteur offrant `HTTPS:443` **et** `HTTP:8080` le satisfaisait donc, tout en servant du clair.

C'est la même erreur de quantificateur que le verrou de capacité par type corrigé en #102, sur un autre objet.

La règle **nomme désormais le listener fautif** : un rapport qui dit « ce LBU a un problème » sans dire lequel oblige à le chercher.

## Le miroir de #108

`loadbalancer_http_redirect_to_https` ne visait que le **port 80**. Un `HTTP` sur 8080, 8000 ou 8888 passait donc à côté — des ports d'application, servis en clair tout autant.

En #108, un port était pris pour un protocole. Ici, un port **restreignait** un protocole que l'API déclare pourtant. Le protocole est ce que l'API affirme ; le port n'en dit rien.

## Ce que je n'ai délibérément pas inclus

Les listeners **TCP** restent hors de l'ensemble « en clair ». Un TCP peut porter du chiffré, et c'est précisément ce que la règle ne sait pas trancher — la branche indéterminée ajoutée en #108 le couvre. Les inclure ici referait le faux positif que cette branche existe pour éviter.

## Mesures

Quatre scénarios, et **les deux corrections éprouvées en les cassant** : remettre la restriction au port 80, et revenir à « au moins un bon listener », font rougir la suite.

Rego 301/301, aucun verdict déplacé, `prepush` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)