### PR TITLE
fix(cmd): an unknown subcommand exits 2, and never runs something else

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -40,6 +40,15 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Une sous-commande inconnue ne rend plus 0, et n'exécute plus autre chose.**
+  `pepin provider inexistant` lançait silencieusement `provider list` ; `pepin control
+  list` — la supposition naturelle, symétrique de `provider list` — rendait un écran
+  d'aide et réussissait. Une étape de pipeline écrite `pepin control list --json >
+  controls.json` écrivait donc l'aide dans le fichier et passait au vert. Chaque
+  commande valide désormais ses arguments et rend **2** sur un argument qu'elle ne
+  comprend pas. Une garde parcourt l'ARBRE des commandes plutôt qu'une liste écrite à
+  la main, et elle a trouvé un cinquième cas que le rapport n'avait pas : `provider
+  list` ignorait tout argument.
 - **`evidence.proves` ne voyage plus en `["","",""]` sur chaque résultat.** `omitempty`
   sur un tableau de taille fixe est sans effet, si bien qu'un lecteur ne pouvait pas
   distinguer « aucune preuve enregistrée » de « trois preuves enregistrées, toutes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ belongs in `git log`.
 
 ### Fixed
 
+- **An unknown subcommand no longer exits 0, and no longer runs something else.**
+  `pepin provider inexistant` silently ran `provider list`; `pepin control list` — the
+  natural guess, symmetric with `provider list` — printed a help screen and succeeded.
+  A pipeline step written `pepin control list --json > controls.json` therefore wrote a
+  help screen into the file and went green. Every command now validates its arguments
+  and exits **2** on one it does not understand. A guard walks the command tree rather
+  than checking a hand-written list, and it found a fifth case the report had not:
+  `provider list` ignored any argument.
 - **`evidence.proves` no longer travels as `["","",""]` on every result.** `omitempty`
   on a fixed-size array is a no-op, so a reader could not tell "no proof recorded" from
   "three proofs recorded, all blank" — including inside sealed bundles archived for

--- a/cmd/args_test.go
+++ b/cmd/args_test.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// Une sous-commande inconnue était acceptée avec le code 0, et dans un cas elle
+// exécutait SILENCIEUSEMENT autre chose que ce qui avait été tapé : `pepin provider
+// inexistant` lançait `provider list`.
+//
+// Ce n'est pas une coquetterie d'ergonomie. `pepin control list` est une supposition
+// naturelle — `provider list` existe, on essaie la forme symétrique — et une étape de
+// pipeline écrite `pepin control list --json > controls.json` réussissait, écrivait un
+// écran d'aide dans le fichier, et le job passait au vert. Cet outil met par ailleurs
+// un soin particulier à ce que ses codes de sortie veuillent dire quelque chose, ce qui
+// est précisément ce qui faisait ressortir l'écart.
+
+// TestEveryCommandValidatesItsArguments parcourt l'ARBRE plutôt qu'une liste écrite à
+// la main.
+//
+// Une liste se périme à la première commande ajoutée, et celle qu'on oublie est
+// justement celle qui repartira en silence. En marchant l'arbre, une commande nouvelle
+// est tenue sans que personne n'ait à y penser.
+func TestEveryCommandValidatesItsArguments(t *testing.T) {
+	var vus int
+	var marcher func(c *cobra.Command, chemin string)
+	marcher = func(c *cobra.Command, chemin string) {
+		if c != rootCmd { // la racine rejette déjà une commande inconnue, c'est cobra
+			vus++
+			if c.Args == nil {
+				t.Errorf("commande %q : aucun validateur d'arguments.\n"+
+					"  Un argument qu'elle ne comprend pas serait IGNORÉ — au mieux un écran\n"+
+					"  d'aide et un code 0, au pire l'exécution d'une autre commande que celle\n"+
+					"  tapée. Poser `Args: cobra.NoArgs` si elle n'en prend aucun, ou le\n"+
+					"  validateur qui décrit ceux qu'elle prend.", chemin)
+			}
+			// Une commande NON exécutable ne valide pas ses arguments : cobra rend
+			// l'aide et s'arrête avant. Poser `Args` sans `RunE` donne donc l'illusion
+			// d'une garde — c'est exactement ce qui laissait `control list` rendre 0.
+			if c.Args != nil && !c.Runnable() {
+				t.Errorf("commande %q : `Args` déclaré sur une commande NON exécutable.\n"+
+					"  Cobra rend l'aide avant de valider : la garde ne s'applique jamais.\n"+
+					"  Lui donner un `RunE`, même trivial (`return cmd.Help()`).", chemin)
+			}
+		}
+		for _, e := range c.Commands() {
+			marcher(e, strings.TrimSpace(chemin+" "+e.Name()))
+		}
+	}
+	marcher(rootCmd, "pepin")
+	if vus == 0 {
+		t.Fatal("aucune commande parcourue : la garde ne mesure rien")
+	}
+	t.Logf("%d commande(s) parcourue(s)", vus)
+}
+
+// TestAnUnknownSubcommandExitsTwo mesure sur le BINAIRE ce que la garde d'arbre
+// vérifie sur la structure.
+//
+// Les deux sont nécessaires : la première dit qu'un validateur EXISTE, celle-ci qu'il
+// produit le bon code. Un validateur posé sur une commande non exécutable satisfait la
+// première et ne change rien au comportement — c'est exactement ce qui laissait
+// `control list` rendre 0.
+func TestAnUnknownSubcommandExitsTwo(t *testing.T) {
+	bin := buildPepin(t)
+	cas := [][]string{
+		{"control", "list"},          // la supposition naturelle, symétrique de `provider list`
+		{"provider", "inexistant"},   // exécutait `provider list` en silence
+		{"provider", "list", "trop"}, // trouvée par la garde d'arbre
+		{"scsl", "inexistant"},
+		{"version", "parasite"},
+		{"nimportequoi"}, // la racine, qui était déjà correcte
+	}
+	for _, args := range cas {
+		if code := exitCodeOfArgs(t, bin, args...); code != exitErreur {
+			t.Errorf("pepin %v rend %d, attendu %d.\n"+
+				"  Une sous-commande incomprise qui rend 0 fait passer une étape de pipeline\n"+
+				"  au vert, en écrivant au mieux un écran d'aide dans le fichier de sortie.",
+				args, code, exitErreur)
+		}
+	}
+	// Et les formes VALIDES doivent tenir : une correction qui refuserait tout serait
+	// pire que le défaut.
+	for _, args := range [][]string{{"provider"}, {"provider", "list"}, {"control"}, {"version"}} {
+		if code := exitCodeOfArgs(t, bin, args...); code != 0 {
+			t.Errorf("pepin %v rend %d : la correction refuse une forme valide", args, code)
+		}
+	}
+}
+
+// exitCodeOfArgs lance le binaire et rend son code de sortie : ici, le code EST la
+// mesure, donc une erreur d'exécution ne doit pas faire échouer le test.
+func exitCodeOfArgs(t *testing.T, bin string, args ...string) int {
+	t.Helper()
+	c := exec.Command(bin, args...)
+	c.Dir = repoRoot
+	if err := c.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return ee.ExitCode()
+		}
+		t.Fatalf("exécution de %v : %v", args, err)
+	}
+	return 0
+}

