### PR TITLE
feat(findings): a finding says how sure it is, not only how bad it would be

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -24,6 +24,23 @@ l'une ni l'autre appartient au `git log`.
 
 ### Ajouté
 
+- **Un finding déclare désormais sa CONFIANCE, distincte de sa sévérité.** La sévérité
+  dit la conséquence si le problème est réel ; la confiance dit à quel point Pépin est
+  sûr de l'avoir établi. Un volume sans sauvegarde récente et une VM dont SSH est ouvert
+  à Internet étaient tous deux `high` et indiscernables — le premier est `contextual`
+  (la règle le documente elle-même : un volume peut être sauvegardé autrement), le
+  second `confirmed`. `labels.confidence` vaut `confirmed`, `probable`, `heuristic` ou
+  `contextual`, déclarée règle par règle, et une règle sans confiance casse la CI.
+- **`labels.category` gagne `sovereignty` et `hygiene`.** La souveraineté est la raison
+  d'être de ce produit et était rangée sous `compliance`, où un filtre ne pouvait pas la
+  trouver ; l'hygiène documentaire n'est ni une faille ni un manquement normatif, et la
+  confondre avec l'un des deux est ce qui rend un premier scan irritant. Sept findings
+  passent en `sovereignty`, trois en `hygiene`.
+- **Le vocabulaire de confiance de la détection de secrets rejoint le vocabulaire
+  commun** : `high`/`medium`/`low` deviennent `confirmed`/`probable`/`heuristic`, sans
+  perdre de granularité. Un `secrets.min_confidence` écrit avec les anciens mots reste
+  accepté, au même rang, et normalisé dans la configuration résolue — une politique
+  committée ne change pas de sens en silence.
 - **La carte de qualité publie désormais la précision, dérivée du corpus de
   contre-exemples.** « 42 contrôles » est une phrase que tous les CSPM prononcent.
   Détecter et se TAIRE sont deux mesures différentes, et elles s'impriment maintenant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ belongs in `git log`.
 
 ### Added
 
+- **A finding now declares its CONFIDENCE, distinct from its severity.** Severity says
+  the consequence if the problem is real; confidence says how sure Pépin is that it
+  established the problem at all. A volume with no recent snapshot and a VM with SSH
+  open to the internet were both `high` and indistinguishable — the first is
+  `contextual` (the rule documents it itself: a volume may be backed up otherwise), the
+  second `confirmed`. `labels.confidence` is one of `confirmed`, `probable`,
+  `heuristic`, `contextual`, declared per rule, and a rule without one breaks CI.
+- **`labels.category` gains `sovereignty` and `hygiene`.** Sovereignty is this
+  product's reason to exist and was filed under `compliance`, where a filter could not
+  find it; documentation hygiene is neither a vulnerability nor a normative breach, and
+  conflating it with either is what makes a first scan irritating. Seven findings move
+  to `sovereignty`, three to `hygiene`.
+- **The secret-detection confidence vocabulary is unified with the common one**:
+  `high`/`medium`/`low` become `confirmed`/`probable`/`heuristic`, with no granularity
+  lost. A `secrets.min_confidence` written with the old words is still accepted, at the
+  same rank, and normalised in the resolved configuration — a committed policy does not
+  change meaning in silence.
 - **The quality map now publishes precision, derived from the counterexample corpus.**
   "42 controls" is a sentence every CSPM says. Catching and staying SILENT are two
   different measurements, and they are now printed side by side: 42 active

