### PR TITLE
feat(cmd): a gate profile that hides nothing, and cannot turn a red chain green

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -48,6 +48,19 @@ l'une ni l'autre appartient au `git log`.
 
 ### Ajouté
 
+- **`scan --gate <all|security|compliance|sovereignty>` : un profil pour la porte de
+  CI, qui ne cache rien.** Un premier scan doit provoquer « ah oui, ça c'est
+  intéressant », pas « oui, je sais que ma VM de test n'a pas de protection contre la
+  suppression ». Le rapport reste COMPLET dans tous les formats — c'est la règle déjà
+  appliquée aux dérogations et aux constats d'incertitude : le rapport dit tout, seule
+  la porte filtre. Ce qui change est ce qui pèse dans le **code de sortie**, et chaque
+  scan imprime ce qui a été mis de côté et pourquoi.
+  **Aucun profil ne peut faire passer une chaîne de rouge à vert** : un `1` devient au
+  pire un `3` — « n'établit pas la conformité », la lecture honnête d'un scan
+  volontairement partiel (ADR-0005, et toujours pas de cinquième code) —, jamais un
+  `0`. Le défaut reste `all`, donc rien ne change sans le drapeau. Surface CLI v5 → v6.
+  Le drapeau ne s'appelle pas `--profile` : ce nom désigne déjà le profil
+  d'identifiants de la collecte live.
 - **Un finding déclare désormais sa CONFIANCE, distincte de sa sévérité.** La sévérité
   dit la conséquence si le problème est réel ; la confiance dit à quel point Pépin est
   sûr de l'avoir établi. Un volume sans sauvegarde récente et une VM dont SSH est ouvert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,17 @@ belongs in `git log`.
 
 ### Added
 
+- **`scan --gate <all|security|compliance|sovereignty>`: a profile for the CI gate,
+  which hides nothing.** A first scan should trigger "oh, that one is interesting", not
+  "yes, I know my test VM has no deletion protection". The report stays COMPLETE in
+  every format — the rule already applied to exemptions and inconclusive findings: the
+  report says everything, only the gate filters. What changes is what weighs in the
+  **exit code**, and every scan prints what was set aside and why.
+  **No profile can turn a red chain green**: a `1` becomes a `3` at worst — "does not
+  establish compliance", the honest reading of a deliberately partial scan (ADR-0005,
+  and still no fifth code) — never a `0`. The default stays `all`, so nothing changes
+  without the flag. CLI surface v5 → v6. The flag is not `--profile`: that name already
+  designates the live-collection credentials profile.
 - **A finding now declares its CONFIDENCE, distinct from its severity.** Severity says
   the consequence if the problem is real; confidence says how sure Pépin is that it
   established the problem at all. A volume with no recent snapshot and a VM with SSH

--- a/cmd/policy_network_test.go
+++ b/cmd/policy_network_test.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -118,4 +120,53 @@ func TestNoResultCarriesAnEmptyProof(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestNoGateProfileTurnsARedChainGreen — l'invariant de l'issue #112, mesuré sur le
+// binaire.
+//
+// Un profil de porte allège ce qui pèse dans le code de sortie. C'est utile, et c'est
+// aussi la façon la plus discrète de casser une chaîne de CI : une équipe qui échoue
+// aujourd'hui sur un écart passerait au vert après une mise à jour, sans que personne
+// n'ait rien décidé. Ce serait le faux vert que cette vague a passé trois lots à
+// combattre, à ceci près qu'il viendrait d'un réglage plutôt que d'une règle — donc
+// invisible.
+//
+// La règle : un profil peut transformer un 1 en 3 (« le scan n'établit pas la
+// conformité »), JAMAIS en 0. L'ordre de précédence de l'ADR-0005 tient — un écart
+// resté visible rend toujours 1.
+func TestNoGateProfileTurnsARedChainGreen(t *testing.T) {
+	bin := buildPepin(t)
+	const nonConforme = "examples/scaleway/inventory.json"
+
+	// Référence : sans profil, cet inventaire est non conforme.
+	if code := exitCodeOf(t, bin, "scan", "scaleway", nonConforme); code != 1 {
+		t.Fatalf("l'inventaire de référence rend %d au lieu de 1 : le test ne mesure rien", code)
+	}
+	for _, p := range []string{"all", "security", "compliance", "sovereignty"} {
+		code := exitCodeOf(t, bin, "scan", "scaleway", nonConforme, "--gate", p)
+		if code == 0 {
+			t.Errorf("profil %q : un inventaire NON CONFORME rend 0.\n"+
+				"  Une chaîne rouge est passée au vert sans que personne ne l'ait décidé.\n"+
+				"  Un profil ne peut alléger que jusqu'à 3, jamais jusqu'à 0.", p)
+		}
+		if code != 1 && code != 3 {
+			t.Errorf("profil %q : code %d inattendu (1 ou 3 attendus)", p, code)
+		}
+	}
+}
+
+// exitCodeOf lance le binaire et rend son code de sortie, sans faire échouer le test.
+func exitCodeOf(t *testing.T, bin string, args ...string) int {
+	t.Helper()
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = repoRoot
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return ee.ExitCode()
+		}
+		t.Fatalf("exécution de %v : %v", args, err)
+	}
+	return 0
 }

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stephrobert/pepin/internal/genprovider"
 	"github.com/stephrobert/pepin/internal/i18n"
 	"github.com/stephrobert/pepin/internal/model"
