### PR TITLE
fix(cmd): the version prints one v, the doc links resolve, an n/a explains itself

### DIFF
--- a/cmd/docurl_test.go
+++ b/cmd/docurl_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/pepin/referentiel"
+)
+
+// Chaque finding imprime un lien de documentation, et ce lien ne servait aucune page :
+// la racine concaténée à plat (`…/scsl/CLD-NET-1`) renvoyait le lecteur à l'accueil du
+// site. Le référentiel est publié par FAMILLE, chaque exigence y étant une ancre.
+//
+// Cette garde vaut pour la suite : elle refuse une famille d'exigences ajoutée au
+// référentiel sans sa page. Elle ne demande aucun réseau — elle ne peut donc pas
+// prouver qu'une page RÉPOND, seulement qu'aucun code n'est laissé sans destination,
+// ce qui est exactement le défaut qu'elle existe pour empêcher.
+// famillesSansPage — les familles d'exigences dont la page publiée n'est pas connue.
+// Chacune coûte un lien de documentation absent sur tous ses contrôles ; aucune ne
+// coûte un lien FAUX, ce qui est la seule propriété qu'on refuse de perdre.
+//
+// La table de l'issue #138 en listait huit ; l'index SCSL gelé en porte neuf. La
+// neuvième a été trouvée par cette garde même, à sa première exécution — c'est
+// l'argument pour la dériver du référentiel plutôt que de la recopier.
+var famillesSansPage = map[string]string{
+	"K8S": "12 exigences à l'index gelé, absentes de la table de #138 ; slug de la page à confirmer",
+}
+
+func TestEverySCSLFamilyHasItsDocPage(t *testing.T) {
+	var verifies int
+	for code, ctl := range referentiel.All() {
+		for _, id := range ctl.Scsl {
+			verifies++
+			if url := scslDocURL(id); url != "" {
+				continue
+			}
+			parts := strings.Split(id, "-")
+			famille := id
+			if len(parts) == 3 {
+				famille = parts[1]
+			}
+			if _, connue := famillesSansPage[famille]; connue {
+				continue
+			}
+			t.Errorf("contrôle %q : l'exigence %q ne produit aucun lien (famille %q inconnue).\n"+
+				"  Ses findings s'imprimeraient sans documentation. Ajouter la page de cette\n"+
+				"  famille à scslFamilyPage, ou consigner la lacune dans famillesSansPage.",
+				code, id, famille)
+		}
+	}
+	if verifies == 0 {
+		t.Fatal("aucune exigence vérifiée : la garde ne mesure rien")
+	}
+	t.Logf("%d exigence(s) SCSL vérifiée(s), %d famille(s) sans page connue", verifies, len(famillesSansPage))
+}
+
+// Une lacune CONSIGNÉE doit rester réelle : une famille qui gagne sa page et reste
+// inscrite ici masquerait la suivante. Le registre est une porte dans les deux sens,
+// comme celui de la dette de véracité.
+func TestNoStaleGapInTheDocPageRegistry(t *testing.T) {
+	for famille := range famillesSansPage {
+		if _, a := scslFamilyPage[famille]; a {
+			t.Errorf("famille %q : consignée comme sans page, alors que scslFamilyPage en déclare une. "+
+				"Retirer l'entrée de famillesSansPage.", famille)
+		}
+	}
+}
+
+// Un lien FAUX coûte plus cher que pas de lien : il est suivi, et celui qui le suit
+// croit avoir lu la bonne page. Ce qui n'est pas une exigence SCSL n'en produit donc
+// aucun — notamment le code de check agnostique, qui n'a pas de page publiée.
+func TestNoDocLinkIsInventedForANonSCSLCode(t *testing.T) {
+	for _, code := range []string{
+		"objectstorage_bucket_public_access", // check agnostique
+		"CLD-XXX-1",                          // famille inconnue
+		"CLD-NET",                            // tronqué
+		"SCSL-CLD-NET-1",                     // forme préfixée, non dépréfixée
+		"",
+	} {
+		if url := scslDocURL(code); url != "" {
+			t.Errorf("code %q : lien inventé %q", code, url)
+		}
+	}
+}
+
+// Le lien construit doit être exactement celui que la publication sert : page de la
+// famille, puis ancre en minuscules.
+func TestDocLinkShape(t *testing.T) {
+	got := scslDocURL("CLD-NET-1")
+	want := "https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/" +
+		"exposition-filtrage-reseau/#socle-cld-net-1"
+	if got != want {
+		t.Errorf("lien construit :\n  %s\nattendu :\n  %s", got, want)
+	}
+}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -1000,7 +1000,7 @@ func buildRun(provider string, rtypes map[string]bool) assessment.Run {
 	}
 	sort.Strings(included)
 	return assessment.Run{
-		Tool:      assessment.Component{Name: "pepin", Version: version, Digest: binaryDigest()},
+		Tool:      assessment.Component{Name: "pepin", Version: bareVersion(), Digest: binaryDigest()},
 		Ruleset:   assessment.Component{Name: "pepin-config", Digest: configDigest()},
 		Target:    assessment.Target{ID: targetID(provider), Provider: provider, Region: scanRegion, Platform: provider},
 		Timestamp: scanTimestamp,
@@ -1179,14 +1179,53 @@ func hasGovernanceResource(resources any) bool {
 	return false
 }
 
-// scslDocBase est la racine de la doc SCSL ; on y concatène l'id de l'exigence
-// SCSL (CLD-*) du contrôle pour pointer sa page (explication + remédiation).
-const scslDocBase = "https://stephane-robert.info/scsl/"
+// scslDocBase est la racine de la doc SCSL publiée.
+//
+// Le référentiel n'est PAS publié à raison d'une page par exigence : il est découpé
+// par FAMILLE, et chaque exigence y est une ancre (`#socle-<code en minuscules>`),
+// posée par le composant `Exigences`. La concaténation à plat qui précédait —
+// `…/scsl/CLD-NET-1` — ne servait aucune page, et chaque finding imprimait donc un
+// lien qui renvoyait le lecteur à la racine du site.
+const scslDocBase = "https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/"
+
+// scslFamilyPage associe le préfixe de famille d'une exigence à sa page publiée.
+// `mise run validate` ne peut pas vérifier une URL distante ; c'est
+// TestEverySCSLFamilyHasItsDocPage qui refuse une famille sans page, à partir de
+// l'index SCSL gelé lui-même.
+var scslFamilyPage = map[string]string{
+	"GEN": "index",
+	"IAM": "iam-acces-cloud",
+	"NET": "exposition-filtrage-reseau",
+	"STO": "stockage-donnees",
+	"CHF": "chiffrement-cles",
+	"CMP": "compute-instances",
+	"LOG": "journalisation-audit",
+	"GVN": "gouvernance-inventaire-cloud",
+}
+
+// scslDocURL construit l'URL publiée d'une exigence telle que `CLD-NET-1`.
+//
+// Une famille inconnue, ou un code qui n'est pas une exigence SCSL, ne rend AUCUN
+// lien. C'est délibéré et c'est le même raisonnement que celui appliqué au
+// `not-evaluated` : un lien faux coûte plus cher que pas de lien du tout, parce
+// qu'il est suivi, et que celui qui le suit croit avoir lu la bonne page.
+func scslDocURL(code string) string {
+	parts := strings.Split(code, "-") // CLD-NET-1
+	if len(parts) != 3 || parts[0] != "CLD" {
+		return ""
+	}
+	page, ok := scslFamilyPage[parts[1]]
+	if !ok {
+		return ""
+	}
+	return scslDocBase + page + "/#socle-" + strings.ToLower(code)
+}
 
 // docURL pointe la page SCSL du finding. Après enrichissement, `code` est l'id
-// SCSL (CLD-*) ; sinon le check agnostique sert de repli.
+// SCSL (CLD-*) ; le check agnostique, lui, n'a pas de page publiée et ne rend donc
+// pas de lien.
 func docURL(f finding.Finding) string {
-	return scslDocBase + f.Code
+	return scslDocURL(f.Code)
 }
 
 // verdictHeadline dérive le bandeau de verdict de l'ASSESSMENT, pas des seuls findings :
@@ -1291,14 +1330,16 @@ func scanReportOptions(provName, path string) screport.Options {
 	}
 	return screport.Options{
 		ToolName: "pepin",
-		Version:  version,
-		Mode:     mode,
-		Source:   path,
-		Banner:   pepinBanner(),
-		Tagline:  tr("scanner de posture cloud (sécurité · conformité)", "cloud posture scanner (security · compliance)"),
-		Brand:    lipgloss.Color("#C792EA"),
-		TierOf:   func(f finding.Finding) string { return f.Label("provider") },
-		DocURL:   docURL,
+		// Le rendu partagé ajoute lui-même son « v » : lui passer une chaîne déjà
+		// préfixée imprimait « vv0.3.0… » sur chaque scan.
+		Version: bareVersion(),
+		Mode:    mode,
+		Source:  path,
+		Banner:  pepinBanner(),
+		Tagline: tr("scanner de posture cloud (sécurité · conformité)", "cloud posture scanner (security · compliance)"),
+		Brand:   lipgloss.Color("#C792EA"),
+		TierOf:  func(f finding.Finding) string { return f.Label("provider") },
+		DocURL:  docURL,
 	}
 }
 

