### PR TITLE
feat(quality): publish precision, and refuse to publish what nothing measures

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -24,6 +24,15 @@ l'une ni l'autre appartient au `git log`.
 
 ### Ajouté
 
+- **La carte de qualité publie désormais la précision, dérivée du corpus de
+  contre-exemples.** « 42 contrôles » est une phrase que tous les CSPM prononcent.
+  Détecter et se TAIRE sont deux mesures différentes, et elles s'impriment maintenant
+  côte à côte : 42 contrôles `high`/`critical` actifs, 18 dont un chemin de détection
+  est prouvé de bout en bout, 16 dont un contre-exemple légitime l'est, 0 faux positif
+  mesuré sur les contre-témoins durcis. Il n'y a délibérément **aucune ligne « faux
+  négatifs »** : rien dans le dépôt ne les mesure, et un « 0 » publié voudrait dire
+  « nous n'avons pas cherché ». Une garde échoue si ce champ est ajouté, une autre
+  refuse tout chiffre de précision supérieur à son dénominateur.
 - **Chaque règle `high`/`critical` doit désormais prouver ce sur quoi elle REFUSE de
   se déclencher.** Le contrat de véracité prouvait que Pépin sait produire le verdict
   attendu ; il ne prouvait jamais qu'il le RETIENT sur une configuration voisine et

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ belongs in `git log`.
 
 ### Added
 
+- **The quality map now publishes precision, derived from the counterexample corpus.**
+  "42 controls" is a sentence every CSPM says. Catching and staying SILENT are two
+  different measurements, and they are now printed side by side: 42 active
+  `high`/`critical` controls, 18 with a detection path proven end to end, 16 with a
+  legitimate counterexample, 0 false positives measured on the hardened
+  counter-witnesses. There is deliberately **no false-negative row**: nothing in the
+  repository measures them, and a published "0" would mean "we did not look". A gate
+  fails if that field is ever added, and another refuses any precision figure larger
+  than its denominator.
 - **Every `high`/`critical` rule must now prove what it REFUSES to fire on.** The
   veracity contract proved Pépin could produce the expected verdict; it never proved
   it *withholds* that verdict on a near-identical but legitimate configuration. A rule

--- a/docs/detection-quality.fr.md
+++ b/docs/detection-quality.fr.md
@@ -70,6 +70,31 @@ Un endpoint qui répond existe et se résout ; un `moved` (404) dit qu'il a boug
 | `outscale` | 2026-08-21 | 17 | 0 | 0 |
 | `scaleway` | 2026-08-21 | 5 | 0 | 0 |
 
+## Précision des règles high/critical
+
+Détecter et se TAIRE sont deux mesures différentes, et elles se publient ensemble :
+« 21 chemins de détection prouvés » se lit dans le sens le plus flatteur tant que
+rien ne dit sur combien de configurations légitimes ces mêmes règles se sont tues.
+Une règle qui se déclenche sur tout est parfaitement sensible.
+
+Un CONTRE-EXEMPLE est un couple sur un même chemin contrôle × fournisseur ×
+source : un cas fautif, et un cas correct qui lui ressemble. Les contrôles qui
+n'en ont pas encore sont comptés dans
+`internal/veracity/testdata/counterexamples-debt.txt`.
+
+| Chiffre | Nombre |
+|---|---:|
+| Contrôles high/critical actifs | 42 |
+| Dont un chemin de détection est prouvé de bout en bout | 18 |
+| Dont un contre-exemple légitime est prouvé | 16 |
+| Faux positifs mesurés sur les contre-témoins | 0 |
+
+Il n'y a pas de ligne « faux négatifs », et son absence est le chiffre le plus
+honnête de cette page. Aucun artefact du dépôt ne les mesure : il faudrait un
+corpus de configurations fautives dont on SAIT qu'elles échappent aux règles,
+c'est-à-dire savoir ce qu'on ne sait pas. Publier « 0 » serait le faux vert exact
+que cette page combat — zéro mesuré n'est pas zéro existant.
+
 ## Faux positifs
 
 Le dépôt ne tient pas de registre de faux positifs, et en publier un compte serait

