### PR TITLE
fix(bundle): verify refuses a dossier that contradicts itself

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -24,6 +24,29 @@ l'une ni l'autre appartient au `git log`.
 
 ### Sécurité
 
+- **`verify` n'accepte plus un bundle qui se contredit.** Réécrire quatre résultats
+  `fail` en `pass` puis recalculer l'empreinte du fichier touché produisait un bundle
+  déclaré « cohérent en interne », code 0 — alors que son propre `manifest.json`
+  annonçait encore `"fail": 4`. Le bundle portait déjà l'information qui le
+  contredisait, et rien ne comparait les deux. Trois recoupements le font désormais,
+  aucun n'exigeant de clé : le résumé du manifeste est confronté aux statuts réellement
+  présents dans `assessment.json`, la **taille** déclarée de chaque artefact est
+  vérifiée à côté de son empreinte, et `checksums.txt` est lu **strictement** — une
+  ligne illisible ou dupliquée est un refus, là où un octet ajouté passait inaperçu.
+- **`verify --require-signature`** échoue si aucune signature n'a été vérifiée. Un
+  appelant qui script `verify` recevait 0 pour un bundle que l'outil qualifie lui-même
+  de non opposable : l'avertissement était sur stdout, le code disait « réussi », et
+  l'automatisation lit le code. Opt-in, donc aucune chaîne existante ne change. Surface
+  CLI v5 → v6.
+
+  Ce que cela ne fait **pas**, et la limite mérite d'être dite : fermer la chaîne
+  d'empreintes. Rien dans un bundle ne peut ancrer `checksums.txt`, puisque qui réécrit
+  un fichier réécrit aussi l'ancre. Seule la signature détachée cosign le peut. Ces
+  recoupements attrapent la corruption et la contradiction interne, pas un
+  falsificateur déterminé.
+
+### Sécurité
+
 - **Une politique tierce pouvait exfiltrer l'inventaire audité, en silence.** Les règles
   chargées à chaud via `--policy-dir` sont du code tiers, exécuté sur tout ce que le
   scan a collecté. Le moteur avait retiré `http.send`, `net.lookup_ip_addr` et

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@ belongs in `git log`.
 
 ### Security
 
+- **`verify` no longer accepts a bundle that contradicts itself.** Rewriting four
+  `fail` results into `pass` and recomputing the digest of the file touched produced a
+  bundle reported as "internally consistent", exit 0 — while its own `manifest.json`
+  still announced `"fail": 4`. The bundle already carried the information that
+  contradicted it, and nothing compared the two. Three cross-checks now do, none of
+  them needing a key: the manifest summary is reconciled with the statuses actually
+  present in `assessment.json`, each artifact's declared **size** is checked alongside
+  its digest, and `checksums.txt` is parsed **strictly** — an unreadable or duplicated
+  line is a refusal, where an appended byte used to go unnoticed.
+- **`verify --require-signature`** fails when no signature was verified. A caller
+  scripting `verify` received 0 for a bundle the tool itself calls non-defensible: the
+  warning was on stdout, the exit code said success, and automation reads the exit
+  code. Opt-in, so no existing chain changes. CLI surface v5 → v6.
+
+  What this does **not** do is close the digest chain, and the limit is worth stating:
+  nothing inside a bundle can anchor `checksums.txt`, because whoever rewrites a file
+  rewrites the anchor too. Only the detached cosign signature closes it. These checks
+  catch corruption and self-contradiction, not a determined forger.
+
+### Security
+
 - **A third-party policy could exfiltrate the audited inventory, silently.** Rules
   hot-loaded through `--policy-dir` are third-party code, run over everything the scan
   collected. The engine had removed `http.send`, `net.lookup_ip_addr` and `opa.runtime`