--- a/cmd/testdata/lang/scan-fr.stdout
+++ b/cmd/testdata/lang/scan-fr.stdout
@@ -27,7 +27,7 @@
   Remediation
     Rendre le bucket privé (ACL private, retrait du grant AllUsers, suppression de la policy publique) ; servir via des URLs pré-signées si nécessaire.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-STO-1
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/stockage-donnees/#socle-cld-sto-1
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-CHF-2  ·  scaleway
@@ -41,7 +41,7 @@
   Remediation
     Activer le chiffrement au repos de l'instance (à la création ou par mise à niveau).
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-CHF-2
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/chiffrement-cles/#socle-cld-chf-2
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-CMP-9  ·  scaleway
@@ -55,7 +55,7 @@
   Remediation
     Bannir les secrets des données utilisateur ; utiliser un coffre de secrets et l'injection au démarrage. Révoquer le secret exposé.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-CMP-9
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/compute-instances/#socle-cld-cmp-9
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-IAM-12  ·  scaleway
@@ -69,7 +69,7 @@
   Remediation
     Réserver la gestion IAM à une politique d'administration dédiée ; retirer le PermissionSet de gestion des politiques d'usage.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-IAM-12
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/iam-acces-cloud/#socle-cld-iam-12
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-NET-1  ·  scaleway
@@ -84,7 +84,7 @@
   Remediation
     Restreindre l'ACL de la base aux seuls CIDR applicatifs (réseau privé quand disponible) ; retirer 0.0.0.0/0.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-NET-1
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/exposition-filtrage-reseau/#socle-cld-net-1
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-NET-2  ·  scaleway
@@ -98,7 +98,7 @@
   Remediation
     Basculer la politique entrante par défaut sur « drop » et n'ouvrir que les flux légitimes par des règles explicites.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-NET-2
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/exposition-filtrage-reseau/#socle-cld-net-2
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-STO-3  ·  scaleway
@@ -112,7 +112,7 @@
   Remediation
     Réactiver les sauvegardes automatiques et fixer une rétention adaptée au RPO.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-STO-3
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/stockage-donnees/#socle-cld-sto-3
 
 ──────────────────────────────────────────────────────────────────────────────
  MEDIUM  ·  CLD-GVN-1  ·  scaleway