--- a/docs/detection-quality.md
+++ b/docs/detection-quality.md
@@ -70,6 +70,30 @@ An endpoint that answers exists and resolves; a `moved` (404) says it has shifte
 | `outscale` | 2026-08-21 | 17 | 0 | 0 |
 | `scaleway` | 2026-08-21 | 5 | 0 | 0 |
 
+## Precision of the high/critical rules
+
+Catching and STAYING SILENT are two different measurements, and they are published
+together: "21 detection paths proven" reads in the most flattering way for as long
+as nothing says on how many legitimate configurations those same rules held their
+tongue. A rule that fires on everything is perfectly sensitive.
+
+A COUNTEREXAMPLE is a pair on one control × provider × source path: a faulty case,
+and a correct one that resembles it. Controls that do not have one yet are counted
+in `internal/veracity/testdata/counterexamples-debt.txt`.
+
+| Figure | Count |
+|---|---:|
+| Active high/critical controls | 42 |
+| Of which a detection path is proven end to end | 18 |
+| Of which a legitimate counterexample is proven | 16 |
+| False positives measured on the counter-witnesses | 0 |
+
+There is no "false negatives" row, and its absence is the most honest figure on
+this page. No repository artefact measures them: it would take a corpus of faulty
+configurations KNOWN to escape the rules, that is, knowing what one does not know.
+Publishing "0" would be the exact false green this page fights — a measured zero is
+not an existing zero.
+
 ## False positives
 
 The repository keeps no false-positive register, and publishing a count would be