--- a/cmd/control.go
+++ b/cmd/control.go
@@ -33,6 +33,17 @@ var explainProvider string
 var controlCmd = &cobra.Command{
 	Use:   "control",
 	Short: "Inspecter les contrôles du référentiel commun",
+	// `pepin control list` est une supposition NATURELLE — `provider list` existe, on
+	// essaie la forme symétrique. Elle rendait un écran d'aide et un code 0, laissant
+	// l'utilisateur deviner seul que la sous-commande est `control explain`. Une étape
+	// `pepin control list --json > controls.json` réussissait, écrivait l'aide dans le
+	// fichier, et le job passait au vert.
+	Args: cobra.NoArgs,
+	// `Args` ne suffit PAS sur une commande non exécutable : cobra rend l'aide et
+	// s'arrête AVANT de valider les arguments. Un `RunE`, même trivial, la rend
+	// exécutable et remet la validation dans le chemin — sans quoi `control list`
+	// continuait de rendre l'aide et 0.
+	RunE: func(cmd *cobra.Command, _ []string) error { return cmd.Help() },
 }
 
 var controlExplainCmd = &cobra.Command{

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -19,15 +19,25 @@ var providerCmd = &cobra.Command{
 	Use:     "provider",
 	Aliases: []string{"providers"},
 	Short:   "Gérer les providers déclaratifs (lister, valider, créer)",
-	Run:     func(_ *cobra.Command, _ []string) { listProviders() },
+	// Sans sous-commande, il liste — mais un argument QU'IL NE COMPREND PAS est une
+	// erreur, pas un silence. `pepin provider inexistant` exécutait `provider list`
+	// et rendait 0 : la sous-commande demandée n'était pas comprise, et rien ne le
+	// disait. Dans un pipeline, l'étape passait au vert en écrivant une liste que
+	// personne n'avait demandée.
+	Args: cobra.NoArgs,
+	Run:  func(_ *cobra.Command, _ []string) { listProviders() },
 }
 
 // providerListCmd liste les providers enregistrés (descripteurs chargés).
 var providerListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
-	Short:   "Lister les providers cloud disponibles",
-	Run:     func(_ *cobra.Command, _ []string) { listProviders() },
+	// Trouvée par la garde qui parcourt l'arbre, et non par l'issue : elle ignorait
+	// tout argument. `pepin provider list scaleway` se lit comme « décris scaleway »
+	// et rendait la liste entière, sans un mot.
+	Args:  cobra.NoArgs,
+	Short: "Lister les providers cloud disponibles",
+	Run:   func(_ *cobra.Command, _ []string) { listProviders() },
 }
 
 // listProviders affiche les providers enregistrés (nom + description).