@@ -126,7 +126,7 @@
   Remediation
     Ajouter les étiquettes obligatoires (CostCenter, Project, Env, Owner) sur la ressource.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-GVN-1
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/gouvernance-inventaire-cloud/#socle-cld-gvn-1
 
 ──────────────────────────────────────────────────────────────────────────────
  LOW  ·  CLD-STO-8  ·  scaleway
@@ -140,7 +140,7 @@
   Remediation
     Activer l'Object Lock (mode conformité/gouvernance) sur les buckets de sauvegarde et d'objets critiques.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-STO-8
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/stockage-donnees/#socle-cld-sto-8
 
   Controls
   ╭────────────┬──────────────────────────────────────────────────┬──────────┬──────────┬───╮

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,12 +2,28 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 // version est surchargée au build via -ldflags.
+//
+// Sa forme n'est PAS stable d'un build à l'autre : le repli ci-dessous est nu, tandis
+// que `git describe` rend une chaîne préfixée (`v0.3.0-18-g25888fc`). Ses trois
+// lecteurs supposaient chacun une forme différente, et deux d'entre eux se
+// contredisaient — le bandeau ajoutait un « v » à une chaîne qui en portait déjà un,
+// d'où le `vv0.3.0…` imprimé à chaque scan. On ne lit donc plus cette variable
+// directement : `bareVersion` et `displayVersion` en donnent les deux seules formes.
 var version = "0.1.0-dev"
