### PR TITLE
feat(assessment): provenance attests that a field was sought, and that can conclude

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -74,6 +74,32 @@ l'une ni l'autre appartient au `git log`.
 
 ### Modifié
 
+- **La souveraineté se mesure désormais sur les ressources qui hébergent des données,
+  et sur elles seules.** Le contrôle de localisation UE concluait depuis une *voisine* :
+  une seule ressource portant une région ouvrait le `pass` à toutes les autres, y
+  compris à des types que la règle n'examine jamais — un `iam_user` en `fr-par`
+  certifiait une VM dont la région n'avait jamais été collectée. Une région ne compte
+  comme observée que si chaque ressource du type la porte. **Verdict déplacé sur un
+  tenant inchangé** : un tenant sans ressource localisée (réseaux, sous-réseaux,
+  peering) passe de `pass` à `not-evaluated`, et un tenant partiellement localisé
+  aussi.
+- **Une jointure rompue ne se lit plus comme un écart.** La donnée décisive se déclare
+  par type de ressource, si bien qu'un contrôle corrélant deux types se dégrade quand
+  le *lien* manque, au lieu de conclure sans lui. `volume_id` non collecté sur les
+  snapshots faisait paraître tous les volumes sans sauvegarde — un faux positif de
+  masse, en `high`, causé par une lacune de collecte. **Verdict déplacé sur un tenant
+  inchangé** : ces écarts deviennent `not-evaluated` en nommant le champ manquant. Un
+  volume réellement sans snapshot, et un tenant sans aucune snapshot, échouent
+  toujours.
+- **Un écart déduit d'une absence que personne n'a cherchée est retiré.** Certaines
+  règles concluent d'une absence, et elles ont raison — chez Scaleway un `ExpiresAt`
+  nul *est* « aucune expiration ». Mais un champ non mappé est absent lui aussi, et les
+  deux étaient indiscernables : `iam_accesskey_expiration_set` levait un `critical`
+  dans les deux cas. L'assessment lit désormais la provenance, qui consigne ce qui a
+  été **cherché**, et retire l'écart quand le champ n'a jamais été demandé
+  ([ADR-0017](docs/adr/0017-provenance-atteste-une-recherche.md)). **Verdict déplacé
+  sur un tenant inchangé**, dans un seul sens : une affirmation est retirée, jamais
+  ajoutée. Un inventaire sans provenance — export d'un tiers — n'est pas touché.
 - **La dette de véracité passe de 445 à 395 verdicts restant à prouver**, et les chemins
   entièrement prouvés de 5 à 23 sur 178. Les tenants de référence et les scénarios
   écrits à la main alimentent **un seul** registre : deux chiffres de couverture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,30 @@ belongs in `git log`.
 
 ### Changed
 