--- a/cmd/policy_test.go
+++ b/cmd/policy_test.go
@@ -111,7 +111,7 @@ func TestADefaultScanDeclaresItsConfiguration(t *testing.T) {
 	if len(doc.Config.Relaxations) != 0 {
 		t.Errorf("un scan par défaut ne doit annoncer AUCUN assouplissement, obtenu %d", len(doc.Config.Relaxations))
 	}
-	if doc.Config.Effective.Snapshots.MaxAgeDays != 7 || doc.Config.Effective.Secrets.MinConfidence != "low" {
+	if doc.Config.Effective.Snapshots.MaxAgeDays != 7 || doc.Config.Effective.Secrets.MinConfidence != "heuristic" {
 		t.Errorf("la configuration effective publiée ne correspond pas au profil par défaut : %+v", doc.Config.Effective)
 	}
 }
@@ -358,7 +358,10 @@ func TestASecretConfidenceTravelsInTheParsableFormats(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
 		t.Fatalf("sortie JSON illisible : %v", err)
 	}
-	levels := map[string]bool{"low": true, "medium": true, "high": true}
+	// Le vocabulaire est COMMUN à tous les findings depuis #111 : cette règle portait
+	// auparavant le sien (`high`/`medium`/`low`), et deux mots pour une même idée
+	// rendaient un filtre `confidence=` dépendant de la règle qu'on regardait.
+	levels := map[string]bool{"heuristic": true, "probable": true, "confirmed": true}
 	found := 0
 	for _, f := range doc.Findings {
 		if f.Labels["check"] != "compute_instance_no_secrets_in_user_data" {

--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -219,6 +219,7 @@ ressources, pas une liste à cocher de contrôles.
   },
   "labels": {
     "category": "security",
+    "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
     "tf_line": "81"
@@ -462,6 +463,7 @@ exception, c'est-à-dire le même faux vert avec une étape de plus.
   },
   "labels": {
     "category": "security",
+    "confidence": "confirmed",
     "exemption_approved_by": "security@example.org",
     "exemption_expires_at": "2099-12-31",
     "exemption_owner": "platform-security",

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -219,6 +219,7 @@ resources, not a checklist of controls.
   },
   "labels": {
     "category": "security",
+    "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
     "tf_line": "81"
@@ -457,6 +458,7 @@ with one more step.
   },
   "labels": {
     "category": "security",
+    "confidence": "confirmed",
     "exemption_approved_by": "security@example.org",
     "exemption_expires_at": "2099-12-31",
     "exemption_owner": "platform-security",

--- a/docs/concepts/terraform-vs-live.fr.md
+++ b/docs/concepts/terraform-vs-live.fr.md
@@ -240,6 +240,7 @@ insensiblement à la casse. L'écart est bien trouvé :
   "labels": {
     "category": "security",
     "check": "compute_image_not_public",
+    "confidence": "confirmed",
     "provider": "outscale",
     "tf_file": "main.tf",
     "tf_line": "32"

--- a/docs/concepts/terraform-vs-live.md
+++ b/docs/concepts/terraform-vs-live.md
@@ -235,6 +235,7 @@ a shared helper (`truthy` in `internal/commonrules/rules/lib.rego`) that accepts
   "labels": {
     "category": "security",
     "check": "compute_image_not_public",
+    "confidence": "confirmed",
     "provider": "outscale",
     "tf_file": "main.tf",
     "tf_line": "32"

--- a/docs/getting-started/understanding-a-scan.fr.md
+++ b/docs/getting-started/understanding-a-scan.fr.md
@@ -401,6 +401,7 @@ mot.
   },
   "labels": {
     "category": "security",
+    "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
     "tf_line": "81"

--- a/docs/getting-started/understanding-a-scan.md
+++ b/docs/getting-started/understanding-a-scan.md
@@ -398,6 +398,7 @@ documented in
   },
   "labels": {
     "category": "security",
+    "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
     "tf_line": "81"

--- a/docs/guides/control-configuration.fr.md
+++ b/docs/guides/control-configuration.fr.md
@@ -36,7 +36,7 @@ controls:
     max_age_days: 7
     accepted_states: [completed, created]
   secrets:
-    min_confidence: low
+    min_confidence: heuristic
 
 exceptions:
   - control: objectstorage_bucket_public_access
@@ -74,7 +74,7 @@ répondre** — qui paye, pour quoi, à quel stade, qui répond —, jamais des 
 | `tagging.resource_types` | 8 types, listés plus bas | où l'étiquetage est exigé |
 | `snapshots.max_age_days` | `7` | fenêtre de fraîcheur d'une snapshot |
 | `snapshots.accepted_states` | `completed, created` | états natifs d'une snapshot exploitable |
-| `secrets.min_confidence` | `low` | tout signaler, heuristiques génériques comprises |
+| `secrets.min_confidence` | `heuristic` | tout signaler, heuristiques génériques comprises |
 
 **La comparaison est insensible à la casse et aux séparateurs.** `cost-center`,
 `cost_center`, `Cost Center` et `CostCenter` sont la même exigence — un outil qui crie au loup
@@ -170,11 +170,11 @@ Chaque détection porte son niveau de confiance, dans `labels.confidence` :
 
 | Niveau | Fondement | Exemple |
 |---|---|---|
-| `high` | confirmé par sa forme | `-----BEGIN … PRIVATE KEY-----` |
-| `medium` | préfixe reconnu et format attendu | `ghp_…`, `AKIA…`, `SCW…`, `glpat-…`, JWT |
-| `low` | heuristique générique | `password=…`, `api_key=…` |
+| `confirmed` | confirmé par sa forme | `-----BEGIN … PRIVATE KEY-----` |
+| `probable` | préfixe reconnu et format attendu | `ghp_…`, `AKIA…`, `SCW…`, `glpat-…`, JWT |
+| `heuristic` | heuristique générique | `password=…`, `api_key=…` |
 
-Le défaut est `low` : tout est signalé. C'est le seul défaut défendable pour un détecteur de
+Le défaut est `heuristic` : tout est signalé. C'est le seul défaut défendable pour un détecteur de
 secrets — taire par défaut ce qu'on ne sait pas confirmer, c'est échanger un faux positif
 contre un faux négatif, sur le seul sujet où le faux négatif se paye en fuite.
 
@@ -191,7 +191,7 @@ Rendre le scan lui-même plus silencieux — et en assumer le prix :
 ```yaml
 controls:
   secrets:
-    min_confidence: medium   # les heuristiques génériques ne sont plus signalées
+    min_confidence: probable   # les heuristiques génériques ne sont plus signalées
 ```
 
 Cela fait tomber la correspondance CLD-CMP-9 / SecNumCloud 10.5, et le rapport le dit.

--- a/docs/guides/control-configuration.md
+++ b/docs/guides/control-configuration.md
@@ -34,7 +34,7 @@ controls:
     max_age_days: 7
     accepted_states: [completed, created]
   secrets:
-    min_confidence: low
+    min_confidence: heuristic
 
 exceptions:
   - control: objectstorage_bucket_public_access
@@ -71,7 +71,7 @@ for what, at which stage, who is accountable — never the exact words.
 | `tagging.resource_types` | 8 types, listed below | where tagging is required |
 | `snapshots.max_age_days` | `7` | freshness window of a snapshot |
 | `snapshots.accepted_states` | `completed, created` | native states of a usable snapshot |
-| `secrets.min_confidence` | `low` | report everything, including generic heuristics |
+| `secrets.min_confidence` | `heuristic` | report everything, including generic heuristics |
 
 **The comparison ignores case and separators.** `cost-center`, `cost_center`, `Cost Center`
 and `CostCenter` are the same requirement — a tool that cries wolf over typography gets
@@ -164,11 +164,11 @@ Secret detection carries a confidence level on every finding, in `labels.confide
 
 | Level | Basis | Example |
 |---|---|---|
-| `high` | confirmed by its shape | `-----BEGIN … PRIVATE KEY-----` |
-| `medium` | recognized prefix and expected format | `ghp_…`, `AKIA…`, `SCW…`, `glpat-…`, JWT |
-| `low` | generic heuristic | `password=…`, `api_key=…` |
+| `confirmed` | confirmed by its shape | `-----BEGIN … PRIVATE KEY-----` |
+| `probable` | recognized prefix and expected format | `ghp_…`, `AKIA…`, `SCW…`, `glpat-…`, JWT |
+| `heuristic` | generic heuristic | `password=…`, `api_key=…` |
 
-The default is `low`: everything is reported. That is the only defensible default for a
+The default is `heuristic`: everything is reported. That is the only defensible default for a
 secret detector — silencing by default what you cannot confirm trades a false positive for a
 false negative, on the one subject where a false negative is paid in a leak.
 
@@ -185,7 +185,7 @@ Make the scan itself quieter — and accept the cost:
 ```yaml
 controls:
   secrets:
-    min_confidence: medium   # generic heuristics are no longer reported
+    min_confidence: probable   # generic heuristics are no longer reported
 ```
 
 This drops the CLD-CMP-9 / SecNumCloud 10.5 mapping, and the report says so. "No cleartext

--- a/docs/guides/remediation.fr.md
+++ b/docs/guides/remediation.fr.md
@@ -63,6 +63,7 @@ Avant, sur `examples/scaleway/terraform/plan.json` :
   },
   "labels": {
     "category": "security",
+    "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
     "tf_line": "81"

--- a/docs/guides/remediation.md
+++ b/docs/guides/remediation.md
@@ -61,6 +61,7 @@ Before, on `examples/scaleway/terraform/plan.json`:
   },
   "labels": {
     "category": "security",
+    "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
     "tf_line": "81"

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -404,7 +404,7 @@ dans les deux langues, et le référentiel le consigne dans la description du co
 
 Les heuristiques génériques (`password=…`, `api_key=…`) ne distinguent pas
 `password=changeme123456` d'un vrai secret. Chaque finding porte `labels.confidence`
-(`high` | `medium` | `low`) pour qu'un pipeline puisse trier, et le seuil de signalement est
+(`confirmed` | `probable` | `heuristic`) pour qu'un pipeline puisse trier, et le seuil de signalement est
 configurable. Le relever est un assouplissement : « aucun secret en clair » ne se prouve plus
 dès lors qu'on a choisi de ne pas regarder une partie de ce qui a été trouvé, donc la
 correspondance CLD-CMP-9 tombe et le rapport le dit. La valeur détectée, elle, n'apparaît

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -393,7 +393,7 @@ both languages, and the reference records it in the control description.
 ### Secret detection has confidence levels, not certainty
 
 Generic heuristics (`password=…`, `api_key=…`) cannot tell `password=changeme123456` from a
-real secret. Each finding carries `labels.confidence` (`high` | `medium` | `low`) so a
+real secret. Each finding carries `labels.confidence` (`confirmed` | `probable` | `heuristic`) so a
 pipeline can triage, and the reporting threshold is configurable. Raising it is a relaxation:
 "no cleartext secret" cannot be proven once you have chosen not to look at part of what was
 found, so the CLD-CMP-9 mapping is dropped and the report says so. The detected value never

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -97,6 +97,7 @@ Forme gelée : `{"findings": [...], "summary": {...}}`.
   "labels": {
     "category": "security",
     "check": "objectstorage_bucket_public_access",
+    "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
     "tf_line": "81"
@@ -130,9 +131,40 @@ qu'un pipeline lise ce qu'il accepte au lieu de le déduire :
   projette. Sa forme est décrite dans
   [l'inventaire normalisé](inventory.fr.md#létat-de-collecte).
 
-Un finding de détection de secret porte en outre `labels.confidence` (`high` | `medium` |
-`low`), pour qu'un pipeline trie les heuristiques génériques à part des secrets confirmés sans
-changer le scan. La valeur détectée, elle, n'apparaît jamais, quel que soit le niveau.
+### Trier un rapport : la confiance, distincte de la sévérité
+
+Trois dimensions voyagent dans `labels`, et les confondre est ce qui rend un premier
+scan irritant :
+
+| Label | Ce qu'il dit | Valeurs |
+|---|---|---|
+| `severity` (champ, pas label) | la **conséquence** si le problème est réel | `critical` `high` `medium` `low` |
+| `labels.confidence` | la **certitude** que Pépin a correctement établi le problème | `confirmed` `probable` `heuristic` `contextual` |
+| `labels.category` | la **nature** du problème | `security` `compliance` `sovereignty` `hygiene` |
+
+Un volume sans sauvegarde récente et une VM dont SSH est ouvert à Internet sont tous
+deux `high`. Le premier est `contextual` — la règle le documente elle-même, un volume
+peut être sauvegardé autrement —, le second `confirmed`. Leur donner le même poids
+dans une porte de CI fait douter des deux.
+
+```bash
+# Ne bloquer que sur ce qui est établi, et voir le reste sans qu'il bloque
+pepin scan scaleway inv.json -f json \
+  | jq '[.findings[] | select(.labels.confidence == "confirmed")]'
+
+# Ce qui relève de la souveraineté, quelle que soit la sévérité
+pepin scan scaleway inv.json -f json \
+  | jq '[.findings[] | select(.labels.category == "sovereignty")]'
+```
+
+`confidence` et `category` voyagent dans `labels` plutôt qu'en champs de premier rang
+parce que le modèle `Finding` vient du module partagé `scankit` : y ajouter un champ
+imposerait le vocabulaire de Pépin à pitstop. C'est le même choix que pour les
+messages bilingues et l'origine Terraform.
+
+Pour la détection de secrets, la confiance est celle du MOTIF qui a déclenché, et le
+seuil de signalement est réglable (`secrets.min_confidence`). La valeur détectée, elle,
+n'apparaît jamais, quel que soit le niveau.
 
 **Ce que ce format ne sait pas dire** : il liste des écarts, donc un tableau `findings` vide
 signifie « aucun écart trouvé », ce qui recouvre aussi bien « le tenant est propre » que « rien
@@ -233,6 +265,7 @@ Un résultat :
   },
   "labels": {
     "category": "security",
+    "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
     "tf_line": "81"

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -97,6 +97,7 @@ Frozen shape: `{"findings": [...], "summary": {...}}`.
   "labels": {
     "category": "security",
     "check": "objectstorage_bucket_public_access",
+    "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
     "tf_line": "81"
@@ -129,9 +130,40 @@ read what it is accepting rather than infer it:
   unit, and the resource types the source carried that no spec projects. Its shape is described
   in [the normalized inventory](inventory.md#the-collection-state).
 
-A secret-detection finding also carries `labels.confidence` (`high` | `medium` | `low`), so a
-pipeline can triage generic heuristics apart from confirmed secrets without changing the scan.
-The detected value itself never appears, at any level.
+### Triaging a report: confidence, distinct from severity
+
+Three dimensions travel in `labels`, and conflating them is what makes a first scan
+irritating:
+
+| Label | What it says | Values |
+|---|---|---|
+| `severity` (field, not a label) | the **consequence** if the problem is real | `critical` `high` `medium` `low` |
+| `labels.confidence` | the **certainty** that Pépin established the problem correctly | `confirmed` `probable` `heuristic` `contextual` |
+| `labels.category` | the **nature** of the problem | `security` `compliance` `sovereignty` `hygiene` |
+
+A volume with no recent snapshot and a VM with SSH open to the internet are both
+`high`. The first is `contextual` — the rule documents it itself, a volume may be
+backed up by other means — the second is `confirmed`. Giving them the same weight in
+a CI gate makes people doubt both.
+
+```bash
+# Block only on what is established, and see the rest without it blocking
+pepin scan scaleway inv.json -f json \
+  | jq '[.findings[] | select(.labels.confidence == "confirmed")]'
+
+# What is a matter of sovereignty, whatever its severity
+pepin scan scaleway inv.json -f json \
+  | jq '[.findings[] | select(.labels.category == "sovereignty")]'
+```
+
+`confidence` and `category` travel in `labels` rather than as first-class fields
+because the `Finding` model comes from the shared `scankit` module: adding a field
+there would impose Pépin's vocabulary on pitstop. It is the same choice as for the
+bilingual messages and the Terraform origin.
+
+For secret detection, the confidence is that of the PATTERN that fired, and the
+reporting threshold is configurable (`secrets.min_confidence`). The detected value
+itself never appears, at any level.
 
 **What this format cannot tell you**: it lists deviations, so an empty `findings` array means
 "no deviation found", which covers both "the tenant is clean" and "nothing was collected". The
@@ -230,6 +262,7 @@ One result:
   },
   "labels": {
     "category": "security",
+    "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
     "tf_line": "81"

--- a/internal/commonrules/rules/blockstorage_snapshot_not_public.rego
+++ b/internal/commonrules/rules/blockstorage_snapshot_not_public.rego
@@ -22,6 +22,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("Snapshot \"%s\" shared publicly (anyone is allowed to create a volume from it).", [id]),
 			"remediation_en": "Remove the global permission; share the snapshot with legitimate accounts only.",
 		},

--- a/internal/commonrules/rules/blockstorage_volume_encryption.rego
+++ b/internal/commonrules/rules/blockstorage_volume_encryption.rego
@@ -36,6 +36,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(v),
 			"category": "compliance",
+			"confidence": "confirmed",
 			"message_en": sprintf("Block storage volume \"%s\": encryption at rest is disabled (data in cleartext on the platform side).", [name]),
 			"remediation_en": "Enable encryption at rest on the volume (depending on the provider: transparent, provider-managed key, or client-side encryption).",
 		},

--- a/internal/commonrules/rules/blockstorage_volume_snapshots_exist.rego
+++ b/internal/commonrules/rules/blockstorage_volume_snapshots_exist.rego
@@ -51,6 +51,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(v),
 			"category": "compliance",
+			"confidence": "contextual",
 			"message_en": sprintf("Volume \"%s\" (in use) has no completed snapshot younger than %d days.", [vid, snapshot_max_age_days]),
 			"remediation_en": "Set up an automated, regular snapshot schedule; test the restore periodically. If this volume is backed up by other means, file a dated, justified exemption rather than disabling the control.",
 		},

--- a/internal/commonrules/rules/compute_image_not_public.rego
+++ b/internal/commonrules/rules/compute_image_not_public.rego
@@ -21,6 +21,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("Machine image \"%s\" shared publicly (anyone is allowed to launch it).", [id]),
 			"remediation_en": "Remove the image's public sharing; reserve it for legitimate accounts.",
 		},

--- a/internal/commonrules/rules/compute_instance_deletion_protection.rego
+++ b/internal/commonrules/rules/compute_instance_deletion_protection.rego
@@ -32,6 +32,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "compliance",
+			"confidence": "contextual",
 			"message_en": sprintf("Instance \"%s\" has no deletion protection — an accidental or malicious action destroys it.", [id]),
 			"remediation_en": "Enable deletion protection on the instances carrying a production service.",
 		},
@@ -58,6 +59,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "compliance",
+			"confidence": "contextual",
 			"inconclusive": "true",
 			"message_en": sprintf("VM \"%s\" has no deletion protection and no environment tag — whether it carries a production service cannot be told.", [id]),
 			"remediation_en": "Tag the environment (Env / environment / stage) so this control knows whether it applies; enable protection on production instances.",

--- a/internal/commonrules/rules/compute_instance_has_security_group.rego
+++ b/internal/commonrules/rules/compute_instance_has_security_group.rego
@@ -25,6 +25,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(vm),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("VM \"%s\" has no security group: no network filtering applies to it.", [id]),
 			"remediation_en": "Attach a restrictive security group (deny by default) to the VM.",
 		},

--- a/internal/commonrules/rules/compute_instance_no_secrets_confidence_test.rego
+++ b/internal/commonrules/rules/compute_instance_no_secrets_confidence_test.rego
@@ -27,21 +27,21 @@ _weak := "password=hunter2000plus"
 test_private_key_is_high_confidence if {
 	some f in deny with input as _ud_vm(_pem)
 	f.code == "compute_instance_no_secrets_in_user_data"
-	f.labels.confidence == "high"
+	f.labels.confidence == "confirmed"
 }
 
 # ✗ jeton de forge à préfixe reconnu → confiance MEDIUM.
 test_prefixed_token_is_medium_confidence if {
 	some f in deny with input as _ud_vm(_token)
 	f.code == "compute_instance_no_secrets_in_user_data"
-	f.labels.confidence == "medium"
+	f.labels.confidence == "probable"
 }
 
 # ✗ heuristique générique → confiance LOW.
 test_generic_password_is_low_confidence if {
 	some f in deny with input as _ud_vm(_weak)
 	f.code == "compute_instance_no_secrets_in_user_data"
-	f.labels.confidence == "low"
+	f.labels.confidence == "heuristic"
 }
 
 # ── LA VALEUR NE SORT JAMAIS, quel que soit le niveau ────────────────────────

--- a/internal/commonrules/rules/compute_instance_no_secrets_in_user_data.rego
+++ b/internal/commonrules/rules/compute_instance_no_secrets_in_user_data.rego
@@ -6,17 +6,22 @@
 #
 # Chaque motif porte son niveau, et le finding le publie (`labels.confidence`) :
 #
-#   high   — secret CONFIRMÉ par sa forme : un bloc PEM `-----BEGIN … PRIVATE KEY-----`
-#            n'est pas autre chose qu'une clé privée ;
-#   medium — secret PROBABLE : préfixe reconnu ET format attendu (AKIA…, SCW…,
-#            EXO…, ghp_…, glpat-…, JWT à trois segments) ;
-#   low    — SUSPECT : heuristique générique (`password=…`, `api_key=…`), qui ne
-#            distingue pas `password=changeme123456` d'un vrai secret.
+#   confirmed — secret CONFIRMÉ par sa forme : un bloc PEM `-----BEGIN … PRIVATE
+#               KEY-----` n'est pas autre chose qu'une clé privée ;
+#   probable  — préfixe reconnu ET format attendu (AKIA…, SCW…, EXO…, ghp_…,
+#               glpat-…, JWT à trois segments) ;
+#   heuristic — SUSPECT : heuristique générique (`password=…`, `api_key=…`), qui
+#               ne distingue pas `password=changeme123456` d'un vrai secret.
+#
+# Ce vocabulaire est COMMUN à tous les findings depuis #111 : il portait auparavant
+# `high`/`medium`/`low`, propres à cette règle. Les anciennes valeurs restent
+# acceptées par `secrets.min_confidence` (cf. `confidence_rank` dans lib.rego), pour
+# qu'une politique déjà committée ne change pas de sens en silence.
 #
 # Pourquoi ça compte : donner à `password=…` le même poids qu'une clé privée rend
 # l'outil irritant en CI, et un outil irritant finit désactivé — ce qui coûte plus
 # cher que le faux positif qu'on voulait éviter. Le seuil est donc RÉGLABLE
-# (`secrets.min_confidence`, défaut `low` = tout signaler, le comportement
+# (`secrets.min_confidence`, défaut `heuristic` = tout signaler, le comportement
 # d'avant). Le monter est un ASSOUPLISSEMENT : le référentiel adosse la
 # correspondance CLD-CMP-9 à `secrets.min_confidence: au_plus_le_defaut`, et un
 # seuil plus haut la fait tomber, visiblement.
@@ -25,7 +30,7 @@
 # le message d'un contrôle est une surface que des captures, des tickets et des
 # annotations de forge recopient — le déplacer d'un octet pour une information
 # structurée serait le payer partout —, et un niveau est fait pour être FILTRÉ
-# (`jq '.findings[] | select(.labels.confidence == "low")'`), pas lu au milieu
+# (`jq '.findings[] | select(.labels.confidence == "heuristic")'`), pas lu au milieu
 # d'une phrase. Le rendu par défaut n'a donc pas bougé d'un caractère.
 #
 # # LA VALEUR DÉTECTÉE NE SORT JAMAIS
@@ -113,38 +118,38 @@ _secret_regexes := {
 	"clé d'accès Outscale (format AKIA…)": {
 		"en": "Outscale access key (AKIA… format)",
 		"re": `AKIA[0-9A-Z]{16}`,
-		"confidence": "medium",
+		"confidence": "probable",
 	},
 	"clé d'accès Scaleway (SCW…)": {
 		"en": "Scaleway access key (SCW…)",
 		"re": `SCW[A-Z0-9]{17,}`,
-		"confidence": "medium",
+		"confidence": "probable",
 	},
 	"clé d'accès Exoscale (EXO…)": {
 		"en": "Exoscale access key (EXO…)",
 		"re": `EXO[A-Za-z0-9]{16,}`,
-		"confidence": "medium",
+		"confidence": "probable",
 	},
 	# Jetons de forge / d'identité fréquemment collés dans le user-data.
 	"jeton GitHub": {
 		"en": "GitHub token",
 		"re": `(gh[pousr]_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{22,})`,
-		"confidence": "medium",
+		"confidence": "probable",
 	},
 	"jeton GitLab (glpat-)": {
 		"en": "GitLab token (glpat-)",
 		"re": `glpat-[A-Za-z0-9_-]{20}`,
-		"confidence": "medium",
+		"confidence": "probable",
 	},
 	"jeton JWT": {
 		"en": "JWT token",
 		"re": `eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}`,
-		"confidence": "medium",
+		"confidence": "probable",
 	},
 	"en-tête Authorization Bearer": {
 		"en": "Authorization Bearer header",
 		"re": `(?i)authorization\s*:\s*bearer\s+[A-Za-z0-9._-]{12,}`,
-		"confidence": "medium",
+		"confidence": "probable",
 	},
 	# Affectation de mot de passe EN CLAIR. La valeur doit suivre le séparateur SUR LA MÊME
 	# LIGNE (>=4 caractères non blancs) : évite le faux positif sur les blocs cloud-init
@@ -154,7 +159,7 @@ _secret_regexes := {
 	"mot de passe en clair": {
 		"en": "cleartext password",
 		"re": `(?i)(password|passwd|pwd)[ \t]*[:=][ \t]*['"]?[^\s'"]{4,}`,
-		"confidence": "low",
+		"confidence": "heuristic",
 	},
 	# Bloc cloud-init `chpasswd` : la façon la PLUS courante de poser un mot de passe.
 	# La valeur est sur une ligne indentée `utilisateur:motdepasse` — sans espace après
@@ -162,12 +167,12 @@ _secret_regexes := {
 	"mot de passe cloud-init (chpasswd)": {
 		"en": "cloud-init password (chpasswd)",
 		"re": `(?i)chpasswd:[\s\S]{0,300}?\n[ \t]+[A-Za-z0-9_.-]+:[^\s]{6,}`,
-		"confidence": "low",
+		"confidence": "heuristic",
 	},
 	"clé/API générique affectée": {
 		"en": "generic key/API assignment",
 		"re": `(?i)(api[_-]?key|secret[_-]?key|access[_-]?key|secret[_-]?access[_-]?key|auth[_-]?token|api[_-]?token)\s*[:=]\s*['"]?[A-Za-z0-9/+._-]{16,}`,
-		"confidence": "low",
+		"confidence": "heuristic",
 	},
 }
 
@@ -183,9 +188,10 @@ _secret_patterns(s) := patterns if {
 	}
 
 	# Un bloc PEM est un secret CONFIRMÉ : sa forme ne laisse pas de place au doute.
-	private_key := {{"fr": "bloc PRIVATE KEY", "en": "PRIVATE KEY block", "confidence": "high"} |
+	private_key := {{"fr": "bloc PRIVATE KEY", "en": "PRIVATE KEY block", "confidence": "confirmed"} |
 		contains(s, "BEGIN ")
 		contains(s, "PRIVATE KEY")
 	}
 	patterns := by_regex | private_key
 }
+

--- a/internal/commonrules/rules/compute_instance_public_ip_with_open_securitygroup.rego
+++ b/internal/commonrules/rules/compute_instance_public_ip_with_open_securitygroup.rego
@@ -70,6 +70,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(vm),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("VM \"%s\" publicly exposed: security group %s opens EVERY port to the internet.", [id, sg_id]),
 			"remediation_en": "Restrict the inbound rule to the ports actually served, or detach the public IP and go through an LBU / NAT.",
 		},
@@ -94,6 +95,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(vm),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("VM \"%s\" publicly exposed: security group %s opens sensitive port(s) %v to the internet.", [id, sg_id, ports]),
 			"remediation_en": "Restrict those ports to administration networks, or go through a bastion / VPN; leave open only the ports the service actually needs.",
 		},

--- a/internal/commonrules/rules/database_backup_enabled.rego
+++ b/internal/commonrules/rules/database_backup_enabled.rego
@@ -22,6 +22,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "compliance",
+			"confidence": "confirmed",
 			"message_en": sprintf("Managed database \"%s\": automatic backups are disabled.", [id]),
 			"remediation_en": "Re-enable automatic backups and set a retention that matches the RPO.",
 		},

--- a/internal/commonrules/rules/database_encryption_at_rest_enabled.rego
+++ b/internal/commonrules/rules/database_encryption_at_rest_enabled.rego
@@ -23,6 +23,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("Managed database \"%s\" has no encryption at rest.", [id]),
 			"remediation_en": "Enable encryption at rest on the instance (at creation time, or through an upgrade).",
 		},

--- a/internal/commonrules/rules/database_service_not_open_to_internet.rego
+++ b/internal/commonrules/rules/database_service_not_open_to_internet.rego
@@ -29,6 +29,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("Managed database \"%s\": ACL allowing a public CIDR (%s) — the service is exposed to the internet.", [id, cidr]),
 			"remediation_en": "Restrict the database ACL to the application CIDRs only (a private network where one is available); remove 0.0.0.0/0.",
 		},

--- a/internal/commonrules/rules/governance_provider_sovereignty.rego
+++ b/internal/commonrules/rules/governance_provider_sovereignty.rego
@@ -23,7 +23,8 @@ deny contains f if {
 		"remediation": "Pour une exigence souveraine, retenir un fournisseur établi dans l'UE (idéalement qualifié SecNumCloud).",
 		"labels": {
 			"provider": provider_of(r),
-			"category": "compliance",
+			"category": "sovereignty",
+			"confidence": "contextual",
 			"message_en": sprintf("Provider \"%s\": headquarters outside the European Union (jurisdiction %s) — the EU establishment requirement is not met.", [r.id, object.get(r.attributes, "jurisdiction", "?")]),
 			"remediation_en": "For a sovereignty requirement, pick a provider established in the EU (ideally SecNumCloud qualified).",
 		},
@@ -42,7 +43,8 @@ deny contains f if {
 		"remediation": "Privilégier un fournisseur dont le contrôle capitalistique reste dans l'UE ; documenter l'exposition.",
 		"labels": {
 			"provider": provider_of(r),
-			"category": "compliance",
+			"category": "sovereignty",
+			"confidence": "contextual",
 			"message_en": sprintf("Provider \"%s\": decisive non-EU capital control — risk of falling under a foreign jurisdiction.", [r.id]),
 			"remediation_en": "Prefer a provider whose capital control stays within the EU; document the exposure.",
 		},
@@ -65,7 +67,8 @@ deny contains f if {
 		"remediation": "Tracer la chaîne capitalistique ultime du fournisseur sur des sources officielles et confirmer l'absence de contrôle déterminant extra-UE ; à défaut, retenir une offre qualifiée SecNumCloud.",
 		"labels": {
 			"provider": provider_of(r),
-			"category": "compliance",
+			"category": "sovereignty",
+			"confidence": "contextual",
 			"message_en": sprintf("Provider \"%s\": capital control not established (to be checked) — sovereignty cannot be presumed compliant.", [r.id]),
 			"remediation_en": "Trace the provider's ultimate ownership chain against official sources and confirm there is no decisive non-EU control; failing that, pick a SecNumCloud qualified offer.",
 		},
@@ -86,7 +89,8 @@ deny contains f if {
 		"remediation": "Évaluer l'exposition extraterritoriale ; retenir une offre qualifiée SecNumCloud (immunité reconnue par l'ANSSI).",
 		"labels": {
 			"provider": provider_of(r),
-			"category": "compliance",
+			"category": "sovereignty",
+			"confidence": "contextual",
 			"message_en": sprintf("Provider \"%s\": exposed to an extraterritorial law, with no SecNumCloud qualification establishing immunity.", [r.id]),
 			"remediation_en": "Assess the extraterritorial exposure; pick a SecNumCloud qualified offer (immunity recognised by the ANSSI).",
 		},

--- a/internal/commonrules/rules/governance_resource_region_in_eu.rego
+++ b/internal/commonrules/rules/governance_resource_region_in_eu.rego
@@ -46,7 +46,8 @@ deny contains f if {
 		"remediation": "Si une localisation strictement UE est exigée, migrer vers une région de l'Union européenne ; sinon documenter l'acceptation du risque (zone adéquate).",
 		"labels": {
 			"provider": p,
-			"category": "compliance",
+			"category": "sovereignty",
+			"confidence": "confirmed",
 			"message_en": sprintf("Resource \"%s\" in region \"%s\": outside the European Union but within the European trusted area (EEA/Switzerland), an adequate level of protection with no extraterritorial law.", [name, reg]),
 			"remediation_en": "If a strictly EU location is required, migrate to a European Union region; otherwise document the accepted risk (adequate area).",
 		},
@@ -72,7 +73,8 @@ deny contains f if {
 		"remediation": "Recréer ou migrer la ressource dans une région de l'Union européenne ; restreindre les régions autorisées au niveau de l'organisation.",
 		"labels": {
 			"provider": p,
-			"category": "compliance",
+			"category": "sovereignty",
+			"confidence": "confirmed",
 			"message_en": sprintf("Resource \"%s\" hosted in region \"%s\", outside the European sovereign area — the EU location requirement is not met.", [name, reg]),
 			"remediation_en": "Recreate or migrate the resource in a European Union region; restrict the allowed regions at the organisation level.",
 		},
@@ -100,7 +102,8 @@ deny contains f if {
 		"remediation": "Vérifier la localisation réelle de cette région auprès du fournisseur, puis l'ajouter aux tables de classification (lib.rego) ; migrer la ressource si elle est hors UE.",
 		"labels": {
 			"provider": p,
-			"category": "compliance",
+			"category": "sovereignty",
+			"confidence": "confirmed",
 			# La règle CONSTATE qu'elle ne sait pas ; l'assessment en fait un
 			# `not-evaluated`. Se taire aurait valu « conforme » — les tables de
 			# classification sont des listes blanches (ADR-0015).

--- a/internal/commonrules/rules/governance_resource_required_tags.rego
+++ b/internal/commonrules/rules/governance_resource_required_tags.rego
@@ -40,7 +40,8 @@ deny contains f if {
 		"remediation": sprintf("Ajouter les étiquettes obligatoires (%s) sur la ressource.", [required_tags_label(required_tags_billable)]),
 		"labels": {
 			"provider": provider_of(r),
-			"category": "compliance",
+			"category": "hygiene",
+			"confidence": "contextual",
 			"message_en": sprintf("Resource \"%s\": governance tags missing (%s).", [name, concat(", ", missing)]),
 			"remediation_en": sprintf("Add the mandatory tags (%s) to the resource.", [required_tags_label(required_tags_billable)]),
 		},

--- a/internal/commonrules/rules/iam_accesskey_expiration_set.rego
+++ b/internal/commonrules/rules/iam_accesskey_expiration_set.rego
@@ -20,6 +20,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(k),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("Access key \"%s\" has no expiry date — a leak would stay exploitable indefinitely.", [id]),
 			"remediation_en": "Set an expiry date on the key and put a rotation in place; prefer a short-lived identity (OIDC).",
 		},

--- a/internal/commonrules/rules/iam_account_mfa_enforced.rego
+++ b/internal/commonrules/rules/iam_account_mfa_enforced.rego
@@ -25,6 +25,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": "The API access policy does not enforce MFA for all users (trusted environment disabled).",
 			"remediation_en": "Enable the trusted environment requirement (RequireTrustedEnv) to enforce MFA on every account; configure WebAuthn/OTP.",
 		},

--- a/internal/commonrules/rules/iam_apiaccess.rego
+++ b/internal/commonrules/rules/iam_apiaccess.rego
@@ -26,6 +26,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("API access rule \"%s\": calls allowed from %s (public CIDR).", [object.get(r.attributes, "api_access_rule_id", r.id), cidr]),
 			"remediation_en": "Restrict the rule's IP ranges to legitimate addresses; remove any rule open to 0.0.0.0/0 or ::/0.",
 		},
@@ -50,6 +51,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": "No API access rule is defined: the account's API is reachable from anywhere with a valid key.",
 			"remediation_en": "Create at least one API access rule restricting calls to legitimate IP ranges.",
 		},
@@ -70,6 +72,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "contextual",
 			"message_en": "API access policy: no maximum expiry is enforced on access keys.",
 			"remediation_en": "Configure a maximum access key expiry (90 days, for instance).",
 		},

--- a/internal/commonrules/rules/iam_no_root_access_key.rego
+++ b/internal/commonrules/rules/iam_no_root_access_key.rego
@@ -44,6 +44,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("API key \"%s\" attached to the root account — it bypasses IAM policies.", [name]),
 			"remediation_en": "Create a dedicated least-privilege IAM application, then revoke the root key.",
 		},

--- a/internal/commonrules/rules/iam_policy_no_administrative_privileges.rego
+++ b/internal/commonrules/rules/iam_policy_no_administrative_privileges.rego
@@ -25,6 +25,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(p),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("EIM policy \"%s\": Allow statement carrying Action=\"*\" (every action granted).", [name]),
 			"remediation_en": "Replace Action=\"*\" with the exhaustive list of the actions actually needed (least privilege).",
 		},

--- a/internal/commonrules/rules/iam_policy_no_notaction_notresource.rego
+++ b/internal/commonrules/rules/iam_policy_no_notaction_notresource.rego
@@ -23,6 +23,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(p),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("EIM policy \"%s\": Allow statement using NotAction/NotResource (dangerous inversion).", [name]),
 			"remediation_en": "Rewrite it as an explicit allow list (Action/Resource); NotAction/NotResource is only acceptable with an Effect Deny.",
 		},

--- a/internal/commonrules/rules/iam_policy_no_privilege_escalation.rego
+++ b/internal/commonrules/rules/iam_policy_no_privilege_escalation.rego
@@ -39,6 +39,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(p),
 			"category": "security",
+			"confidence": "heuristic",
 			"message_en": sprintf("Policy \"%s\": allows an identity management action that enables privilege escalation (%s).", [name, a]),
 			"remediation_en": "Remove identity management actions (attach/create a policy, create a key) from everyday policies; reserve them for a dedicated, scoped administration role.",
 		},
@@ -81,6 +82,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "heuristic",
 			"message_en": sprintf("IAM role \"%s\": its policy allows managing IAM roles — a privilege escalation path.", [name]),
 			"remediation_en": "Reserve IAM role and key management for a dedicated administration role; remove those permissions from everyday roles.",
 		},
@@ -102,6 +104,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(p),
 			"category": "security",
+			"confidence": "heuristic",
 			"message_en": sprintf("Policy \"%s\": grants IAM management (PermissionSet) — a privilege escalation path.", [name]),
 			"remediation_en": "Reserve IAM management for a dedicated administration policy; remove the management PermissionSet from everyday policies.",
 		},