--- a/cmd/scsl.go
+++ b/cmd/scsl.go
@@ -22,6 +22,9 @@ var scslIndex string
 var scslCmd = &cobra.Command{
 	Use:   "scsl",
 	Short: "Vérifier la cohérence avec l'index SCSL et piloter la roadmap",
+	// Aucune sous-commande : tout argument est donc une faute de frappe, et l'ignorer
+	// ferait exécuter autre chose que ce qui a été tapé.
+	Args: cobra.NoArgs,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		exs, err := referentiel.ParseCLDExigences(scslIndex)
 		if err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -28,6 +28,7 @@ func displayVersion() string { return "v" + bareVersion() }
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Afficher la version",
+	Args:  cobra.NoArgs,
 	Run: func(_ *cobra.Command, _ []string) {
 		// L'accent tombe en anglais : `pepin version` est la sortie la plus
 		// susceptible d'être coupée, collée et comparée par un script.

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -337,6 +337,7 @@ Global Flags:
 Inspecter les contrôles du référentiel commun
 
 Usage:
+  pepin control [flags]
   pepin control [command]
 
 Available Commands:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -336,6 +336,7 @@ Global Flags:
 Inspect the controls of the common reference
 
 Usage:
+  pepin control [flags]
   pepin control [command]
 
 Available Commands:


### PR DESCRIPTION
## Le défaut

Une sous-commande inconnue était acceptée avec le code **0**, et dans un cas elle
exécutait **autre chose que ce qui avait été tapé** :

| Commande | Avant | Après |
|---|---|---|
| `pepin provider inexistant` | exécutait `provider list`, code **0** | code **2** |
| `pepin control list` | écran d'aide, code **0** | code **2** |
| `pepin provider list parasite` | liste entière, code **0** | code **2** |
| `pepin scsl inexistant` | code **0** | code **2** |
| `pepin version parasite` | code **0** | code **2** |

La racine, elle, rejetait correctement : les deux niveaux se contredisaient.

## Pourquoi ce n'est pas qu'une coquetterie

`pepin control list` est une supposition **naturelle** — `provider list` existe, on
essaie la forme symétrique. Une étape de pipeline écrite

```bash
pepin control list --json > controls.json
```

réussissait, écrivait un **écran d'aide dans le fichier**, et le job passait au vert.
Cet outil met par ailleurs un soin particulier à ce que ses codes de sortie veuillent
dire quelque chose, ce qui est précisément ce qui faisait ressortir l'écart.

## Deux causes, et la seconde mérite d'être retenue

`provider` avait un `Run` et **aucun validateur** : un argument parasite était ignoré et
le défaut se déclenchait.

`control` n'avait **aucun `Run`**. Or cobra rend l'aide **avant** de valider les
arguments : y poser `Args: cobra.NoArgs` aurait été une garde qui ne s'applique jamais.
Il lui fallait un `RunE`, même trivial, pour redevenir exécutable et remettre la
validation dans le chemin.

## La garde parcourt l'ARBRE

Une liste écrite à la main se périme à la première commande ajoutée, et celle qu'on
oublie est justement celle qui repartira en silence. La garde marche l'arbre et vérifie
**deux** propriétés :

1. un validateur existe ;
2. il est posé sur une commande **exécutable** — c'est ce second point qui aurait
   attrapé le cas `control` tout seul.

**Elle a trouvé un cinquième cas que le rapport n'avait pas** : `provider list` ignorait
tout argument, si bien que `pepin provider list scaleway`, qui se lit « décris
scaleway », rendait la liste entière sans un mot.

Un second test mesure les codes **sur le binaire**, et vérifie que les formes valides
tiennent : une correction qui refuserait tout serait pire que le défaut.

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)