+- **Sovereignty is now measured on the resources that host data, and only those.** The
+  EU-location control asserted compliance from a *neighbour*: one resource carrying a
+  region opened a `pass` for every other, including types the rule never examines — an
+  `iam_user` in `fr-par` certified a VM whose own region had never been collected. A
+  region now counts as observed only when every resource of that type carries one.
+  **Verdict change on an unchanged tenant**: a tenant holding no located resource (only
+  networks, subnets, peerings) moves from `pass` to `not-evaluated`, and one whose
+  located resources are partly unlocated does too.
+- **A broken join no longer reads as a deviation.** Deciding data is declared per
+  resource type, so a control that correlates two types degrades when the *link* is
+  missing rather than concluding without it. `volume_id` uncollected on snapshots made
+  every volume look unbacked — a mass false positive, `high` severity, caused by a
+  collection gap. **Verdict change on an unchanged tenant**: those become
+  `not-evaluated` naming the missing field. A volume genuinely without a snapshot, and
+  a tenant with no snapshot at all, still fail.
+- **A deviation inferred from an absence nobody sought is withdrawn.** Some rules
+  conclude from an absence and are right to — on Scaleway a nil `ExpiresAt` *is* "no
+  expiry". But an unmapped field is absent too, and the two were indistinguishable, so
+  `iam_accesskey_expiration_set` raised a `critical` either way. The assessment now
+  reads provenance, which records what was **sought**, and withdraws the deviation when
+  the field was never asked for ([ADR-0017](docs/adr/0017-provenance-atteste-une-recherche.md)).
+  **Verdict change on an unchanged tenant**, one way only: an assertion is withdrawn,
+  never added. An inventory carrying no provenance — a third-party export — is
+  untouched.
 - **The veracity debt drops from 445 to 395 verdicts left to prove**, and fully proven
   paths go from 5 to 23 out of 178. The reference tenants and the hand-written
   scenarios feed **one** ledger: two coverage figures would diverge, and the one that

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -179,6 +179,12 @@ var scanCmd = &cobra.Command{
 		// La provenance des attributs décisifs, en PASSE POSTÉRIEURE : elle enrichit la
 		// preuve (d'où vient la donnée, a-t-elle été observée) et ne touche aucun statut.
 		asmt = assess.WithProvenance(asmt, assess.ProvenanceOf(input), controlTypes())
+		// L'absence ATTESTÉE, en passe postérieure elle aussi (ADR-0017). Elle ne
+		// retire qu'un écart né d'une absence que personne n'a cherchée : un
+		// `critical` déduit d'un champ non mappé n'est pas un écart, c'est une lacune
+		// de collecte. Elle n'en crée jamais, et laisse intact un inventaire sans
+		// provenance.
+		asmt = assess.WithAttestedAbsence(asmt, assess.ProvenanceOf(input))
 		// L'incomplétude de la collecte, en passe postérieure elle aussi, et
 		// STRICTEMENT directionnelle : elle ne produit qu'une transition,
 		// `pass → not-evaluated`, et remplace la raison d'un « non évalué » par la

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -230,6 +230,11 @@ func reDeriveInEitherLanguage(name string, findings []finding.Finding, input any
 		got := assess.Build(name, referentiel.All(), f, resourceTypesOf(input),
 			naReasons, providerVerified(name), controlTypes(), attrsByTypeOf(input), run)
 		got = assess.WithProvenance(got, assess.ProvenanceOf(input), controlTypes())
+		// La requalification d'une absence non attestée se REJOUE, pour la raison
+		// exacte de la dégradation ci-dessous : elle déplace des verdicts (ADR-0017),
+		// donc l'oublier reconstruirait un assessment plus affirmatif que celui qui a
+		// été scellé, et crierait à la falsification sur un bundle honnête.
+		got = assess.WithAttestedAbsence(got, assess.ProvenanceOf(input))
 		// La dégradation par incomplétude de collecte se REJOUE elle aussi : l'état de
 		// collecte voyage dans input.json précisément pour cela. Sans ce rejeu, le
 		// vérificateur reconstruirait un assessment PLUS AFFIRMATIF que celui qui a été

--- a/docs/adr/0007-provenance-index-parallele.md
+++ b/docs/adr/0007-provenance-index-parallele.md
@@ -55,12 +55,17 @@ l'écart devient *détectable*, ce qui est tout l'objet.
 
 ## Invariants
 
-- La provenance ne modifie jamais un statut.
+- ~~La provenance ne modifie jamais un statut.~~ **RÉVISÉ par l'ADR-0017.** Cet
+  invariant était déjà contredit par le verrou de capacité, qui traite un attribut
+  cherché et non exposé comme une observation. L'ADR-0017 le remplace par : *la
+  provenance ne modifie jamais un statut depuis une RÈGLE ; seul l'assessment la
+  lit, pour distinguer une absence attestée d'une absence jamais cherchée.* Le
+  reste du présent ADR est inchangé.
 - Une source `api` nomme un appel réellement servi.
 - Une origine absente n'est jamais fabriquée.
 
-*Gardes : `TestProvenanceNeverMovesAVerdict`,
-`TestProvenanceNamesTheCallThatActuallyHappened`.*
+*Gardes : `TestProvenanceNeverMovesAVerdict` (passe d'annotation seule, cf.
+ADR-0017), `TestProvenanceNamesTheCallThatActuallyHappened`.*
 
 ## Validation
 

--- a/docs/adr/0017-provenance-atteste-une-recherche.md
+++ b/docs/adr/0017-provenance-atteste-une-recherche.md
@@ -1,0 +1,141 @@
+# ADR-0017 — La provenance atteste qu'un champ a été CHERCHÉ, et cette attestation peut faire conclure
+
+```yaml
+status: Accepted
+date: 2026-09-08
+scope:
+  - assessment
+  - model
+```
+
+## Contexte
+
+L'ADR-0007 a posé la provenance comme index parallèle et lui a donné trois
+invariants, dont le premier : **« La provenance ne modifie jamais un statut. »**
+
+Cet invariant est **déjà faux**, et il l'est depuis la construction en deux passes
+de la carte des attributs collectés. Mesuré sur deux inventaires qui ne diffèrent
+que par une entrée de provenance :
+
+| `user_data` absent des `attributes` de la seconde VM… | Verdict |
+|---|---|
+| …mais **présent en provenance** (cherché, non exposé) | `pass` |
+| …et **absent de la provenance** (jamais cherché) | `not-evaluated` |
+
+La garde censée protéger l'invariant, `TestProvenanceNeverMovesAVerdict`, ne l'a
+pas vu : elle éprouve la passe d'ANNOTATION (`WithProvenance`), qui n'écrit que
+`evidence`, et non le verrou de capacité, qui décide.
+
+Ce n'est pas un accident à corriger. C'est la seule donnée du modèle qui porte une
+distinction dont les verdicts ont besoin :
+
+| Situation | Ce que la règle voit | Ce que ça vaut |
+|---|---|---|
+| Le pointeur était nul : aucune expiration définie | attribut absent | une **observation** |
+| L'endpoint n'a pas été appelé, ou le champ n'est pas mappé | attribut absent | une **lacune** |
+
+La première doit produire un écart ; la seconde ne le doit pas (ADR-0014). Sans la
+provenance, elles sont indiscernables, et `iam_accesskey_expiration_set` émettait
+un `critical` dans les deux cas — un écart fabriqué depuis un champ jamais cherché.
+
+## Décision
+
+**La provenance atteste qu'un champ a été CHERCHÉ.** Cette attestation est une
+observation à part entière, et l'**assessment** a le droit d'en conclure.
+
+L'invariant 1 de l'ADR-0007 est **révisé** et remplacé par :
+
+> La provenance ne modifie jamais un statut **depuis une règle**. Seul
+> l'assessment la lit, et il ne s'en sert que pour distinguer une absence
+> ATTESTÉE (cherchée, non exposée) d'une absence NON ATTESTÉE (jamais cherchée).
+
+Trois bornes, qui font que cette lecture n'est pas une porte ouverte :
+
+1. **Aucune règle ne lit la provenance.** L'entrée des règles reste identique
+   octet pour octet, ce qui était la raison d'être de l'index parallèle.
+2. **Une absence de provenance ne conclut jamais seule.** Un inventaire reçu d'un
+   tiers n'en porte aucune ; il ne doit donc rien perdre. La dégradation n'a lieu
+   que si la ressource porte une provenance pour d'AUTRES attributs — c'est ce qui
+   prouve que Pépin l'a collectée et savait quoi y chercher.
+3. **Le sens de la conclusion est borné.** L'attestation ne peut que RETIRER une
+   affirmation (un `fail` devient `not-evaluated`, un `pass` reste soumis au
+   verrou). Elle ne crée jamais un écart, et ne transforme jamais un
+   `not-evaluated` en `pass` sur sa seule foi.
+
+Le reste de l'ADR-0007 est **conservé, non remplacé** : index parallèle plutôt
+qu'enveloppe, source `api` nommant l'appel réellement servi, origine jamais
+fabriquée.
+
+## Justification
+
+La distinction est déjà dans le modèle, déjà scellée dans le bundle, et déjà
+documentée par l'ADR-0007 lui-même :
+
+> Une clé peut y exister sans que l'attribut soit dans `attributes` : c'est un
+> champ **cherché et non exposé** par la source.
+
+Refuser de s'en servir ne préserverait pas l'invariant — il est déjà contredit —
+mais laisserait un `critical` se déclencher sur un champ que personne n'a demandé.
+Entre un invariant qui décrit mal le code et un faux positif `critical`, c'est
+l'invariant qui doit bouger, et il doit bouger **par écrit**.
+
+La séparation des deux passes porte la décision dans le code : `WithProvenance`
+annote et ne décide pas ; `WithAttestedAbsence` décide et n'annote pas. Une
+fonction dont le nom dit qu'elle déplace un verdict est plus honnête qu'un
+invariant qui affirme le contraire de ce que fait le programme.
+
+## Alternatives écartées
+
+**Faire lire la provenance aux règles.** Rejeté, pour la raison exacte de
+l'ADR-0007 : cinquante-neuf règles à réécrire, et une règle réécrite est une règle
+qui peut changer de verdict. La distinction se traite là où les verdicts se
+statuent déjà (ADR-0006, ADR-0015), pas dans la logique métier.
+
+**Retirer le secours par provenance pour restaurer l'invariant.** Rejeté : le cas
+mesuré (`user_data` cherché sur cinq VM, exposé sur trois) redeviendrait
+`not-evaluated` alors qu'il n'y a rien à déclarer. On perdrait une conclusion juste
+pour sauver une phrase.
+
+**Remplacer entièrement l'ADR-0007.** Rejeté : deux de ses trois invariants et
+toute sa décision structurelle restent vrais. Les réécrire dans un nouvel ADR
+créerait deux textes à maintenir sur la même décision, ce que ce registre existe
+pour éviter. La révision est donc PARTIELLE et nommée comme telle — l'ADR-0007
+garde son statut `Accepted` et porte un renvoi sur l'invariant révisé.
+
+**Exiger la présence de l'attribut (`requiredAttr`) pour ce contrôle.** Rejeté :
+cela rendrait `iam_accesskey_expiration_set` aveugle au cas même qu'il existe pour
+voir, puisque chez Scaleway l'absence EST l'expiration non définie
+(`ExpiresAt *time.Time`, contrat `access_key`, `etat: verifie`).
+
+## Conséquences
+
+Un écart né d'une absence non attestée devient `not-evaluated` et dit pourquoi.
+C'est un verdict de moins, et c'est voulu : il valait un `critical` inventé.
+
+Un inventaire sans aucune provenance — export d'un tiers — ne change pas de
+comportement. C'est la borne 2, et elle est mesurée plutôt que supposée.
+
+Un collecteur qui cesse de mapper un champ ne produit plus une vague d'écarts
+`critical` : il produit des `not-evaluated` qui nomment le champ manquant. La
+panne devient lisible au lieu d'être bruyante.
+
+## Invariants
+
+- Aucune règle ne lit la provenance.
+- L'attestation ne crée jamais un écart ; elle ne peut qu'en retirer un.
+- Une ressource sans aucune provenance ne subit aucune dégradation.
+- `WithProvenance` n'écrit que `evidence`, et ne déplace aucun statut.
+
+*Gardes : `TestProvenanceNeverMovesAVerdict` (passe d'annotation),
+`TestNoRuleReadsProvenance`, `TestAttestedAbsenceOnlyRemovesFindings`,
+`TestInventoryWithoutProvenanceIsUntouched`.*
+
+## Validation
+
+Comparaison des verdicts avant/après sur toutes les fixtures du dépôt, et les deux
+cas construits de l'issue #121 — l'absence attestée reste un écart, l'absence non
+attestée devient `not-evaluated`.
+
+## Liens
+
+ADR-0006, ADR-0007 (invariant 1 révisé ici), ADR-0014, ADR-0015 · issue #121.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -88,13 +88,13 @@ Avant d'implémenter, établir si A, B et C ont cessé d'être vraies.
 |---|---|
 | Architecture des règles, providers | [0001](0001-regles-communes-providers-collecteurs.md) |
 | Moteur, findings, rendu, scoring | [0002](0002-moteur-partage-scankit.md) |
-| Modèle de données, inventaire | [0003](0003-inventaire-contrat-gele.md), [0007](0007-provenance-index-parallele.md) |
+| Modèle de données, inventaire | [0003](0003-inventaire-contrat-gele.md), [0007](0007-provenance-index-parallele.md), [0017](0017-provenance-atteste-une-recherche.md) |
 | Référentiel, frameworks normatifs | [0004](0004-index-scsl-gele.md), [0009](0009-configuration-lie-mapping.md) |
 | Codes de sortie, portes de CI | [0005](0005-codes-de-sortie.md), [0008](0008-derogation-nest-pas-conformite.md) |
-| Assessment, verdicts, dégradation | [0006](0006-jamais-un-pass-non-prouve.md), [0014](0014-jamais-fabriquer-une-donnee-absente.md) |
+| Assessment, verdicts, dégradation | [0006](0006-jamais-un-pass-non-prouve.md), [0014](0014-jamais-fabriquer-une-donnee-absente.md), [0015](0015-une-regle-qui-ne-peut-conclure-le-dit.md), [0017](0017-provenance-atteste-une-recherche.md) |
 | Tests, preuve, véracité | [0010](0010-dette-de-veracite-comptee.md) |
 | Langue, documentation | [0011](0011-bilinguisme-francais-normatif.md) |
-| Sécurité de la mesure, identifiants | [0012](0012-aucun-identifiant-en-ci.md) |
+| Sécurité de la mesure, identifiants | [0012](0012-aucun-identifiant-en-ci.md), [0016](0016-chaine-dapprovisionnement-verifiable.md) |
 | Compatibilité des consommateurs | [0013](0013-un-code-de-controle-ne-se-renomme-pas.md) |
 
 Chaque ADR porte aussi un `scope:` en tête, pour que cette identification soit

--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -323,6 +323,26 @@ L'une des trois : le contrat ne confirme pas la collecte de la donnée ; aucune 
 visé n'est dans le périmètre ; ou l'attribut décisif n'a pas été collecté. Le résultat dit
 toujours laquelle.
 
+Deux cas de plus le produisent, non pas faute d'avoir conclu, mais parce que la conclusion
+atteinte n'était adossée à rien :
+
+- **La corrélation est rompue.** Un contrôle qui relie deux types perd sa conclusion quand le
+  lien n'a pas été collecté. `blockstorage_volume_snapshots_exist` rapproche les volumes de
+  leurs snapshots par `volume_id` : sans ce champ, aucune snapshot n'est attribuable, et
+  *tous* les volumes paraîtraient sans sauvegarde. L'écart n'est alors pas observé, il est
+  produit par la lacune.
+- **L'absence n'est pas attestée.** Certaines règles concluent d'une absence, et elles ont
+  raison : chez Scaleway, `ExpiresAt` est un pointeur, et un pointeur nul *est* la façon dont
+  l'API dit « aucune expiration ». Mais un champ jamais demandé au collecteur est absent lui
+  aussi. La [provenance](../adr/0007-provenance-index-parallele.md) sépare les deux — elle
+  indexe ce qui a été **cherché**, même non exposé — et un écart déduit d'une absence que
+  personne n'a cherchée devient `not-evaluated`
+  ([ADR-0017](../adr/0017-provenance-atteste-une-recherche.md)).
+
+Ces deux requalifications ne vont que dans un sens : elles retirent une affirmation, jamais
+elles n'en ajoutent. Un inventaire dépourvu de provenance — un export reçu d'un tiers — n'est
+pas touché : Pépin ne l'a pas collecté, il n'a donc rien à en attester.
+
 <!-- pepin:gen assessment-ne -->
 ```json
 {

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -322,6 +322,24 @@ Not a deviation, and not a compliance either. It is a documented absence of subj
 Any of: the contract does not confirm the data is collected; no resource of the target type is
 in scope; or the deciding attribute was not collected. The result always says which.
 
+Two further cases produce it — not for want of reaching a conclusion, but because the
+conclusion reached rested on nothing:
+
+- **The correlation is broken.** A control that relates two types loses its conclusion when
+  the link was not collected. `blockstorage_volume_snapshots_exist` matches volumes to their
+  snapshots through `volume_id`: without that field no snapshot can be attributed, and *every*
+  volume would look unbacked. The deviation is then not observed, it is produced by the gap.
+- **The absence is not attested.** Some rules conclude from an absence, and rightly so: on
+  Scaleway, `ExpiresAt` is a pointer, and a nil pointer *is* how the API says "no expiry". But
+  a field never asked of the collector is absent too. [Provenance](../adr/0007-provenance-index-parallele.md)
+  separates the two — it indexes what was **sought**, even when not exposed — and a deviation
+  inferred from an absence nobody sought becomes `not-evaluated`
+  ([ADR-0017](../adr/0017-provenance-atteste-une-recherche.md)).
+
+Both reclassifications run one way only: they withdraw an assertion, never add one. An
+inventory carrying no provenance — an export received from a third party — is left untouched:
+Pépin did not collect it, so it has nothing to attest about it.
+
 <!-- pepin:gen assessment-ne -->
 ```json
 {

--- a/internal/assess/attested_absence.go
+++ b/internal/assess/attested_absence.go
@@ -1,0 +1,157 @@
+package assess
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/stephrobert/pepin/internal/genprovider"
+	"github.com/stephrobert/pepin/internal/i18n"
+	"github.com/stephrobert/scankit/assessment"
+)
+
+// Distinguer « cherché et non exposé » de « jamais cherché » (ADR-0017, issue #121).
+//
+// Certaines règles concluent depuis une ABSENCE, et elles ont raison de le faire :
+// chez Scaleway, `ExpiresAt` est un `*time.Time` et un pointeur nul EST la façon dont
+// l'API dit « aucune expiration ». Exiger la présence du champ rendrait
+// `iam_accesskey_expiration_set` aveugle au cas même qu'il existe pour voir.
+//
+// Mais pour la règle, deux situations sont indiscernables :
+//
+//	le pointeur était nul        -> attribut absent -> une OBSERVATION, l'écart est réel
+//	le champ n'est pas mappé     -> attribut absent -> une LACUNE, l'écart est inventé
+//
+// La provenance porte cette distinction, et elle seule : une clé qui y figure sans
+// figurer dans `attributes` est un champ CHERCHÉ et non exposé par la source
+// (ADR-0007). Mesuré avant correction : les deux cas sortaient `fail`, dont un
+// `critical` fabriqué depuis un champ que personne n'avait demandé — exactement ce
+// que l'ADR-0014 interdit.
+//
+// La lecture se fait ICI, dans l'assessment, et jamais dans une règle : c'était la
+// raison d'être de l'index parallèle, et elle tient toujours.
+
+// absenceMustBeAttested — les contrôles dont l'ÉCART NAÎT D'UNE ABSENCE, avec le
+// type qui porte le champ et le champ lui-même.
+//
+// La table est courte à dessein. Un contrôle n'y entre que si sa règle conclut
+// VRAIMENT depuis l'absence d'un attribut : c'est une propriété du Rego, pas une
+// préférence, et TestAbsenceDecidersReallyReadAnAbsence la confronte aux règles.
+//
+// Elle est distincte de `requiredAttr`, et ne peut pas fusionner avec elle : cette
+// dernière exige la PRÉSENCE d'un attribut pour conclure, celle-ci décrit un contrôle
+// qui conclut de son ABSENCE. Inscrire un contrôle dans les deux le rendrait muet.
+var absenceMustBeAttested = map[string]map[string][]string{
+	"iam_accesskey_expiration_set": {"access_key": {"expiration_date"}},
+}
+
+// AbsenceDeciders expose la table pour les gardes et la documentation générée.
+func AbsenceDeciders() map[string]map[string][]string {
+	out := make(map[string]map[string][]string, len(absenceMustBeAttested))
+	for code, parType := range absenceMustBeAttested {
+		m := map[string][]string{}
+		for t, attrs := range parType {
+			m[t] = append([]string(nil), attrs...)
+		}
+		out[code] = m
+	}
+	return out
+}
+
+// WithAttestedAbsence requalifie en `not-evaluated` tout écart né d'une absence que
+// la provenance n'atteste pas.
+//
+// C'est la passe qui DÉCIDE, par opposition à `WithProvenance` qui ANNOTE. Les deux
+// sont séparées et nommées pour ce qu'elles font : une fonction dont le nom dit
+// qu'elle déplace un verdict est plus honnête qu'un invariant qui affirme le
+// contraire de ce que fait le programme (ADR-0017).
+//
+// Trois bornes, et ce sont elles qui rendent la lecture sûre :
+//
+//   - elle ne CRÉE jamais un écart, elle ne peut qu'en retirer un ;
+//   - une ressource sans AUCUNE provenance n'est pas touchée — un inventaire reçu
+//     d'un tiers n'a pas été collecté par Pépin, qui n'a donc rien à en attester,
+//     ni dans un sens ni dans l'autre ;
+//   - seuls les contrôles déclarés dans `absenceMustBeAttested` sont concernés.
+func WithAttestedAbsence(a assessment.Assessment, idx ProvenanceIndex) assessment.Assessment {
+	if len(idx) == 0 {
+		return a
+	}
+	res := append([]assessment.Result(nil), a.Results...)
+	for i := range res {
+		if res[i].Status != assessment.Fail {
+			continue // on ne retire que des écarts, jamais on n'en ajoute
+		}
+		parType, decide := absenceMustBeAttested[res[i].Control]
+		if !decide {
+			continue
+		}
+		motif, nonAtteste := unattestedAbsence(parType, idx)
+		if !nonAtteste {
+			continue
+		}
+		res[i].Status = assessment.NotEvaluated
+		res[i].Evidence.Observed = motif
+	}
+	a.Results = res
+	return a
+}
+
+// unattestedAbsence dit si le champ dont dépend l'écart n'a JAMAIS été cherché, et
+// pourquoi on peut l'affirmer.
+//
+// La condition « le type porte une provenance pour d'autres attributs » est le cœur
+// du mécanisme : c'est elle qui prouve que Pépin a collecté ce type et savait quoi y
+// chercher. Sans elle, un export sans provenance ferait disparaître tous ces écarts,
+// ce qui remplacerait un faux positif par un faux vert.
+func unattestedAbsence(parType map[string][]string, idx ProvenanceIndex) (string, bool) {
+	types := make([]string, 0, len(parType))
+	for t := range parType {
+		types = append(types, t)
+	}
+	sort.Strings(types) // ordre stable : ce motif part dans un rapport opposable
+
+	var jamaisCherches []string
+	for _, t := range types {
+		byAttr := idx[t]
+		if len(byAttr) == 0 {
+			continue // ce type n'a aucune attestation : on ne conclut rien
+		}
+		attrs := append([]string(nil), parType[t]...)
+		sort.Strings(attrs)
+		for _, attr := range attrs {
+			if _, cherche := byAttr[attr]; cherche {
+				continue // le champ a été cherché : l'absence EST l'observation
+			}
+			jamaisCherches = append(jamaisCherches, fmt.Sprintf(i18n.T(
+				"« %s » sur les ressources de type « %s »",
+				"\"%s\" on the resources of type \"%s\""), attr, t))
+		}
+	}
+	if len(jamaisCherches) == 0 {
+		return "", false
+	}
+	return fmt.Sprintf(i18n.T(
+		"écart déduit d'une absence NON attestée : %s n'a jamais été cherché par le collecteur — "+
+			"l'absence ne vaut donc pas observation, et l'écart ne peut être affirmé",
+		"deviation inferred from an UNATTESTED absence: %s was never sought by the collector — "+
+			"the absence is therefore not an observation, and the deviation cannot be asserted"),
+		strings.Join(jamaisCherches, ", ")), true
+}
+
+// absenceDeciderTypesAreKnown : les types déclarés doivent être ceux que le contrôle
+// lit réellement. Exposé pour la garde, qui vit dans le paquet de test.
+func absenceDeciderTypesAreKnown(code string, parType map[string][]string) []string {
+	lus := map[string]bool{}
+	for _, t := range genprovider.ControlTypes(code) {
+		lus[t] = true
+	}
+	var inconnus []string
+	for t := range parType {
+		if !lus[t] {
+			inconnus = append(inconnus, t)
+		}
+	}
+	sort.Strings(inconnus)
+	return inconnus
+}

--- a/internal/assess/attested_absence_test.go
+++ b/internal/assess/attested_absence_test.go
@@ -1,0 +1,208 @@
+package assess
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/scankit/assessment"
+)
+
+// prov construit un index de provenance minimal : type -> attributs CHERCHÉS.
+func prov(typ string, attrs ...string) ProvenanceIndex {
+	byAttr := map[string]AttrOrigin{}
+	for _, a := range attrs {
+		byAttr[a] = AttrOrigin{Sources: []string{"api:ListAPIKeys"}, Total: 1}
+	}
+	return ProvenanceIndex{typ: byAttr}
+}
+
+func resultats() assessment.Assessment {
+	return assessment.Assessment{Results: []assessment.Result{
+		{Control: "iam_accesskey_expiration_set", Status: assessment.Fail, Subject: "SCW123"},
+	}}
+}
+
+// TestAttestedAbsenceDistinguishesSoughtFromNeverSought est le cœur de l'issue #121.
+//
+// Les deux situations sont indiscernables pour une règle ; la provenance les sépare,
+// et l'assessment en conclut (ADR-0017).
+func TestAttestedAbsenceDistinguishesSoughtFromNeverSought(t *testing.T) {
+	cas := []struct {
+		nom  string
+		idx  ProvenanceIndex
+		veut assessment.Status
+	}{
+		{
+			// Le champ a été demandé, la source ne l'expose pas : chez Scaleway
+			// `ExpiresAt` est un *time.Time et un nil signifie « aucune expiration ».
+			// L'absence EST l'observation, et l'écart est réel.
+			nom:  "cherché et non exposé : l'écart reste",
+			idx:  prov("access_key", "access_key_id", "expiration_date"),
+			veut: assessment.Fail,
+		},
+		{
+			// Le type a bien été collecté — d'autres attributs sont attestés — mais
+			// celui-ci n'a jamais été cherché. L'écart était déduit de rien.
+			nom:  "jamais cherché, alors que le type est attesté : l'écart tombe",
+			idx:  prov("access_key", "access_key_id"),
+			veut: assessment.NotEvaluated,
+		},
+		{
+			// Aucune attestation sur ce type : Pépin n'a pas collecté cet inventaire,
+			// il l'a reçu. Il n'a donc rien à en dire, ni dans un sens ni dans l'autre.
+			nom:  "aucune attestation sur le type : inchangé",
+			idx:  prov("autre_type", "champ"),
+			veut: assessment.Fail,
+		},
+	}
+
+	for _, c := range cas {
+		t.Run(c.nom, func(t *testing.T) {
+			got := WithAttestedAbsence(resultats(), c.idx)
+			if got.Results[0].Status != c.veut {
+				t.Fatalf("statut %q, attendu %q", got.Results[0].Status, c.veut)
+			}
+			if c.veut == assessment.NotEvaluated && got.Results[0].Evidence.Observed == "" {
+				t.Error("un « non évalué » muet n'est pas opposable : il doit nommer le champ jamais cherché")
+			}
+		})
+	}
+}
+
+// TestInventoryWithoutProvenanceIsUntouched — invariant 3 de l'ADR-0017.
+//
+// Un inventaire reçu d'un tiers ne porte aucune provenance. Dégrader sur cette base
+// remplacerait un faux positif par un faux vert, ce qui serait strictement pire.
+func TestInventoryWithoutProvenanceIsUntouched(t *testing.T) {
+	before := resultats()
+	after := WithAttestedAbsence(before, ProvenanceIndex{})
+	if after.Results[0].Status != before.Results[0].Status {
+		t.Errorf("statut %q → %q sans aucune provenance : une absence d'attestation ne conclut rien",
+			before.Results[0].Status, after.Results[0].Status)
+	}
+}
+
+// TestAttestedAbsenceOnlyRemovesFindings — invariant 2 de l'ADR-0017.
+//
+// L'attestation ne peut que RETIRER une affirmation. Créer un écart, ou transformer
+// un « non évalué » en « conforme » sur la seule foi d'une provenance, serait une
+// porte ouverte que cet ADR n'accorde pas.
+func TestAttestedAbsenceOnlyRemovesFindings(t *testing.T) {
+	// `exempted` est le cinquième statut, propre à Pépin (internal/exempt) : il est
+	// écrit en clair ici pour ne pas faire dépendre le paquet assess du paquet exempt.
+	depart := []assessment.Status{
+		assessment.Pass, assessment.NotEvaluated, assessment.NotApplicable,
+		assessment.Error, assessment.Status("exempted"),
+	}
+	for _, st := range depart {
+		a := assessment.Assessment{Results: []assessment.Result{
+			{Control: "iam_accesskey_expiration_set", Status: st, Subject: "SCW123"},
+		}}
+		// L'index le plus « dégradant » possible : le type est attesté, le champ non.
+		got := WithAttestedAbsence(a, prov("access_key", "access_key_id"))
+		if got.Results[0].Status != st {
+			t.Errorf("statut %q → %q : la passe a touché autre chose qu'un écart", st, got.Results[0].Status)
+		}
+	}
+}
+
+// TestAbsenceDecidersReallyReadAnAbsence confronte la table aux règles.
+//
+// Un contrôle n'a sa place dans `absenceMustBeAttested` que si sa règle conclut
+// VRAIMENT depuis l'absence d'un attribut — la forme `object.get(…, "attr", "") == ""`
+// ou son équivalent. Sans cette garde, la table deviendrait une liste d'intentions,
+// et un contrôle y resterait après que sa règle a changé de forme.
+func TestAbsenceDecidersReallyReadAnAbsence(t *testing.T) {
+	dir := filepath.Join("..", "commonrules", "rules")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Skipf("règles indisponibles : %v", err)
+	}
+	byCode := map[string]string{}
+	for _, e := range entries {
+		n := e.Name()
+		if !strings.HasSuffix(n, ".rego") || strings.HasSuffix(n, "_test.rego") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, n)) //nolint:gosec // chemin du dépôt
+		if err != nil {
+			t.Fatalf("lecture de %s : %v", n, err)
+		}
+		byCode[strings.TrimSuffix(n, ".rego")] = string(b)
+	}
+
+	for code, parType := range absenceMustBeAttested {
+		src, ok := byCode[code]
+		if !ok {
+			t.Errorf("%q est déclaré comme concluant depuis une absence, mais aucune règle ne porte ce nom", code)
+			continue
+		}
+		// Un contrôle ne peut pas à la fois EXIGER un attribut et conclure de son
+		// absence : les deux tables ensemble le rendraient muet.
+		if _, exige := requiredAttr[code]; exige {
+			t.Errorf("%q figure dans requiredAttr ET dans absenceMustBeAttested.\n"+
+				"  Le verrou exigerait la présence de l'attribut, tandis que la règle conclut\n"+
+				"  de son absence : le contrôle ne pourrait plus rien dire.", code)
+		}
+		if inconnus := absenceDeciderTypesAreKnown(code, parType); len(inconnus) > 0 {
+			t.Errorf("%q déclare le(s) type(s) %v que ce contrôle ne lit pas", code, inconnus)
+		}
+		for _, attrs := range parType {
+			for _, attr := range attrs {
+				if !strings.Contains(src, `"`+attr+`"`) {
+					t.Errorf("%q : l'attribut %q n'apparaît pas dans sa règle — la table décrit une règle qui n'existe plus",
+						code, attr)
+					continue
+				}
+				// La règle doit COMPARER cet attribut à un vide, sinon elle ne conclut
+				// pas d'une absence et n'a rien à faire dans cette table.
+				if !strings.Contains(src, `"`+attr+`", "") == ""`) &&
+					!strings.Contains(src, `object.get(k.attributes, "`+attr+`", "")`) {
+					t.Errorf("%q : la règle ne semble pas conclure de l'ABSENCE de %q.\n"+
+						"  Cette table ne vaut que pour les règles dont l'écart naît d'un champ vide ou absent.",
+						code, attr)
+				}
+			}
+		}
+	}
+}
+
+// TestNoRuleReadsProvenance — invariant 1 de l'ADR-0017, et la borne qui rend la
+// révision de l'ADR-0007 acceptable.
+//
+// L'index parallèle existe pour que l'entrée des règles reste identique octet pour
+// octet : une règle réécrite est une règle qui peut changer de verdict. La provenance
+// se lit dans l'assessment, jamais dans le Rego. Cette garde le vérifie plutôt que de
+// l'espérer — c'est précisément parce que l'invariant précédent n'était gardé qu'à
+// moitié qu'il a pu devenir faux sans que personne ne le voie.
+func TestNoRuleReadsProvenance(t *testing.T) {
+	dir := filepath.Join("..", "commonrules", "rules")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Skipf("règles indisponibles : %v", err)
+	}
+	var lues int
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".rego") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, e.Name())) //nolint:gosec // chemin du dépôt
+		if err != nil {
+			t.Fatalf("lecture de %s : %v", e.Name(), err)
+		}
+		lues++
+		if strings.Contains(string(b), "provenance") {
+			t.Errorf("%s lit `provenance`.\n"+
+				"  L'ADR-0007 a choisi un index PARALLÈLE pour que l'entrée des règles ne bouge\n"+
+				"  pas, et l'ADR-0017 n'a levé cette borne pour personne : la distinction\n"+
+				"  « cherché » / « jamais cherché » se traite dans l'assessment, où les verdicts\n"+
+				"  se statuent déjà.", e.Name())
+		}
+	}
+	if lues == 0 {
+		t.Fatal("aucune règle lue : la garde ne mesure rien")
+	}
+	t.Logf("%d fichier(s) de règles vérifié(s)", lues)
+}