--- a/internal/commonrules/rules/iam_policy_no_wildcard_resource.rego
+++ b/internal/commonrules/rules/iam_policy_no_wildcard_resource.rego
@@ -27,6 +27,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(p),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("EIM policy \"%s\": Allow statement carrying Resource=\"*\" (every resource of the account).", [name]),
 			"remediation_en": "Restrict Resource to the identifiers (ORN) the policy must actually cover.",
 		},

--- a/internal/commonrules/rules/iam_role_key_lifetime_bounded.rego
+++ b/internal/commonrules/rules/iam_role_key_lifetime_bounded.rego
@@ -32,6 +32,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "contextual",
 			"message_en": sprintf("IAM role \"%s\": no bound on credential lifetime (no session TTL, no expiry) — credentials assuming this role are permanent.", [name]),
 			"remediation_en": "Bound that lifetime: set a maximum session TTL on the role, or an expiry condition in its policy.",
 		},

--- a/internal/commonrules/rules/iam_role_no_admin_privileges.rego
+++ b/internal/commonrules/rules/iam_role_no_admin_privileges.rego
@@ -26,6 +26,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("IAM role \"%s\": policy set to \"allow\" by default — broad privileges, against least privilege.", [name]),
 			"remediation_en": "Start again from a default \"deny\" service strategy and explicitly allow only what is strictly needed.",
 		},