+
+// bareVersion rend la version SANS préfixe : c'est la forme des surfaces parsables
+// (`tool.version` d'un assessment, d'un bundle, d'un OSCAL) et celle qu'on passe à un
+// rendu qui ajoute lui-même son « v ».
+func bareVersion() string { return strings.TrimPrefix(version, "v") }
+
+// displayVersion rend la version telle qu'on la MONTRE, avec un « v » et un seul.
+func displayVersion() string { return "v" + bareVersion() }
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
@@ -15,6 +31,6 @@ var versionCmd = &cobra.Command{
 	Run: func(_ *cobra.Command, _ []string) {
 		// L'accent tombe en anglais : `pepin version` est la sortie la plus
 		// susceptible d'être coupée, collée et comparée par un script.
-		_, _ = fmt.Println(tr("pépin ", "pepin ") + version)
+		_, _ = fmt.Println(tr("pépin ", "pepin ") + displayVersion())
 	},
 }

--- a/cmd/version_render_test.go
+++ b/cmd/version_render_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// La version est injectée au build par `git describe`, qui rend `v0.3.0-18-g25888fc`,
+// alors que le repli codé en dur est nu (`0.1.0-dev`). Ses lecteurs supposaient chacun
+// une forme, et deux d'entre eux se contredisaient : le bandeau ajoutait un « v » à une
+// chaîne qui en portait déjà un, imprimant `vv0.3.0-18-g25888fc` sur CHAQUE scan — dans
+// le GIF de démonstration comme dans toute capture d'écran de la documentation.
+//
+// Ces deux tests éprouvent les deux formes canoniques sur les deux formes d'entrée, ce
+// qui est le seul moyen de ne pas refaire le même pari.
+func TestVersionRendersExactlyOnePrefix(t *testing.T) {
+	original := version
+	t.Cleanup(func() { version = original })
+
+	for _, entree := range []string{"0.3.0", "v0.3.0", "0.1.0-dev", "v0.3.0-18-g25888fc"} {
+		version = entree
+
+		if got := displayVersion(); !strings.HasPrefix(got, "v") || strings.HasPrefix(got, "vv") {
+			t.Errorf("version %q : affichée %q — il en faut un « v », et un seul", entree, got)
+		}
+		if got := bareVersion(); strings.HasPrefix(got, "v") {
+			t.Errorf("version %q : forme nue %q — les surfaces parsables ne portent pas le préfixe",
+				entree, got)
+		}
+		// Le rendu partagé ajoute son propre « v » à ce qu'on lui passe : c'est la
+		// composition exacte qui produisait le défaut.
+		if got := "v" + bareVersion(); strings.HasPrefix(got, "vv") {
+			t.Errorf("version %q : le bandeau imprimerait %q", entree, got)
+		}
+	}
+}
+
+// Les deux formes doivent rester cohérentes entre elles, quelle que soit l'entrée :
+// `displayVersion` est exactement `bareVersion` précédée d'un « v ». Sans cette
+// vérification, corriger l'une et oublier l'autre reproduirait le désaccord d'origine.
+func TestVersionFormsAgreeWithEachOther(t *testing.T) {
+	original := version
+	t.Cleanup(func() { version = original })
+
+	for _, entree := range []string{"0.3.0", "v0.3.0", "", "v"} {
+		version = entree
+		if displayVersion() != "v"+bareVersion() {
+			t.Errorf("version %q : affichée %q, nue %q — les deux formes divergent",
+				entree, displayVersion(), bareVersion())
+		}
+	}
+}