--- a/cmd/bundle_tamper_test.go
+++ b/cmd/bundle_tamper_test.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Le bundle de preuve est la promesse centrale de cet outil : un dossier qu'un tiers
+// peut rouvrir et opposer. `verify` déclarait « cohérent en interne » un bundle qui se
+// contredisait lui-même — quatre `fail` réécrits en `pass`, avec un manifeste annonçant
+// encore `"fail": 4`.
+//
+// Ce que ces gardes NE prétendent pas : fermer la chaîne. Rien dans le bundle ne peut
+// ancrer `checksums.txt`, parce que qui réécrit un fichier réécrit aussi l'ancre — seule
+// la signature détachée le peut, et l'outil le dit déjà. Ce qui est corrigé ici, c'est
+// que le bundle portait DÉJÀ l'information qui le contredisait, et que personne ne la
+// regardait.
+//
+// Le test est table-driven par MOTIF d'altération : chacun doit rendre non nul.
+
+// sceller produit un bundle neuf dans un dossier jetable.
+func sceller(t *testing.T, bin string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "bundle")
+	runPepin(t, bin, nil, "scan", "scaleway", "examples/scaleway/inventory.json", "--seal", dir)
+	if _, err := os.Stat(filepath.Join(dir, "manifest.json")); err != nil {
+		t.Fatalf("scellement raté : %v", err)
+	}
+	return dir
+}
+
+// redigest recalcule l'empreinte d'un fichier dans checksums.txt — ce qu'un
+// falsificateur fait naturellement après avoir modifié un artefact.
+func redigest(t *testing.T, dir, nom string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, nom)) // #nosec G304 -- dossier jetable du test.
+	if err != nil {
+		t.Fatalf("lecture de %s : %v", nom, err)
+	}
+	somme := sha256.Sum256(data)
+	cs := filepath.Join(dir, "checksums.txt")
+	raw, err := os.ReadFile(cs) // #nosec G304 -- dossier jetable du test.
+	if err != nil {
+		t.Fatalf("lecture de checksums.txt : %v", err)
+	}
+	re := regexp.MustCompile(`(?m)^[0-9a-f]{64}(\s+\*?` + regexp.QuoteMeta(nom) + `)$`)
+	out := re.ReplaceAllString(string(raw), hex.EncodeToString(somme[:])+"$1")
+	if out == string(raw) {
+		t.Fatalf("l'empreinte de %s n'a pas été remplacée : le test ne mesurerait rien", nom)
+	}
+	if err := os.WriteFile(cs, []byte(out), 0o600); err != nil {
+		t.Fatalf("écriture de checksums.txt : %v", err)
+	}
+}
+
+func TestVerifyRefusesEveryTamperingPattern(t *testing.T) {
+	bin := buildPepin(t)
+
+	// Référence : un bundle intact se vérifie. Sans ce point, une correction qui
+	// refuserait TOUT passerait ce test entier.
+	if code := exitCodeOfArgs(t, bin, "verify", sceller(t, bin)); code != 0 {
+		t.Fatalf("un bundle intact rend %d : la correction refuse tout", code)
+	}
+
+	motifs := []struct {
+		nom      string
+		pourquoi string
+		altere   func(t *testing.T, dir string)
+	}{
+		{
+			nom: "verdicts réécrits, empreinte recalculée",
+			pourquoi: "l'altération la plus tentante : c'est celle qui change le verdict. " +
+				"Le manifeste continue d'annoncer les `fail` que l'assessment n'a plus.",
+			altere: func(t *testing.T, dir string) {
+				p := filepath.Join(dir, "assessment.json")
+				raw, err := os.ReadFile(p) // #nosec G304 -- dossier jetable du test.
+				if err != nil {
+					t.Fatalf("lecture : %v", err)
+				}
+				var doc map[string]any
+				if err := json.Unmarshal(raw, &doc); err != nil {
+					t.Fatalf("assessment illisible : %v", err)
+				}
+				res, _ := doc["results"].([]any)
+				var mues int
+				for _, it := range res {
+					r, _ := it.(map[string]any)
+					if r != nil && r["status"] == "fail" {
+						r["status"] = "pass"
+						mues++
+					}
+				}
+				if mues == 0 {
+					t.Fatal("aucun `fail` à réécrire : le motif ne mesurerait rien")
+				}
+				out, _ := json.MarshalIndent(doc, "", "  ")
+				if err := os.WriteFile(p, out, 0o600); err != nil {
+					t.Fatalf("écriture : %v", err)
+				}
+				redigest(t, dir, "assessment.json")
+			},
+		},
+		{
+			nom:      "un octet ajouté à checksums.txt",
+			pourquoi: "corruption pure : rien ne couvre checksums.txt, mais elle se VOIT à la lecture.",
+			altere: func(t *testing.T, dir string) {
+				p := filepath.Join(dir, "checksums.txt")
+				raw, err := os.ReadFile(p) // #nosec G304 -- dossier jetable du test.
+				if err != nil {
+					t.Fatalf("lecture : %v", err)
+				}
+				if err := os.WriteFile(p, append(raw, '\n'), 0o600); err != nil {
+					t.Fatalf("écriture : %v", err)
+				}
+			},
+		},
+		{
+			nom:      "résumé du manifeste maquillé",
+			pourquoi: "l'attaque symétrique : maquiller le manifeste plutôt que l'assessment.",
+			altere: func(t *testing.T, dir string) {
+				p := filepath.Join(dir, "manifest.json")
+				raw, err := os.ReadFile(p) // #nosec G304 -- dossier jetable du test.
+				if err != nil {
+					t.Fatalf("lecture : %v", err)
+				}
+				var man map[string]any
+				if err := json.Unmarshal(raw, &man); err != nil {
+					t.Fatalf("manifeste illisible : %v", err)
+				}
+				sum, _ := man["summary"].(map[string]any)
+				if sum == nil {
+					t.Fatal("manifeste sans résumé : le motif ne mesurerait rien")
+				}
+				sum["fail"] = 0
+				out, _ := json.MarshalIndent(man, "", "  ")
+				if err := os.WriteFile(p, out, 0o600); err != nil {
+					t.Fatalf("écriture : %v", err)
+				}
+				redigest(t, dir, "manifest.json")
+			},
+		},
+		{
+			nom:      "artefact tronqué, empreinte recalculée mais taille laissée",
+			pourquoi: "la taille du manifeste est un second témoin : on pense à l'empreinte, moins à elle.",
+			altere: func(t *testing.T, dir string) {
+				p := filepath.Join(dir, "input.json")
+				raw, err := os.ReadFile(p) // #nosec G304 -- dossier jetable du test.
+				if err != nil {
+					t.Fatalf("lecture : %v", err)
+				}
+				if err := os.WriteFile(p, raw[:len(raw)/2], 0o600); err != nil {
+					t.Fatalf("écriture : %v", err)
+				}
+				redigest(t, dir, "input.json")
+			},
+		},
+	}
+
+	for _, m := range motifs {
+		t.Run(m.nom, func(t *testing.T) {
+			dir := sceller(t, bin)
+			m.altere(t, dir)
+			if code := exitCodeOfArgs(t, bin, "verify", dir); code == 0 {
+				t.Errorf("verify accepte un bundle altéré (%s).\n  %s", m.nom, m.pourquoi)
+			}
+		})
+	}
+}
+
+// TestRequireSignatureRefusesAnUnsignedBundle : un appelant qui script `verify`
+// recevait 0 pour un bundle que l'outil qualifie lui-même de NON opposable —
+// l'avertissement était sur stdout, le code disait « réussi », et l'automatisation lit
+// le code.
+//
+// Le drapeau est OPT-IN, et le test le vérifie DANS LES DEUX SENS : changer le défaut
+// ferait échouer, en silence, des chaînes qui passent aujourd'hui.
+func TestRequireSignatureRefusesAnUnsignedBundle(t *testing.T) {
+	bin := buildPepin(t)
+	dir := sceller(t, bin)
+
+	if code := exitCodeOfArgs(t, bin, "verify", dir); code != 0 {
+		t.Errorf("sans le drapeau, un bundle non signé rend %d : le défaut a changé", code)
+	}
+	if code := exitCodeOfArgs(t, bin, "verify", dir, "--require-signature"); code == 0 {
+		t.Error("--require-signature accepte un bundle dont aucune signature n'a été vérifiée")
+	}
+	out, _ := runPepin(t, bin, nil, "verify", dir)
+	if !strings.Contains(out, "NON opposable") && !strings.Contains(out, "NOT defensible") {
+		t.Errorf("le rendu ne dit pas que le bundle n'est pas opposable :\n%s", out)
+	}
+}
+
+// exitCodeOfArgs lance le binaire et rend son code : ici, le code EST la mesure, donc
+// une sortie non nulle ne doit pas faire échouer le test.
+func exitCodeOfArgs(t *testing.T, bin string, args ...string) int {
+	t.Helper()
+	c := exec.Command(bin, args...)
+	c.Dir = repoRoot
+	if err := c.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return ee.ExitCode()
+		}
+		t.Fatalf("exécution de %v : %v", args, err)
+	}
+	return 0
+}