--- a/internal/commonrules/rules/iam_role_source_ip_restricted.rego
+++ b/internal/commonrules/rules/iam_role_source_ip_restricted.rego
@@ -26,6 +26,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("IAM role \"%s\": no source IP restriction — a key assuming this role is usable from any address.", [name]),
 			"remediation_en": "Add a source IP condition to the role's policy (legitimate administration ranges).",
 		},

--- a/internal/commonrules/rules/iam_user_mfa_enabled.rego
+++ b/internal/commonrules/rules/iam_user_mfa_enabled.rego
@@ -23,6 +23,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("Account \"%s\" has no multi-factor authentication (MFA) enabled.", [name]),
 			"remediation_en": "Enable MFA on the account; enforce it for every administrative access and for the cloud console.",
 		},

--- a/internal/commonrules/rules/k8s_incluster.rego
+++ b/internal/commonrules/rules/k8s_incluster.rego
@@ -32,6 +32,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(b),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("ClusterRoleBinding \"%s\" grants cluster-admin to %s — full power over the cluster.", [name, subject]),
 			"remediation_en": "Remove cluster-admin from this subject; grant a Role/ClusterRole restricted to what it strictly needs.",
 		},
@@ -68,6 +69,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(n),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("Namespace \"%s\" has no Pod Security Standards enforced (enforce = %s) — a privileged pod is accepted there.", [name, lvl]),
 			"remediation_en": "Set the pod-security.kubernetes.io/enforce label (baseline or restricted) on the namespace.",
 		},
