### PR TITLE
test(veracity): a rule must prove what it refuses to fire on, not only what it catches

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -24,6 +24,15 @@ l'une ni l'autre appartient au `git log`.
 
 ### Ajouté
 
+- **Chaque règle `high`/`critical` doit désormais prouver ce sur quoi elle REFUSE de
+  se déclencher.** Le contrat de véracité prouvait que Pépin sait produire le verdict
+  attendu ; il ne prouvait jamais qu'il le RETIENT sur une configuration voisine et
+  légitime. Une règle qui se déclenche sur tout est parfaitement sensible et sans
+  précision aucune. Un contre-exemple est un **couple** sur un même chemin contrôle ×
+  fournisseur × source : un cas `fail` et un cas `pass` proche. 13 écrits à ce jour,
+  chacun éprouvé dans les deux sens ; les 26 manquants sont comptés dans un registre
+  exact dans les deux sens, et un contrôle `high`/`critical` ajouté sans son
+  contre-exemple casse la CI. `mise run counterexamples-update` le régénère.
 - **Les tenants de référence : des configurations tierces, rejouées à chaque build.**
   Une fixture est écrite par l'auteur de la règle : elle prouve que la règle *se
   déclenche*, jamais qu'elle a *raison* sur une configuration que personne n'a conçue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ belongs in `git log`.
 
 ### Added
 
+- **Every `high`/`critical` rule must now prove what it REFUSES to fire on.** The
+  veracity contract proved Pépin could produce the expected verdict; it never proved
+  it *withholds* that verdict on a near-identical but legitimate configuration. A rule
+  that fires on everything is perfectly sensitive and has no measured precision at all.
+  A counterexample is a **pair** on one control × provider × source path: a `fail` case
+  and a close `pass` case. 13 written so far, each proven in both directions; the 26
+  still missing are counted in a ledger that is exact both ways, and a new
+  `high`/`critical` control without its counterexample breaks CI.
+  `mise run counterexamples-update` regenerates it.
 - **Reference tenants: third-party configurations, replayed on every build.** A
   fixture is written by the author of the rule, so it proves the rule *fires* — never
   that it is *right* about a configuration nobody designed for it. Six real, published,

--- a/docs/detection-quality.fr.md
+++ b/docs/detection-quality.fr.md
@@ -16,7 +16,7 @@ pourcentage sans mesure derrière est un faux vert déplacé dans un tableau de
 bord, et il y est pire qu'ailleurs : personne ne relit un tableau de bord.
 
 Les chiffres sont donc laids, et c'est le point. « 57 contrôles » ne dit rien de
-la qualité d'une détection ; « 63 verdicts prouvés sur 458 » dit où en est le
+la qualité d'une détection ; « 83 verdicts prouvés sur 458 » dit où en est le
 produit, et rétrécit dans le bon sens à chaque scénario écrit.
 
 ## Les chiffres
@@ -25,9 +25,9 @@ produit, et rétrécit dans le bon sens à chaque scénario écrit.
 |---|---:|
 | Contrôles au référentiel | 57 |
 | Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 178 |
-| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 23 |
+| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 24 |
 | Verdicts à prouver au total | 458 |
-| Verdicts prouvés | 63 |
+| Verdicts prouvés | 83 |
 
 ## Couverture de véracité, par verdict
 
@@ -37,11 +37,11 @@ demanderait d'inventer une non-applicabilité.
 
 | Verdict | Ce qu'il met en scène | À prouver | Prouvés | % |
 |---|---|---:|---:|---:|
-| `fail` | une configuration vulnérable est détectée | 140 | 10 | 7 |
-| `pass` | une configuration réellement correcte est confirmée | 140 | 24 | 17 |
+| `fail` | une configuration vulnérable est détectée | 140 | 21 | 15 |
+| `pass` | une configuration réellement correcte est confirmée | 140 | 33 | 23 |
 | `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 156 | 18 | 11 |
 | `not-applicable` | le contrat du fournisseur déclare le mécanisme inexistant | 22 | 11 | 50 |
-| **Total** | | **458** | **63** | **13** |
+| **Total** | | **458** | **83** | **18** |
 
 ## Validé en live
 

--- a/docs/detection-quality.md
+++ b/docs/detection-quality.md
@@ -16,7 +16,7 @@ with no measurement behind it is a false green moved into a dashboard, and it is
 worse there than anywhere else: nobody re-reads a dashboard.
 
 The figures are therefore ugly, and that is the point. "57 controls" says nothing
-about the quality of a detection; "63 verdicts proven out of 458" says where the
+about the quality of a detection; "83 verdicts proven out of 458" says where the
 product stands, and shrinks the right way with every scenario written.
 
 ## The figures
@@ -25,9 +25,9 @@ product stands, and shrinks the right way with every scenario written.
 |---|---:|
 | Controls in the reference | 57 |
 | Control x provider x source paths on which Pépin concludes | 178 |
-| Paths whose EVERY reachable verdict is proven end to end | 23 |
+| Paths whose EVERY reachable verdict is proven end to end | 24 |
 | Verdicts to prove in total | 458 |
-| Verdicts proven | 63 |
+| Verdicts proven | 83 |
 
 ## Veracity coverage, by verdict
 
@@ -37,11 +37,11 @@ inventing a non-applicability.
 
 | Verdict | What it stages | To prove | Proven | % |
 |---|---|---:|---:|---:|
-| `fail` | a vulnerable configuration is detected | 140 | 10 | 7 |
-| `pass` | a genuinely correct configuration is confirmed | 140 | 24 | 17 |
+| `fail` | a vulnerable configuration is detected | 140 | 21 | 15 |
+| `pass` | a genuinely correct configuration is confirmed | 140 | 33 | 23 |
 | `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 156 | 18 | 11 |
 | `not-applicable` | the provider's contract declares the mechanism non-existent | 22 | 11 | 50 |
-| **Total** | | **458** | **63** | **13** |
+| **Total** | | **458** | **83** | **18** |
 
 ## Validated live
 

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -205,9 +205,9 @@ Ce qui n'est pas encore prouvé est **compté**, pas masqué :
 | Chiffre | Nombre |
 |---|---:|
 | Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 178 |
-| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 23 |
+| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 24 |
 | Verdicts à prouver au total | 458 |
-| Verdicts restant à prouver | 395 |
+| Verdicts restant à prouver | 375 |
 <!-- /pepin:gen veracity-debt -->
 
 Le reste est listé chemin par chemin dans `internal/veracity/testdata/debt.txt`. Ce registre est

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -205,9 +205,9 @@ What is not yet proven is **counted**, not hidden:
 | Figure | Count |
 |---|---:|
 | Control x provider x source paths on which Pépin concludes | 178 |
-| Paths whose every reachable verdict is proven end to end | 23 |
+| Paths whose every reachable verdict is proven end to end | 24 |
 | Verdicts to prove in total | 458 |
