### PR TITLE
fix(scan): an unknown --format is refused, not silently downgraded

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -63,6 +63,14 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Une valeur inconnue de `--format` est refusée au lieu de retomber sur la table.**
+  Le scan tournait et imprimait le rapport table, avec le code de sortie d'un scan
+  réussi. Le cas dangereux n'est pas l'humain qui tape `xml` à un prompt et le
+  remarque : c'est l'étape de pipeline écrite `--format oscal` éditée en
+  `--format oscal2`, qui publie un tableau colorié là où toute la chaîne en aval croit
+  recevoir de l'OSCAL. Un format inconnu appartient à la famille de l'export illisible
+  et du fournisseur inconnu — une erreur d'invocation, code **2**, pas un résultat de
+  scan.
 - **Le mode français ne laisse plus l'ossature du rapport en anglais.** Titres de
   section, en-têtes de table et ligne « aucun écart » sortaient en anglais au milieu
   d'un rapport français — `Total deviations: 1` au-dessus d'un finding français, se

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ belongs in `git log`.
 
 ### Fixed
 
+- **An unknown `--format` value is refused instead of falling back to the table.** The
+  scan ran and printed the table report, with the exit code of a successful scan. The
+  dangerous case is not someone typing `xml` at a prompt and noticing: it is a pipeline
+  step written `--format oscal` edited to `--format oscal2`, publishing a coloured table
+  where the whole downstream chain believes it is receiving OSCAL. An unknown format
+  belongs with an unreadable export and an unknown provider — an invocation error, exit
+  **2**, not a scan result.
 - **French mode no longer leaves the report scaffolding in English.** Section titles,
   table headers and the "no deviations" line came out English inside an otherwise
   French report — `Total deviations: 1` above a French finding, closing on a French

--- a/cmd/args_test.go
+++ b/cmd/args_test.go
@@ -111,3 +111,36 @@ func exitCodeOfArgs(t *testing.T, bin string, args ...string) int {
 	}
 	return 0
 }