--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -284,6 +284,15 @@ rejeté par n'importe quel auditeur, l'outil refuse donc d'en produire.
 ```json
 {
   "control": "blockstorage_volume_encryption",
+  "evidence": {
+    "observed": "Chiffrement au repos des volumes block côté invité (LUKS/Cryptsetup), responsabilité du client (responsabilité partagée) ; l'API block n'expose aucun champ de chiffrement → non observable côté plateforme (CHF-2).",
+    "proves": [
+      "",
+      "",
+      ""
+    ],
+    "source": "terraform-plan"
+  },
   "references": [
     {
       "framework": "scsl",

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -284,6 +284,15 @@ rejected by any auditor, so the tool refuses to produce one.
 ```json
 {
   "control": "blockstorage_volume_encryption",
+  "evidence": {
+    "observed": "Encryption at rest of block volumes is guest-side (LUKS/Cryptsetup), a customer responsibility (shared responsibility model); the block API exposes no encryption field, hence unobservable on the platform side (CHF-2).",
+    "proves": [
+      "",
+      "",
+      ""
+    ],
+    "source": "terraform-plan"
+  },
   "references": [
     {
       "framework": "scsl",

--- a/docs/getting-started/quickstart.fr.md
+++ b/docs/getting-started/quickstart.fr.md
@@ -147,7 +147,7 @@ Son bloc, extrait du run ci-dessus :
   Remediation
     Activer le chiffrement au repos de l'instance (à la création ou par mise à niveau).
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-CHF-2
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/chiffrement-cles/#socle-cld-chf-2
 ```
 <!-- /pepin:gen scan-control-encryption -->
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -144,7 +144,7 @@ lifted from the run above:
   Remediation
     Enable encryption at rest on the instance (at creation time, or through an upgrade).
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-CHF-2
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/chiffrement-cles/#socle-cld-chf-2
 ```
 <!-- /pepin:gen scan-control-encryption -->
 

--- a/docs/getting-started/understanding-a-scan.fr.md
+++ b/docs/getting-started/understanding-a-scan.fr.md
@@ -77,7 +77,7 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
   Remediation
     Rendre le bucket privé (ACL private, retrait du grant AllUsers, suppression de la policy publique) ; servir via des URLs pré-signées si nécessaire.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-STO-1
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/stockage-donnees/#socle-cld-sto-1
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-CHF-2  ·  scaleway
@@ -91,7 +91,7 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
   Remediation
     Activer le chiffrement au repos de l'instance (à la création ou par mise à niveau).
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-CHF-2
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/chiffrement-cles/#socle-cld-chf-2
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-CMP-9  ·  scaleway
@@ -105,7 +105,7 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
   Remediation
     Bannir les secrets des données utilisateur ; utiliser un coffre de secrets et l'injection au démarrage. Révoquer le secret exposé.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-CMP-9
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/compute-instances/#socle-cld-cmp-9
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-IAM-12  ·  scaleway
@@ -119,7 +119,7 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
   Remediation
     Réserver la gestion IAM à une politique d'administration dédiée ; retirer le PermissionSet de gestion des politiques d'usage.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-IAM-12
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/iam-acces-cloud/#socle-cld-iam-12
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-NET-1  ·  scaleway
@@ -134,7 +134,7 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
   Remediation
     Restreindre l'ACL de la base aux seuls CIDR applicatifs (réseau privé quand disponible) ; retirer 0.0.0.0/0.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-NET-1
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/exposition-filtrage-reseau/#socle-cld-net-1
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-NET-2  ·  scaleway
@@ -148,7 +148,7 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
   Remediation
     Basculer la politique entrante par défaut sur « drop » et n'ouvrir que les flux légitimes par des règles explicites.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-NET-2
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/exposition-filtrage-reseau/#socle-cld-net-2
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-STO-3  ·  scaleway
@@ -162,7 +162,7 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
   Remediation
     Réactiver les sauvegardes automatiques et fixer une rétention adaptée au RPO.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-STO-3
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/stockage-donnees/#socle-cld-sto-3
 
 ──────────────────────────────────────────────────────────────────────────────
  MEDIUM  ·  CLD-GVN-1  ·  scaleway
@@ -176,7 +176,7 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
   Remediation
     Ajouter les étiquettes obligatoires (CostCenter, Project, Env, Owner) sur la ressource.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-GVN-1
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/gouvernance-inventaire-cloud/#socle-cld-gvn-1
 
 ──────────────────────────────────────────────────────────────────────────────
  LOW  ·  CLD-STO-8  ·  scaleway
@@ -190,7 +190,7 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
   Remediation
     Activer l'Object Lock (mode conformité/gouvernance) sur les buckets de sauvegarde et d'objets critiques.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-STO-8
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/stockage-donnees/#socle-cld-sto-8
 
   Controls
   ╭────────────┬──────────────────────────────────────────────────┬──────────┬──────────┬───╮
@@ -261,7 +261,7 @@ premier écran d'un long rapport soit déjà actionnable.
   Remediation
     Rendre le bucket privé (ACL private, retrait du grant AllUsers, suppression de la policy publique) ; servir via des URLs pré-signées si nécessaire.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-STO-1
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/stockage-donnees/#socle-cld-sto-1
 ```
 <!-- /pepin:gen scan-control-objectstore -->
 
@@ -499,6 +499,15 @@ mot.
 ```json
 {
   "control": "blockstorage_volume_encryption",
+  "evidence": {
+    "observed": "Chiffrement au repos des volumes block côté invité (LUKS/Cryptsetup), responsabilité du client (responsabilité partagée) ; l'API block n'expose aucun champ de chiffrement → non observable côté plateforme (CHF-2).",
+    "proves": [
+      "",
+      "",
+      ""
+    ],
+    "source": "terraform-plan"
+  },
   "references": [
     {
       "framework": "scsl",

--- a/docs/getting-started/understanding-a-scan.md
+++ b/docs/getting-started/understanding-a-scan.md
@@ -78,7 +78,7 @@ large tenant, you want to know the tool started. The closing line is
   Remediation
     Make the bucket private (private ACL, remove the AllUsers grant, delete the public policy); serve through pre-signed URLs if needed.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-STO-1
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/stockage-donnees/#socle-cld-sto-1
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-CHF-2  ·  scaleway
@@ -92,7 +92,7 @@ large tenant, you want to know the tool started. The closing line is
   Remediation
     Enable encryption at rest on the instance (at creation time, or through an upgrade).
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-CHF-2
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/chiffrement-cles/#socle-cld-chf-2
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-CMP-9  ·  scaleway
@@ -106,7 +106,7 @@ large tenant, you want to know the tool started. The closing line is
   Remediation
     Ban secrets from user data; use a secrets vault and inject them at boot. Revoke the exposed secret.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-CMP-9
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/compute-instances/#socle-cld-cmp-9
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-IAM-12  ·  scaleway
@@ -120,7 +120,7 @@ large tenant, you want to know the tool started. The closing line is
   Remediation
     Reserve IAM management for a dedicated administration policy; remove the management PermissionSet from everyday policies.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-IAM-12
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/iam-acces-cloud/#socle-cld-iam-12
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-NET-1  ·  scaleway
@@ -135,7 +135,7 @@ large tenant, you want to know the tool started. The closing line is
   Remediation
     Restrict the database ACL to the application CIDRs only (a private network where one is available); remove 0.0.0.0/0.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-NET-1
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/exposition-filtrage-reseau/#socle-cld-net-1
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-NET-2  ·  scaleway
@@ -149,7 +149,7 @@ large tenant, you want to know the tool started. The closing line is
   Remediation
     Switch the default inbound policy to "drop" and open only the legitimate flows through explicit rules.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-NET-2
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/exposition-filtrage-reseau/#socle-cld-net-2
 
 ──────────────────────────────────────────────────────────────────────────────
  HIGH  ·  CLD-STO-3  ·  scaleway
@@ -163,7 +163,7 @@ large tenant, you want to know the tool started. The closing line is
   Remediation
     Re-enable automatic backups and set a retention that matches the RPO.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-STO-3
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/stockage-donnees/#socle-cld-sto-3
 
 ──────────────────────────────────────────────────────────────────────────────
  MEDIUM  ·  CLD-GVN-1  ·  scaleway
@@ -177,7 +177,7 @@ large tenant, you want to know the tool started. The closing line is
   Remediation
     Add the mandatory tags (CostCenter, Project, Env, Owner) to the resource.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-GVN-1
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/gouvernance-inventaire-cloud/#socle-cld-gvn-1
 
 ──────────────────────────────────────────────────────────────────────────────
  LOW  ·  CLD-STO-8  ·  scaleway
@@ -191,7 +191,7 @@ large tenant, you want to know the tool started. The closing line is
   Remediation
     Enable Object Lock (compliance or governance mode) on backup buckets and critical objects.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-STO-8
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/stockage-donnees/#socle-cld-sto-8
 
   Controls
   ╭────────────┬──────────────────────────────────────────────────┬──────────┬──────────┬───╮
@@ -261,7 +261,7 @@ screen of a long report is already actionable.
   Remediation
     Make the bucket private (private ACL, remove the AllUsers grant, delete the public policy); serve through pre-signed URLs if needed.
 
-  ↳ docs: https://stephane-robert.info/scsl/CLD-STO-1
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/stockage-donnees/#socle-cld-sto-1
 ```
 <!-- /pepin:gen scan-control-objectstore -->
 
@@ -496,6 +496,15 @@ documented in
 ```json
 {
   "control": "blockstorage_volume_encryption",
+  "evidence": {
+    "observed": "Encryption at rest of block volumes is guest-side (LUKS/Cryptsetup), a customer responsibility (shared responsibility model); the block API exposes no encryption field, hence unobservable on the platform side (CHF-2).",
+    "proves": [
+      "",
+      "",
+      ""
+    ],
+    "source": "terraform-plan"
+  },
   "references": [
     {
       "framework": "scsl",

--- a/internal/assess/assess.go
+++ b/internal/assess/assess.go
@@ -435,6 +435,13 @@ func Build(provider string, controls map[string]referentiel.Control, findings []
 			// Contract-declared not-applicable, with its justification — the auditor gold.
 			res.Status = assessment.NotApplicable
 			res.Waiver = &assessment.Waiver{Justification: naReasons[code]}
+			// La justification est AUSSI portée par `evidence.observed`. Elle était déjà
+			// là, dans `waiver`, mais `not-applicable` était le seul statut dont
+			// `evidence` restait nul : un lecteur qui parcourt les preuves d'un rapport
+			// trouvait une explication partout sauf ici, et devait savoir qu'un autre
+			// champ existait. Rien n'est retiré, rien ne bouge : la même phrase est
+			// lisible là où toutes les autres le sont.
+			res.Evidence = assessment.Evidence{Observed: naReasons[code], Source: run.Source}
 		case contains(c.Fournisseurs, provider):
 			// Implemented for this provider. Pass is asserted ONLY when the contract confirms
 			// the needed data is collected (verified) AND a resource of that service is present.

--- a/internal/docgen/blocks.go
+++ b/internal/docgen/blocks.go
@@ -309,12 +309,17 @@ func captureAll(root, bin, lang string) (captures, error) {
 	// Les documents PARSABLES, eux, portent la version nue (`"version": "0.2.0"`) : la
 	// forme citée y est donc celle du champ JSON, sans quoi la page de formats divergerait
 	// à chaque build.
-	if version != "" {
+	// Les DEUX formes se dérivent d'une seule, nue. Elles étaient auparavant supposées :
+	// ce code ajoutait un « v » à ce que `pepin version` imprime, tandis que le bandeau
+	// en ajoutait un de son côté — les deux chemins se contredisaient, et c'est ce
+	// désaccord qui imprimait « vv0.3.0… » sur chaque scan.
+	nue := strings.TrimPrefix(version, "v")
+	if nue != "" {
 		for _, capt := range c.all() {
-			capt.Stdout = strings.ReplaceAll(capt.Stdout, "v"+version, "v"+versionPlaceholder)
-			capt.Stderr = strings.ReplaceAll(capt.Stderr, "v"+version, "v"+versionPlaceholder)
-			capt.Stdout = strings.ReplaceAll(capt.Stdout, `"`+version+`"`, `"`+versionPlaceholder+`"`)
-			capt.Stderr = strings.ReplaceAll(capt.Stderr, `"`+version+`"`, `"`+versionPlaceholder+`"`)
+			capt.Stdout = strings.ReplaceAll(capt.Stdout, "v"+nue, "v"+versionPlaceholder)
+			capt.Stderr = strings.ReplaceAll(capt.Stderr, "v"+nue, "v"+versionPlaceholder)
+			capt.Stdout = strings.ReplaceAll(capt.Stdout, `"`+nue+`"`, `"`+versionPlaceholder+`"`)
+			capt.Stderr = strings.ReplaceAll(capt.Stderr, `"`+nue+`"`, `"`+versionPlaceholder+`"`)
 		}
 	}
 	return c, nil

--- a/internal/docgen/bundle.go
+++ b/internal/docgen/bundle.go
@@ -190,8 +190,13 @@ func captureBundle(r Runner, tmp, version string) (bundleCaptures, error) {
 func normalizeBundleText(s, tmp, version string) string {
 	s = strings.ReplaceAll(s, tmp+string(os.PathSeparator), "")
 	s = strings.ReplaceAll(s, tmp, "")
-	if version != "" {
-		s = strings.ReplaceAll(s, `"`+version+`"`, `"<version>"`)
+	// Le manifest porte la version NUE (`"version": "0.3.0"`), comme toute surface
+	// parsable ; `version` arrive ici telle que `pepin version` l'imprime, donc
+	// préfixée. Comparer les deux sans dépréfixer laissait passer la version réelle
+	// dans une page générée, qui divergeait alors à chaque build. C'était le troisième
+	// endroit où ces deux formes se contredisaient.
+	if nue := strings.TrimPrefix(version, "v"); nue != "" {
+		s = strings.ReplaceAll(s, `"`+nue+`"`, `"<version>"`)
 	}
 	s = vcsDigest.ReplaceAllString(s, "<provenance>")
 	s = sha64.ReplaceAllString(s, "<sha256>")


### PR DESCRIPTION
Trois défauts trouvés en rédigeant la documentation, chacun visible à chaque scan.

## #140 — le `v` doublé, et sa vraie cause

Le bandeau imprimait `vv0.3.0-18-g25888fc`. La cause n'était pas le bandeau :
`version` n'a pas de forme stable. Son repli codé en dur est nu, `git describe`
en injecte une préfixée, et ses lecteurs supposaient chacun une forme différente.

**Trois endroits se contredisaient, pas les deux que l'issue avait trouvés.** Le
troisième — la neutralisation du manifest de bundle — laissait passer une version
de build réelle dans une page générée, qui divergeait donc à chaque build.

`bareVersion()` et `displayVersion()` sont désormais les deux seules formes,
éprouvées sur les deux formes d'entrée (`0.3.0` et `v0.3.0`).

## #138 — des liens qui ne servaient aucune page

Le référentiel est publié **par famille**, chaque exigence étant une ancre — pas
une page par contrôle. Une famille inconnue ne rend maintenant **aucun** lien :
un lien faux coûte plus cher que pas de lien, parce qu'il est suivi, et que celui
qui le suit croit avoir lu la bonne page.

**La garde a trouvé une neuvième famille à sa première exécution.** La table de
l'issue en listait huit ; l'index SCSL gelé porte `CLD-K8S` avec 12 exigences,
utilisées par 8 contrôles Pépin. Son slug publié est inconnu ici et n'a **pas pu
être vérifié** — le CDN répond 403 depuis cet environnement. Il est donc
**consigné comme lacune plutôt que deviné** : ces 8 contrôles n'impriment aucun
lien, et un second test refuse une lacune qui survivrait à sa cause.

> Les 8 autres familles sont corrigées et leurs liens se construisent. Le slug
> K8S reste à confirmer côté site.

## #139 — l'issue se trompait à moitié

La justification d'un `not-applicable` **n'était pas absente** : elle est portée
depuis toujours par `waiver.justification`, et la promesse du README était tenue.
Vérifié sur le binaire avant de toucher au code.

Ce qui était vrai est plus étroit : `not-applicable` était le **seul** statut dont
`evidence` restait nul. Un lecteur qui parcourt les preuves d'un rapport trouvait
une explication partout sauf là, et devait savoir qu'un autre champ existait. La
même phrase est désormais lisible là où toutes les autres le sont. Rien n'est
retiré.

## Mouvement de verdicts

**0 sur les 19 fixtures.**

## Portes

`mise run prepush` au vert. La capture française gelée (`cmd/testdata/lang/`) est
mise à jour : elle portait les anciennes URL cassées, et c'est exactement le
mouvement que ce correctif veut produire.

Closes #138
Closes #139
Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