+	"github.com/stephrobert/pepin/internal/profile"
 	"github.com/stephrobert/pepin/internal/provider"
 	"github.com/stephrobert/pepin/internal/scoring"
 	"github.com/stephrobert/pepin/internal/tfparse"
@@ -51,6 +52,7 @@ var (
 	scanRedact     bool   // caviarder les valeurs sensibles de l'input.json embarqué
 	scanStrict     bool   // porte CI stricte : échec sur couverture nulle ou écart medium/low
 	scanTimestamp  string // instant d'évaluation (RFC3339 UTC), partagé input.evaluated_at + Run.Timestamp
+	scanGate       string // profil de PORTE : ce qui pèse dans le code de sortie, jamais dans le rapport
 )
 
 var scanCmd = &cobra.Command{
@@ -76,6 +78,10 @@ var scanCmd = &cobra.Command{
 			return errors.New(tr(
 				"préciser un fichier (export JSON ou plan Terraform), ou utiliser --live",
 				"give a file (JSON export or Terraform plan), or use --live"))
+		}
+		if !profile.Valid(scanGate) {
+			return fmt.Errorf(tr("profil de porte inconnu : %q (valeurs : %s)",
+				"unknown gate profile: %q (values: %s)"), scanGate, strings.Join(profile.Names(), ", "))
 		}
 		scanTimestamp = time.Now().UTC().Format(time.RFC3339) // un seul instant, partagé input + run
 
@@ -250,6 +256,12 @@ var scanCmd = &cobra.Command{
 		// sévérité, donc il ne peut pas rendre 1 (ADR-0015). Le sortir ICI, et non
 		// à la collecte des findings, garde le rapport complet.
 		deviations, _ := assess.SplitInconclusive(findings)
+		// Le PROFIL, au même endroit et pour la même raison : il ne retire rien du
+		// rapport, il change ce qui PÈSE dans la porte. Un écart hors profil reste
+		// imprimé, exporté et scellé — seul son poids dans le code de sortie change,
+		// et un écart grave mis de côté empêche de rendre 0 (cf. plus bas).
+		deviations, setAside := profile.Split(scanGate, deviations)
+		asideCodes, asideSevere := profile.SetAside(setAside)
 		open := openFindings(deviations, exemptedKeys(asmt))
 		enrichFromReferentiel(findings)
 		res := scoring.Summarize(deviations)
@@ -287,6 +299,10 @@ var scanCmd = &cobra.Command{
 		}
 		// Portée prestataire/commanditaire : obligatoire pour l'opposabilité (un rapport pepin
 		// ne prouve pas une qualification, seulement la posture d'un tenant).
+		// Ce que le profil a mis de côté se DIT, toujours. Un profil qui allégerait
+		// une porte sans nommer ce qu'il n'a plus regardé serait le faux vert que ce
+		// projet combat, simplement déplacé dans un réglage — donc invisible.
+		renderGateProfile(os.Stderr, scanGate, asideCodes, asideSevere)
 		_, _ = fmt.Fprintf(os.Stderr, "\nⓘ %s\n", assess.ScopeDisclaimer())
 		if !gate.Conforme {
 			os.Exit(exitNonConformite)
@@ -297,6 +313,14 @@ var scanCmd = &cobra.Command{
 		// inventaire tronqué rendraient une porte de CI verte sur un périmètre jamais regardé.
 		// Le bandeau annonce déjà « INDÉTERMINÉ » dans ce cas — le code de sortie doit le suivre.
 		if evaluatedNonGov(asmt) == 0 {
+			os.Exit(exitStrict)
+		}
+		// Un écart critical/high MIS DE CÔTÉ par le profil : jamais 0. Le scan a
+		// délibérément regardé moins que tout, ce qui est la définition même de « le
+		// scan n'établit pas la conformité ». Placé APRÈS le test de conformité : un
+		// écart resté visible rend 1, et l'ordre de précédence de l'ADR-0005 tient —
+		// une mise de côté n'efface jamais un écart observé.
+		if asideSevere {
 			os.Exit(exitStrict)
 		}
 		// Périmètre PARTIELLEMENT lu : jamais 0 non plus. Le code 3 est réutilisé, et
@@ -595,6 +619,12 @@ func init() {
 	scanCmd.Flags().StringVar(&scanRegion, "region", "", "région cible pour la collecte live")
 	scanCmd.Flags().StringVar(&scanKubeconfig, "kubeconfig", "", "chemin d'un kubeconfig pour auditer l'état DANS un cluster Kubernetes (utiliser un accès en LECTURE SEULE, TTL court — jamais cluster-admin)")
 	scanCmd.Flags().StringVar(&scanProfile, "profile", "", "profil d'identifiants pour la collecte live (ex. ~/.osc/config.json)")
+	// `--profile` désigne DÉJÀ le profil d'identifiants. Celui-ci s'appelle donc
+	// `--gate`, et le nom dit mieux ce qu'il fait : il ne filtre pas le rapport, il
+	// filtre ce qui pèse dans le code de sortie.
+	scanCmd.Flags().StringVar(&scanGate, "gate", profile.All,
+		tr("profil de PORTE ("+strings.Join(profile.Names(), " | ")+") : ce qui pèse dans le code de sortie. Le rapport reste COMPLET quel que soit le profil ; un écart critical/high mis de côté rend 3, jamais 0",
+			"GATE profile ("+strings.Join(profile.Names(), " | ")+"): what weighs in the exit code. The report stays COMPLETE whatever the profile; a critical/high deviation set aside yields 3, never 0"))
 	scanCmd.Flags().StringVar(&scanS3Endpoint, "s3-endpoint", "", "endpoint S3 custom pour le stockage objet (collecte live ; ex. MinIO http://localhost:9000)")
 	scanCmd.Flags().StringVar(&scanSeal, "seal", "", "écrire un bundle de preuve opposable (assessment + OSCAL + manifest + checksums) dans ce dossier")
 	scanCmd.Flags().StringVar(&scanExceptions, "exceptions", "", "`fichier` YAML de dérogations (control, justification, expires_at, owner, approved_by) : un écart couvert passe au statut exempted, jamais conforme")
@@ -1387,4 +1417,30 @@ func renderJSON(findings []finding.Finding, res scoring.Result, ex exempt.Report
 	}
 	_, _ = fmt.Println(string(b))
 	return nil
+}
+
+// renderGateProfile dit ce que le profil de porte a mis de côté.
+//
+// Il l'écrit MÊME quand rien n'a été mis de côté, dès qu'un profil est demandé : un
+// opérateur doit pouvoir vérifier que sa porte regarde ce qu'il croit, et l'absence
+// de message se lirait « le profil n'a rien changé » aussi bien que « le profil n'a
+// pas été pris en compte ».
+func renderGateProfile(w io.Writer, gate string, codes []string, severe bool) {
+	if gate == profile.All {
+		return
+	}
+	_, _ = fmt.Fprintf(w, tr("\npepin: porte « %s » — le rapport ci-dessus reste COMPLET, seul le code de sortie est filtré.\n",
+		"\npepin: gate \"%s\" — the report above stays COMPLETE, only the exit code is filtered.\n"), gate)
+	if len(codes) == 0 {
+		_, _ = fmt.Fprintln(w, tr("       aucun écart mis de côté : la porte a pesé tout ce qui a été trouvé.",
+			"       nothing set aside: the gate weighed everything that was found."))
+		return
+	}
+	_, _ = fmt.Fprintf(w, tr("       %d contrôle(s) mis de côté, hors du profil : %s\n",
+		"       %d control(s) set aside, outside the profile: %s\n"), len(codes), strings.Join(codes, ", "))
+	if severe {
+		_, _ = fmt.Fprintln(w, tr(
+			"       dont au moins un critical/high : le scan sort en 3 (« n'établit pas la conformité »), jamais 0.",
+			"       at least one of them critical/high: the scan exits 3 (\"does not establish compliance\"), never 0."))
+	}
 }

--- a/cmd/surface.go
+++ b/cmd/surface.go
@@ -58,7 +58,16 @@ const (
 // aucun drapeau et aucun code de sortie existant ne bouge. L'incrément est dû
 // quand même — la surface est la liste de ce qu'un intégrateur a le droit de
 // brancher, et elle vient de s'allonger.
-const cliSurfaceVersion = 5
+// v6 : ajout de `scan --gate` (all | security | compliance | sovereignty), le profil
+// de PORTE. Il ne filtre pas le rapport — celui-ci reste complet dans tous les
+// formats — il filtre ce qui pèse dans le CODE DE SORTIE, et c'est pourquoi
+// l'incrément est dû : un pipeline qui pose ce drapeau doit savoir qu'un écart mis
+// de côté rend 3 (« n'établit pas la conformité »), jamais 0. Le défaut reste `all`,
+// donc aucune chaîne existante ne change de code sans qu'on l'ait écrit.
+//
+// Le drapeau ne s'appelle PAS `--profile` : ce nom désigne déjà le profil
+// d'identifiants de la collecte live.
+const cliSurfaceVersion = 6
 
 // findingsSurfaceVersion est la version de FORME de `--format json`
 // ({"findings": [...], "summary": {...}}), la sortie qu'un pipeline parse le

--- a/cmd/testdata/frozen/cli.json
+++ b/cmd/testdata/frozen/cli.json
@@ -294,6 +294,74 @@
           }
         }
       }
+    },
+    {
+      "schema_version": 6,
+      "content": {
+        "exit_codes": {
+          "conforme": 0,
+          "derogation": 4,
+          "erreur": 2,
+          "non_conformite": 1,
+          "strict": 3
+        },
+        "verbs": {
+          "control": {
+            "flags": {}
+          },
+          "control explain": {
+            "flags": {
+              "provider": ""
+            }
+          },
+          "provider": {
+            "flags": {}
+          },
+          "provider list": {
+            "flags": {}
+          },
+          "provider new": {
+            "flags": {}
+          },
+          "provider validate": {
+            "flags": {}
+          },
+          "scan": {
+            "flags": {
+              "exceptions": "",
+              "format": "f",
+              "gate": "",
+              "kubeconfig": "",
+              "lang": "",
+              "live": "",
+              "policy": "",
+              "policy-dir": "p",
+              "profile": "",
+              "redact": "",
+              "region": "",
+              "s3-endpoint": "",
+              "seal": "",
+              "strict": "",
+              "terraform": "t"
+            }
+          },
+          "scsl": {
+            "flags": {
+              "index": ""
+            }
+          },
+          "verify": {
+            "flags": {
+              "bundle": "",
+              "pubkey": "",
+              "re-derive": ""
+            }
+          },
+          "version": {
+            "flags": {}
+          }
+        }
+      }
     }
   ]
 }