@@ -89,6 +91,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(n),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("Namespace \"%s\" has no NetworkPolicy at all — every pod can reach every other pod (flat network).", [name]),
 			"remediation_en": "Define a default-deny NetworkPolicy (ingress and egress) in the namespace, then allow the legitimate flows.",
 		},
@@ -117,6 +120,7 @@ deny contains f if {
 		"labels": {
 			"provider": "kubernetes",
 			"category": "security",
+			"confidence": "contextual",
 			"message_en": "No external secrets manager detected (External Secrets Operator, Secrets Store CSI, Vault agent) — secrets rely on the native Kubernetes storage.",
 			"remediation_en": "Deploy an external secrets manager (External Secrets Operator or Secrets Store CSI) and mount secrets from the vault, never in cleartext in the manifests.",
 		},

--- a/internal/commonrules/rules/kubernetes_cluster_audit_logging_enabled.rego
+++ b/internal/commonrules/rules/kubernetes_cluster_audit_logging_enabled.rego
@@ -27,6 +27,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(c),
 			"category": "compliance",
+			"confidence": "confirmed",
 			"message_en": sprintf("Kubernetes cluster \"%s\": audit logging disabled — no audit endpoint is configured, an incident could not be investigated.", [name]),
 			"remediation_en": "Configure the cluster's Kubernetes audit (collection endpoint) and centralise the logs according to the retention policy.",
 		},