+
+// TestAnUnknownFormatIsRefused — l'issue #149.
+//
+// Une valeur inconnue de `--format` était ignorée sans un mot : le scan tournait et
+// imprimait la table. Le cas dangereux n'est pas l'humain qui tape `xml` à un prompt et
+// le remarque ; c'est l'étape de pipeline écrite `--format oscal` éditée en
+// `--format oscal2`, ou la variable qui s'évalue à autre chose que prévu. Le job garde
+// sa sémantique de code de sortie, publie un fichier, et l'artefact de conformité que
+// toute la chaîne en aval croit être de l'OSCAL est un tableau colorié.
+//
+// La liste des formats valides est LUE depuis le code, pas recopiée : une liste
+// recopiée se périme au premier format ajouté, et le format oublié serait justement
+// celui que personne n'éprouve.
+func TestAnUnknownFormatIsRefused(t *testing.T) {
+	bin := buildPepin(t)
+	const fixture = "examples/scaleway/inventory.json"
+
+	if len(scanFormats) == 0 {
+		t.Fatal("aucun format déclaré : le test ne mesure rien")
+	}
+	for _, f := range scanFormats {
+		if code := exitCodeOfArgs(t, bin, "scan", "scaleway", fixture, "--format", f); code == exitErreur {
+			t.Errorf("le format valide %q rend %d : la correction refuse ce qu'elle doit accepter", f, code)
+		}
+	}
+	for _, f := range []string{"xml", "oscal2", "TABLE", "", "jsonl"} {
+		if code := exitCodeOfArgs(t, bin, "scan", "scaleway", fixture, "--format", f); code != exitErreur {
+			t.Errorf("le format inconnu %q rend %d, attendu %d.\n"+
+				"  Un pipeline publierait un tableau colorié là où il croit écrire de l'OSCAL,\n"+
+				"  avec le code de sortie d'un scan réussi.", f, code, exitErreur)
+		}
+	}
+}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -12,6 +12,7 @@ import (
 	"maps"
 	"os"
 	"runtime/debug"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -55,6 +56,19 @@ var (
 	scanGate       string // profil de PORTE : ce qui pèse dans le code de sortie, jamais dans le rapport
 )
 
+// scanFormats : les formats de sortie acceptés, source UNIQUE de la validation et du
+// texte d'aide.
+//
+// Une valeur inconnue retombait silencieusement sur la table : `--format oscal2` dans
+// un pipeline publiait un tableau colorié à la place de l'artefact OSCAL que toute la
+// chaîne en aval croyait recevoir, en gardant le code de sortie d'un scan réussi. Le
+// cas dangereux n'est pas l'humain qui tape `xml` et le voit ; c'est l'étape éditée à
+// une lettre près, ou la variable qui s'évalue à autre chose que prévu.
+//
+// Un format inconnu appartient à la famille de l'export illisible et du fournisseur
+// inconnu : une erreur d'INVOCATION, pas un résultat de scan. Donc le code 2.
+var scanFormats = []string{"table", "json", "assessment", "oscal", "sarif"}
+
 var scanCmd = &cobra.Command{
 	Use:   "scan <provider> [export.json]",
 	Short: "Évaluer la posture d'un cloud contre les politiques",
@@ -78,6 +92,11 @@ var scanCmd = &cobra.Command{
 			return errors.New(tr(
 				"préciser un fichier (export JSON ou plan Terraform), ou utiliser --live",
 				"give a file (JSON export or Terraform plan), or use --live"))
+		}
+		if !slices.Contains(scanFormats, scanFormat) {
+			return fmt.Errorf(tr(
+				"format de sortie inconnu : %q (valeurs : %s)",
+				"unknown output format: %q (values: %s)"), scanFormat, strings.Join(scanFormats, ", "))
 		}
 		if !profile.Valid(scanGate) {
 			return fmt.Errorf(tr("profil de porte inconnu : %q (valeurs : %s)",
@@ -609,7 +628,8 @@ func evaluatedNonGov(asmt assessment.Assessment) int {
 }
 
 func init() {
-	scanCmd.Flags().StringVarP(&scanFormat, "format", "f", "table", "format de sortie : table | json | assessment | oscal | sarif")
+	scanCmd.Flags().StringVarP(&scanFormat, "format", "f", "table",
+		tr("format de sortie : ", "output format: ")+strings.Join(scanFormats, " | "))
 	scanCmd.Flags().StringArrayVarP(&policyDirs, "policy-dir", "p", nil,
 		"répertoire de règles externes (.rego), répétable — chargé sans recompilation")
 	scanCmd.Flags().BoolVarP(&scanTF, "terraform", "t", false,


### PR DESCRIPTION
## Le défaut

Une valeur inconnue de `--format` était ignorée sans un mot : le scan tournait et
imprimait le rapport table, avec **le code de sortie d'un scan réussi**.

```bash
./pepin scan scaleway inv.json -f xml   > out-xml.txt   ; echo $?   # 1
./pepin scan scaleway inv.json -f table > out-table.txt
diff out-xml.txt out-table.txt && echo "identiques"                 # identiques
```

## Pourquoi une erreur plutôt qu'un repli

Le cas dangereux n'est pas l'humain qui tape `xml` à un prompt et le remarque. C'est
l'étape de pipeline écrite `--format oscal` **éditée en `--format oscal2`**, ou la
variable qui s'évalue à autre chose que prévu : le job garde sa sémantique de code de
sortie, publie un fichier, et **l'artefact de conformité que toute la chaîne en aval
croit être de l'OSCAL est un tableau colorié**.

L'outil est par ailleurs strict sur exactement cette classe d'ambiguïté — code **2**
pour un export illisible ou un fournisseur inconnu. Un format inconnu appartient à cette
famille : une erreur **d'invocation**, pas un résultat de scan.

## Une source, pas deux

La liste des formats était tenue **deux fois** — dans le `switch` et dans le texte
d'aide. Elle est maintenant déclarée une fois et alimente les deux, plus la validation.

Le test **lit** cette liste au lieu de la recopier : une liste recopiée se périme au
premier format ajouté, et le format oublié serait justement celui que personne
n'éprouve.

| Invocation | Avant | Après |
|---|---|---|
| `-f table` · `json` · `assessment` · `oscal` · `sarif` | scan | scan |
| `-f xml` · `oscal2` · `TABLE` · `` · `jsonl` | **table silencieuse** | **2** |

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