--- a/docs/guides/control-configuration.fr.md
+++ b/docs/guides/control-configuration.fr.md
@@ -103,6 +103,53 @@ qu'un risque orphelin.
   `governance_provider` (ressource synthétique, pas une ressource du tenant) ; `k8s_*`
   (portée intra-cluster, hors posture cloud).
 
+## Le profil de PORTE : ce qui casse une chaîne, sans rien cacher
+
+Un premier scan doit provoquer « ah oui, ça c'est intéressant », pas « oui, je sais que
+ma VM de test n'a pas de protection contre la suppression ». Une VM publique dont SSH
+est ouvert à Internet et un volume sans snapshot récente sont tous deux `high` : le
+second est un faux positif **assumé** — la règle le documente elle-même —, et lui
+donner le poids du premier fait douter du premier.
+
+```bash
+pepin scan scaleway inv.json                        # all — le défaut, rien n'est filtré
+pepin scan scaleway inv.json --gate security        # l'exposition et les secrets, quand la règle est sûre
+pepin scan scaleway inv.json --gate compliance      # l'audit normatif et l'hygiène documentaire
+pepin scan scaleway inv.json --gate sovereignty     # la localisation et l'extraterritorialité
+```
+
+### Ce qu'un profil ne fait pas
+
+**Il ne cache rien.** Le rapport reste complet dans tous les formats — table, `json`,
+`sarif`, `assessment`, bundle scellé. C'est la règle déjà appliquée aux dérogations et
+aux constats d'incertitude : *le rapport dit tout, seule la porte filtre*.
+
+Un profil qui retirerait des écarts du rapport transformerait le silence en faux vert,
+et il le ferait depuis un **réglage** plutôt qu'un défaut de règle — donc invisible.
+
+### Ce qu'il change, et la garantie qui va avec
+
+Il change ce qui pèse dans le **code de sortie**, et il le dit à chaque scan :
+
+```
+pepin: porte « sovereignty » — le rapport ci-dessus reste COMPLET, seul le code de sortie est filtré.
+       4 contrôle(s) mis de côté, hors du profil : iam_accesskey_expiration_set, …
+       dont au moins un critical/high : le scan sort en 3 (« n'établit pas la conformité »), jamais 0.
+```
+
+| Situation | Code |
+|---|---|
+| le profil voit l'écart | **1** — inchangé |
+| le profil met de côté un écart critical/high | **3** — n'établit pas la conformité |
+| plus rien à mettre de côté | **0** |
+
+**Aucun profil ne peut faire passer une chaîne de rouge à vert.** Un `1` devient au
+pire un `3`, jamais un `0`, et `TestNoGateProfileTurnsARedChainGreen` le mesure sur le
+binaire à chaque build. Le défaut reste `all` : sans le drapeau, rien ne change.
+
+> `--gate` ne s'appelle pas `--profile` : ce nom désigne déjà le profil d'identifiants
+> de la collecte live (`--profile ~/.osc/config.json`).
+
 ## Ce qu'un assouplissement fait perdre
 
 Chaque correspondance du référentiel porte les contraintes de configuration sous lesquelles