--- a/cmd/bundle_tamper_test.go
+++ b/cmd/bundle_tamper_test.go
@@ -4,9 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -196,20 +194,4 @@ func TestRequireSignatureRefusesAnUnsignedBundle(t *testing.T) {
 	if !strings.Contains(out, "NON opposable") && !strings.Contains(out, "NOT defensible") {
 		t.Errorf("le rendu ne dit pas que le bundle n'est pas opposable :\n%s", out)
 	}
-}
-
-// exitCodeOfArgs lance le binaire et rend son code : ici, le code EST la mesure, donc
-// une sortie non nulle ne doit pas faire échouer le test.
-func exitCodeOfArgs(t *testing.T, bin string, args ...string) int {
-	t.Helper()
-	c := exec.Command(bin, args...)
-	c.Dir = repoRoot
-	if err := c.Run(); err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
-			return ee.ExitCode()
-		}
-		t.Fatalf("exécution de %v : %v", args, err)
-	}
-	return 0
 }

--- a/cmd/surface.go
+++ b/cmd/surface.go
@@ -58,7 +58,14 @@ const (
 // aucun drapeau et aucun code de sortie existant ne bouge. L'incrément est dû
 // quand même — la surface est la liste de ce qu'un intégrateur a le droit de
 // brancher, et elle vient de s'allonger.
-const cliSurfaceVersion = 5
+// v6 : ajout de `verify --require-signature`, qui refuse un bundle dont aucune
+// signature n'a été vérifiée. Un appelant qui script `verify` recevait 0 pour un
+// dossier que l'outil qualifie lui-même de NON opposable : l'avertissement est sur
+// stdout, le code disait « réussi », et l'automatisation lit le code. Le drapeau est
+// OPT-IN — changer le défaut ferait échouer en silence des chaînes qui passent
+// aujourd'hui —, d'où un ajout pur, et l'incrément est dû quand même : la surface est
+// la liste de ce qu'un intégrateur a le droit de brancher.
+const cliSurfaceVersion = 6
 
 // findingsSurfaceVersion est la version de FORME de `--format json`
 // ({"findings": [...], "summary": {...}}), la sortie qu'un pipeline parse le

--- a/cmd/testdata/frozen/cli.json
+++ b/cmd/testdata/frozen/cli.json
@@ -294,6 +294,74 @@
           }
         }
       }
