### PR TITLE
fix(assessment): sovereignty is measured on what hosts data, not on a neighbour

### DIFF
--- a/cmd/region_capability_test.go
+++ b/cmd/region_capability_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import "testing"
+
+// La région suit-elle l'INTERSECTION, comme les autres attributs décisifs ?
+//
+// Elle ne la suivait pas. Champ du modèle et non attribut, elle était enregistrée en
+// UNION sous une clé vide commune à tous les types : une seule ressource localisée
+// suffisait à déclarer la donnée collectée pour l'inventaire entier. Le contrôle de
+// souveraineté — celui dont la localisation EST le sujet — rendait alors « conforme »
+// un bucket dont la région n'était jamais arrivée, et le rendait même sur la foi d'un
+// `iam_user`, type qu'il ne regarde pas (#110).
+//
+// C'est le même défaut que l'union des attributs, corrigé au même endroit, et ces
+// trois cas sont ceux qui ont été mesurés sur le binaire avant correction.
+func TestRegionFollowsTheIntersectionLikeAnyDecidingAttribute(t *testing.T) {
+	res := func(typ, id, region string) map[string]any {
+		return map[string]any{"type": typ, "id": id, "name": id, "region": region, "attributes": map[string]any{}}
+	}
+
+	cas := []struct {
+		nom       string
+		resources []any
+		veut      map[string]bool // type -> la région y est-elle réputée collectée ?
+	}{
+		{
+			nom:       "toutes les ressources du type portent leur région",
+			resources: []any{res("compute_instance", "vm-1", "fr-par"), res("compute_instance", "vm-2", "nl-ams")},
+			veut:      map[string]bool{"compute_instance": true},
+		},
+		{
+			nom:       "une seule ressource du type manque la sienne",
+			resources: []any{res("compute_instance", "vm-1", "fr-par"), res("compute_instance", "vm-2", "")},
+			veut:      map[string]bool{"compute_instance": false},
+		},
+		{
+			// Le faux vert exact : la région d'un type n'établit RIEN sur un autre.
+			nom:       "un type localisé, un autre non",
+			resources: []any{res("compute_instance", "vm-1", "fr-par"), res("object_storage_bucket", "b-1", "")},
+			veut:      map[string]bool{"compute_instance": true, "object_storage_bucket": false},
+		},
+	}
+
+	for _, c := range cas {
+		t.Run(c.nom, func(t *testing.T) {
+			got := attrsByTypeOf(map[string]any{"resources": c.resources})
+			for typ, veut := range c.veut {
+				if got[typ]["region"] != veut {
+					t.Errorf("type %q : région réputée collectée = %v, attendu %v.\n"+
+						"  Une région n'est une observation que si CHAQUE ressource du type la porte ;\n"+
+						"  sinon le contrôle de souveraineté conclut sur une localisation jamais vue.",
+						typ, got[typ]["region"], veut)
+				}
+			}
+			// La clé vide ne doit plus rien porter : c'est elle qui mélangeait les types.
+			if got[""]["region"] {
+				t.Error("la région est de nouveau enregistrée sous la clé vide, commune à tous " +
+					"les types — c'est l'union qui produisait le faux vert de #110")
+			}
+		})
+	}
+}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -776,16 +776,25 @@ func attrsByTypeOf(input any) map[string]map[string]bool {
 	//
 	// Sans la passe 1, le deuxième cas devenait un `pass` — un faux vert bâti sur la
 	// seule intention de chercher.
+	//
+	// La RÉGION suit le même chemin, sous la clé « region » du type de la ressource
+	// qui la porte. C'est un champ du modèle et non un attribut, mais la question
+	// posée est identique — a-t-on observé cette donnée sur CHAQUE ressource ? — et
+	// elle mérite donc la même intersection. Elle était auparavant enregistrée en
+	// UNION sous une clé vide commune : une seule ressource localisée ouvrait le
+	// `pass` du contrôle de souveraineté à toutes les autres, y compris à celles
+	// d'un type qu'il ne regarde pas.
 	type seenAttrs struct {
-		attrs map[string]any
-		prov  map[string]bool
+		attrs  map[string]any
+		prov   map[string]bool
+		region string
 	}
 	perType := map[string][]seenAttrs{}
-	add := func(typ string, attrs map[string]any, prov map[string]bool) {
+	add := func(typ string, attrs map[string]any, prov map[string]bool, region string) {
 		if typ == "" {
 			return
 		}
-		perType[typ] = append(perType[typ], seenAttrs{attrs: attrs, prov: prov})
+		perType[typ] = append(perType[typ], seenAttrs{attrs: attrs, prov: prov, region: region})
 	}
 	finish := func() {
 		for typ, rs := range perType {
@@ -796,6 +805,9 @@ func attrsByTypeOf(input any) map[string]map[string]bool {
 						exposed[k] = true
 					}
 				}
+				if r.region != "" {
+					exposed["region"] = true
+				}
 			}
 			var inter map[string]bool
 			for i, r := range rs {
@@ -804,6 +816,9 @@ func attrsByTypeOf(input any) map[string]map[string]bool {
 					if collected(v) {
 						present[k] = true
 					}
+				}
+				if r.region != "" {
+					present["region"] = true
 				}
 				for k := range r.prov {
 					if _, in := r.attrs[k]; !in && exposed[k] {
@@ -831,19 +846,6 @@ func attrsByTypeOf(input any) map[string]map[string]bool {
 			}
 		}
 	}
-	// La RÉGION est un champ de la ressource, pas un attribut : on l'enregistre sous la clé
-	// vide, celle des contrôles de gouvernance (dont le type visé est ""). Sans ça,
-	// governance_resource_region_in_eu — qui lit r.region sur CHAQUE ressource — pouvait
-	// s'afficher conforme alors qu'aucune région n'avait été collectée.
-	addRegion := func(region string) {
-		if region == "" {
-			return
-		}
-		if out[""] == nil {
-			out[""] = map[string]bool{}
-		}
-		out[""]["region"] = true
-	}
 	m, ok := input.(map[string]any)
 	if !ok {
 		return out
@@ -855,8 +857,7 @@ func attrsByTypeOf(input any) map[string]map[string]bool {
 			for k := range r.Provenance {
 				prov[k] = true
 			}
-			add(r.Type, r.Attributes, prov)
-			addRegion(r.Region)
+			add(r.Type, r.Attributes, prov, r.Region)
 		}
 	case []any:
 		for _, it := range rs {
@@ -869,9 +870,8 @@ func attrsByTypeOf(input any) map[string]map[string]bool {
 						prov[k] = true
 					}
 				}
-				add(t, attrs, prov)
 				reg, _ := rm["region"].(string)
-				addRegion(reg)
+				add(t, attrs, prov, reg)
 			}
 		}
 	}

--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -379,8 +379,7 @@ voici les motifs distincts observés :
 <!-- pepin:gen not-evaluated-reasons -->
 | Motif | Nombre | Contrôle témoin |
 |---|---:|---|
-| attribut « … » non collecté sur les ressources collectées (garde de capacité) | 1 | `governance_resource_region_in_eu` |
-| attribut « … » non collecté sur les ressources de type « … » (garde de capacité) | 4 | `compute_instance_has_security_group` |
+| attribut « … » non collecté sur les ressources de type « … » (garde de capacité) | 5 | `compute_instance_has_security_group` |
 | aucune ressource de type « … » dans l'inventaire évalué | 3 | `iam_accesskey_expiration_set` |
 | collecte de la donnée nécessaire non confirmée pour ce fournisseur (contrat non « … ») | 1 | `network_documented` |
 <!-- /pepin:gen not-evaluated-reasons -->

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -378,8 +378,7 @@ reasons observed:
 <!-- pepin:gen not-evaluated-reasons -->
 | Reason | Count | Witness control |
 |---|---:|---|
-| attribute "…" not collected on the collected resources (capability guard) | 1 | `governance_resource_region_in_eu` |
-| attribute "…" not collected on the resources of type "…" (capability guard) | 4 | `compute_instance_has_security_group` |
+| attribute "…" not collected on the resources of type "…" (capability guard) | 5 | `compute_instance_has_security_group` |
 | collection of the required data is not confirmed for this provider (contract not "…") | 1 | `network_documented` |
 | no resource of type "…" in the assessed inventory | 3 | `iam_accesskey_expiration_set` |
 <!-- /pepin:gen not-evaluated-reasons -->

--- a/internal/assess/assess.go
+++ b/internal/assess/assess.go
@@ -142,9 +142,14 @@ func RequiredAttrs() map[string][]string {
 // fournisseur). Leur source est donc intrinsèquement collectée ; les autres contrôles de
 // gouvernance (ex. étiquettes, qui dépendent de la collecte d'attributs par ressource) ne
 // sont PAS présumés vérifiés.
+// `governance_resource_region_in_eu` n'y figure PAS, bien qu'il y ait figuré : il lit
+// la région de chaque ressource du tenant, pas le descripteur. L'y inscrire lui
+// accordait le verrou sans condition, et trois mécanismes se contredisaient alors sur
+// le même contrôle — `requiredAttr` le tenait par « region », `ControlType` rendait ""
+// et ce marqueur le déclarait intrinsèquement vérifié. C'est ce dernier qui gagnait.
+// Il passe désormais par ses types déclarés, comme n'importe quel contrôle mesuré.
 var governanceProviderReaders = map[string]bool{
-	"governance_resource_region_in_eu": true,
-	"governance_provider_sovereignty":  true,
+	"governance_provider_sovereignty": true,
 }
 
 // Verified indique si le contrat du fournisseur CONFIRME que la donnée dont un contrôle a
@@ -161,6 +166,18 @@ func Verified(provider, code string) bool {
 	case genprovider.ControlType(code) != "":
 		return genprovider.TypeEtat(provider, genprovider.ControlType(code)) == "verifie"
 	default:
+		// Contrôle TRANSVERSE : aucun type déduit de son code, mais des types
+		// déclarés — le contrôle de souveraineté, qui mesure la localisation sur les
+		// sept types qui hébergent quelque chose. Le contrat doit confirmer qu'AU
+		// MOINS un de ces types est collecté pour ce fournisseur, sans quoi il n'y a
+		// rien à localiser. Ce que le contrat ne dit pas, en revanche, c'est si la
+		// région est arrivée sur chaque ressource : c'est `attrCollected` qui le
+		// mesure sur l'inventaire, et c'est lui le verrou effectif du « pass ».
+		for _, t := range genprovider.ControlTypes(code) {
+			if genprovider.TypeEtat(provider, t) == "verifie" {
+				return true
+			}
+		}
 		return false
 	}
 }
@@ -197,6 +214,18 @@ func References(c referentiel.Control) []assessment.Reference {
 // resource and are gated by `verified` instead, so they always apply here.
 func applicable(code string, controlType map[string]string, resourceTypes map[string]bool) bool {
 	if strings.HasPrefix(code, "governance_") {
+		// Un contrôle de gouvernance qui DÉCLARE les types qu'il lit s'applique
+		// seulement si l'un d'eux est là. Le contrôle de souveraineté en déclare sept
+		// et n'en juge aucun autre : sans ressource localisée, il n'a rien à dire —
+		// et « rien à dire » ne s'écrit pas « conforme ».
+		if declared := genprovider.ControlTypes(code); len(declared) > 0 {
+			for _, t := range declared {
+				if resourceTypes[t] {
+					return true
+				}
+			}
+			return false
+		}
 		return true
 	}
 	t := controlType[code]
@@ -274,7 +303,7 @@ func Build(provider string, controls map[string]referentiel.Control, findings []
 			// Otherwise the control could not actually be evaluated (attribute not collected, or
 			// nothing of this type in scope) — NotEvaluated, never a silent Pass.
 			switch {
-			case verified[code] && applicable(code, controlType, resourceTypes) && attrCollected(code, typ, attrsByType):
+			case verified[code] && applicable(code, controlType, resourceTypes) && attrCollected(code, typ, resourceTypes, attrsByType):
 				// A Pass carries WHAT was checked (basis of the assertion), not just a status.
 				res.Status = assessment.Pass
 				observed := i18n.T(
@@ -291,6 +320,18 @@ func Build(provider string, controls map[string]referentiel.Control, findings []
 					observed = i18n.T(
 						"conforme selon les faits de souveraineté déclarés au descripteur du fournisseur (attestation, non mesuré sur le tenant)",
 						"compliant according to the sovereignty facts declared in the provider descriptor (an attestation, not measured on the tenant)")
+				} else if scope := typesInScope(code, typ, resourceTypes); len(scope) > 0 {
+					// Contrôle transverse MESURÉ sur le tenant : la preuve nomme les types
+					// sur lesquels la donnée a effectivement été observée. « Contrat
+					// vérifié » ne disait rien de ce qui avait été regardé, et c'est
+					// précisément la phrase qui accompagnait le faux vert de la
+					// souveraineté — un bucket sans région, déclaré conforme.
+					sorted := append([]string(nil), scope...)
+					sort.Strings(sorted)
+					observed = fmt.Sprintf(i18n.T(
+						"aucune non-conformité détectée sur les ressources de type « %s », dont la donnée décisive a été observée sur chacune",
+						"no deviation detected on the resources of type \"%s\", whose deciding data was observed on every one of them"),
+						strings.Join(sorted, " / "))
 				}
 				res.Evidence = assessment.Evidence{Observed: observed, Source: run.Source}
 			default:
@@ -323,17 +364,58 @@ var requireAll = map[string]bool{
 	"network_peering_cross_organization": true,
 }
 
+// typesInScope rend les types sur lesquels ce contrôle JUGE réellement dans cet
+// inventaire — ceux qu'il lit et qui sont présents.
+//
+// Pour un contrôle ordinaire, c'est le type déduit de son code, et cette fonction ne
+// change rien. Elle existe pour le contrôle TRANSVERSE : `ControlType` rend "" pour
+// la gouvernance, et le contrôle de souveraineté lit pourtant sept types. Sans elle,
+// sa donnée décisive était cherchée sous une clé vide alimentée par n'importe quelle
+// ressource — un `iam_user` localisé certifiait une VM qui ne l'était pas.
+func typesInScope(code, typ string, resourceTypes map[string]bool) []string {
+	if typ != "" {
+		return []string{typ}
+	}
+	var out []string
+	for _, t := range genprovider.ControlTypes(code) {
+		if resourceTypes[t] {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
 // attrCollected dit si la donnée qui DÉCIDE a été collectée pour ce contrôle.
 //
 // `attrsByType` est construit par INTERSECTION sur les ressources d'un type
 // (cf. attrsByTypeOf) : un attribut n'y figure que si CHAQUE ressource le porte.
 // C'est ce qui empêche une ressource voisine d'ouvrir la porte du `pass` à une
 // ressource dont on n'a rien observé.
-func attrCollected(code, typ string, attrsByType map[string]map[string]bool) bool {
+//
+// Un contrôle transverse doit l'avoir sur CHACUN de ses types en scope : la
+// souveraineté ne se conclut pas des VMs vers les buckets. Et un scope VIDE ne
+// conclut rien — il n'y a alors aucune ressource à localiser, ce que
+// `notEvaluatedReason` dit avec ses mots.
+func attrCollected(code, typ string, resourceTypes map[string]bool, attrsByType map[string]map[string]bool) bool {
 	attrs := requiredAttr[code]
 	if len(attrs) == 0 {
 		return true
 	}
+	scope := typesInScope(code, typ, resourceTypes)
+	if len(scope) == 0 {
+		return false
+	}
+	for _, t := range scope {
+		if !attrsOnType(code, t, attrs, attrsByType) {
+			return false
+		}
+	}
+	return true
+}
+
+// attrsOnType applique la règle de suffisance d'un contrôle à UN type : tous les
+// attributs déclarés (`requireAll`), ou au moins un.
+func attrsOnType(code, typ string, attrs []string, attrsByType map[string]map[string]bool) bool {
 	if requireAll[code] {
 		for _, a := range attrs {
 			if !attrsByType[typ][a] {
@@ -363,10 +445,29 @@ func notEvaluatedReason(code, typ string, verified bool, resourceTypes map[strin
 			"aucune ressource de type « %s » dans l'inventaire évalué",
 			"no resource of type \"%s\" in the assessed inventory"), typ)
 	}
-	if attrs := requiredAttr[code]; len(attrs) > 0 && !attrCollected(code, typ, attrsByType) {
+	scope := typesInScope(code, typ, resourceTypes)
+	// Contrôle transverse dont AUCUN type lu n'est présent : il n'y a rien à juger.
+	// Le dire ainsi vaut mieux que « attribut non collecté », qui laisserait croire à
+	// une collecte défaillante là où l'inventaire ne contient simplement rien de
+	// localisable.
+	if typ == "" && len(scope) == 0 && len(genprovider.ControlTypes(code)) > 0 {
+		return i18n.T(
+			"aucune ressource des types que ce contrôle examine dans l'inventaire évalué",
+			"no resource of the types this control examines in the assessed inventory")
+	}
+	if attrs := requiredAttr[code]; len(attrs) > 0 && !attrCollected(code, typ, resourceTypes, attrsByType) {
 		where := fmt.Sprintf(i18n.T("les ressources de type « %s »", "the resources of type \"%s\""), typ)
-		if typ == "" { // contrôle transverse (gouvernance) : aucun type visé
-			where = i18n.T("les ressources collectées", "the collected resources")
+		if typ == "" { // contrôle transverse (gouvernance) : plusieurs types lus
+			// Nommer les types FAUTIFS, pas tous ceux en scope : l'opérateur doit
+			// savoir où la donnée manque pour aller la chercher.
+			var missing []string
+			for _, t := range scope {
+				if !attrsOnType(code, t, attrs, attrsByType) {
+					missing = append(missing, t)
+				}
+			}
+			where = fmt.Sprintf(i18n.T("les ressources de type « %s »", "the resources of type \"%s\""),
+				strings.Join(missing, " / "))
 		}
 		return fmt.Sprintf(i18n.T(
 			"attribut « %s » non collecté sur %s (garde de capacité)",

--- a/internal/assess/assess_test.go
+++ b/internal/assess/assess_test.go
@@ -74,8 +74,25 @@ func TestApplicable(t *testing.T) {
 	if applicable("compute_image_not_public", ct, present) {
 		t.Error("compute_image control must NOT be applicable on a compute_instance-only inventory")
 	}
-	if !applicable("governance_provider_sovereignty", ct, present) {
-		t.Error("governance controls always apply (synthetic resource)")
+	// Un contrôle de gouvernance SANS type déclaré s'applique toujours : sa donnée est
+	// le descripteur, toujours là.
+	if !applicable("governance_resource_required_tags", ct, present) {
+		t.Error("un contrôle de gouvernance sans type déclaré s'applique toujours")
+	}
+	// Mais celui qui DÉCLARE ses types ne s'applique que si l'un d'eux est présent.
+	// Le contrôle de souveraineté lit sept types localisés ; sur un inventaire qui
+	// n'en porte aucun, il n'a rien à juger — et « rien à juger » n'est pas « conforme ».
+	if !applicable("governance_resource_region_in_eu", ct, present) {
+		t.Error("le contrôle de souveraineté s'applique dès qu'un type localisé est présent")
+	}
+	if applicable("governance_resource_region_in_eu", ct, map[string]bool{"iam_user": true}) {
+		t.Error("le contrôle de souveraineté ne s'applique PAS sans ressource localisée : " +
+			"une identité n'héberge rien, et la déclarer conforme serait le faux vert corrigé (#110)")
+	}
+	// Le contrôle du descripteur, lui, reste applicable : son type synthétique est
+	// publié à chaque scan.
+	if !applicable("governance_provider_sovereignty", ct, map[string]bool{"governance_provider": true}) {
+		t.Error("le contrôle du descripteur s'applique dès que la ressource synthétique est là")
 	}
 }
 

--- a/internal/genprovider/controltypes.go
+++ b/internal/genprovider/controltypes.go
@@ -32,6 +32,24 @@ var extraControlTypes = map[string][]string{
 	// lit bien un type — la ressource synthétique que le descripteur publie. Sans
 	// cette entrée, une collecte incomplète de cette ressource ne le dégradait pas.
 	"governance_provider_sovereignty": {"governance_provider"},
+
+	// Les types LOCALISÉS, ceux sur lesquels la souveraineté se mesure. La règle les
+	// énumère dans son ensemble `_located_types` et n'en regarde aucun autre : une
+	// identité ou une règle de filtrage n'héberge rien.
+	//
+	// Sans cette déclaration, le contrôle n'avait AUCUN type — `ControlType` rend ""
+	// pour la gouvernance — et la région d'une ressource quelconque suffisait à le
+	// rendre « conforme ». Mesuré avant correction : un `iam_user` en fr-par certifiait
+	// une VM dont la région n'avait jamais été collectée.
+	"governance_resource_region_in_eu": {
+		"compute_instance",
+		"object_storage_bucket",
+		"blockstorage_volume",
+		"blockstorage_snapshot",
+		"kubernetes_cluster",
+		"load_balancer",
+		"managed_database",
+	},
 }
 
 // ControlTypes rend TOUS les types normalisés qu'un contrôle lit : celui qui décide

--- a/internal/genprovider/controltypes_test.go
+++ b/internal/genprovider/controltypes_test.go
@@ -14,7 +14,41 @@ import (
 var (
 	reReadsType = regexp.MustCompile(`resources_of_type\("([a-z_]+)"\)`)
 	reEmitsCode = regexp.MustCompile(`"code":\s*"([a-z0-9_]+)"`)
+
+	// Une règle peut aussi filtrer sur un ENSEMBLE nommé de types :
+	//
+	//	_located_types := {"compute_instance", "load_balancer"}
+	//	...
+	//	r.type in _located_types
+	//
+	// C'est par là que `governance_resource_region_in_eu` est passé : il lit sept
+	// types, n'en déclarait aucun, et la porte le trouvait conforme parce qu'elle ne
+	// cherchait que des `resources_of_type` littéraux.
+	reTypeSet    = regexp.MustCompile(`(?s)(_[a-z_]+)\s*:=\s*\{([^}]*)\}`)
+	reInTypeSet  = regexp.MustCompile(`\.type\s+in\s+(_[a-z_]+)`)
+	reSetMembers = regexp.MustCompile(`"([a-z_]+)"`)
 )
+
+// typesReadViaSets rend les types qu'une règle lit à travers un ensemble nommé
+// comparé à `.type`. Seuls les ensembles RÉELLEMENT confrontés à `.type` comptent :
+// une règle qui définit un ensemble de protocoles ou de ports ne déclare pas des
+// types de ressource.
+func typesReadViaSets(text string) map[string]bool {
+	used := map[string]bool{}
+	for _, m := range reInTypeSet.FindAllStringSubmatch(text, -1) {
+		used[m[1]] = true
+	}
+	out := map[string]bool{}
+	for _, m := range reTypeSet.FindAllStringSubmatch(text, -1) {
+		if !used[m[1]] {
+			continue
+		}
+		for _, mm := range reSetMembers.FindAllStringSubmatch(m[2], -1) {
+			out[mm[1]] = true
+		}
+	}
+	return out
+}
 
 // TestControlTypesMatchTheRules confronte la table déclarée à ce que les règles
 // LISENT réellement.
@@ -24,10 +58,16 @@ var (
 // lit. Ici la source de vérité reste le Rego : la table le déclare, ce test le
 // vérifie, et la CI casse dans les deux sens.
 //
-// Ce qu'il ne peut PAS voir : un type lu à travers un helper de lib.rego plutôt que
-// par un `resources_of_type` littéral. Aucune règle ne le fait aujourd'hui ; si
-// l'une venait à le faire, ce test la déclarerait conforme à tort. C'est la limite
-// d'une analyse textuelle, et elle est écrite plutôt que tue.
+// Il dérive DEUX formes : `resources_of_type("t")`, et un ensemble nommé de types
+// confronté à `.type`. La seconde a été ajoutée après coup, parce que la première
+// laissait passer exactement le contrôle qui en avait le plus besoin — celui de la
+// souveraineté, qui lit sept types sans jamais écrire `resources_of_type`.
+//
+// Ce qu'il ne peut PAS voir : un type lu à travers un helper de lib.rego. Aucune
+// règle ne le fait aujourd'hui ; si l'une venait à le faire, ce test la déclarerait
+// conforme à tort. C'est la limite d'une analyse textuelle, et elle est écrite
+// plutôt que tue — la version précédente de cette phrase disait la même chose et
+// s'était trompée sur l'étendue du trou, ce qui est l'argument pour la mesurer.
 func TestControlTypesMatchTheRules(t *testing.T) {
 	dir := filepath.Join("..", "commonrules", "rules")
 	entries, err := os.ReadDir(dir)
@@ -50,6 +90,9 @@ func TestControlTypesMatchTheRules(t *testing.T) {
 		read := map[string]bool{}
 		for _, m := range reReadsType.FindAllStringSubmatch(text, -1) {
 			read[m[1]] = true
+		}
+		for ty := range typesReadViaSets(text) {
+			read[ty] = true
 		}
 		if len(read) == 0 {
 			continue


### PR DESCRIPTION
## Ce que l'issue supposait, et ce que la mesure a dit

L'issue soupçonnait un faux `NOT_EVALUATED` : une VM Scaleway en `fr-par` qui
resterait non évaluée au lieu de passer. **Mesuré d'abord, et l'hypothèse était
fausse** — ce chemin rend bien `pass`, et les deux chemins voisins rendent
`not-evaluated` avec la bonne raison. Rien à corriger pour le symptôme décrit.

En revanche sa PRÉMISSE était juste : trois mécanismes se contredisaient sur ce
contrôle. `requiredAttr` le tenait par `region`, `ControlType` rendait `""`, et
`governanceProviderReaders` le déclarait intrinsèquement vérifié. C'est le
dernier qui gagnait, et il était **factuellement faux** : la règle lit la région
de chaque ressource, jamais le descripteur.

## Les deux faux verts que ça cachait

Mesurés sur le binaire, avant correction :

| Inventaire | Verdict avant | Verdict après |
|---|---|---|
| VM `fr-par` + bucket sans région collectée | `pass` | `not-evaluated` |
| `iam_user` en `fr-par` + VM sans région | `pass` | `not-evaluated` |

Le second est le plus net. Une identité n'héberge rien, et la règle l'exclut
explicitement de ses sept types localisés — sa région suffisait pourtant à
certifier une VM dont la localisation n'avait jamais été observée. **Le contrôle
dont la localisation des données EST le sujet concluait depuis une voisine.**

## La cause

Une union qui avait survécu à la réécriture en deux passes. La région est un
champ du modèle et non un attribut, donc elle était enregistrée sous une clé
vide commune que n'importe quelle ressource pouvait remplir. Elle suit désormais
la même **intersection par type** que toute donnée décisive : une région ne
compte comme observée que si chaque ressource du type la porte.

Pour que ça ait un sens, le contrôle doit savoir quels types il juge — il
déclare donc les sept. `TestControlTypesMatchTheRules` confronte déjà une telle
déclaration au Rego, et il était **passé à côté de cette règle** : il dérive les
`resources_of_type("t")` littéraux, et celle-ci filtre sur un ensemble nommé.
Son propre en-tête affirmait qu'aucune règle ne faisait ça. La dérivation couvre
maintenant les deux formes, vérifiée en retirant la déclaration et en la
regardant échouer.

## Mouvement de verdicts

**2 fixtures sur 19**, toutes deux des tenants de corpus ne portant que des VPC,
sous-réseaux et peering. Rien n'y héberge quoi que ce soit, et le contrôle les
déclarait conformes à l'exigence de localisation UE. Il dit maintenant qu'il n'y
a rien à localiser — la réponse honnête, et celle que l'ADR-0006 demande.

La ligne de preuve suit : « aucune non-conformité détectée (contrat vérifié) »
ne disait rien de ce qui avait été regardé, et c'était la phrase imprimée sous
le faux vert. Un `pass` nomme désormais les types dont la donnée décisive a été
observée sur chaque ressource ; un `not-evaluated` nomme le type où elle manque.

## Portes

`mise run prepush` au vert (validate, test, audit, adr-drift, secrets, falsify).
`mise run gen-docs` régénère `assessment-model.{md,fr.md}` : le message
transverse rejoint le message typé des autres, une forme de moins.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)