--- a/docs/guides/control-configuration.md
+++ b/docs/guides/control-configuration.md
@@ -99,6 +99,53 @@ resource that costs money without a known owner is an orphan cost as much as an 
   `governance_provider` (a synthetic resource, not a tenant resource); `k8s_*` (in-cluster
   scope, outside cloud posture).
 
+## The GATE profile: what breaks a chain, without hiding anything
+
+A first scan should trigger "oh, that one is interesting", not "yes, I know my test VM
+has no deletion protection". A public VM with SSH open to the internet and a volume with
+no recent snapshot are both `high`: the second is an **assumed** false positive — the
+rule documents it itself — and giving it the weight of the first makes people doubt the
+first.
+
+```bash
+pepin scan scaleway inv.json                        # all — the default, nothing filtered
+pepin scan scaleway inv.json --gate security        # exposure and secrets, where the rule is sure
+pepin scan scaleway inv.json --gate compliance      # the normative audit and documentation hygiene
+pepin scan scaleway inv.json --gate sovereignty     # location and extraterritoriality
+```
+
+### What a profile does not do
+
+**It hides nothing.** The report stays complete in every format — table, `json`,
+`sarif`, `assessment`, sealed bundle. This is the rule already applied to exemptions and
+inconclusive findings: *the report says everything, only the gate filters*.
+
+A profile that removed deviations from the report would turn silence into a false green,
+and it would do so from a **setting** rather than a rule defect — so, invisibly.
+
+### What it changes, and the guarantee that comes with it
+
+It changes what weighs in the **exit code**, and it says so on every scan:
+
+```
+pepin: gate "sovereignty" — the report above stays COMPLETE, only the exit code is filtered.
+       4 control(s) set aside, outside the profile: iam_accesskey_expiration_set, …
+       at least one of them critical/high: the scan exits 3 ("does not establish compliance"), never 0.
+```
+
+| Situation | Code |
+|---|---|
+| the profile sees the deviation | **1** — unchanged |
+| the profile sets a critical/high deviation aside | **3** — does not establish compliance |
+| nothing left to set aside | **0** |
+
+**No profile can turn a red chain green.** A `1` becomes a `3` at worst, never a `0`,
+and `TestNoGateProfileTurnsARedChainGreen` measures it on the binary on every build.
+The default stays `all`: without the flag, nothing changes.
+
+> `--gate` is not called `--profile`: that name already designates the credentials
+> profile of a live collection (`--profile ~/.osc/config.json`).
+
 ## What a relaxation costs
 
 Each mapping in the reference carries the configuration constraints under which it holds:

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -24,7 +24,7 @@ de drapeaux viennent de la surface gelée ; chaque aide ci-dessous est la sortie
 | `pepin provider list` | _(aucun drapeau propre)_ |
 | `pepin provider new` | _(aucun drapeau propre)_ |
 | `pepin provider validate` | _(aucun drapeau propre)_ |
