### PR TITLE
fix(scan): refuse an inventory whose origin contradicts the requested ruleset

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -40,6 +40,16 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Un inventaire dont l'origine contredit le jeu de règles demandé est désormais
+  refusé.** Scanner un inventaire Scaleway avec les règles Exoscale était accepté sans
+  un mot et produisait six verdicts `pass`. Ces `pass` n'étaient pas faux par accident :
+  ils étaient **vides de sens**, les formes de ressources se recouvrant juste assez pour
+  que des règles s'évaluent et concluent. Le mode d'échec était silencieux et réaliste —
+  une faute de frappe dans un pipeline, un job copié-collé — et le rapport avait l'air
+  parfaitement normal, avec un code de sortie non nul qui suggérait même que le scan
+  avait travaillé. La déclaration est lue à la racine de l'export et sur ses ressources,
+  et une discordance sort en **2**, le code déjà employé pour un export illisible. Un
+  inventaire qui ne déclare rien n'est pas refusé : une origine absente ne s'invente pas.
 - **`evidence.proves` ne voyage plus en `["","",""]` sur chaque résultat.** `omitempty`
   sur un tableau de taille fixe est sans effet, si bien qu'un lecteur ne pouvait pas
   distinguer « aucune preuve enregistrée » de « trois preuves enregistrées, toutes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ belongs in `git log`.
 
 ### Fixed
 
+- **An inventory whose origin contradicts the requested ruleset is now refused.**
+  Scanning a Scaleway inventory with the Exoscale rules was accepted without a word and
+  produced six `pass` verdicts. Those passes were not wrong by accident, they were
+  meaningless: the resource shapes overlap just enough for rules to evaluate and
+  conclude. The failure mode was quiet and realistic — a typo in a pipeline, a
+  copy-pasted job — and the report looked entirely normal, with a non-zero exit code
+  that even suggested the scan had done its job. The declaration is read from the root
+  of the export and from its resources, and a mismatch exits **2**, the code already
+  used for an unreadable export. An inventory that declares nothing is not refused: an
+  absent origin is not invented.
 - **`evidence.proves` no longer travels as `["","",""]` on every result.** `omitempty`
   on a fixed-size array is a no-op, so a reader could not tell "no proof recorded" from
   "three proofs recorded, all blank" — including inside sealed bundles archived for