--- a/internal/commonrules/rules/kubernetes_cluster_not_publicly_accessible.rego
+++ b/internal/commonrules/rules/kubernetes_cluster_not_publicly_accessible.rego
@@ -22,6 +22,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(c),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("OKS cluster \"%s\": admin_whitelist contains %s — the Kubernetes API is exposed to the internet.", [name, cidr]),
 			"remediation_en": "Restrict admin_whitelist to administration CIDRs (bastion, CI runners, VPN); remove 0.0.0.0/0 and ::/0.",
 		},

--- a/internal/commonrules/rules/kubernetes_cluster_resilience.rego
+++ b/internal/commonrules/rules/kubernetes_cluster_resilience.rego
@@ -22,6 +22,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(c),
 			"category": "compliance",
+			"confidence": "contextual",
 			"message_en": sprintf("OKS cluster \"%s\": control plane is not multi-AZ — losing one zone means an outage.", [name]),
 			"remediation_en": "Enable a multi-AZ / multi-master control plane on the cluster.",
 		},
@@ -42,6 +43,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(c),
 			"category": "compliance",
+			"confidence": "contextual",
 			"message_en": sprintf("OKS cluster \"%s\": automatic upgrades disabled — fixes are not applied.", [name]),
 			"remediation_en": "Enable automatic maintenance and upgrades on the cluster.",
 		},
@@ -62,6 +64,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(c),
 			"category": "compliance",
+			"confidence": "contextual",
 			"message_en": sprintf("OKS cluster \"%s\" has no deletion protection.", [name]),
 			"remediation_en": "Enable deletion protection on the cluster.",
 		},

--- a/internal/commonrules/rules/lib.rego
+++ b/internal/commonrules/rules/lib.rego
@@ -357,8 +357,22 @@ secret_min_confidence := object.get(_config_secrets, "min_confidence", _default_
 # confidence_rank — rang ordonné d'un niveau de confiance. Un niveau inconnu vaut
 # le rang le plus bas : une détection ne se perd pas parce qu'on n'a pas su lire
 # son étiquette.
+#
+# Le vocabulaire est celui de TOUS les findings depuis #111 — `confirmed`,
+# `probable`, `heuristic` — et non plus un vocabulaire propre à la détection de
+# secrets. Un même mot devait signifier la même chose partout, sans quoi filtrer
+# `confidence=heuristic` sur un rapport n'aurait pas de sens stable.
+#
+# Les anciennes valeurs `high`/`medium`/`low` restent acceptées, au même rang que
+# leur équivalent. Une politique déjà committée ne doit pas changer de SENS en
+# silence : elle continuerait de s'appliquer en donnant un autre seuil, ce qui est
+# le pire des deux mondes. Elles sont dépréciées, pas ignorées.
 confidence_rank(level) := r if {
-	ranks := {"low": 0, "medium": 1, "high": 2}
+	ranks := {
+		"heuristic": 0, "low": 0,
+		"probable": 1, "medium": 1,
+		"confirmed": 2, "high": 2,
+	}
 	r := object.get(ranks, level, 0)
 }
 
@@ -395,7 +409,7 @@ _default_snapshot_max_age_days := 7
 
 _default_snapshot_states := ["completed", "created"]
 
-_default_min_confidence := "low"
+_default_min_confidence := "heuristic"
 
 # ── L'ENVIRONNEMENT d'une ressource, et ce qu'il autorise à conclure ──────────
 #

--- a/internal/commonrules/rules/loadbalancer_http_redirect.rego
+++ b/internal/commonrules/rules/loadbalancer_http_redirect.rego
@@ -34,6 +34,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(lb),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("LBU \"%s\": HTTP listener (port %d) with no redirect to HTTPS — cleartext traffic is possible.", [name, object.get(l, "load_balancer_port", 0)]),
 			"remediation_en": "Set up a 301 redirect from the HTTP:80 listener to HTTPS.",
 		},

--- a/internal/commonrules/rules/loadbalancer_logging_enabled.rego
+++ b/internal/commonrules/rules/loadbalancer_logging_enabled.rego
@@ -28,6 +28,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(lb),
 			"category": "compliance",
+			"confidence": "confirmed",
 			"message_en": sprintf("LBU \"%s\" has no access log enabled — no investigation is possible.", [name]),
 			"remediation_en": "Enable access_log (a dedicated OOS bucket, with a configured retention).",
 		},

--- a/internal/commonrules/rules/loadbalancer_ssl_listeners.rego
+++ b/internal/commonrules/rules/loadbalancer_ssl_listeners.rego
@@ -24,6 +24,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(lb),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("Internet-facing LBU \"%s\" has no HTTPS/SSL listener — traffic in cleartext.", [name]),
 			"remediation_en": "Add an HTTPS/SSL listener (TLS 1.2 or above) with a certificate; redirect cleartext traffic to HTTPS.",
 		},
@@ -68,6 +69,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(lb),
 			"category": "security",
+			"confidence": "confirmed",
 			# La règle CONSTATE son incapacité à conclure ; l'assessment en fait un
 			# `not-evaluated`. Compter ce listener comme sécurisé était un FAUX VERT
 			# (ADR-0015) : un port n'est pas un protocole.
@@ -104,6 +106,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(lb),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("LBU \"%s\": listener %s:%d serves cleartext while another listener is encrypted — the protection is not what it looks like.", [name, object.get(l, "load_balancer_protocol", ""), port]),
 			"remediation_en": "Encrypt or remove that listener: an HTTPS listener elsewhere does not protect the traffic going through this one.",
 		},