-| `pepin scan` | `--exceptions`, `--format` / `-f`, `--kubeconfig`, `--lang`, `--live`, `--policy`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
+| `pepin scan` | `--exceptions`, `--format` / `-f`, `--gate`, `--kubeconfig`, `--lang`, `--live`, `--policy`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
 | `pepin scsl` | `--index` |
 | `pepin verify` | `--bundle`, `--pubkey`, `--re-derive` |
 | `pepin version` | _(aucun drapeau propre)_ |
@@ -39,7 +39,7 @@ séparément :
 <!-- pepin:gen surface-versions -->
 | Surface | Ce qui est gelé | Version |
 |---|---|:-:|
-| `cli` | verbes, drapeaux et codes de sortie | **v5** |
+| `cli` | verbes, drapeaux et codes de sortie | **v6** |
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
@@ -118,6 +118,7 @@ Usage:
 Flags:
       --exceptions fichier               fichier YAML de dérogations (control, justification, expires_at, owner, approved_by) : un écart couvert passe au statut exempted, jamais conforme
   -f, --format string                    format de sortie : table | json | assessment | oscal | sarif (default "table")
+      --gate string                      GATE profile (all | security | compliance | sovereignty): what weighs in the exit code. The report stays COMPLETE whatever the profile; a critical/high deviation set aside yields 3, never 0 (default "all")
   -h, --help                             help for scan
       --kubeconfig string                chemin d'un kubeconfig pour auditer l'état DANS un cluster Kubernetes (utiliser un accès en LECTURE SEULE, TTL court — jamais cluster-admin)
       --live                             collecter l'inventaire en direct via l'API du provider (identifiants requis)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,7 +24,7 @@ by running the binary. A public flag that is missing here fails
 | `pepin provider list` | _(no flag of its own)_ |
 | `pepin provider new` | _(no flag of its own)_ |
 | `pepin provider validate` | _(no flag of its own)_ |
-| `pepin scan` | `--exceptions`, `--format` / `-f`, `--kubeconfig`, `--lang`, `--live`, `--policy`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
+| `pepin scan` | `--exceptions`, `--format` / `-f`, `--gate`, `--kubeconfig`, `--lang`, `--live`, `--policy`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
 | `pepin scsl` | `--index` |
 | `pepin verify` | `--bundle`, `--pubkey`, `--re-derive` |
 | `pepin version` | _(no flag of its own)_ |
@@ -39,7 +39,7 @@ independently:
 <!-- pepin:gen surface-versions -->
 | Surface | What is frozen | Version |
 |---|---|:-:|
-| `cli` | verbs, flags and exit codes | **v5** |
+| `cli` | verbs, flags and exit codes | **v6** |
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
@@ -117,6 +117,7 @@ Usage:
 Flags:
       --exceptions file                  exemptions YAML file (control, justification, expires_at, owner, approved_by) — a covered deviation becomes exempted, never compliant
   -f, --format string                    output format: table | json | assessment | oscal | sarif (default "table")
+      --gate string                      GATE profile (all | security | compliance | sovereignty): what weighs in the exit code. The report stays COMPLETE whatever the profile; a critical/high deviation set aside yields 3, never 0 (default "all")
   -h, --help                             help for scan
       --kubeconfig string                path to a kubeconfig to audit the state INSIDE a Kubernetes cluster (use READ-ONLY, short-lived access — never cluster-admin)
       --live                             collect the inventory live through the provider API (credentials required)

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -26,7 +26,7 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 <!-- pepin:gen surface-versions -->
 | Surface | Ce qui est gelé | Version |
 |---|---|:-:|