-| Verdicts left to prove | 395 |
+| Verdicts left to prove | 375 |
 <!-- /pepin:gen veracity-debt -->
 
 The remainder is listed path by path in `internal/veracity/testdata/debt.txt`. That ledger is a

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -1,13 +1,13 @@
 {
   "controls": 57,
   "paths": 178,
-  "paths_proven": 23,
+  "paths_proven": 24,
   "obligations": 458,
-  "proven": 63,
+  "proven": 83,
   "verdicts": {
     "fail": {
       "required": 140,
-      "proven": 10
+      "proven": 21
     },
     "not-applicable": {
       "required": 22,
@@ -19,7 +19,7 @@
     },
     "pass": {
       "required": 140,
-      "proven": 24
+      "proven": 33
     }
   },
   "live_paths": 100,
@@ -247,8 +247,15 @@
             "fail",
             "pass",
             "not-evaluated"
+          ],
+          "proven": [
+            "fail",
+            "pass"
           ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/image-public-outscale-terraform.yaml"
       ],
       "rego_tests": [
         "internal/commonrules/rules/compute_image_not_public_test.rego"
@@ -421,8 +428,15 @@
             "fail",
             "pass",
             "not-evaluated"
+          ],
+          "proven": [
+            "fail",
+            "pass"
           ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/user-data-secrets-scaleway-terraform.yaml"
       ],
       "tenants": [
         "outscale/ztiac-two-tier"
@@ -474,6 +488,8 @@
             "not-evaluated"
           ],
           "proven": [
+            "fail",
+            "pass",
             "not-evaluated"
           ]
         },
@@ -496,6 +512,9 @@
           ]
         }
       ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/public-vm-open-sg-outscale-terraform.yaml"
+      ],
       "tenants": [
         "outscale/ztiac-two-tier"
       ],
@@ -516,9 +535,13 @@
             "not-evaluated"
           ],
           "proven": [
-            "fail"
+            "fail",
+            "pass"
           ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/database-backup-scaleway-terraform.yaml"
       ],
       "tenants": [
         "scaleway/ducklake"
@@ -562,9 +585,13 @@
             "not-evaluated"
           ],
           "proven": [
-            "fail"
+            "fail",
+            "pass"
           ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/database-open-scaleway-terraform.yaml"
       ],
       "tenants": [
         "scaleway/ducklake"
@@ -843,8 +870,15 @@
             "fail",
             "pass",
             "not-evaluated"
+          ],
+          "proven": [
+            "fail",
+            "pass"
           ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/accesskey-expiration-scaleway-terraform.yaml"
       ],
       "rego_tests": [
         "internal/commonrules/rules/iam_accesskey_expiration_set_test.rego"
@@ -971,8 +1005,15 @@
             "fail",
             "pass",
             "not-evaluated"
+          ],
+          "proven": [
+            "fail",
+            "pass"
           ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/policy-admin-outscale-terraform.yaml"
       ],
       "rego_tests": [
         "internal/commonrules/rules/iam_policy_no_administrative_privileges_test.rego",
@@ -999,8 +1040,15 @@
             "fail",
             "pass",
             "not-evaluated"
+          ],
+          "proven": [
+            "fail",
+            "pass"
           ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/policy-notaction-outscale-terraform.yaml"
       ],
       "rego_tests": [
         "internal/commonrules/rules/iam_policy_wildcard_resource_notaction_test.rego"
@@ -1721,6 +1769,7 @@
             "not-evaluated"
           ],
           "proven": [
+            "fail",
             "pass"
           ]
         },
@@ -1744,6 +1793,9 @@
             "not-evaluated"
           ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/all-ports-open-outscale-terraform.yaml"
       ],
       "tenants": [
         "exoscale/zone-demo",
@@ -1798,6 +1850,7 @@
             "not-evaluated"
           ],
           "proven": [
+            "fail",
             "pass"
           ]
         },
@@ -1821,6 +1874,9 @@
             "not-evaluated"
           ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/high-risk-tcp-outscale-terraform.yaml"
       ],
       "tenants": [
         "exoscale/zone-demo",
@@ -1875,6 +1931,7 @@
             "not-evaluated"
           ],
           "proven": [
+            "fail",
             "pass"
           ]
         },
@@ -1898,6 +1955,9 @@
             "not-evaluated"
           ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/high-risk-udp-outscale-terraform.yaml"
       ],
       "tenants": [
         "exoscale/zone-demo",
@@ -2044,6 +2104,7 @@
             "not-evaluated"
           ],
           "proven": [
+            "fail",
             "pass"
           ]
         },
@@ -2068,6 +2129,9 @@
           ]
         }
       ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/rdp-open-outscale-terraform.yaml"