--- a/internal/commonrules/rules/network_documented.rego
+++ b/internal/commonrules/rules/network_documented.rego
@@ -37,7 +37,8 @@ deny contains f if {
 		"remediation": sprintf("Étiqueter chaque réseau (%s) ; tenir la cartographie réseau à jour.", [required_tags_label(required_tags_network)]),
 		"labels": {
 			"provider": provider_of(n),
-			"category": "compliance",
+			"category": "hygiene",
+			"confidence": "contextual",
 			"message_en": sprintf("Network \"%s\": mapping tags missing (%s) — the network mapping is not maintained.", [name, concat(", ", missing)]),
 			"remediation_en": sprintf("Tag every network (%s); keep the network mapping up to date.", [required_tags_label(required_tags_network)]),
 		},

--- a/internal/commonrules/rules/network_flow_matrix_documented.rego
+++ b/internal/commonrules/rules/network_flow_matrix_documented.rego
@@ -24,7 +24,8 @@ deny contains f if {
 		"remediation": "Documenter chaque règle de security group (service, raison) via sa description ; tenir la matrice des flux à jour.",
 		"labels": {
 			"provider": provider_of(r),
-			"category": "compliance",
+			"category": "hygiene",
+			"confidence": "contextual",
 			"message_en": sprintf("Allowed inbound flow (port %v) with no justification: the flow matrix requires a description per rule.", [port]),
 			"remediation_en": "Document every security group rule (service, reason) in its description; keep the flow matrix up to date.",
 		},

--- a/internal/commonrules/rules/network_peering_cross_organization.rego
+++ b/internal/commonrules/rules/network_peering_cross_organization.rego
@@ -28,6 +28,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(p),
 			"category": "compliance",
+			"confidence": "confirmed",
 			"message_en": sprintf("Network peering \"%s\" between two distinct accounts (%s <-> %s): internal flows opened towards another information system — the segregation must be justified.", [object.get(p.attributes, "peering_id", p.id), src, acc]),
 			"remediation_en": "Limit peerings to networks of the same information system; for a partner, justify the peering and restrict the routes and flows exchanged (flow matrix).",
 		},

--- a/internal/commonrules/rules/network_securitygroup_default_deny.rego
+++ b/internal/commonrules/rules/network_securitygroup_default_deny.rego
@@ -23,6 +23,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("Security group \"%s\": default inbound policy set to \"accept\" — any unfiltered traffic is admitted.", [id]),
 			"remediation_en": "Switch the default inbound policy to \"drop\" and open only the legitimate flows through explicit rules.",
 		},

--- a/internal/commonrules/rules/network_securitygroup_default_restrict_traffic.rego
+++ b/internal/commonrules/rules/network_securitygroup_default_restrict_traffic.rego
@@ -25,6 +25,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("Security group \"default\" (%s) carries an inbound rule — it applies automatically to every resource created without an explicit SG.", [sg]),
 			"remediation_en": "Empty the \"default\" security group of all its rules; explicitly attach a dedicated, restrictive SG to every resource.",
 		},

--- a/internal/commonrules/rules/network_securitygroup_ingress.rego
+++ b/internal/commonrules/rules/network_securitygroup_ingress.rego
@@ -79,6 +79,12 @@ _sg_finding(r, code, sev, what, what_en) := {
 	"labels": {
 		"provider": provider_of(r),
 		"category": "security",
+		# CONFIRMÉ pour toutes les règles d'exposition que ce constructeur sert : une
+		# origine `0.0.0.0/0` sur un port sensible est OBSERVÉE dans la configuration,
+		# pas inférée. Le contexte n'y change rien — il n'existe pas de raison
+		# légitime d'ouvrir SSH ou RDP à tout Internet, seulement des raisons
+		# temporaires, qui se posent en dérogation datée.
+		"confidence": "confirmed",
 		"message_en": sprintf("Security group \"%s\": %s accepted from/to the internet.", [object.get(r.attributes, "security_group_id", r.id), what_en]),
 		"remediation_en": "Restrict the rule to legitimate sources/destinations and ports (administration CIDR, bastion, VPN); never expose a sensitive service to 0.0.0.0/0.",
 	},

--- a/internal/commonrules/rules/network_subnet_no_public_ip_by_default.rego
+++ b/internal/commonrules/rules/network_subnet_no_public_ip_by_default.rego
@@ -23,6 +23,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("Subnet \"%s\": a public IP is assigned automatically at creation (exposed to the internet by default).", [id]),
 			"remediation_en": "Disable the subnet's automatic public IP assignment; assign a public IP only to the interfaces that need one.",
 		},

--- a/internal/commonrules/rules/objectstorage_bucket_default_encryption.rego
+++ b/internal/commonrules/rules/objectstorage_bucket_default_encryption.rego
@@ -27,6 +27,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(b),
 			"category": "security",
+			"confidence": "confirmed",
 			"message_en": sprintf("Bucket \"%s\" has no default encryption at rest — objects are written in cleartext on the provider side.", [name]),
 			"remediation_en": "Enable the bucket's default encryption (SSE); check that the objects already stored are rewritten encrypted.",
 		},

--- a/internal/commonrules/rules/objectstorage_bucket_kms_encryption.rego
+++ b/internal/commonrules/rules/objectstorage_bucket_kms_encryption.rego
@@ -46,6 +46,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(b),
 			"category": "compliance",
+			"confidence": "confirmed",
 			"message_en": sprintf("Bucket \"%s\" is classified sensitive but encrypted without a customer-managed key (SSE-KMS): its data stays under the provider's exclusive control.", [name]),
 			"remediation_en": "Create a key in Key Manager and attach it to the bucket as its default encryption key (SSE-KMS) for sensitive data.",
 		},

--- a/internal/commonrules/rules/objectstorage_bucket_object_lock_enabled.rego
+++ b/internal/commonrules/rules/objectstorage_bucket_object_lock_enabled.rego
@@ -24,6 +24,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(b),
 			"category": "compliance",
+			"confidence": "contextual",
 			"message_en": sprintf("Bucket \"%s\" has no Object Lock: objects are mutable (no WORM protection against deletion or overwrite).", [name]),
 			"remediation_en": "Enable Object Lock (compliance or governance mode) on backup buckets and critical objects.",
 		},