-| `cli` | verbes, drapeaux et codes de sortie | **v5** |
+| `cli` | verbes, drapeaux et codes de sortie | **v6** |
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -26,7 +26,7 @@ See [Exit codes](exit-codes.md).
 <!-- pepin:gen surface-versions -->
 | Surface | What is frozen | Version |
 |---|---|:-:|
-| `cli` | verbs, flags and exit codes | **v5** |
+| `cli` | verbs, flags and exit codes | **v6** |
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -1,0 +1,148 @@
+// Package profile porte les PROFILS DE SCAN : ce qu'une porte de CI retient, sans
+// jamais retirer quoi que ce soit du rapport.
+//
+// # Le problème
+//
+// Un premier scan doit provoquer « ah oui, ça c'est intéressant », pas « oui, je sais
+// que ma VM de test n'a pas de protection contre la suppression ». Une VM publique
+// dont SSH est ouvert à Internet et un volume sans snapshot récente sont tous deux
+// `high` : le second est un faux positif ASSUMÉ — la règle le documente elle-même —
+// et lui donner le poids du premier fait douter du premier.
+//
+// # Ce qu'un profil NE fait PAS, et c'est le cœur
+//
+// Il ne cache RIEN. Le rapport reste complet dans tous les formats, et c'est la
+// doctrine déjà appliquée aux dérogations et aux constats d'incertitude : « le rapport
+// dit tout, seule la porte tient compte des dérogations ». Un profil qui retirerait
+// des écarts du rapport transformerait le silence en faux vert — précisément ce que
+// ce projet passe son temps à combattre, et ce serait pire ici, parce que ça viendrait
+// d'un réglage plutôt que d'un défaut de règle, donc ce serait invisible.
+//
+// Ce qu'il change est le POIDS dans la porte de CI, et il le DIT :
+//
+//   - les écarts hors profil ne rendent pas 1 ;
+//   - mais un écart critical/high mis de côté empêche de rendre 0 : le scan sort en
+//     3, « le scan n'établit pas la conformité », qui est exactement ce qu'un scan
+//     volontairement partiel est (ADR-0005, et aucun cinquième code) ;
+//   - le nombre et les codes mis de côté sont publiés.
+//
+// # Le défaut ne change pas
+//
+// `all` reste le profil par défaut. Changer un défaut ferait passer au vert, en
+// silence et sans que personne ne l'ait décidé, une chaîne qui échoue aujourd'hui.
+package profile
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/stephrobert/scankit/finding"
+)
+
+// Noms des profils. `all` est le défaut et ne filtre rien.
+const (
+	All         = "all"
+	Security    = "security"
+	Compliance  = "compliance"
+	Sovereignty = "sovereignty"
+)
+
+// Names énumère les profils, dans l'ordre où l'aide les présente.
+func Names() []string { return []string{All, Security, Compliance, Sovereignty} }
+
+// def décrit ce qu'un profil RETIENT dans la porte.
+type def struct {
+	// categories : les valeurs de `labels.category` retenues. Vide = toutes.
+	categories map[string]bool
+	// confidences : les valeurs de `labels.confidence` retenues. Vide = toutes.
+	confidences map[string]bool
+}
+
+// Les profils sont définis sur les DEUX dimensions que porte un finding depuis #111.
+// Filtrer sur la seule sévérité mélangerait encore « grave » et « certain », ce qui
+// est le défaut que la confiance existe pour corriger.
+var defs = map[string]def{
+	All: {},
+	// L'exposition et les secrets, quand la règle est sûre de ce qu'elle avance. Un
+	// écart `contextual` dépend d'un contexte que le scan ne voit pas : il reste au
+	// rapport, il ne casse pas une chaîne.
+	Security: {
+		categories:  set("security"),
+		confidences: set("confirmed", "probable"),
+	},
+	// L'audit normatif : ce qui se défend devant un référentiel, y compris l'hygiène
+	// documentaire sans laquelle un auditeur ne peut rien retracer.
+	Compliance: {categories: set("compliance", "hygiene")},
+	// La localisation et l'extraterritorialité — la raison d'être du produit.
+	Sovereignty: {categories: set("sovereignty")},
+}
+
+func set(vals ...string) map[string]bool {
+	m := make(map[string]bool, len(vals))
+	for _, v := range vals {
+		m[v] = true
+	}
+	return m
+}
+
+// Valid dit si le nom est un profil connu.
+func Valid(name string) bool {
+	_, ok := defs[name]
+	return ok
+}
+
+// Retains dit si un finding pèse dans la porte de ce profil.
+//
+// Un finding dont le label manque est RETENU. Le repli penche vers plus de sévérité :
+// une étiquette absente ne doit pas faire disparaître un écart d'une porte de CI, ce
+// qui serait exactement le silence-devenu-vert que ce paquet refuse.
+func Retains(name string, f finding.Finding) bool {
+	d, ok := defs[name]
+	if !ok {
+		return true
+	}
+	if len(d.categories) > 0 {
+		if c := f.Label("category"); c != "" && !d.categories[c] {
+			return false
+		}
+	}
+	if len(d.confidences) > 0 {
+		if c := f.Label("confidence"); c != "" && !d.confidences[c] {
+			return false
+		}
+	}
+	return true
+}
+
+// Split partage les findings entre ceux que la porte retient et ceux qu'elle met de
+// côté. L'ordre d'origine est conservé dans les deux.
+func Split(name string, findings []finding.Finding) (retenus, ecartes []finding.Finding) {
+	for _, f := range findings {
+		if Retains(name, f) {
+			retenus = append(retenus, f)
+			continue
+		}
+		ecartes = append(ecartes, f)
+	}
+	return retenus, ecartes
+}
+
+// SetAside résume ce qu'un profil a mis de côté : les codes concernés, triés et
+// dédoublonnés, et s'il en reste un de sévérité critical ou high.
+//
+// Le second est ce qui empêche de rendre 0 : mettre de côté un écart grave est une
+// décision de lecture, pas une absence d'écart.
+func SetAside(ecartes []finding.Finding) (codes []string, grave bool) {
+	vus := map[string]bool{}
+	for _, f := range ecartes {
+		if !vus[f.Code] {
+			vus[f.Code] = true
+			codes = append(codes, f.Code)
+		}
+		if s := strings.ToLower(f.Severity); s == "critical" || s == "high" {
+			grave = true
+		}
+	}
+	sort.Strings(codes)
+	return codes, grave
+}

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -1,0 +1,104 @@
+package profile
+
+import (
+	"testing"
+
+	"github.com/stephrobert/scankit/finding"
+)
+
+func f(code, sev, cat, conf string) finding.Finding {
+	return finding.Finding{
+		Code: code, Severity: sev,
+		Labels: map[string]string{"category": cat, "confidence": conf},
+	}
+}
+
+// TestTheDefaultProfileFiltersNothing — l'invariant qui rend cette fonctionnalité
+// sûre à livrer.
+//
+// Changer un défaut ferait passer au vert, en silence et sans que personne ne l'ait
+// décidé, une chaîne qui échoue aujourd'hui. Ce serait le faux vert que ce projet
+// combat, déplacé dans un réglage — donc invisible, donc pire.
+func TestTheDefaultProfileFiltersNothing(t *testing.T) {
+	tous := []finding.Finding{
+		f("a", "critical", "security", "confirmed"),
+		f("b", "high", "compliance", "contextual"),
+		f("c", "low", "sovereignty", "heuristic"),
+		f("d", "medium", "hygiene", "probable"),
+		{Code: "e", Severity: "high"}, // sans aucun label
+	}
+	retenus, ecartes := Split(All, tous)
+	if len(retenus) != len(tous) || len(ecartes) != 0 {
+		t.Errorf("le profil par défaut a filtré : %d retenus, %d écartés sur %d",
+			len(retenus), len(ecartes), len(tous))
+	}
+}
+
+// TestAnUnlabelledFindingIsAlwaysRetained : le repli penche vers PLUS de sévérité.
+//
+// Une étiquette absente ne doit pas faire disparaître un écart d'une porte de CI.
+// C'est le sens qui compte : dans l'autre, une règle qui oublierait son label
+// sortirait silencieusement de toutes les portes.
+func TestAnUnlabelledFindingIsAlwaysRetained(t *testing.T) {
+	nu := finding.Finding{Code: "sans-label", Severity: "critical"}
+	for _, p := range Names() {
+		if !Retains(p, nu) {
+			t.Errorf("profil %q : un finding sans label a été mis de côté", p)
+		}
+	}
+}
+
+// TestAnUnknownProfileRetainsEverything : un nom inconnu ne doit jamais ALLÉGER une
+// porte. La commande le refuse en amont ; si ce refus tombait, le repli doit rester
+// du côté sûr.
+func TestAnUnknownProfileRetainsEverything(t *testing.T) {
+	if !Retains("paranoid", f("a", "low", "hygiene", "heuristic")) {
+		t.Error("un profil inconnu a filtré : le repli doit retenir")
+	}
+}
+
+func TestEachProfileRetainsWhatItNames(t *testing.T) {
+	cas := []struct {
+		profil string
+		f      finding.Finding
+		veut   bool
+	}{
+		{Security, f("a", "high", "security", "confirmed"), true},
+		{Security, f("b", "high", "security", "probable"), true},
+		// La confiance est ce qui distingue « grave » de « certain » : un écart dont
+		// la règle dit elle-même qu'il dépend d'un contexte invisible ne casse pas
+		// une chaîne, mais il reste au rapport.
+		{Security, f("c", "high", "security", "contextual"), false},
+		{Security, f("d", "critical", "compliance", "confirmed"), false},
+		{Compliance, f("e", "medium", "compliance", "contextual"), true},
+		{Compliance, f("f", "low", "hygiene", "heuristic"), true},
+		{Compliance, f("g", "critical", "security", "confirmed"), false},
+		{Sovereignty, f("h", "high", "sovereignty", "confirmed"), true},
+		{Sovereignty, f("i", "critical", "security", "confirmed"), false},
+	}
+	for _, c := range cas {
+		if got := Retains(c.profil, c.f); got != c.veut {
+			t.Errorf("profil %q, finding %s (%s/%s) : retenu=%v, attendu %v",
+				c.profil, c.f.Code, c.f.Label("category"), c.f.Label("confidence"), got, c.veut)
+		}
+	}
+}
+
+// TestSetAsideNamesWhatItHidAndWhetherItWasSevere : ce que la porte met de côté doit
+// être NOMMÉ et son poids connu — c'est ce qui empêche de rendre 0.
+func TestSetAsideNamesWhatItHidAndWhetherItWasSevere(t *testing.T) {
+	codes, grave := SetAside([]finding.Finding{
+		f("zeta", "low", "hygiene", "heuristic"),
+		f("alpha", "medium", "compliance", "probable"),
+		f("alpha", "medium", "compliance", "probable"), // même code, deux sujets
+	})
+	if len(codes) != 2 || codes[0] != "alpha" || codes[1] != "zeta" {
+		t.Errorf("codes = %v, attendu [alpha zeta] dédoublonnés et triés", codes)
+	}
+	if grave {
+		t.Error("aucun critical/high mis de côté, et pourtant signalé comme grave")
+	}
+	if _, grave := SetAside([]finding.Finding{f("x", "HIGH", "compliance", "confirmed")}); !grave {
+		t.Error("un `high` mis de côté n'a pas été signalé (la casse ne doit pas compter)")
+	}
+}