--- a/internal/docgen/quality.go
+++ b/internal/docgen/quality.go
@@ -63,11 +63,44 @@ func BuildQuality(root string, m Matrix) (quality.Snapshot, error) {
 	// relève aucun écart critical/high. TestEveryPostureIsTheOneMeasured confronte
 	// cette déclaration au scan, donc ce compteur est mesuré et non annoncé.
 	counterwitnesses := 0
+	// Les FAUX POSITIFS, mesurés et non annoncés : un écart critical/high relevé sur
+	// un tenant qui se déclare DURCI. Le relevé `expected.txt` est régénéré depuis le
+	// binaire, donc ce compteur suit le produit et non une intention. C'est le seul
+	// faux positif que ce dépôt sache mesurer, et un « 0 » n'y vaut que parce qu'il
+	// est publié avec son dénominateur (le nombre de contre-témoins).
+	faussesAlertes := 0
+	ctl := referentiel.All()
 	for _, t := range list {
-		if t.Posture == tenants.PostureHardened {
-			counterwitnesses++
+		if t.Posture != tenants.PostureHardened {
+			continue
+		}
+		counterwitnesses++
+		attendus, lerr := tenants.LoadExpected(t.ExpectedPath())
+		if lerr != nil {
+			return quality.Snapshot{}, lerr
+		}
+		for code, statut := range attendus {
+			if statut != "fail" {
+				continue
+			}
+			if s := ctl[code].Severite; s == "high" || s == "critical" {
+				faussesAlertes++
+			}
 		}
 	}
+	// Les contrôles sur lesquels la précision se mesure : actifs, et de sévérité
+	// haute. Un contrôle dormant n'est jamais évalué.
+	var hautes []string
+	for code, c := range ctl {
+		if len(c.Fournisseurs) == 0 {
+			continue
+		}
+		if c.Severite == "high" || c.Severite == "critical" {
+			hautes = append(hautes, code)
+		}
+	}
+	sort.Strings(hautes)
+
 	return quality.Compute(quality.Inputs{
 		Cells:              VeracityCells(m),
 		Covered:            veracity.Merge(veracity.Covered(files), fromTenants),
@@ -78,6 +111,12 @@ func BuildQuality(root string, m Matrix) (quality.Snapshot, error) {
 		RegoTestsByControl: regoTests,
 		Counterwitnesses:   counterwitnesses,
 		TenantsTotal:       len(list),
+		// La précision lit le MÊME calcul de contre-exemples que la porte qui refuse
+		// un contrôle sans le sien : deux calculs de couverture divergent toujours,
+		// et celui qui diverge est celui qu'on publie.
+		HighSeverityControls: hautes,
+		CounterexamplePairs:  veracity.CounterexamplePairs(files),
+		FalsePositives:       faussesAlertes,
 	}), nil
 }
 
@@ -158,6 +197,8 @@ type qualityText struct {
 	canaryTitle, canaryIntro                               string
 	colProvider, colRecorded, colAnswered, colMoved, colUn string
 	fpTitle, fpBody, counterwitnesses, tenantsWord         string
+	precTitle, precBody, precControls, precDetect          string
+	precCounter, precFP, precNoFN                          string
 	blindTitle, blindBody                                  string
 	generated                                              string
 }
@@ -192,6 +233,15 @@ func qualityStrings(lang string) qualityText {
 				"Un endpoint qui répond existe et se résout ; un `moved` (404) dit qu'il a bougé.",
 			colProvider: "Fournisseur", colRecorded: "Relevé le", colAnswered: "Ont répondu",
 			colMoved: "Déplacés", colUn: "Injoignables",
+			precTitle: "Précision des règles high/critical",
+			precBody: "Détecter et se TAIRE sont deux mesures différentes, et elles se publient ensemble :\n" +
+				"« 21 chemins de détection prouvés » se lit dans le sens le plus flatteur tant que\nrien ne dit sur combien de configurations légitimes ces mêmes règles se sont tues.\nUne règle qui se déclenche sur tout est parfaitement sensible.\n\nUn CONTRE-EXEMPLE est un couple sur un même chemin contrôle × fournisseur ×\nsource : un cas fautif, et un cas correct qui lui ressemble. Les contrôles qui\nn'en ont pas encore sont comptés dans\n`internal/veracity/testdata/counterexamples-debt.txt`.",
+			precControls: "Contrôles high/critical actifs",
+			precDetect:   "Dont un chemin de détection est prouvé de bout en bout",
+			precCounter:  "Dont un contre-exemple légitime est prouvé",
+			precFP:       "Faux positifs mesurés sur les contre-témoins",
+			precNoFN: "Il n'y a pas de ligne « faux négatifs », et son absence est le chiffre le plus\n" +
+				"honnête de cette page. Aucun artefact du dépôt ne les mesure : il faudrait un\ncorpus de configurations fautives dont on SAIT qu'elles échappent aux règles,\nc'est-à-dire savoir ce qu'on ne sait pas. Publier « 0 » serait le faux vert exact\nque cette page combat — zéro mesuré n'est pas zéro existant.",
 			fpTitle: "Faux positifs",
 			fpBody: "Le dépôt ne tient pas de registre de faux positifs, et en publier un compte serait\n" +
 				"exactement la saisie que cette page refuse. Ce qui est MESURÉ, c'est le\ncontre-témoin : un tenant tiers déclaré durci sur lequel Pépin ne relève aucun\nécart `critical`/`high`. C'est le seul endroit où un faux positif se voit, et une\nporte le vérifie à chaque build.",
@@ -231,6 +281,15 @@ func qualityStrings(lang string) qualityText {
 			"An endpoint that answers exists and resolves; a `moved` (404) says it has shifted.",
 		colProvider: "Provider", colRecorded: "Recorded", colAnswered: "Answered",
 		colMoved: "Moved", colUn: "Unreachable",
+		precTitle: "Precision of the high/critical rules",
+		precBody: "Catching and STAYING SILENT are two different measurements, and they are published\n" +
+			"together: \"21 detection paths proven\" reads in the most flattering way for as long\nas nothing says on how many legitimate configurations those same rules held their\ntongue. A rule that fires on everything is perfectly sensitive.\n\nA COUNTEREXAMPLE is a pair on one control × provider × source path: a faulty case,\nand a correct one that resembles it. Controls that do not have one yet are counted\nin `internal/veracity/testdata/counterexamples-debt.txt`.",
+		precControls: "Active high/critical controls",
+		precDetect:   "Of which a detection path is proven end to end",
+		precCounter:  "Of which a legitimate counterexample is proven",
+		precFP:       "False positives measured on the counter-witnesses",
+		precNoFN: "There is no \"false negatives\" row, and its absence is the most honest figure on\n" +
+			"this page. No repository artefact measures them: it would take a corpus of faulty\nconfigurations KNOWN to escape the rules, that is, knowing what one does not know.\nPublishing \"0\" would be the exact false green this page fights — a measured zero is\nnot an existing zero.",
 		fpTitle: "False positives",
 		fpBody: "The repository keeps no false-positive register, and publishing a count would be\n" +
 			"exactly the data entry this page refuses. What is MEASURED is the\ncounter-witness: a third-party tenant declared hardened on which Pépin raises no\n`critical`/`high` deviation. It is the only place a false positive shows up, and\na gate checks it on every build.",
@@ -293,6 +352,14 @@ func qualityPage(lang string, s quality.Snapshot) string {
 			c.Provider, c.Recorded, c.Answered, c.Moved, c.Unreachable)
 	}
 	b.WriteString("\n")
+
+	b.WriteString("## " + t.precTitle + "\n\n" + t.precBody + "\n\n")
+	b.WriteString("| " + t.colFigure + " | " + t.colCount + " |\n|---|---:|\n")
+	row(t.precControls, s.Precision.Controls)
+	row(t.precDetect, s.Precision.DetectionProven)
+	row(t.precCounter, s.Precision.WithCounterexample)
+	row(t.precFP, s.Precision.FalsePositives)
+	b.WriteString("\n" + t.precNoFN + "\n\n")
 
 	b.WriteString("## " + t.fpTitle + "\n\n" + t.fpBody + "\n\n")
 	b.WriteString("| " + t.colFigure + " | " + t.colCount + " |\n|---|---:|\n")

--- a/internal/quality/quality.go
+++ b/internal/quality/quality.go
@@ -110,6 +110,42 @@ type Snapshot struct {
 	Tenants          int                     `json:"tenants"`
 	Canary           []CanaryProvider        `json:"canary"`
 	ByControl        map[string]ControlProof `json:"by_control"`
+	// Precision : ce que la carte peut dire de la précision des règles high/critical.
+	Precision Precision `json:"precision"`
+}
+
+// Precision est la mesure de ce qu'une règle REFUSE de détecter, à côté de ce
+// qu'elle détecte.
+//
+// Les deux chiffres se publient ENSEMBLE, et c'est délibéré : « 21 chemins de
+// détection prouvés » se lit dans le sens le plus flatteur si rien ne dit sur
+// combien de configurations légitimes ces règles se sont tues. Une règle qui se
+// déclenche sur tout est parfaitement sensible.
+//
+// Ce que cette structure ne porte PAS, et c'est le point le plus important : un
+// compteur de FAUX NÉGATIFS. Aucun artefact du dépôt ne le mesure — il faudrait un
+// corpus de configurations fautives dont on sait qu'elles échappent aux règles,
+// c'est-à-dire savoir ce qu'on ne sait pas. Publier « 0 faux négatif » serait donc
+// le faux vert exact que ce paquet combat : zéro mesuré n'est pas zéro existant. La
+// page le DIT plutôt que d'afficher un chiffre.
+type Precision struct {
+	// Controls : contrôles ACTIFS de sévérité high ou critical. Un contrôle dormant
+	// n'est jamais évalué : sa précision serait une intention.
+	Controls int `json:"controls"`
+	// DetectionProven : ceux dont au moins un chemin prouve un `fail` de bout en
+	// bout, sur une configuration réellement fautive. C'est la sensibilité mesurée.
+	DetectionProven int `json:"detection_proven"`
+	// WithCounterexample : ceux qui portent un COUPLE — un cas `fail` et un cas
+	// `pass` proche, sur le même chemin. C'est la précision mesurée.
+	WithCounterexample int `json:"with_counterexample"`
+	// FalsePositives : écarts critical/high relevés sur un tenant tiers déclaré
+	// DURCI. C'est le seul faux positif que le dépôt sache mesurer, et le compteur
+	// est adossé au scan, pas à une déclaration.
+	FalsePositives int `json:"false_positives"`
+	// Counterwitnesses : les tenants durcis sur lesquels cette mesure porte. Sans
+	// eux, un « 0 faux positif » ne voudrait rien dire : il faut publier le
+	// dénominateur avec le numérateur.
+	Counterwitnesses int `json:"counterwitnesses"`
 }
 
 // Percent rend un pourcentage entier, et 0 quand rien n'est dû — jamais 100 sur un
@@ -143,6 +179,16 @@ type Inputs struct {
 	// Counterwitnesses, Tenants : tenants durcis sans écart critical/high, et total.
 	Counterwitnesses int
 	TenantsTotal     int
+	// HighSeverityControls : les contrôles ACTIFS de sévérité high ou critical, sur
+	// lesquels la précision se mesure. Passés plutôt que recalculés ici : le
+	// référentiel est déjà lu par l'appelant, et deux lectures divergent.
+	HighSeverityControls []string
+	// CounterexamplePairs : les contrôles portant un couple `fail`+`pass` sur un
+	// même chemin (veracity.CounterexamplePairs).
+	CounterexamplePairs map[string]bool
+	// FalsePositives : écarts critical/high relevés sur un tenant DURCI. Mesuré par
+	// le scan des tenants de référence, jamais annoncé.
+	FalsePositives int
 }
 
 // Compute dérive la carte. Rien n'y est saisi : chaque champ vient d'un artefact.
@@ -160,6 +206,25 @@ func Compute(in Inputs) Snapshot {
 		Counterwitnesses: in.Counterwitnesses,
 		Tenants:          in.TenantsTotal,
 		ByControl:        map[string]ControlProof{},
+	}
+
+	// La PRÉCISION, dérivée du corpus de contre-exemples et du scan des tenants
+	// durcis. Aucun de ces trois chiffres n'est saisi, et il n'y en a pas de
+	// quatrième : le faux négatif n'a aucune source de mesure, donc il ne se publie
+	// pas (cf. le commentaire du type Precision).
+	detecte := veracity.DetectionProven(in.Covered)
+	s.Precision = Precision{
+		Controls:         len(in.HighSeverityControls),
+		FalsePositives:   in.FalsePositives,
+		Counterwitnesses: in.Counterwitnesses,
+	}
+	for _, code := range in.HighSeverityControls {
+		if detecte[code] {
+			s.Precision.DetectionProven++
+		}
+		if in.CounterexamplePairs[code] {
+			s.Precision.WithCounterexample++
+		}
 	}
 
 	// Un relevé AUTHENTIFIÉ est le seul qui atteste qu'un droit suffisant a rendu

--- a/internal/quality/quality_test.go
+++ b/internal/quality/quality_test.go
@@ -1,6 +1,7 @@
 package quality_test
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -175,5 +176,60 @@ func TestPercentNeverReadsFullOnAnEmptyDenominator(t *testing.T) {
 	}
 	if got := quality.Percent(3, 3); got != 100 {
 		t.Errorf("Percent(3, 3) = %d, attendu 100", got)
+	}
+}
+
+// TestPrecisionNeverExceedsWhatIsMeasured — la même règle que pour le reste de la
+// carte, appliquée aux chiffres de précision (issue #118).
+//
+// Ces trois-là sont les plus tentants du dépôt : ils décrivent la qualité même du
+// produit, et ce sont exactement ceux qu'on aurait envie d'arrondir. La règle ne
+// change pas : aucun ne peut dépasser son dénominateur, et aucun n'est saisi.
+func TestPrecisionNeverExceedsWhatIsMeasured(t *testing.T) {
+	p := embedded(t).Precision
+	if p.Controls <= 0 {
+		t.Fatal("aucun contrôle high/critical : la mesure de précision serait vide")
+	}
+	if p.DetectionProven > p.Controls {
+		t.Errorf("%d chemins de détection prouvés pour %d contrôles high/critical",
+			p.DetectionProven, p.Controls)
+	}
+	if p.WithCounterexample > p.Controls {
+		t.Errorf("%d contre-exemples pour %d contrôles high/critical",
+			p.WithCounterexample, p.Controls)
+	}
+	// Un faux positif se compte sur un contre-témoin : sans contre-témoin, il ne peut
+	// pas y en avoir de mesuré, et un chiffre non nul serait sorti de nulle part.
+	if p.FalsePositives > 0 && p.Counterwitnesses == 0 {
+		t.Errorf("%d faux positifs annonces sans aucun contre-temoin pour les mesurer",
+			p.FalsePositives)
+	}
+	if p.Counterwitnesses > embedded(t).Tenants {
+		t.Errorf("%d contre-témoins pour %d tenants", p.Counterwitnesses, embedded(t).Tenants)
+	}
+}
+
+// TestPrecisionPublishesNoFalseNegativeCount : l'absence de ce chiffre est une
+// DÉCISION, pas un oubli.
+//
+// Aucun artefact du dépôt ne mesure un faux négatif — il faudrait un corpus de
+// configurations fautives dont on SAIT qu'elles échappent aux règles, c'est-à-dire
+// savoir ce qu'on ne sait pas. Publier « 0 » serait le faux vert exact que cette
+// carte combat : zéro mesuré n'est pas zéro existant.
+//
+// Cette garde est une PORTE CONTRE SOI-MÊME : elle échoue le jour où quelqu'un
+// ajoute le champ, et l'oblige à écrire d'abord d'où viendrait la mesure.
+func TestPrecisionPublishesNoFalseNegativeCount(t *testing.T) {
+	raw, err := json.Marshal(embedded(t).Precision)
+	if err != nil {
+		t.Fatalf("sérialisation : %v", err)
+	}
+	for _, interdit := range []string{"false_negative", "false_negatives", "faux_negatif"} {
+		if strings.Contains(string(raw), interdit) {
+			t.Errorf("la carte publie un compteur %q.\n"+
+				"  Aucun artefact ne le mesure : ce serait un chiffre saisi, et un « 0 » y\n"+
+				"  vaudrait « nous n'avons pas cherché ». Écrire d'abord d'où vient la mesure.",
+				interdit)
+		}
 	}
 }

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -2564,5 +2564,12 @@
         "internal/commonrules/rules/objectstorage_bucket_test.rego"
       ]
     }