--- a/cmd/policy_network_test.go
+++ b/cmd/policy_network_test.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -118,4 +120,67 @@ func TestNoResultCarriesAnEmptyProof(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestAProviderMismatchIsRefused — l'issue #148, un faux vert P0.
+//
+// Scanner un inventaire Scaleway avec les règles Exoscale était accepté SANS UN MOT et
+// produisait six verdicts `pass`. Ces `pass` ne sont pas faux par accident : ils sont
+// vides de sens, les formes de ressources se recouvrant juste assez pour que des règles
+// s'évaluent et concluent. Le mode d'échec est silencieux et réaliste — une faute de
+// frappe dans un pipeline, un job copié-collé — et le rapport a l'air normal, avec un
+// code de sortie non nul qui suggère même que le scan a travaillé.
+//
+// La matrice CROISÉE est ce qui compte : chaque fixture lue par chaque AUTRE
+// fournisseur doit sortir en 2, et lue par le sien doit scanner normalement. Ne
+// vérifier qu'un seul couple laisserait passer une correction qui refuserait tout.
+func TestAProviderMismatchIsRefused(t *testing.T) {
+	fixtures := map[string]string{
+		"scaleway": "examples/scaleway/inventory.json",
+		"outscale": "examples/outscale/inventory.json",
+		"exoscale": "examples/exoscale/inventory.json",
+	}
+	bin := buildPepin(t)
+	var croises int
+	for propre, f := range fixtures {
+		if _, err := os.Stat(filepath.Join(repoRoot, f)); err != nil {
+			t.Fatalf("fixture %s absente : le test ne mesurerait rien", f)
+		}
+		for lu := range fixtures {
+			code := exitCodeOf(t, bin, "scan", lu, f)
+			if lu == propre {
+				if code == exitErreur {
+					t.Errorf("%s lu par son PROPRE fournisseur rend %d : la correction refuse tout",
+						f, code)
+				}
+				continue
+			}
+			croises++
+			if code != exitErreur {
+				t.Errorf("%s (fournisseur %q) lu par %q rend %d, attendu %d.\n"+
+					"  Un jeu de règles rendrait des verdicts sur un inventaire qu'il n'a jamais eu\n"+
+					"  à lire : un « conforme » y serait vide de sens.", f, propre, lu, code, exitErreur)
+			}
+		}
+	}
+	if croises == 0 {
+		t.Fatal("aucun croisement éprouvé : la porte ne mesure rien")
+	}
+	t.Logf("%d croisement(s) fournisseur × inventaire refusé(s)", croises)
+}
+
+// exitCodeOf lance le binaire et rend son code de sortie, sans faire échouer le test :
+// ici, le code EST la mesure.
+func exitCodeOf(t *testing.T, bin string, args ...string) int {
+	t.Helper()
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = repoRoot
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return ee.ExitCode()
+		}
+		t.Fatalf("exécution de %v : %v", args, err)
+	}
+	return 0
 }

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -1117,7 +1117,67 @@ func loadInput(ctx context.Context, p provider.Provider, path string) (any, erro
 	if err := json.Unmarshal(raw, &input); err != nil {
 		return nil, fmt.Errorf(tr("export JSON invalide : %w", "invalid JSON export: %w"), err)
 	}
+	if err := checkProviderMatches(p.Name(), input); err != nil {
+		return nil, err
+	}
 	return input, nil
+}
+
+// checkProviderMatches refuse un inventaire dont l'ORIGINE contredit le jeu de règles
+// demandé.
+//
+// Un export porte son fournisseur, à la racine et sur chaque ressource, et cette
+// déclaration était ignorée. Scanner un inventaire Scaleway avec les règles Exoscale
+// était donc accepté sans un mot, et produisait six verdicts `pass` — asseoir un
+// « conforme » sur des données que ce jeu de règles n'a jamais eu à lire. Ces `pass`
+// ne sont pas faux par accident : ils sont VIDES DE SENS, les formes de ressources se
+// recouvrant juste assez pour que des règles s'évaluent et concluent.
+//
+// Le mode d'échec est silencieux et réaliste : une faute de frappe dans un pipeline,
+// un job copié-collé, et le rapport a l'air parfaitement normal — un mélange crédible
+// de statuts et un code de sortie non nul qui suggère même que le scan a travaillé.
+//
+// On REFUSE plutôt qu'on avertit, et le code 2 (erreur technique) est celui d'un export
+// illisible : un inventaire dont l'origine ne correspond pas n'est pas un scan aux
+// résultats surprenants, c'est un scan qui n'aurait pas dû tourner.
+//
+// Un inventaire qui ne déclare RIEN n'est pas refusé : on ne peut pas inventer une
+// origine, et l'exiger casserait tout export écrit à la main (ADR-0014, une donnée
+// absente se déclare, elle ne se fabrique pas).
+func checkProviderMatches(want string, input any) error {
+	m, ok := input.(map[string]any)
+	if !ok {
+		return nil
+	}
+	refus := func(got, ou string) error {
+		return fmt.Errorf(tr(
+			"cet inventaire déclare le fournisseur %q (%s), et le scan demande %q.\n"+
+				"  Les verdicts seraient rendus par un jeu de règles qui n'a jamais eu à lire ces\n"+
+				"  ressources : un « conforme » y serait vide de sens. Corriger le fournisseur de la\n"+
+				"  ligne de commande, ou scanner l'inventaire du bon tenant.",
+			"this inventory declares provider %q (%s), and the scan asks for %q.\n"+
+				"  The verdicts would be rendered by a ruleset that was never meant to read these\n"+
+				"  resources: a \"pass\" there is meaningless. Fix the provider on the command line,\n"+
+				"  or scan the inventory of the right tenant."), got, ou, want)
+	}
+	// La déclaration RACINE : l'affirmation explicite de l'export.
+	if got, _ := m["provider"].(string); got != "" && got != want {
+		return refus(got, tr("racine de l'export", "root of the export"))
+	}
+	// Les RESSOURCES portent la même information, et un export peut n'avoir que
+	// celle-là. Une seule suffit à trancher : un inventaire panaché n'existe pas,
+	// chaque scan porte sur un tenant.
+	rs, _ := m["resources"].([]any)
+	for _, it := range rs {
+		rm, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
+		if got, _ := rm["provider"].(string); got != "" && got != want {
+			return refus(got, tr("ressources de l'export", "resources of the export"))
+		}
+	}
+	return nil
 }
 
 // withGovernance ajoute, le cas échéant, la ressource synthétique de souveraineté