### PR DESCRIPTION
## La réserve de l'issue est le sujet entier, et c'est elle qui a décidé du design

Changer ce qu'une porte accepte est la façon la plus discrète de casser une chaîne de
CI : une équipe qui échoue aujourd'hui passerait au vert après une mise à jour, **sans
que personne ne l'ait décidé**. C'est le faux vert que cette vague a passé trois lots à
combattre — à ceci près qu'il viendrait d'un **réglage** plutôt que d'une règle, donc
qu'il serait invisible.

## Le profil filtre la PORTE, jamais le rapport

Ce n'est pas une invention : c'est la règle que ce fichier applique **déjà** aux
dérogations et aux constats d'incertitude, écrite quelques lignes au-dessus du point
d'insertion.

> *Le RAPPORT dit tout : aucun écart ne disparaît d'un format analysable parce qu'il est
> exempté. Seule la PORTE tient compte des dérogations.*

Le rapport reste donc complet en `table`, `json`, `sarif`, `assessment` et dans le
bundle scellé. Ce qui change est ce qui pèse dans le **code de sortie**, et chaque scan
imprime ce qui a été mis de côté :

```
pepin: porte « sovereignty » — le rapport ci-dessus reste COMPLET, seul le code de sortie est filtré.
       4 contrôle(s) mis de côté, hors du profil : iam_accesskey_expiration_set, …
       dont au moins un critical/high : le scan sort en 3 (« n'établit pas la conformité »), jamais 0.
```