+    },
+    {
+      "schema_version": 6,
+      "content": {
+        "exit_codes": {
+          "conforme": 0,
+          "derogation": 4,
+          "erreur": 2,
+          "non_conformite": 1,
+          "strict": 3
+        },
+        "verbs": {
+          "control": {
+            "flags": {}
+          },
+          "control explain": {
+            "flags": {
+              "provider": ""
+            }
+          },
+          "provider": {
+            "flags": {}
+          },
+          "provider list": {
+            "flags": {}
+          },
+          "provider new": {
+            "flags": {}
+          },
+          "provider validate": {
+            "flags": {}
+          },
+          "scan": {
+            "flags": {
+              "exceptions": "",
+              "format": "f",
+              "kubeconfig": "",
+              "lang": "",
+              "live": "",
+              "policy": "",
+              "policy-dir": "p",
+              "profile": "",
+              "redact": "",
+              "region": "",
+              "s3-endpoint": "",
+              "seal": "",
+              "strict": "",
+              "terraform": "t"
+            }
+          },
+          "scsl": {
+            "flags": {
+              "index": ""
+            }
+          },
+          "verify": {
+            "flags": {
+              "bundle": "",
+              "pubkey": "",
+              "re-derive": "",
+              "require-signature": ""
+            }
+          },
+          "version": {
+            "flags": {}
+          }
+        }
+      }
     }
   ]
 }

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -30,6 +30,11 @@ var (
 	verifyPubKey   string // clé publique cosign (vérification par clé)
 	verifyBundle   string // bundle de signature cosign (défaut : <dossier>/checksums.txt.bundle)
 	verifyReDerive bool   // rejouer le Rego sur input.json et comparer à l'assessment scellé
+	// verifyRequireSig : refuser un bundle dont aucune signature n'a été vérifiée.
+	// Un appelant qui script `verify` recevait 0 pour un bundle que l'outil qualifie
+	// lui-même de NON opposable : l'avertissement est sur stdout, le code disait
+	// « réussi », et l'automatisation lit le code.
+	verifyRequireSig bool
 )
 
 var verifyCmd = &cobra.Command{
@@ -54,6 +59,11 @@ var verifyCmd = &cobra.Command{
 			_, _ = fmt.Fprintf(os.Stdout, tr(
 				"⚠ bundle cohérent en interne : %s\n  (intégrité ACCIDENTELLE seulement — NON opposable sans --pubkey pour la signature cosign)\n",
 				"⚠ bundle internally consistent: %s\n  (ACCIDENTAL integrity only — NOT defensible without --pubkey for the cosign signature)\n"), dir)
+			if verifyRequireSig {
+				return errors.New(tr(
+					"--require-signature : aucune signature vérifiée. Un bundle cohérent en interne ne prouve que l'absence d'altération ACCIDENTELLE — l'auteur d'une falsification régénère fichiers et empreintes ensemble. Fournir --pubkey.",
+					"--require-signature: no signature verified. An internally consistent bundle only proves the absence of ACCIDENTAL corruption — whoever forges it regenerates files and digests together. Provide --pubkey."))
+			}
 		} else {
 			if err := verifyCosign(dir, verifyPubKey, verifyBundle); err != nil {
 				return err
@@ -319,5 +329,10 @@ func init() {
 	verifyCmd.Flags().StringVar(&verifyPubKey, "pubkey", "", "clé publique cosign pour vérifier la signature de checksums.txt")
 	verifyCmd.Flags().StringVar(&verifyBundle, "bundle", "", "bundle de signature cosign (défaut : <dossier>/checksums.txt.bundle)")
 	verifyCmd.Flags().BoolVar(&verifyReDerive, "re-derive", false, "rejouer les règles sur input.json et vérifier que l'assessment scellé en découle (opposabilité forte)")
+	// OPT-IN : changer le défaut ferait échouer, en silence, des chaînes qui passent
+	// aujourd'hui — exactement ce que ce dépôt refuse par ailleurs.
+	verifyCmd.Flags().BoolVar(&verifyRequireSig, "require-signature", false,
+		tr("échouer si aucune signature n'a été vérifiée : un bundle « cohérent en interne » mais non signé n'est pas opposable",
+			"fail when no signature was verified: a bundle that is \"internally consistent\" but unsigned is not defensible"))
 	rootCmd.AddCommand(verifyCmd)
 }

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -26,7 +26,7 @@ de drapeaux viennent de la surface gelée ; chaque aide ci-dessous est la sortie
 | `pepin provider validate` | _(aucun drapeau propre)_ |
 | `pepin scan` | `--exceptions`, `--format` / `-f`, `--kubeconfig`, `--lang`, `--live`, `--policy`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
 | `pepin scsl` | `--index` |
-| `pepin verify` | `--bundle`, `--pubkey`, `--re-derive` |
+| `pepin verify` | `--bundle`, `--pubkey`, `--re-derive`, `--require-signature` |
 | `pepin version` | _(aucun drapeau propre)_ |
 <!-- /pepin:gen cli-verbs -->
 
@@ -39,7 +39,7 @@ séparément :
 <!-- pepin:gen surface-versions -->
 | Surface | Ce qui est gelé | Version |
 |---|---|:-:|
-| `cli` | verbes, drapeaux et codes de sortie | **v5** |
+| `cli` | verbes, drapeaux et codes de sortie | **v6** |
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
@@ -193,10 +193,11 @@ Usage:
   pepin verify <dossier-bundle> [flags]
 
 Flags:
-      --bundle string   bundle de signature cosign (défaut : <dossier>/checksums.txt.bundle)
-  -h, --help            help for verify
-      --pubkey string   clé publique cosign pour vérifier la signature de checksums.txt
-      --re-derive       rejouer les règles sur input.json et vérifier que l'assessment scellé en découle (opposabilité forte)
+      --bundle string       bundle de signature cosign (défaut : <dossier>/checksums.txt.bundle)
+  -h, --help                help for verify
+      --pubkey string       clé publique cosign pour vérifier la signature de checksums.txt
+      --re-derive           rejouer les règles sur input.json et vérifier que l'assessment scellé en découle (opposabilité forte)
+      --require-signature   fail when no signature was verified: a bundle that is "internally consistent" but unsigned is not defensible
 
 Global Flags:
       --lang string   langue de l'interface : fr | en (défaut : PEPIN_LANG, puis LC_ALL/LANG, sinon en)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -26,7 +26,7 @@ by running the binary. A public flag that is missing here fails
 | `pepin provider validate` | _(no flag of its own)_ |
 | `pepin scan` | `--exceptions`, `--format` / `-f`, `--kubeconfig`, `--lang`, `--live`, `--policy`, `--policy-dir` / `-p`, `--profile`, `--redact`, `--region`, `--s3-endpoint`, `--seal`, `--strict`, `--terraform` / `-t` |
 | `pepin scsl` | `--index` |
-| `pepin verify` | `--bundle`, `--pubkey`, `--re-derive` |
+| `pepin verify` | `--bundle`, `--pubkey`, `--re-derive`, `--require-signature` |
 | `pepin version` | _(no flag of its own)_ |
 <!-- /pepin:gen cli-verbs -->
 
@@ -39,7 +39,7 @@ independently:
 <!-- pepin:gen surface-versions -->
 | Surface | What is frozen | Version |
 |---|---|:-:|
-| `cli` | verbs, flags and exit codes | **v5** |
+| `cli` | verbs, flags and exit codes | **v6** |
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
@@ -192,10 +192,11 @@ Usage:
   pepin verify <dossier-bundle> [flags]
 
 Flags:
-      --bundle string   cosign signature bundle (default: <directory>/checksums.txt.bundle)
-  -h, --help            help for verify
-      --pubkey string   cosign public key used to verify the signature of checksums.txt
-      --re-derive       replay the rules on input.json and check that the sealed assessment follows from it (strong defensibility)
+      --bundle string       cosign signature bundle (default: <directory>/checksums.txt.bundle)
+  -h, --help                help for verify
+      --pubkey string       cosign public key used to verify the signature of checksums.txt
+      --re-derive           replay the rules on input.json and check that the sealed assessment follows from it (strong defensibility)
+      --require-signature   fail when no signature was verified: a bundle that is "internally consistent" but unsigned is not defensible
 
 Global Flags:
       --lang string   interface language: fr | en (default: PEPIN_LANG, then LC_ALL/LANG, otherwise en)

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -26,7 +26,7 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 <!-- pepin:gen surface-versions -->
 | Surface | Ce qui est gelé | Version |
 |---|---|:-:|
-| `cli` | verbes, drapeaux et codes de sortie | **v5** |
+| `cli` | verbes, drapeaux et codes de sortie | **v6** |
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -26,7 +26,7 @@ See [Exit codes](exit-codes.md).
 <!-- pepin:gen surface-versions -->
 | Surface | What is frozen | Version |
 |---|---|:-:|
-| `cli` | verbs, flags and exit codes | **v5** |
+| `cli` | verbs, flags and exit codes | **v6** |
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |

--- a/internal/assess/bundle.go
+++ b/internal/assess/bundle.go
@@ -272,10 +272,24 @@ func VerifyBundle(dir string) error {
 		return fmt.Errorf(i18n.T("lecture de checksums.txt : %w", "reading checksums.txt: %w"), err)
 	}
 	summed := map[string]string{} // nom -> empreinte attendue (checksums.txt)
-	for _, line := range splitLines(string(raw)) {
-		if want, name, ok := parseChecksum(line); ok {
-			summed[name] = want
+	// Parsing STRICT : une ligne illisible était silencieusement ignorée, si bien
+	// qu'ajouter un octet à checksums.txt passait inaperçu et que `verify` rendait 0.
+	// Rien ne couvre checksums.txt — c'est structurel, seule la signature détachée
+	// peut l'ancrer —, mais une CORRUPTION s'y voit à la lecture, et se taire dessus
+	// revenait à ne pas regarder ce qu'on avait sous les yeux.
+	for i, line := range splitLines(string(raw)) {
+		want, name, ok := parseChecksum(line)
+		if !ok {
+			return fmt.Errorf(i18n.T(
+				"checksums.txt, ligne %d : illisible (%q). Le fichier a été modifié ou tronqué.",
+				"checksums.txt, line %d: unreadable (%q). The file was modified or truncated."), i+1, line)
 		}
+		if _, deja := summed[name]; deja {
+			return fmt.Errorf(i18n.T(
+				"checksums.txt : %q listé deux fois — une empreinte en masquerait une autre",
+				"checksums.txt: %q listed twice — one digest would mask another"), name)
+		}
+		summed[name] = want
 	}
 	if len(summed) == 0 {
 		return fmt.Errorf(i18n.T("aucune empreinte à vérifier dans %s", "no digest to verify in %s"), dir)
@@ -320,6 +334,65 @@ func VerifyBundle(dir string) error {
 		got := sha256.Sum256(data)
 		if hex.EncodeToString(got[:]) != want {
 			return fmt.Errorf(i18n.T("empreinte invalide pour %s (fichier altéré)", "invalid digest for %s (tampered file)"), name)
+		}
+	}
+	// La TAILLE déclarée au manifeste, recoupée elle aussi. Elle est gratuite, et
+	// elle est un second témoin : réécrire un artefact oblige à recalculer SON
+	// empreinte dans checksums.txt ET sa taille au manifeste, alors qu'un seul des
+	// deux vient naturellement à l'esprit.
+	for _, a := range man.Artifacts {
+		data, rerr := os.ReadFile(filepath.Join(dir, filepath.Base(a.File))) // #nosec G304 -- nom contraint plus haut.
+		if rerr != nil {
+			return fmt.Errorf("%s : %w", a.File, rerr)
+		}
+		if a.Bytes != len(data) {
+			return fmt.Errorf(i18n.T(
+				"taille invalide pour %s : le manifeste déclare %d octets, le fichier en fait %d (fichier altéré)",
+				"invalid size for %s: the manifest declares %d bytes, the file has %d (tampered file)"),
+				a.File, a.Bytes, len(data))
+		}
+	}
+	return checkSummaryMatchesAssessment(dir, man)
+}
+
+// checkSummaryMatchesAssessment recoupe le RÉSUMÉ du manifeste avec les statuts
+// réellement présents dans l'assessment scellé.
+//
+// Le bundle portait déjà l'information qui se contredisait, et personne ne la
+// regardait : réécrire quatre `fail` en `pass` puis recalculer l'empreinte du fichier
+// touché produisait un bundle que `verify` déclarait « cohérent en interne », avec un
+// manifeste disant encore `"fail": 4`.
+//
+// Ce recoupement ne coûte qu'un parcours des résultats, n'exige aucune clé, et attrape
+// exactement cette altération — la plus tentante de toutes, puisque c'est celle qui
+// change le verdict.
+func checkSummaryMatchesAssessment(dir string, man Manifest) error {
+	if len(man.Summary) == 0 {
+		return nil // manifeste d'une forme antérieure : on ne fabrique pas ce qu'il ne dit pas
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "assessment.json")) // #nosec G304 -- dossier de bundle de l'opérateur.
+	if err != nil {
+		return fmt.Errorf(i18n.T("lecture de assessment.json : %w", "reading assessment.json: %w"), err)
+	}
+	var a assessment.Assessment
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return fmt.Errorf(i18n.T("assessment.json invalide : %w", "invalid assessment.json: %w"), err)
+	}
+	got := summaryOf(a)
+	for statut, veut := range man.Summary {
+		if got[statut] != veut {
+			return fmt.Errorf(i18n.T(
+				"le bundle se contredit : le manifeste annonce %d résultat(s) « %s », l'assessment en porte %d (fichier altéré)",
+				"the bundle contradicts itself: the manifest announces %d \"%s\" result(s), the assessment holds %d (tampered file)"),
+				veut, statut, got[statut])
+		}
+	}
+	for statut, n := range got {
+		if _, declare := man.Summary[statut]; !declare {
+			return fmt.Errorf(i18n.T(
+				"le bundle se contredit : l'assessment porte %d résultat(s) « %s » que le manifeste n'annonce pas (fichier altéré)",
+				"the bundle contradicts itself: the assessment holds %d \"%s\" result(s) the manifest does not announce (tampered file)"),
+				n, statut)
 		}
 	}
 	return nil


### PR DESCRIPTION
> **P0.** Touche l'opposabilité du bundle, qui est la promesse centrale du produit.

## Le défaut

Réécrire quatre `fail` en `pass`, recalculer l'empreinte du fichier touché — et le
bundle était déclaré « cohérent en interne », code **0** :

```
manifest.json dit   {"fail": 4, "not-applicable": 2, "not-evaluated": 14, "pass": 7}
assessment.json a   {           "not-applicable": 2, "not-evaluated": 14, "pass": 11}
```

**Le bundle portait déjà l'information qui le contredisait, et rien ne comparait les
deux.**

## Trois recoupements, aucun n'exigeant de clé

| Recoupement | Ce qu'il attrape |
|---|---|
| résumé du manifeste ↔ statuts réels de `assessment.json` | l'altération la plus tentante : celle qui change le verdict |
| **taille** déclarée de chaque artefact ↔ taille réelle | un second témoin, auquel on pense moins qu'à l'empreinte |
| lecture **stricte** de `checksums.txt` | ligne illisible ou dupliquée ; l'octet ajouté passait inaperçu |

## Un point de l'issue ne pouvait pas fonctionner

L'issue suggère d'enregistrer l'empreinte de `checksums.txt` dans `manifest.json` **et**
celle de `manifest.json` dans `checksums.txt`. C'est **circulaire** : écrire l'un
invalide l'autre.

Plus fondamentalement, **rien dans un bundle ne peut ancrer `checksums.txt`**, puisque
qui réécrit un fichier réécrit aussi l'ancre. Seule la signature détachée ferme la
chaîne — ce que l'outil dit déjà. J'ai donc corrigé ce qui était réellement corrigeable,
et **écrit la limite** plutôt que de laisser croire à une garantie plus forte.

## Le code de sortie

`verify --require-signature` rend le cas non signé distinguable. Un appelant qui script
`verify` recevait `0` pour un bundle que l'outil qualifie lui-même de non opposable :
l'avertissement était sur stdout, le code disait « réussi », **et l'automatisation lit
le code**.

**Opt-in** : changer le défaut ferait échouer en silence des chaînes qui passent
aujourd'hui — le même raisonnement que partout ailleurs dans ce dépôt.

## La garde

Table-driven par **motif d'altération**, et elle commence par vérifier un bundle
**intact** : sans ce point, une correction qui refuserait tout passerait le test entier.

| Motif | Avant |
|---|---|
| verdicts réécrits, empreinte recalculée | **acceptait** |
| un octet ajouté à `checksums.txt` | **acceptait** |
| résumé du manifeste maquillé | refusait |
| artefact tronqué, taille laissée | refusait |

## Note de fusion

Surface CLI **v5 → v6**. La PR #152 revendique aussi v6 — celle qui sera fusionnée en
second devra passer en v7.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)