--- a/internal/commonrules/ablation_test.go
+++ b/internal/commonrules/ablation_test.go
@@ -57,11 +57,16 @@ var ablationExceptions = map[string]string{
 	// dit « aucune expiration ». Ici, l'absence de l'attribut EST l'observation, et
 	// exiger sa présence rendrait le contrôle aveugle au cas qu'il existe pour voir.
 	//
-	// La limite subsiste et elle est réelle : l'absence conflate « pointeur nul
-	// observé » et « attribut jamais collecté ». Les distinguer demande de lire la
-	// PROVENANCE, qui indexe les attributs CHERCHÉS même non exposés (ADR-0007) —
-	// une règle n'y a pas accès aujourd'hui. Suivi en #121.
-	"iam_accesskey_expiration_set\x00expiration_date": "contrat Scaleway : ExpiresAt est un *time.Time, un nil signifie « aucune expiration »",
+	// Cette exception RESTE, mais elle ne consigne plus d'ambiguïté : #121 a tranché.
+	// La limite était réelle — au niveau de la RÈGLE, l'absence conflate « pointeur nul
+	// observé » et « attribut jamais collecté » —, et elle reste vraie ici, parce que
+	// cette porte mesure la règle seule. Ce qui a changé est un cran plus haut :
+	// l'assessment lit désormais la PROVENANCE, qui indexe les attributs CHERCHÉS même
+	// non exposés (ADR-0007), et requalifie en `not-evaluated` un écart déduit d'une
+	// absence que personne n'a cherchée (ADR-0017, WithAttestedAbsence). La règle
+	// continue donc de se déclencher, et c'est l'assessment qui sait s'il faut la
+	// croire.
+	"iam_accesskey_expiration_set\x00expiration_date": "contrat Scaleway : ExpiresAt est un *time.Time, un nil signifie « aucune expiration » ; l'absence non attestée est requalifiée par l'assessment (#121, ADR-0017)",
 
 	// Une snapshot sans `volume_id` n'est attribuable à AUCUN volume : le lien est
 	// ce qui la fait compter. Son absence n'est donc pas un repli défavorable mais

--- a/internal/commonrules/synthetic_ablation_test.go
+++ b/internal/commonrules/synthetic_ablation_test.go
@@ -154,9 +154,14 @@ func findingCodes(t *testing.T, ctx context.Context, inv map[string]any) map[str
 var syntheticExceptions = map[string]string{
 	// Scaleway expose ExpiresAt comme un *time.Time (providers/scaleway.yaml,
 	// contrat access_key, etat: verifie). Un nil EST la façon dont l'API dit
-	// « aucune expiration » : l'absence est ici l'observation. Ambiguïté restante
-	// suivie en #121.
-	"iam_accesskey_expiration_set\x00expiration_date": "contrat Scaleway : ExpiresAt est un *time.Time, un nil signifie « aucune expiration »",
+	// « aucune expiration » : l'absence est ici l'observation.
+	//
+	// L'ambiguïté que cette ligne signalait est tranchée (#121) : l'assessment lit la
+	// provenance et requalifie un écart déduit d'une absence JAMAIS cherchée
+	// (ADR-0017). L'exception subsiste parce que cette porte-ci n'éprouve que la
+	// règle, qui n'a pas accès à la provenance — et n'y aura pas accès, c'est
+	// l'invariant 1 de l'ADR-0017.
+	"iam_accesskey_expiration_set\x00expiration_date": "contrat Scaleway : ExpiresAt est un *time.Time, un nil signifie « aucune expiration » ; l'absence non attestée est requalifiée par l'assessment (#121, ADR-0017)",
 
 	// `editable` absent ⇒ le rôle est traité comme éditable, donc DANS le périmètre.
 	// Le repli inverse exclurait silencieusement tout rôle dont le fournisseur


### PR DESCRIPTION
## Le défaut

Certaines règles concluent depuis une **absence**, et elles ont raison : chez
Scaleway `ExpiresAt` est un `*time.Time`, et un pointeur nul EST la façon dont
l'API dit « aucune expiration ». Exiger la présence du champ rendrait
`iam_accesskey_expiration_set` aveugle au cas même qu'il existe pour voir.

Mais un champ **non mappé** est absent lui aussi, et les deux étaient
indiscernables. Mesuré sur le binaire, deux inventaires ne différant que par une
entrée de provenance :

| `expiration_date` | Avant | Après |
|---|---|---|
| **cherché**, non exposé (pointeur nil) | `fail` | `fail` |
| **jamais cherché** (non mappé) | `fail` | `not-evaluated` |
| aucune provenance (export d'un tiers) | `fail` | `fail` |

Le second était un `critical` déduit d'un champ que personne n'avait demandé —
ce que l'ADR-0014 interdit.

## Ce que la revue ADR a trouvé, et que l'issue n'anticipait pas

L'**ADR-0007** pose comme premier invariant : *« La provenance ne modifie jamais
un statut. »*

**Cet invariant était déjà faux sur `main`.** Le verrou de capacité en deux
passes traite un attribut cherché-et-non-exposé comme une observation, ce qui
déplace un verdict entre `pass` et `not-evaluated` — mesuré. Sa garde ne l'avait
pas vu : `TestProvenanceNeverMovesAVerdict` n'éprouve que la passe d'annotation
`WithProvenance`, qui écrit `evidence` et ne décide rien.

Cette PR n'ouvre donc pas une porte : elle **constate qu'elle est ouverte** et la
borne. J'ai posé la question avant d'implémenter, et la voie retenue est l'ADR de
révision.

## ADR-0017

Révision **partielle et délibérée** : seul l'invariant 1 est remplacé. L'index
parallèle et les deux autres invariants sont intacts — remplacer tout l'ADR aurait
imposé de maintenir deux textes pour une seule décision, ce que ce registre existe
pour éviter. L'ADR-0007 garde son statut `Accepted` et porte le renvoi sur
l'invariant révisé.

**Trois bornes, chacune avec son test :**

1. **Aucune règle ne lit la provenance** — `TestNoRuleReadsProvenance` vérifie
   désormais ce qui n'était qu'une intention. C'est ce qui rend la révision
   acceptable : l'entrée des règles ne bouge pas d'un octet.
2. **La passe ne retire jamais qu'une affirmation**, jamais elle n'en ajoute —
   `TestAttestedAbsenceOnlyRemovesFindings` éprouve les cinq statuts.
3. **Une ressource sans aucune provenance n'est pas touchée** — dégrader là
   échangerait un faux positif contre un faux vert.

`WithProvenance` annote et ne décide pas ; `WithAttestedAbsence` décide et
n'annote pas. Une fonction dont le nom dit qu'elle déplace un verdict est plus
honnête qu'un invariant qui affirme le contraire de ce que fait le programme.

## Rejeu par `verify`

Les deux passes sont rejouées par `verify --re-derive`, pour la raison que ce
fichier documente déjà : une passe qui déplace des verdicts et qu'on ne rejoue
pas reconstruirait un assessment plus affirmatif que celui qui a été scellé, et
crierait à la falsification sur un bundle honnête.

## Mouvement de verdicts

**0 sur les 19 fixtures** : aucune ne porte de clé d'accès avec provenance, ce
qui est précisément pourquoi les cas ont été construits.

## Au passage

La table de portée du registre listait **14 ADR sur 17**. C'est le mécanisme sur
lequel s'appuie l'étape 2 du contrat de revue pour trouver les décisions
applicables, et elle avait cessé d'en couvrir trois — dont 0015, 0016 et celui-ci.
Les trois sont ajoutés.

## Portes

`mise run prepush` au vert, `adr-drift` : 17 ADR contrôlés, rien à signaler.
CHANGELOG dans les deux langues (verdict déplacé sur un tenant inchangé), page du
modèle d'assessment mise à jour FR + EN.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)