+      ],
       "tenants": [
         "exoscale/zone-demo",
         "outscale/ztiac-two-tier"
@@ -2086,8 +2150,15 @@
             "fail",
             "pass",
             "not-evaluated"
+          ],
+          "proven": [
+            "fail",
+            "pass"
           ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/sg-default-deny-scaleway-terraform.yaml"
       ],
       "rego_tests": [
         "internal/commonrules/rules/network_securitygroup_default_deny_test.rego"

--- a/internal/veracity/counterexample_test.go
+++ b/internal/veracity/counterexample_test.go
@@ -1,0 +1,233 @@
+package veracity_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/pepin/internal/veracity"
+	"github.com/stephrobert/pepin/referentiel"
+)
+
+// Le contrat de véracité prouve « Pépin sait-il produire le verdict attendu ? ».
+// Il ne prouvait pas « REFUSE-t-il de le produire sur un cas presque identique mais
+// LÉGITIME ? » — et c'est cette moitié-là qui fait la précision.
+//
+// Un contrôle `high`/`critical` qui n'a jamais été éprouvé sur une configuration
+// correcte n'a pas de précision mesurée : il a une sensibilité mesurée, ce qui n'est
+// pas la même chose. Une règle qui se déclenche sur tout est parfaitement sensible.
+//
+// Un CONTRE-EXEMPLE est donc un couple, dans un même fichier de scénario : un cas
+// `fail` et un cas `pass` sur le MÊME chemin contrôle × fournisseur × source. Le
+// second doit être *proche* du premier — même type de ressource, configuration
+// légitime — sans quoi il ne prouve rien de la frontière que la règle trace.
+//
+// La porte ne peut pas mesurer cette proximité, et elle ne prétend pas le faire :
+// c'est la revue qui la juge. Ce qu'elle mesure, c'est qu'aucune règle `high` ou
+// `critical` ne reste sans couple, et que le compte des manquantes soit ÉCRIT.
+//
+// contreExempleLedger — le registre des contrôles `high`/`critical` encore sans
+// contre-exemple. Le fichier est régénéré (`mise run counterexamples-update`), jamais
+// édité à la main, et la porte est exacte dans les DEUX sens : une ligne de trop est
+// une dette inventée, une ligne manquante un contrôle ajouté sans sa preuve.
+//
+// Pourquoi un registre plutôt qu'une porte stricte tout de suite : 39 des 42
+// contrôles concernés n'ont pas encore leur couple. Les écrire par gabarit
+// produirait exactement le faux vert que l'ADR-0010 refuse — « une matrice engendrée
+// serait verte parce que creuse ». Le chiffre laid est l'information, et il descend
+// à chaque contre-exemple réellement écrit.
+const contreExempleLedger = "testdata/counterexamples-debt.txt"
+
+// counterexamplePairs rend, par contrôle, les verdicts couverts par un scénario.
+func counterexamplePairs(t *testing.T) map[string]map[veracity.Verdict]bool {
+	t.Helper()
+	files, err := veracity.LoadScenarios(scenarioDir)
+	if err != nil {
+		t.Fatalf("chargement des scénarios : %v", err)
+	}
+	out := map[string]map[veracity.Verdict]bool{}
+	for _, f := range files {
+		if out[f.Control] == nil {
+			out[f.Control] = map[veracity.Verdict]bool{}
+		}
+		for _, s := range f.Scenarios {
+			out[f.Control][s.Expect] = true
+		}
+	}
+	return out
+}
+
+// highSeverityControls rend les contrôles ACTIFS de sévérité `high` ou `critical`.
+// Un contrôle dormant (déclaré pour aucun fournisseur) n'est jamais évalué : exiger
+// sa preuve reviendrait à mesurer une intention.
+func highSeverityControls() []string {
+	var out []string
+	for code, c := range referentiel.All() {
+		if len(c.Fournisseurs) == 0 {
+			continue
+		}
+		if c.Severite == "high" || c.Severite == "critical" {
+			out = append(out, code)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sansContreExemple rend les contrôles `high`/`critical` qui n'ont pas de couple
+// fail+pass, dans l'ordre.
+func sansContreExemple(t *testing.T) []string {
+	t.Helper()
+	couvert := counterexamplePairs(t)
+	var out []string
+	for _, code := range highSeverityControls() {
+		v := couvert[code]
+		if v[veracity.Verdict("fail")] && v[veracity.Verdict("pass")] {
+			continue
+		}
+		out = append(out, code)
+	}
+	return out
+}
+
+// TestEveryHighSeverityControlHasALegitimateCounterexample est la porte de l'issue
+// #115. Elle est exacte dans les deux sens, comme celle de la dette de véracité.
+func TestEveryHighSeverityControlHasALegitimateCounterexample(t *testing.T) {
+	tous := highSeverityControls()
+	if len(tous) == 0 {
+		t.Fatal("aucun contrôle high/critical actif : la porte ne mesure rien")
+	}
+	manquants := sansContreExemple(t)
+
+	// La régénération est EXPLICITE, jamais automatique : un registre que le test
+	// réécrirait seul cesserait de dire quoi que ce soit, et la dette grandirait
+	// sans que personne ne la voie grandir.
+	if os.Getenv("PEPIN_UPDATE_COUNTEREXAMPLES") != "" {
+		ecrireRegistre(t, tous, manquants)
+	}
+
+	consigne, err := chargerRegistre(contreExempleLedger)
+	if err != nil {
+		t.Fatalf("chargement du registre : %v", err)
+	}
+	inConsigne := map[string]bool{}
+	for _, c := range consigne {
+		inConsigne[c] = true
+	}
+	inManquants := map[string]bool{}
+	for _, c := range manquants {
+		inManquants[c] = true
+		if !inConsigne[c] {
+			t.Errorf("contrôle %q (high/critical) : aucun contre-exemple légitime.\n"+
+				"  Il n'a jamais été éprouvé sur une configuration CORRECTE : sa précision\n"+
+				"  n'est pas mesurée. Écrire dans %s un scénario portant un cas `fail` ET un\n"+
+				"  cas `pass` proche, ou consigner la dette (mise run counterexamples-update).",
+				c, scenarioDir)
+		}
+	}
+	for _, c := range consigne {
+		if !inManquants[c] {
+			t.Errorf("contrôle %q : consigné comme sans contre-exemple, alors qu'il en a un.\n"+
+				"  Une dette payée qui reste écrite masque la suivante. Régénérer le registre.", c)
+		}
+	}
+	t.Logf("%d contrôle(s) high/critical, %d avec contre-exemple, %d en dette",
+		len(tous), len(tous)-len(manquants), len(manquants))
+}
+
+// TestNoCounterexampleIsASelfConfirmation : un couple doit porter ses deux cas sur le
+// MÊME chemin (contrôle × fournisseur × source).
+//
+// Sans cette garde, un `fail` sur un plan Terraform et un `pass` sur une collecte
+// live compteraient comme un couple, alors qu'ils n'éprouvent pas la même chaîne :
+// la règle pourrait se taire en live pour une raison entièrement étrangère à la
+// configuration légitime qu'on croit avoir prouvée.
+func TestNoCounterexampleIsASelfConfirmation(t *testing.T) {
+	files, err := veracity.LoadScenarios(scenarioDir)
+	if err != nil {
+		t.Fatalf("chargement des scénarios : %v", err)
+	}
+	surLeChemin := map[string]map[veracity.Verdict]bool{}
+	for _, f := range files {
+		cle := f.Control + "|" + f.Provider + "|" + f.Source
+		if surLeChemin[cle] == nil {
+			surLeChemin[cle] = map[veracity.Verdict]bool{}
+		}
+		for _, s := range f.Scenarios {
+			surLeChemin[cle][s.Expect] = true
+		}
+	}
+	horsRegistre := map[string]bool{}
+	for _, c := range sansContreExemple(t) {
+		horsRegistre[c] = true
+	}
+	var couples int
+	for _, code := range highSeverityControls() {
+		if horsRegistre[code] {
+			continue // en dette : rien à vérifier
+		}
+		ok := false
+		for cle, v := range surLeChemin {
+			if strings.HasPrefix(cle, code+"|") &&
+				v[veracity.Verdict("fail")] && v[veracity.Verdict("pass")] {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			t.Errorf("contrôle %q : ses cas `fail` et `pass` sont sur des chemins DIFFÉRENTS.\n"+
+				"  Un couple réparti sur deux sources n'éprouve pas la même chaîne : la règle\n"+
+				"  peut se taire dans l'une pour une raison étrangère à la configuration\n"+
+				"  légitime. Porter les deux cas sur le même fournisseur et la même source.", code)
+			continue
+		}
+		couples++
+	}
+	t.Logf("%d couple(s) fail+pass vérifié(s) sur un chemin unique", couples)
+}
+
+func chargerRegistre(path string) ([]string, error) {
+	b, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, l := range strings.Split(string(b), "\n") {
+		l = strings.TrimSpace(l)
+		if l == "" || strings.HasPrefix(l, "#") {
+			continue
+		}
+		out = append(out, l)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func ecrireRegistre(t *testing.T, tous, manquants []string) {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("# Registre des contrôles high/critical SANS contre-exemple légitime.\n")
+	b.WriteString("#   RÉGÉNÉRÉ par `mise run counterexamples-update`, jamais édité à la main.\n")
+	b.WriteString("#\n")
+	b.WriteString("# Un contre-exemple est un COUPLE : sur un même chemin contrôle × fournisseur\n")
+	b.WriteString("# × source, un cas `fail` et un cas `pass` proche. Sans lui, la règle a une\n")
+	b.WriteString("# sensibilité mesurée et AUCUNE précision mesurée — une règle qui se déclenche\n")
+	b.WriteString("# sur tout est parfaitement sensible.\n")
+	b.WriteString("#\n")
+	b.WriteString("# Une ligne qui disparaît est une dette payée. Une ligne qui apparaît sans\n")
+	b.WriteString("# contre-exemple est une règle high/critical ajoutée sans sa preuve de\n")
+	b.WriteString("# précision, et la CI la refuse.\n")
+	b.WriteString("#\n")
+	_, _ = fmt.Fprintf(&b, "# high/critical actifs : %d · avec contre-exemple : %d · restants : %d\n\n",
+		len(tous), len(tous)-len(manquants), len(manquants))
+	for _, c := range manquants {
+		b.WriteString(c + "\n")
+	}
+	if err := os.WriteFile(contreExempleLedger, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("écriture du registre : %v", err)
+	}
+	t.Logf("registre régénéré : %s", contreExempleLedger)
+}

--- a/internal/veracity/testdata/counterexamples-debt.txt
+++ b/internal/veracity/testdata/counterexamples-debt.txt
@@ -1,0 +1,40 @@
+# Registre des contrôles high/critical SANS contre-exemple légitime.
+#   RÉGÉNÉRÉ par `mise run counterexamples-update`, jamais édité à la main.
+#
+# Un contre-exemple est un COUPLE : sur un même chemin contrôle × fournisseur
+# × source, un cas `fail` et un cas `pass` proche. Sans lui, la règle a une
+# sensibilité mesurée et AUCUNE précision mesurée — une règle qui se déclenche
+# sur tout est parfaitement sensible.
+#
+# Une ligne qui disparaît est une dette payée. Une ligne qui apparaît sans
+# contre-exemple est une règle high/critical ajoutée sans sa preuve de
+# précision, et la CI la refuse.
+#
+# high/critical actifs : 42 · avec contre-exemple : 16 · restants : 26
+
+blockstorage_snapshot_not_public
+blockstorage_volume_encryption
+blockstorage_volume_snapshots_exist
+compute_instance_has_security_group
+database_encryption_at_rest_enabled
+governance_provider_sovereignty
+governance_resource_region_in_eu
+iam_account_mfa_enforced
+iam_apiaccessrule_defined
+iam_apiaccessrule_no_public_cidr
+iam_no_root_access_key
+iam_policy_no_privilege_escalation
+iam_role_key_lifetime_bounded
+iam_role_no_admin_privileges
+iam_role_source_ip_restricted
+iam_user_mfa_enabled
+k8s_namespace_network_policy_defined
+k8s_namespace_pod_security_enforced
+k8s_rbac_no_cluster_admin_binding
+k8s_secrets_external_manager
+kubernetes_cluster_control_plane_highly_available
+kubernetes_cluster_not_publicly_accessible
+loadbalancer_ssl_listeners
+network_peering_cross_organization
+network_securitygroup_default_restrict_traffic
+objectstorage_bucket_default_encryption

--- a/internal/veracity/testdata/debt.txt
+++ b/internal/veracity/testdata/debt.txt
@@ -8,7 +8,7 @@
 # Une ligne qui disparaît est une dette payée. Une ligne qui apparaît sans
 # scénario est un contrôle ajouté sans sa preuve, et la CI la refuse.
 #
-# chemins : 178 · entierement prouves : 23 · obligations : 458 · restantes : 395
+# chemins : 178 · entierement prouves : 24 · obligations : 458 · restantes : 375
 
 blockstorage_snapshot_not_public exoscale live not-applicable
 blockstorage_snapshot_not_public outscale live fail,pass,not-evaluated
@@ -21,7 +21,7 @@ blockstorage_volume_snapshots_exist exoscale live fail,pass,not-evaluated
 blockstorage_volume_snapshots_exist exoscale terraform fail,pass,not-evaluated
 blockstorage_volume_snapshots_exist outscale live fail,pass,not-evaluated
 compute_image_not_public outscale live fail,pass,not-evaluated
-compute_image_not_public outscale terraform fail,pass,not-evaluated
+compute_image_not_public outscale terraform not-evaluated
 compute_instance_deletion_protection outscale live fail,pass,not-evaluated
 compute_instance_has_security_group exoscale live fail,pass,not-evaluated
 compute_instance_has_security_group exoscale terraform fail,pass,not-evaluated
@@ -34,16 +34,15 @@ compute_instance_no_secrets_in_user_data exoscale terraform fail,pass,not-evalua
 compute_instance_no_secrets_in_user_data outscale live fail,pass,not-evaluated
 compute_instance_no_secrets_in_user_data outscale terraform fail,not-evaluated
 compute_instance_no_secrets_in_user_data scaleway live not-evaluated
-compute_instance_no_secrets_in_user_data scaleway terraform fail,pass,not-evaluated
+compute_instance_no_secrets_in_user_data scaleway terraform not-evaluated
 compute_instance_public_ip_with_open_securitygroup exoscale live fail,pass,not-evaluated
 compute_instance_public_ip_with_open_securitygroup exoscale terraform fail,pass,not-evaluated
 compute_instance_public_ip_with_open_securitygroup outscale live fail,pass,not-evaluated
-compute_instance_public_ip_with_open_securitygroup outscale terraform fail,pass
 compute_instance_public_ip_with_open_securitygroup scaleway live fail,pass,not-evaluated
 compute_instance_public_ip_with_open_securitygroup scaleway terraform not-evaluated
-database_backup_enabled scaleway terraform pass,not-evaluated
+database_backup_enabled scaleway terraform not-evaluated
 database_encryption_at_rest_enabled scaleway terraform fail,pass
-database_service_not_open_to_internet scaleway terraform pass,not-evaluated
+database_service_not_open_to_internet scaleway terraform not-evaluated
 governance_provider_sovereignty exoscale live fail,pass,not-evaluated
 governance_provider_sovereignty exoscale terraform pass,not-evaluated
 governance_provider_sovereignty outscale live fail,pass,not-evaluated
@@ -60,7 +59,7 @@ governance_resource_required_tags outscale live not-evaluated
 governance_resource_required_tags scaleway live not-evaluated
 iam_accesskey_expiration_set outscale live fail,pass,not-evaluated
 iam_accesskey_expiration_set scaleway live fail,pass,not-evaluated
-iam_accesskey_expiration_set scaleway terraform fail,pass,not-evaluated
+iam_accesskey_expiration_set scaleway terraform not-evaluated
 iam_account_mfa_enforced outscale live fail,pass,not-evaluated
 iam_apiaccesspolicy_max_key_expiration outscale live fail,pass,not-evaluated
 iam_apiaccessrule_defined outscale live fail,pass,not-evaluated
@@ -69,9 +68,9 @@ iam_no_root_access_key outscale live fail,pass,not-evaluated
 iam_no_root_access_key scaleway live not-evaluated
 iam_no_root_access_key scaleway terraform not-evaluated
 iam_policy_no_administrative_privileges outscale live fail,pass,not-evaluated
-iam_policy_no_administrative_privileges outscale terraform fail,pass,not-evaluated
+iam_policy_no_administrative_privileges outscale terraform not-evaluated
 iam_policy_no_notaction_notresource outscale live fail,pass,not-evaluated
-iam_policy_no_notaction_notresource outscale terraform fail,pass,not-evaluated
+iam_policy_no_notaction_notresource outscale terraform not-evaluated
 iam_policy_no_privilege_escalation outscale live fail,pass,not-evaluated
 iam_policy_no_privilege_escalation outscale terraform fail,pass,not-evaluated
 iam_policy_no_privilege_escalation scaleway terraform fail,pass,not-evaluated
@@ -116,19 +115,19 @@ network_peering_cross_organization outscale live fail,pass,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_all_ports exoscale live fail,pass,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_all_ports exoscale terraform fail,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_all_ports outscale live fail,pass,not-evaluated
-network_securitygroup_allow_ingress_from_internet_to_all_ports outscale terraform fail,not-evaluated
+network_securitygroup_allow_ingress_from_internet_to_all_ports outscale terraform not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_all_ports scaleway live fail,pass,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_all_ports scaleway terraform fail,pass,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports exoscale live fail,pass,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports exoscale terraform fail,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports outscale live fail,pass,not-evaluated
-network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports outscale terraform fail,not-evaluated
+network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports outscale terraform not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports scaleway live fail,pass,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports scaleway terraform fail,pass,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports exoscale live fail,pass,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports exoscale terraform fail,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports outscale live fail,pass,not-evaluated
-network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports outscale terraform fail,not-evaluated
+network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports outscale terraform not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports scaleway live fail,pass,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports scaleway terraform fail,pass,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_tcp_port_22 exoscale live fail,pass,not-evaluated
@@ -138,10 +137,10 @@ network_securitygroup_allow_ingress_from_internet_to_tcp_port_22 outscale terraf
 network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389 exoscale live fail,pass,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389 exoscale terraform fail,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389 outscale live fail,pass,not-evaluated
-network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389 outscale terraform fail,not-evaluated
+network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389 outscale terraform not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389 scaleway live fail,pass,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389 scaleway terraform fail,pass,not-evaluated
-network_securitygroup_default_deny scaleway terraform fail,pass,not-evaluated
+network_securitygroup_default_deny scaleway terraform not-evaluated
 network_securitygroup_default_restrict_traffic outscale live fail,pass,not-evaluated
 network_securitygroup_unrestricted_egress exoscale live fail,pass,not-evaluated
 network_securitygroup_unrestricted_egress exoscale terraform fail,not-evaluated

--- a/internal/veracity/testdata/scenarios/accesskey-expiration-scaleway-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/accesskey-expiration-scaleway-terraform.yaml
@@ -1,0 +1,39 @@
+# Cle d'API sans date d'expiration, chez Scaleway.
+#
+# Ce controle conclut d'une ABSENCE, et c'est legitime : chez Scaleway un
+# `ExpiresAt` nul EST la facon dont l'API dit « aucune expiration » (ADR-0017).
+# Le couple ci-dessous eprouve donc la frontiere la plus fine du referentiel :
+# absence de valeur contre valeur presente, sur le meme champ.
+control: iam_accesskey_expiration_set
+provider: scaleway
+source: terraform
+
+scenarios:
+  - expect: fail
+    why: "la cle ne porte aucune date d'expiration : une fuite resterait exploitable indefiniment"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: scaleway_iam_api_key.ci
+              type: scaleway_iam_api_key
+              name: ci
+              values:
+                access_key: SCWXXXXXXXXXXXXXXXXX
+                description: cle de CI
+
+  - expect: pass
+    why: "MEME cle, avec une expiration datee : la rotation est bornee par le fournisseur lui-meme"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: scaleway_iam_api_key.ci
+              type: scaleway_iam_api_key
+              name: ci
+              values:
+                access_key: SCWXXXXXXXXXXXXXXXXX
+                description: cle de CI
+                expires_at: "2027-01-01T00:00:00Z"

--- a/internal/veracity/testdata/scenarios/all-ports-open-outscale-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/all-ports-open-outscale-terraform.yaml
@@ -1,0 +1,46 @@
+# Tous les ports ouverts a Internet, chez Outscale.
+#
+# Le contre-exemple est ici plus subtil qu'ailleurs : une plage LARGE n'est pas
+# fautive en soi. Entre deux sous-reseaux d'un meme VPC, tout ouvrir est un choix
+# d'architecture discutable mais courant, et ce n'est pas ce que ce controle
+# mesure. Ce qu'il mesure est l'origine : 0.0.0.0/0.
+control: network_securitygroup_allow_ingress_from_internet_to_all_ports
+provider: outscale
+source: terraform
+
+scenarios:
+  - expect: fail
+    why: "toute la plage de ports ouverte depuis 0.0.0.0/0 : aucun filtrage d'entree"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_security_group_rule.tout
+              type: outscale_security_group_rule
+              name: tout
+              values:
+                security_group_id: sg-app
+                flow: Inbound
+                ip_protocol: "-1"
+                from_port_range: 0
+                to_port_range: 65535
+                ip_range: 0.0.0.0/0
+
+  - expect: pass
+    why: "MEME plage complete de ports, mais entre sous-reseaux prives : large et interne, ce n'est pas une exposition"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_security_group_rule.tout
+              type: outscale_security_group_rule
+              name: tout
+              values:
+                security_group_id: sg-app
+                flow: Inbound
+                ip_protocol: "-1"
+                from_port_range: 0
+                to_port_range: 65535
+                ip_range: 10.0.0.0/8

--- a/internal/veracity/testdata/scenarios/database-backup-scaleway-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/database-backup-scaleway-terraform.yaml
@@ -1,0 +1,39 @@
+# Sauvegarde automatique desactivee sur une base manageee Scaleway.
+#
+# Le champ est NEGATIF (`disable_backup`), ce qui est le genre de piege ou une
+# regle se trompe de sens sans que rien ne rougisse : le contre-exemple porte
+# donc explicitement la valeur `false`, et non l'absence du champ.
+control: database_backup_enabled
+provider: scaleway
+source: terraform
+
+scenarios:
+  - expect: fail
+    why: "disable_backup vaut true : aucune sauvegarde automatique n'est prise"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: scaleway_rdb_instance.main
+              type: scaleway_rdb_instance
+              name: main
+              values:
+                name: rdb-prod
+                disable_backup: true
+                encryption_at_rest: true
+
+  - expect: pass
+    why: "MEME base, disable_backup a false : la sauvegarde est active, et c'est la valeur OBSERVEE qui le dit"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: scaleway_rdb_instance.main
+              type: scaleway_rdb_instance
+              name: main
+              values:
+                name: rdb-prod
+                disable_backup: false
+                encryption_at_rest: true

--- a/internal/veracity/testdata/scenarios/database-open-scaleway-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/database-open-scaleway-terraform.yaml
@@ -1,0 +1,44 @@
+# Base managee ouverte a Internet, chez Scaleway.
+#
+# Le defaut d'API est ici l'inverse de l'intuition : tant qu'aucune ACL n'est
+# posee, la base est ATTEIGNABLE. Le controle mesure donc la presence d'une
+# restriction effective, et non l'absence d'une ouverture.
+#
+# Le cas `pass` garde une ACL — la meme forme, la meme ressource — mais bornee a
+# un reseau prive.
+control: database_service_not_open_to_internet
+provider: scaleway
+source: terraform
+
+scenarios:
+  - expect: fail
+    why: "l'ACL de la base autorise 0.0.0.0/0 : le service est joignable depuis Internet"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: scaleway_rdb_acl.main
+              type: scaleway_rdb_acl
+              name: main
+              values:
+                instance_id: rdb-prod
+                acl_rules:
+                  - ip: 0.0.0.0/0
+                    description: ouvert
+
+  - expect: pass
+    why: "MEME ACL, bornee au reseau d'application : la base reste joignable par ce qui doit la joindre"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: scaleway_rdb_acl.main
+              type: scaleway_rdb_acl
+              name: main
+              values:
+                instance_id: rdb-prod
+                acl_rules:
+                  - ip: 10.42.0.0/16
+                    description: reseau applicatif

--- a/internal/veracity/testdata/scenarios/high-risk-tcp-outscale-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/high-risk-tcp-outscale-terraform.yaml
@@ -1,0 +1,46 @@
+# Port TCP a haut risque ouvert a Internet, chez Outscale.
+#
+# Ce controle vise les services d'infrastructure qu'on n'expose jamais
+# volontairement : bases de donnees, annuaires, partages de fichiers. Le
+# contre-exemple garde le MEME port — une base doit bien etre jointe par ses
+# clients — et ne change que l'origine.
+control: network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports
+provider: outscale
+source: terraform
+
+scenarios:
+  - expect: fail
+    why: "PostgreSQL (5432) ouvert depuis 0.0.0.0/0 : la base est joignable depuis Internet"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_security_group_rule.pg
+              type: outscale_security_group_rule
+              name: pg
+              values:
+                security_group_id: sg-data
+                flow: Inbound
+                ip_protocol: tcp
+                from_port_range: 5432
+                to_port_range: 5432
+                ip_range: 0.0.0.0/0
+
+  - expect: pass
+    why: "MEME port 5432, ouvert au seul reseau applicatif : c'est ainsi qu'une base sert ses clients"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_security_group_rule.pg
+              type: outscale_security_group_rule
+              name: pg
+              values:
+                security_group_id: sg-data
+                flow: Inbound
+                ip_protocol: tcp
+                from_port_range: 5432
+                to_port_range: 5432
+                ip_range: 10.42.0.0/16

--- a/internal/veracity/testdata/scenarios/high-risk-udp-outscale-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/high-risk-udp-outscale-terraform.yaml
@@ -1,0 +1,45 @@
+# Port UDP a haut risque ouvert a Internet, chez Outscale.
+#
+# Les services UDP exposes servent d'amplificateurs a des attaques par deni de
+# service : le risque ne pese pas que sur le tenant, il pese sur des tiers. Le
+# contre-exemple garde le MEME service, borne a son reseau.
+control: network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports
+provider: outscale
+source: terraform
+
+scenarios:
+  - expect: fail
+    why: "SNMP (161/UDP) ouvert depuis 0.0.0.0/0 : service d'administration expose et amplificateur connu"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_security_group_rule.snmp
+              type: outscale_security_group_rule
+              name: snmp
+              values:
+                security_group_id: sg-infra
+                flow: Inbound
+                ip_protocol: udp
+                from_port_range: 161
+                to_port_range: 161
+                ip_range: 0.0.0.0/0
+
+  - expect: pass
+    why: "MEME port SNMP, ouvert a la seule supervision interne : la sonde doit pouvoir interroger"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_security_group_rule.snmp
+              type: outscale_security_group_rule
+              name: snmp
+              values:
+                security_group_id: sg-infra
+                flow: Inbound
+                ip_protocol: udp
+                from_port_range: 161
+                to_port_range: 161
+                ip_range: 10.9.0.0/24

--- a/internal/veracity/testdata/scenarios/image-public-outscale-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/image-public-outscale-terraform.yaml
@@ -1,0 +1,39 @@
+# Image machine publiee a tous les comptes, chez Outscale.
+#
+# Le contre-exemple est le meme partage, RESTREINT : `global_permission` a false.
+# Une image partagee explicitement a un compte tiers reste un partage voulu ;
+# c'est la publication A TOUS que ce controle refuse.
+control: compute_image_not_public
+provider: outscale
+source: terraform
+
+scenarios:
+  - expect: fail
+    why: "l'image est publiee globalement : n'importe quel compte du cloud peut la demarrer"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_image_launch_permission.diffusion
+              type: outscale_image_launch_permission
+              name: diffusion
+              values:
+                image_id: ami-prod
+                permission_additions:
+                  - global_permission: true
+
+  - expect: pass
+    why: "MEME ressource de partage, global_permission a false : le partage reste borne"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_image_launch_permission.diffusion
+              type: outscale_image_launch_permission
+              name: diffusion
+              values:
+                image_id: ami-prod
+                permission_additions:
+                  - global_permission: false

--- a/internal/veracity/testdata/scenarios/policy-admin-outscale-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/policy-admin-outscale-terraform.yaml
@@ -1,0 +1,45 @@
+# Politique IAM accordant tous les droits, chez Outscale.
+#
+# Le contre-exemple est une politique LARGE mais bornee : `Allow` sur un service
+# entier reste une politique legitime et tres repandue. Ce que le controle refuse
+# est l'action totale (`*`) sur la ressource totale.
+#
+# Une regle qui rougirait sur toute politique permissive rendrait le controle
+# inutilisable des le premier tenant reel.
+#
+# Le champ `document` est une CHAINE JSON, comme le fournisseur la porte : le
+# mapping la parse (transform `iampolicy`). Le lui donner deja eclate en liste
+# produisait `statements: []`, donc un `not-evaluated` — un scenario qui aurait
+# eu l'air de passer pour une raison etrangere a ce qu'il pretend montrer.
+control: iam_policy_no_administrative_privileges
+provider: outscale
+source: terraform
+
+scenarios:
+  - expect: fail
+    why: "Allow sur toutes les actions et toutes les ressources : la politique est administrateur"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_policy.admin
+              type: outscale_policy
+              name: admin
+              values:
+                policy_name: admin
+                document: "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": \"*\", \"Resource\": \"*\"}]}"
+
+  - expect: pass
+    why: "MEME forme de politique, large mais BORNEE a un service et a ses ressources : c'est une delegation ordinaire"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_policy.admin
+              type: outscale_policy
+              name: admin
+              values:
+                policy_name: lecture-objet
+                document: "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": [\"ReadObjects\", \"ListBuckets\"], \"Resource\": [\"arn:osc:oos:::sauvegardes/*\"]}]}"

--- a/internal/veracity/testdata/scenarios/policy-notaction-outscale-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/policy-notaction-outscale-terraform.yaml
@@ -1,0 +1,38 @@
+# Politique IAM ecrite en NotAction / NotResource, chez Outscale.
+#
+# Une politique par exclusion accorde tout ce que personne n'a pense a exclure :
+# elle se perime silencieusement des qu'une action nouvelle apparait au catalogue
+# du fournisseur. Le contre-exemple exprime la MEME intention par enumeration
+# positive, ce qui est la correction attendue et non un contournement.
+control: iam_policy_no_notaction_notresource
+provider: outscale
+source: terraform
+
+scenarios:
+  - expect: fail
+    why: "la politique s'ecrit par exclusion : elle accordera toute action future non listee"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_policy.exclusion
+              type: outscale_policy
+              name: exclusion
+              values:
+                policy_name: tout-sauf-iam
+                document: "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"NotAction\": [\"DeleteUser\"], \"Resource\": \"*\"}]}"
+
+  - expect: pass
+    why: "MEME intention, exprimee par enumeration positive : ce qui n'est pas accorde ne l'est pas"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_policy.exclusion
+              type: outscale_policy
+              name: exclusion
+              values:
+                policy_name: tout-sauf-iam
+                document: "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": [\"ReadVms\", \"ReadVolumes\"], \"Resource\": [\"arn:osc:api:::vm/*\"]}]}"

--- a/internal/veracity/testdata/scenarios/public-vm-open-sg-outscale-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/public-vm-open-sg-outscale-terraform.yaml
@@ -1,0 +1,69 @@
+# VM exposée : IP publique ET groupe de sécurité ouvert sur Internet, chez Outscale.
+#
+# C'est le premier couple de la table de l'issue #115, et il éprouve la frontière
+# que ce contrôle trace : ce n'est pas l'IP publique qui fait l'écart, ni le port
+# ouvert seul, c'est leur CONJONCTION. Un serveur web public est légitime ; le même
+# serveur avec SSH ouvert à tout Internet ne l'est pas.
+#
+# Le cas `pass` est délibérément PROCHE du cas `fail` : même VM, même IP publique,
+# même groupe de sécurité ouvert à 0.0.0.0/0 — seul le port change. Un contre-exemple
+# qui retirerait l'IP publique ne prouverait rien de la règle, seulement que le
+# contrôle a besoin d'une VM exposée pour parler.
+control: compute_instance_public_ip_with_open_securitygroup
+provider: outscale
+source: terraform
+
+scenarios:
+  - expect: fail
+    why: "VM a IP publique dont le groupe de securite ouvre SSH a 0.0.0.0/0 : la conjonction expose l'administration"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_vm.web
+              type: outscale_vm
+              name: web
+              values:
+                vm_id: i-expose
+                public_ip: 203.0.113.10
+                state: running
+                security_group_ids:
+                  - sg-web
+            - address: outscale_security_group_rule.ssh
+              type: outscale_security_group_rule
+              name: ssh
+              values:
+                security_group_id: sg-web
+                flow: Inbound
+                ip_protocol: tcp
+                from_port_range: 22
+                to_port_range: 22
+                ip_range: 0.0.0.0/0
+
+  - expect: pass
+    why: "MEME VM publique, MEME groupe ouvert a 0.0.0.0/0, mais sur 443 : un serveur web public est sa raison d'etre"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_vm.web
+              type: outscale_vm
+              name: web
+              values:
+                vm_id: i-expose
+                public_ip: 203.0.113.10
+                state: running
+                security_group_ids:
+                  - sg-web
+            - address: outscale_security_group_rule.https
+              type: outscale_security_group_rule
+              name: https
+              values:
+                security_group_id: sg-web
+                flow: Inbound
+                ip_protocol: tcp
+                from_port_range: 443
+                to_port_range: 443
+                ip_range: 0.0.0.0/0

--- a/internal/veracity/testdata/scenarios/rdp-open-outscale-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/rdp-open-outscale-terraform.yaml
@@ -1,0 +1,48 @@
+# RDP ouvert a Internet, chez Outscale.
+#
+# La frontiere que ce controle trace n'est pas « le port 3389 est ouvert » mais
+# « il est ouvert A TOUT INTERNET ». Une plage d'administration interne sur le
+# meme port est la configuration normale d'un parc Windows.
+#
+# Le cas `pass` ne change donc QUE le CIDR : meme groupe, meme port, meme
+# protocole. Fermer le port prouverait seulement que la regle sait lire un port.
+control: network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389
+provider: outscale
+source: terraform
+
+scenarios:
+  - expect: fail
+    why: "TCP/3389 ouvert depuis 0.0.0.0/0 : le bureau a distance est expose a Internet"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_security_group_rule.rdp
+              type: outscale_security_group_rule
+              name: rdp
+              values:
+                security_group_id: sg-win
+                flow: Inbound
+                ip_protocol: tcp
+                from_port_range: 3389
+                to_port_range: 3389
+                ip_range: 0.0.0.0/0
+
+  - expect: pass
+    why: "MEME port 3389, restreint au reseau d'administration : c'est la configuration attendue d'un parc Windows"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: outscale_security_group_rule.rdp
+              type: outscale_security_group_rule
+              name: rdp
+              values:
+                security_group_id: sg-win
+                flow: Inbound
+                ip_protocol: tcp
+                from_port_range: 3389
+                to_port_range: 3389
+                ip_range: 10.42.0.0/16

--- a/internal/veracity/testdata/scenarios/sg-default-deny-scaleway-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/sg-default-deny-scaleway-terraform.yaml
@@ -1,0 +1,52 @@
+# Politique par defaut d'un groupe de securite Scaleway.
+#
+# Ce controle ne juge aucune regle : il juge ce qui se passe quand AUCUNE ne
+# correspond. Un groupe en `accept` par defaut laisse passer tout ce que ses
+# regles n'ont pas prevu, ce qui inverse la logique d'un pare-feu.
+#
+# Le contre-exemple garde le meme groupe et les memes regles ; seule la politique
+# par defaut change. Retirer les regles prouverait autre chose.
+control: network_securitygroup_default_deny
+provider: scaleway
+source: terraform
+
+scenarios:
+  - expect: fail
+    why: "politique entrante par defaut a accept : tout ce que les regles n'interdisent pas passe"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: scaleway_instance_security_group.web
+              type: scaleway_instance_security_group
+              name: web
+              values:
+                id: sg-web
+                name: sg-web
+                inbound_default_policy: accept
+                inbound_rule:
+                  - action: accept
+                    protocol: TCP
+                    port: 443
+                    ip_range: 0.0.0.0/0
+
+  - expect: pass
+    why: "MEME groupe, MEMES regles, politique par defaut a drop : le pare-feu refuse ce qu'il n'a pas prevu"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: scaleway_instance_security_group.web
+              type: scaleway_instance_security_group
+              name: web
+              values:
+                id: sg-web
+                name: sg-web
+                inbound_default_policy: drop
+                inbound_rule:
+                  - action: accept
+                    protocol: TCP
+                    port: 443
+                    ip_range: 0.0.0.0/0

--- a/internal/veracity/testdata/scenarios/user-data-secrets-scaleway-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/user-data-secrets-scaleway-terraform.yaml
@@ -1,0 +1,50 @@
+# Secret en clair dans le user-data d'une VM Scaleway.
+#
+# Le contre-exemple qui compte ici n'est pas « un user-data vide » : il est
+# « un user-data qui parle de secrets sans en contenir ». Une regle qui
+# rougirait sur le mot `token` ou sur l'appel a un gestionnaire de secrets
+# rendrait le controle inutilisable, puisque c'est exactement la BONNE pratique
+# qu'elle punirait.
+control: compute_instance_no_secrets_in_user_data
+provider: scaleway
+source: terraform
+
+scenarios:
+  - expect: fail
+    why: "une cle d'API en clair dans le user-data : lisible par quiconque decrit l'instance"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: scaleway_instance_server.app
+              type: scaleway_instance_server
+              name: app
+              values:
+                id: srv-app
+                security_group_id: sg-app
+                user_data:
+                  cloud-init: |
+                    #!/bin/sh
+                    export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY
+                    /opt/app/start.sh
+
+  - expect: pass
+    why: "MEME script, qui RECUPERE son secret au demarrage au lieu de le porter : la bonne pratique ne doit pas rougir"
+    plan:
+      format_version: "1.2"
+      planned_values:
+        root_module:
+          resources:
+            - address: scaleway_instance_server.app
+              type: scaleway_instance_server
+              name: app
+              values:
+                id: srv-app
+                security_group_id: sg-app
+                user_data:
+                  cloud-init: |
+                    #!/bin/sh
+                    SECRET=$(scw secret-manager version access --secret-name app-key)
+                    export AWS_SECRET_ACCESS_KEY="$SECRET"
+                    /opt/app/start.sh

--- a/mise.toml
+++ b/mise.toml
@@ -92,6 +92,14 @@ run = "python3 scripts/scsl-drift.py --update"
 description = "Régénère le registre de dette du contrat de véracité (internal/veracity/testdata/debt.txt) après avoir ajouté un contrôle ou un scénario"
 run = "PEPIN_UPDATE_VERACITY=1 go test ./internal/veracity/ -run 'DebtLedgerIsExact' -count=1"
 
+# Le contre-exemple LÉGITIME (issue #115). Le contrat de véracité prouve que
+# Pépin sait produire le verdict attendu ; il ne prouvait pas qu'il REFUSE de le
+# produire sur une configuration correcte et voisine. Une règle qui se déclenche
+# sur tout est parfaitement sensible et sans précision aucune.
+[tasks.counterexamples-update]
+description = "Régénère le registre des contrôles high/critical sans contre-exemple légitime (internal/veracity/testdata/counterexamples-debt.txt)"
+run = "PEPIN_UPDATE_COUNTEREXAMPLES=1 go test ./internal/veracity/ -run 'HasALegitimateCounterexample' -count=1"
+
 # Tracer les appels RÉELS d'un collecteur (issue #84). Le contrat de véracité
 # prouve la chaîne à partir d'une réponse canned ; celle-ci ne prouve rien du
 # CÂBLAGE de la spec `collecte`, c'est-à-dire quels endpoints partent vraiment


### PR DESCRIPTION
## Le manque

Le contrat de véracité prouvait que Pépin **sait produire** le verdict attendu.
Il ne prouvait jamais qu'il **le retient** sur une configuration voisine et
légitime — et c'est de cette moitié-là qu'est faite la précision.

> Une règle qui se déclenche sur tout est parfaitement sensible.

## Ce qu'est un contre-exemple ici

Un **couple** sur un même chemin contrôle × fournisseur × source : un cas `fail`
et un cas `pass` **proche**.

La proximité fait tout le travail. Retirer l'IP publique du cas « VM exposée »
prouverait seulement que le contrôle a besoin d'une VM exposée pour parler.
Garder la même VM, la même IP publique, la même règle `0.0.0.0/0`, et déplacer le
port de 22 à 443 prouve la **frontière que la règle trace réellement**.

## 13 écrits, à la main

| Contrôle | Fautif | Légitime, et proche |
|---|---|---|
| VM publique + SG ouvert | SSH 22 depuis `0.0.0.0/0` | **même** VM, **même** `0.0.0.0/0`, port 443 |
| RDP exposé | 3389 depuis `0.0.0.0/0` | **même** port, `10.42.0.0/16` |
| Tous ports ouverts | 0-65535 depuis `0.0.0.0/0` | **même** plage complète, entre sous-réseaux privés |
| TCP à haut risque | PostgreSQL 5432 depuis Internet | **même** port, réseau applicatif |
| UDP à haut risque | SNMP 161 depuis Internet | **même** port, supervision interne |
| Secret en user-data | clé d'API en clair | **même** script, qui va chercher son secret |
| Base ouverte | ACL `0.0.0.0/0` | **même** ACL, bornée au réseau |
| Sauvegarde base | `disable_backup: true` | **même** base, `false` **observé** |
| Expiration de clé | aucune date | **même** clé, avec expiration |
| Image publique | `global_permission: true` | **même** partage, `false` |
| SG politique par défaut | `accept` | **mêmes** règles, défaut `drop` |
| Politique admin | `Allow *` sur `*` | **même** forme, large mais **bornée** à un service |
| Politique par exclusion | `NotAction` | **même** intention, énumérée positivement |

Écrits un par un, délibérément : un corpus engendré par gabarit est exactement le
faux vert que l'**ADR-0010** refuse déjà — *« une matrice engendrée serait verte
parce que creuse »*.

## Deux se sont trompés, et l'ont dit

Le couple de politiques IAM donnait `document` en liste déjà éclatée. La
transformation `iampolicy` du mapper rendait alors `statements: []`, et le
contrôle sortait `not-evaluated`. **Les deux scénarios auraient eu l'air de
passer pour une raison étrangère à ce qu'ils prétendent montrer.** `document` est
désormais la chaîne JSON que le fournisseur porte réellement.

## Le harnais a été éprouvé en le faisant rougir

Passer `disable_backup` à `false` dans le cas fautif transforme le `fail` attendu
en `pass`, et la porte le signale. C'est ce que l'issue demandait explicitement.

## La dette est comptée, pas cachée

**26 contrôles** restent sans couple. Le registre est **exact dans les deux
sens** : une lacune non consignée échoue, une lacune consignée après avoir été
comblée échoue aussi. Un contrôle `high`/`critical` ajouté sans son
contre-exemple **casse la CI**. `mise run counterexamples-update` le régénère.

Une seconde porte refuse un couple **réparti sur deux chemins** : un `fail` sur
plan Terraform et un `pass` en live n'éprouvent pas la même chaîne, et la règle
pourrait se taire dans l'une pour une raison sans rapport avec la configuration
légitime qu'on croit avoir prouvée.

## Effet mesuré

Verdicts prouvés : **63 → 83** sur 458. Les preuves de `pass` — celles qu'un
contre-exemple apporte — passent de **24 à 33**.

Publier une précision par contrôle depuis ces chiffres est **#118**, et y reste.

## Portes

`mise run prepush` au vert. `debt.txt`, `counterexamples-debt.txt`,
`snapshot.json` et la carte de qualité régénérés et committés.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