--- a/internal/commonrules/rules/objectstorage_bucket_public_access.rego
+++ b/internal/commonrules/rules/objectstorage_bucket_public_access.rego
@@ -58,6 +58,7 @@ _bucket_public_finding(r, cause, cause_en) := {
 	"labels": {
 		"provider": provider_of(r),
 		"category": "security",
+		"confidence": "confirmed",
 		"message_en": sprintf("Bucket \"%s\" is publicly accessible (%s).", [object.get(r.attributes, "name", r.id), cause_en]),
 		"remediation_en": "Make the bucket private (private ACL, remove the AllUsers grant, delete the public policy); serve through pre-signed URLs if needed.",
 	},

--- a/internal/commonrules/rules/objectstorage_bucket_versioning_enabled.rego
+++ b/internal/commonrules/rules/objectstorage_bucket_versioning_enabled.rego
@@ -24,6 +24,7 @@ deny contains f if {
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
+			"confidence": "contextual",
 			"message_en": sprintf("Bucket \"%s\" has no versioning enabled (status %q) — a deletion or an overwrite is irreversible.", [bucket, versioning]),
 			"remediation_en": "Enable versioning on the bucket, at least for critical data.",
 		},

--- a/internal/policy/resolved.go
+++ b/internal/policy/resolved.go
@@ -52,10 +52,28 @@ type ResolvedSecrets struct {
 // ConfidenceLevels énumère les niveaux de confiance d'une détection de secret,
 // du plus faible au plus fort. L'ORDRE est signifiant : c'est lui qui décide
 // qu'un seuil plus haut est un assouplissement.
-var ConfidenceLevels = []string{"low", "medium", "high"}
+//
+// Le vocabulaire est celui de TOUS les findings depuis #111 : un même mot doit
+// signifier la même chose partout, sans quoi filtrer un rapport sur
+// `labels.confidence` n'aurait pas de sens stable.
+var ConfidenceLevels = []string{"heuristic", "probable", "confirmed"}
+
+// legacyConfidence — les valeurs d'AVANT #111, acceptées au rang de leur
+// équivalent. Une politique déjà committée ne doit pas changer de SENS en silence :
+// refuser `low` casserait un pipeline, l'ignorer appliquerait un autre seuil que
+// celui écrit. Elles sont dépréciées, pas ignorées, et `pepin control explain`
+// affiche le nom courant.
+var legacyConfidence = map[string]string{
+	"low":    "heuristic",
+	"medium": "probable",
+	"high":   "confirmed",
+}
 
 // rankOfConfidence rend le rang d'un niveau de confiance, -1 s'il est inconnu.
 func rankOfConfidence(level string) int {
+	if moderne, ok := legacyConfidence[level]; ok {
+		level = moderne
+	}
 	for i, l := range ConfidenceLevels {
 		if strings.EqualFold(strings.TrimSpace(level), l) {
 			return i
@@ -151,7 +169,7 @@ var (
 	// qui les porte ne restaure rien.
 	defaultSnapshotStates = []string{"completed", "created"}
 
-	// defaultMinConfidence : `low`, c'est-à-dire TOUT signaler. C'est le
+	// defaultMinConfidence : `heuristic`, c'est-à-dire TOUT signaler. C'est le
 	// comportement d'avant ce lot, et c'est le seul défaut défendable pour un
 	// détecteur de secrets : taire par défaut ce qu'on ne sait pas confirmer,
 	// c'est choisir le faux négatif contre le faux positif, sur le seul sujet où
@@ -219,7 +237,15 @@ func Resolve(c *Controls) Resolved {
 		}
 	}
 	if s := c.Secrets; s != nil && s.MinConfidence != "" {
-		out.Secrets.MinConfidence = strings.ToLower(strings.TrimSpace(s.MinConfidence))
+		// NORMALISÉ au vocabulaire courant : une politique écrite `low` et une écrite
+		// `heuristic` disent la même chose, et doivent produire la MÊME configuration
+		// résolue. Sans ça, le bundle scellé porterait deux orthographes pour un seul
+		// réglage, et `verify --re-derive` verrait diverger deux dossiers identiques.
+		niveau := strings.ToLower(strings.TrimSpace(s.MinConfidence))
+		if moderne, deprecie := legacyConfidence[niveau]; deprecie {
+			niveau = moderne
+		}
+		out.Secrets.MinConfidence = niveau
 	}
 	return out
 }

--- a/referentiel/validate_test.go
+++ b/referentiel/validate_test.go
@@ -467,3 +467,78 @@ func TestEnglishControlFieldsCarryNoAccent(t *testing.T) {
 		}
 	}
 }
+
+// confidenceValues — le vocabulaire COMMUN d'une confiance de finding (issue #111).
+//
+// La confiance dit la certitude que Pépin a correctement ÉTABLI le problème ; la
+// sévérité dit la conséquence s'il est réel. Les confondre est ce qui rend un premier
+// scan irritant : un volume peut être sauvegardé autrement, et lui donner le poids
+// d'un SSH ouvert à Internet fait douter des deux.
+var confidenceValues = map[string]bool{
+	// La configuration fautive est OBSERVÉE, directement et sans ambiguïté.
+	"confirmed": true,
+	// Préfixe reconnu ET format attendu : très vraisemblable, pas certain.
+	"probable": true,
+	// La règle INFÈRE depuis un signal qui peut ne pas vouloir dire ce qu'il paraît.
+	"heuristic": true,
+	// L'écart dépend d'un contexte que le scan ne voit pas : une sauvegarde ailleurs,
+	// un environnement de développement, une politique interne.
+	"contextual": true,
+}
+
+// TestEveryFindingDeclaresItsConfidence — la porte de l'issue #111.
+//
+// Une règle sans confiance déclarée publierait un écart dont personne ne peut dire
+// s'il faut le croire, et la valeur par défaut qu'on serait tenté de lui donner
+// rendrait le label décoratif — ce qui est pire que son absence, puisqu'on cesserait
+// de s'en méfier.
+func TestEveryFindingDeclaresItsConfidence(t *testing.T) {
+	entries, err := os.ReadDir(rulesDir)
+	if err != nil {
+		t.Fatalf("lecture de %s : %v", rulesDir, err)
+	}
+	// La confiance se déclare dans le MÊME bloc `labels` que la catégorie, qui est
+	// présente sur chaque finding : c'est donc `category` qui sert d'ancre, et un
+	// finding qui perdrait sa catégorie serait attrapé par ailleurs.
+	reCat := regexp.MustCompile(`"category":\s*"([a-z]+)",`)
+	reConf := regexp.MustCompile(`"confidence":\s*(?:"([a-z]+)"|[a-z_]+[.(])`)
+	var vus int
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".rego") || strings.HasSuffix(e.Name(), "_test.rego") {
+			continue
+		}
+		b, rerr := os.ReadFile(filepath.Join(rulesDir, e.Name()))
+		if rerr != nil {
+			t.Fatalf("lecture de %s : %v", e.Name(), rerr)
+		}
+		text := string(b)
+		cats := reCat.FindAllStringIndex(text, -1)
+		confs := reConf.FindAllStringSubmatchIndex(text, -1)
+		if len(cats) == 0 {
+			continue // fichier sans finding
+		}
+		vus += len(cats)
+		if len(confs) < len(cats) {
+			t.Errorf("%s : %d finding(s) portent une catégorie, %d une confiance.\n"+
+				"  Un écart sans confiance déclarée ne dit pas s'il faut le croire.\n"+
+				"  Ajouter `\"confidence\": \"confirmed\" | \"probable\" | \"heuristic\" | \"contextual\"`\n"+
+				"  dans le bloc `labels`, choisie pour CETTE règle.", e.Name(), len(cats), len(confs))
+			continue
+		}
+		for _, m := range confs {
+			if m[2] < 0 {
+				continue // valeur calculée (ex. pattern.confidence) : vérifiée par opa test
+			}
+			if v := text[m[2]:m[3]]; !confidenceValues[v] {
+				t.Errorf("%s : confiance %q inconnue.\n"+
+					"  Le vocabulaire est commun à tous les findings : un même mot doit\n"+
+					"  signifier la même chose partout, sans quoi filtrer un rapport sur\n"+
+					"  `labels.confidence` n'a pas de sens stable.", e.Name(), v)
+			}
+		}
+	}
+	if vus == 0 {
+		t.Fatal("aucun finding vu : la porte ne mesure rien")
+	}
+	t.Logf("%d finding(s) porteurs d'une confiance vérifié(s)", vus)
+}


### PR DESCRIPTION
## Le manque

La sévérité dit la **conséquence** si le problème est réel. Elle n'a jamais dit à
quel point Pépin est **sûr** de l'avoir établi, si bien que deux findings étaient
indiscernables :

```
VM + IP publique + SSH ouvert       severity HIGH
Volume sans sauvegarde récente      severity HIGH
```

Le second est un faux positif assumé — la règle le documente elle-même : un volume
peut être sauvegardé autrement. **Lui donner le poids du premier est ce qui fait
douter du premier.**

## Ce qui change

Chaque finding déclare `labels.confidence` : `confirmed` · `probable` · `heuristic`
· `contextual`. Choisie **règle par règle** — 42 / 7 / 6 / 18. Une valeur par défaut
appliquée en masse aurait rendu le label décoratif, ce qui est pire que son absence :
on cesserait de s'en méfier.

Une règle sans confiance **casse la CI**.

## Sur le `kind` demandé

L'issue demande un label `kind`. **Cette dimension existait déjà** sous le nom
`labels.category`, sur les 63 findings, et ajouter un second nom pour un seul axe
serait la divergence que ce projet combat partout ailleurs.

`category` gagne donc les deux valeurs qui lui manquaient :

| Valeur | Pourquoi | Findings déplacés |
|---|---|---|
| `sovereignty` | la raison d'être du produit, rangée sous `compliance` où aucun filtre ne la trouvait | 7 |
| `hygiene` | ni une faille ni un manquement normatif ; les confondre rend un premier scan irritant | 3 |

## La collision que l'issue ne pouvait pas connaître

**`labels.confidence` existait déjà**, depuis #48, sur la règle des secrets — avec un
vocabulaire différent (`high`/`medium`/`low`), 3 tests Rego, 5 pages de doc, et une
liaison normative via `config_requise: secrets.min_confidence`.

Deux labels du même nom avec deux vocabulaires ne peuvent pas coexister. Vous avez
tranché pour **l'unification sans perte de granularité** :

| Avant | Après |
|---|---|
| `high` | `confirmed` |
| `medium` | `probable` |
| `low` | `heuristic` |

Le seuil réglable continue de trier sur les trois mêmes rangs. **Un
`secrets.min_confidence` écrit avec les anciens mots reste accepté**, au même rang, et
**normalisé** dans la configuration résolue — sinon un bundle scellé porterait deux
orthographes pour un seul réglage, et `verify --re-derive` verrait diverger deux
dossiers identiques. Vérifié de bout en bout : une politique écrite `low` résout en
`heuristic`.

## Deux choses que j'ai cassées et corrigées

**Une ligne de doc corrompue.** Mon remplacement en masse du vocabulaire a touché la
correspondance SARIF « `warning` pour `medium`, `note` pour `low` » — qui parle de
**sévérité**, pas de confiance. Attrapée en relisant le diff entier plutôt que les
lignes que j'attendais, et restaurée.

**Une règle manquée.** La garde a trouvé le constructeur de finding partagé des règles
d'exposition, dont le code est passé par l'appelant : il n'y avait aucun littéral où
s'ancrer.

## Mouvement de verdicts

**0 sur les 19 fixtures.**

## Critères d'acceptation

- [x] `confidence` et `kind` voyagent dans `labels`, sans modifier scankit
- [x] Les deux apparaissent dans `--format json` et dans l'assessment
- [x] Chaque règle déclare sa confiance, et une règle sans confiance casse la CI
- [x] La documentation dit comment filtrer, dans les deux langues

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