## La garantie, mesurée sur le binaire

| Profil | Inventaire non conforme | Plan corrigé |
|---|---|---|
| `all` (défaut) | **1** | 0 |
| `security` | **1** | 0 |
| `compliance` | **3** | 0 |
| `sovereignty` | **3** | 0 |

Un `1` devient au pire un `3` — « n'établit pas la conformité », la lecture honnête d'un
scan volontairement partiel, et exactement ce à quoi **ADR-0005** réserve déjà le 3.
**Jamais un `0`.**

Le test est placé **après** celui de conformité : un écart resté visible rend `1`, et
l'ordre de précédence d'ADR-0005 tient — une mise de côté n'efface jamais un écart
observé. Aucun cinquième code.

`TestNoGateProfileTurnsARedChainGreen` le mesure, et je l'ai éprouvé en neutralisant la
porte : il rapporte alors le vert obtenu à tort.

**Le défaut reste `all`.** Sans le drapeau, rien ne change.

## Deux choses que l'issue ne pouvait pas connaître

**`--profile` est déjà pris** — c'est le profil d'identifiants de la collecte live
(`--profile ~/.osc/config.json`). Le drapeau s'appelle donc `--gate`, ce qui dit
d'ailleurs mieux ce qu'il fait.

**La surface CLI gelée a attrapé le nouveau drapeau au premier passage**, ce qui est
exactement son rôle : v5 → v6, avec sa ligne de CHANGELOG, selon le rituel que le
message d'échec indique.

## Un détail qui compte

Un finding sans label `category` ou `confidence` est **toujours retenu**. Le repli
penche vers plus de sévérité : une règle qui oublierait son label ne doit pas sortir
silencieusement de toutes les portes.

## Mouvement de verdicts

**0 sur les 19 fixtures**, sans drapeau.

## Critères d'acceptation

- [x] Les profils existent et sont documentés dans les deux langues
- [x] Le rapport dit toujours ce que le profil n'a **pas** regardé
- [x] Aucun changement de défaut ne peut faire passer une chaîne de rouge à vert en silence
- [x] Le CHANGELOG porte la ligne, et la sémantique des codes de sortie est inchangée

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