### PR DESCRIPTION
> **P0 — faux vert.** À fusionner avant #152.

## Le défaut

Scanner un inventaire Scaleway avec les règles Exoscale était accepté **sans un mot**.

| | `fail` | `pass` | `not-applicable` | `not-evaluated` |
|---|---|---|---|---|
| `exoscale` lisant l'inventaire **scaleway** | 6 | **6** | 5 | 17 |
| `scaleway` lisant le même fichier | 4 | 7 | 2 | 14 |

Ces six `pass` ne sont pas faux par accident : ils sont **vides de sens**. Les formes de
ressources se recouvrent juste assez pour que des règles s'évaluent et concluent sur des
données que ce jeu de règles n'a jamais eu à lire. Et la discordance ne change pas
seulement la formulation — **elle déplace les verdicts, dans les deux sens**.

Le mode d'échec est silencieux et réaliste : une faute de frappe dans un pipeline, un
job copié-collé, et le rapport a l'air parfaitement normal — un mélange crédible de
statuts et un code de sortie non nul qui suggère même que le scan a travaillé. Sceller
ce run enregistre un assessment dont la cible dit `exoscale` alors que l'inventaire dit
`scaleway`, sans que rien du manifest ne signale la contradiction.

## Le correctif

L'information était **des deux côtés** et n'était simplement jamais confrontée. Elle est
lue à la racine de l'export **et** sur ses ressources, et une discordance sort en **2** —
le code déjà employé pour un export illisible.

Refuser plutôt qu'avertir est la lecture la plus fidèle au reste de l'outil : un
inventaire dont l'origine ne correspond pas n'est pas un scan aux résultats surprenants,
c'est **un scan qui n'aurait pas dû tourner**.

Un inventaire qui **ne déclare rien** n'est pas refusé : une origine absente ne
s'invente pas, et l'exiger casserait tout export écrit à la main (ADR-0014).

## La garde est la matrice CROISÉE

```
  scaleway  lu par scaleway  code=1   scan normal
  scaleway  lu par outscale  code=2   refus
  scaleway  lu par exoscale  code=2   refus
  outscale  lu par scaleway  code=2   refus
  outscale  lu par outscale  code=1   scan normal
  …
```

Vérifier un seul couple laisserait passer une correction qui **refuse tout**. La
diagonale est donc éprouvée autant que les croisements.

## Il a attrapé un défaut chez moi

Au premier passage, la correction a refusé quatre tenants du corpus. Ils déclarent
`outscale`, et **mon harnais de mesure les scannait avec le jeu de règles `scaleway`**,
depuis plusieurs lots — il comparait donc du non-sens à du non-sens sur ces quatre
fichiers. Harnais corrigé, mesure refaite avec chaque fixture lue par son propre
fournisseur : **0 mouvement de verdict**.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