+  },
+  "precision": {
+    "controls": 42,
+    "detection_proven": 18,
+    "with_counterexample": 16,
+    "false_positives": 0,
+    "counterwitnesses": 2
   }
 }

--- a/internal/veracity/counterexample.go
+++ b/internal/veracity/counterexample.go
@@ -1,0 +1,82 @@
+package veracity
+
+import "sort"
+
+// Le CONTRE-EXEMPLE légitime (issue #115), et ce qu'il permet de publier (#118).
+//
+// Le contrat de véracité prouve qu'un chemin sait produire le verdict attendu. Il ne
+// prouve pas qu'il RETIENT ce verdict sur une configuration voisine et légitime, et
+// c'est de cette moitié-là qu'est faite la précision : une règle qui se déclenche sur
+// tout est parfaitement sensible.
+//
+// Ce calcul vit ici, et non dans un fichier de test, pour une raison qui a déjà servi
+// dans ce paquet : la carte de qualité et la porte qui refuse un contrôle sans
+// contre-exemple doivent lire la MÊME source. Deux calculs de couverture divergent
+// toujours, et celui qui diverge est celui qu'on publie.
+
+// CounterexamplePairs rend les contrôles pour lesquels un MÊME chemin contrôle ×
+// fournisseur × source porte à la fois un cas `fail` et un cas `pass`.
+//
+// L'unicité du chemin n'est pas un détail : un `fail` sur un plan Terraform et un
+// `pass` sur une collecte live n'éprouvent pas la même chaîne, et la règle pourrait
+// se taire dans la seconde pour une raison entièrement étrangère à la configuration
+// légitime qu'on croit avoir prouvée.
+//
+// Ce que ce calcul NE mesure PAS, et qui ne se mesure pas : la PROXIMITÉ du cas
+// légitime au cas fautif. Un `pass` sur un inventaire vide satisferait cette fonction
+// sans rien prouver. C'est la revue qui juge cette proximité, et les scénarios la
+// portent dans leur champ `why`.
+func CounterexamplePairs(files []File) map[string]bool {
+	surLeChemin := map[Path]map[Verdict]bool{}
+	for _, f := range files {
+		p := f.PathOf()
+		if surLeChemin[p] == nil {
+			surLeChemin[p] = map[Verdict]bool{}
+		}
+		for _, s := range f.Scenarios {
+			surLeChemin[p][s.Expect] = true
+		}
+	}
+	out := map[string]bool{}
+	for p, v := range surLeChemin {
+		if v[Fail] && v[Pass] {
+			out[p.Control] = true
+		}
+	}
+	return out
+}
+
+// DetectionProven rend les contrôles dont AU MOINS un chemin prouve le verdict
+// `fail` de bout en bout — c'est-à-dire que la chaîne complète, de la source au
+// verdict, a été observée sur une configuration réellement fautive.
+//
+// C'est la SENSIBILITÉ mesurée, à distinguer de la précision : les deux se publient
+// côte à côte, parce qu'un chiffre seul se lit toujours dans le sens le plus
+// flatteur.
+func DetectionProven(covered map[Path][]Verdict) map[string]bool {
+	out := map[string]bool{}
+	for p, verdicts := range covered {
+		for _, v := range verdicts {
+			if v == Fail {
+				out[p.Control] = true
+				break
+			}
+		}
+	}
+	return out
+}
+
+// WithoutCounterexample rend, triés, les contrôles de `codes` qui n'ont pas de
+// couple. C'est la dette que le registre consigne, et elle se lit dans les deux
+// sens : une ligne de trop est une dette inventée, une ligne manquante un contrôle
+// ajouté sans sa preuve de précision.
+func WithoutCounterexample(codes []string, pairs map[string]bool) []string {
+	var out []string
+	for _, c := range codes {
+		if !pairs[c] {
+			out = append(out, c)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/veracity/counterexample_test.go
+++ b/internal/veracity/counterexample_test.go
@@ -41,23 +41,18 @@ import (
 // à chaque contre-exemple réellement écrit.
 const contreExempleLedger = "testdata/counterexamples-debt.txt"
 
-// counterexamplePairs rend, par contrôle, les verdicts couverts par un scénario.
-func counterexamplePairs(t *testing.T) map[string]map[veracity.Verdict]bool {
+// couples rend les contrôles portant un couple `fail`+`pass` sur un même chemin.
+//
+// La porte et la CARTE DE QUALITÉ lisent la même fonction (veracity.CounterexamplePairs) :
+// deux calculs de couverture divergent toujours, et celui qui diverge est celui qu'on
+// publie. C'est pourquoi ce calcul a quitté ce fichier de test pour le paquet.
+func couples(t *testing.T) map[string]bool {
 	t.Helper()
 	files, err := veracity.LoadScenarios(scenarioDir)
 	if err != nil {
 		t.Fatalf("chargement des scénarios : %v", err)
 	}
-	out := map[string]map[veracity.Verdict]bool{}
-	for _, f := range files {
-		if out[f.Control] == nil {
-			out[f.Control] = map[veracity.Verdict]bool{}
-		}
-		for _, s := range f.Scenarios {
-			out[f.Control][s.Expect] = true
-		}
-	}
-	return out
+	return veracity.CounterexamplePairs(files)
 }
 
 // highSeverityControls rend les contrôles ACTIFS de sévérité `high` ou `critical`.
@@ -81,16 +76,7 @@ func highSeverityControls() []string {
 // fail+pass, dans l'ordre.
 func sansContreExemple(t *testing.T) []string {
 	t.Helper()
-	couvert := counterexamplePairs(t)
-	var out []string
-	for _, code := range highSeverityControls() {
-		v := couvert[code]
-		if v[veracity.Verdict("fail")] && v[veracity.Verdict("pass")] {
-			continue
-		}
-		out = append(out, code)
-	}
-	return out
+	return veracity.WithoutCounterexample(highSeverityControls(), couples(t))
 }
 
 // TestEveryHighSeverityControlHasALegitimateCounterexample est la porte de l'issue


### PR DESCRIPTION
## Ce que la carte ne disait pas

« 42 contrôles » est une phrase que tous les CSPM prononcent. **Détecter** et **se
taire** sont deux mesures différentes, et une seule était publiée.

> « 21 chemins de détection prouvés » se lit dans le sens le plus flatteur tant que
> rien ne dit sur combien de configurations légitimes ces mêmes règles se sont tues.

## Ce qui est publié maintenant

Dérivé du corpus de contre-exemples livré en #115 :

| Chiffre | Nombre |
|---|---:|
| Contrôles `high`/`critical` actifs | 42 |
| Dont un chemin de détection est prouvé de bout en bout | 18 |
| Dont un contre-exemple légitime est prouvé | 16 |
| Faux positifs mesurés sur les contre-témoins | 0 |

**Le faux positif est mesuré, pas déclaré** : un écart `critical`/`high` relevé sur
un tenant qui se déclare *durci*. Ce relevé est régénéré depuis le binaire, donc le
chiffre suit le produit. Il est publié **avec son dénominateur** — un « 0 faux
positif » ne dit rien sans le nombre de configurations sur lesquelles il a été
mesuré.

## Le chiffre absent, qui est le plus important

**Il n'y a délibérément aucune ligne « faux négatifs ».**

Rien dans le dépôt ne les mesure : il faudrait un corpus de configurations fautives
dont on *sait* qu'elles échappent aux règles — c'est-à-dire savoir ce qu'on ne sait
pas. Un « 0 » publié voudrait dire « nous n'avons pas cherché » tout en se lisant
« il n'y en a pas ». C'est le faux vert exact que cette carte existe pour combattre.

`TestPrecisionPublishesNoFalseNegativeCount` est une **porte contre nous-mêmes** :
elle échoue le jour où quelqu'un ajoute le champ, et l'oblige à écrire d'abord d'où
viendrait la mesure.

## Une divergence en moins

Le calcul des contre-exemples a quitté son fichier de test pour le paquet. La carte
et la porte qui refuse un contrôle sans contre-exemple lisent désormais **la même
fonction** — pour la raison que ce paquet énonce déjà à propos de la couverture :
*deux calculs divergent, et celui qui diverge est celui qu'on lit*.

## Éprouvé en flattant un chiffre

Passer `with_counterexample` à 99 dans l'instantané est attrapé et rapporté contre
son dénominateur :

```
quality_test.go:198: 99 contre-exemples pour 42 contrôles high/critical
```

## Critères d'acceptation

- [x] La précision est dérivée du corpus, jamais saisie
- [x] Un faux positif connu est compté, même documenté — il l'est **depuis le
      relevé du scan**, donc une documentation ne peut pas l'effacer
- [x] Une garde interdit qu'un chiffre publié dépasse la mesure
- [x] La carte reste générée, donc elle ne dérive pas

## Portes

`mise run prepush` au vert. `snapshot.json` et la carte régénérés dans les deux
langues, CHANGELOG bilingue.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)
