### PR TITLE
fix(cmd): the CLI stops describing itself inaccurately

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -63,6 +63,18 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **La description racine nomme les fournisseurs qui existent.** La première phrase
+  qu'un nouvel utilisateur lit annonçait OVH — une entrée de feuille de route, pas un
+  fournisseur — et omettait Kubernetes, qui en est un. La liste est désormais dérivée du
+  registre : une liste recopiée se périme au premier fournisseur ajouté ou retiré, et
+  personne ne relit une phrase d'accueil.
+- **`pepin scsl --index` ne pointe plus par défaut vers la disposition locale d'un
+  mainteneur.** Le défaut était un chemin relatif remontant hors du répertoire courant
+  vers un dépôt dont le lecteur n'a jamais entendu parler. L'erreur était juste et ne
+  disait rien : impossible de savoir si `framework-scsl` était à installer, un
+  sous-module oublié, ou un projet interne. `--index` est désormais requis, et le
+  message dit ce qu'est le fichier, que la commande est un outil de **maintenance** dont
+  un scan n'a pas besoin, et donne un exemple.
 - **Le mode français ne laisse plus l'ossature du rapport en anglais.** Titres de
   section, en-têtes de table et ligne « aucun écart » sortaient en anglais au milieu
   d'un rapport français — `Total deviations: 1` au-dessus d'un finding français, se

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,17 @@ belongs in `git log`.
 
 ### Fixed
 
+- **The root description names the providers that exist.** The first sentence a new
+  user reads advertised OVH — a roadmap entry, not a provider — and omitted Kubernetes,
+  which is one. The list is now derived from the registry: a copied list goes stale at
+  the first provider added or removed, and nobody rereads a welcome sentence.
+- **`pepin scsl --index` no longer defaults to a maintainer's checkout layout.** The
+  default was a relative path climbing out of the working directory into a repository
+  the reader has never heard of. The error was correct and said nothing: one could not
+  tell whether `framework-scsl` was something to install, a submodule left
+  uninitialised, or an internal project. `--index` is now required, and the message says
+  what the file is, that the command is a **maintenance** tool a scan does not need, and
+  gives an example.
 - **French mode no longer leaves the report scaffolding in English.** Section titles,
   table headers and the "no deviations" line came out English inside an otherwise
   French report — `Total deviations: 1` above a French finding, closing on a French

--- a/cmd/args_test.go
+++ b/cmd/args_test.go
@@ -111,3 +111,72 @@ func exitCodeOfArgs(t *testing.T, bin string, args ...string) int {
 	}
 	return 0
 }
+
+// TestTheRootDescriptionNamesTheProvidersThatExist — l'issue #150.
+//
+// La première phrase qu'un nouvel utilisateur lit annonçait OVH — une entrée de feuille
+// de route, pas un fournisseur — et omettait Kubernetes, qui en est un. La liste est
+// désormais DÉRIVÉE du registre : une liste recopiée se périme au premier fournisseur
+// ajouté ou retiré, et personne ne relit une phrase d'accueil.
+func TestTheRootDescriptionNamesTheProvidersThatExist(t *testing.T) {
+	bin := buildPepin(t)
+	stdout, _ := runPepin(t, bin, nil, "--help")
+
+	// Les fournisseurs sont lus depuis le BINAIRE, pas depuis le processus de test :
+	// le registre se peuple à partir des descripteurs du dépôt, et un test qui
+	// tournerait dans un autre répertoire mesurerait un registre vide.
+	liste, _ := runPepin(t, bin, nil, "provider", "list")
+	var enregistres []string
+	for _, l := range strings.Split(liste, "\n") {
+		champs := strings.Fields(l)
+		if len(champs) > 0 && !strings.HasPrefix(champs[0], "/") && champs[0] != "" {
+			if n := champs[0]; strings.ToLower(n) == n && !strings.Contains(n, "é") {
+				enregistres = append(enregistres, n)
+			}
+		}
+	}
+	if len(enregistres) == 0 {
+		t.Fatal("aucun fournisseur listé par le binaire : le test ne mesure rien")
+	}
+	for _, p := range enregistres {
+		if !strings.Contains(stdout, p) {
+			t.Errorf("la description racine omet le fournisseur %q, qui est enregistré", p)
+		}
+	}
+	// Le cas EXACT du rapport : un nom annoncé qui n'existe pas.
+	for _, p := range enregistres {
+		if p == "ovh" {
+			return // le jour où il existe, cette garde s'efface d'elle-même
+		}
+	}
+	if strings.Contains(strings.ToLower(stdout), "ovh") {
+		t.Error("la description racine annonce OVH, qui n'est pas un fournisseur enregistré")
+	}
+}
+
+// TestTheSCSLIndexHasNoMaintainerDefault — l'issue #154.
+//
+// Le défaut de `--index` était un chemin relatif remontant hors du répertoire courant
+// vers un dépôt dont le lecteur n'a jamais entendu parler : la disposition locale d'un
+// mainteneur échappée dans un binaire publié. L'erreur était juste et ne disait rien.
+func TestTheSCSLIndexHasNoMaintainerDefault(t *testing.T) {
+	bin := buildPepin(t)
+	_, stderr := runPepin(t, bin, nil, "scsl")
+
+	// Ce qui était fautif n'est pas de MENTIONNER ce chemin — l'exemple aide — c'est
+	// de le poser en DÉFAUT, comme s'il allait de soi sur la machine du lecteur.
+	aide, _ := runPepin(t, bin, nil, "scsl", "--help")
+	if strings.Contains(aide, `(default "../framework-scsl`) {
+		t.Error("`--index` porte encore le chemin d'un mainteneur comme valeur par défaut")
+	}
+	// Le message doit dire ce QU'EST le fichier, et que la commande est un outil de
+	// maintenance : sans cela, le lecteur ne peut pas savoir si c'est à lui d'agir.
+	for _, attendu := range []string{"--index", "SCSL", "MAINTENANCE"} {
+		if !strings.Contains(strings.ToUpper(stderr), strings.ToUpper(attendu)) {
+			t.Errorf("le message n'explique pas %q :\n%s", attendu, stderr)
+		}
+	}
+	if code := exitCodeOfArgs(t, bin, "scsl"); code != exitErreur {
+		t.Errorf("`pepin scsl` sans index rend %d, attendu %d", code, exitErreur)
+	}
+}

--- a/cmd/i18n.go
+++ b/cmd/i18n.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stephrobert/pepin/internal/i18n"
+	"github.com/stephrobert/pepin/internal/provider"
 )
 
 // langFlag porte --lang. Déclaré en persistant sur la racine : la langue vaut
@@ -57,6 +58,15 @@ func langFromArgs(args []string) string {
 // setUsage remplace le texte d'aide d'un drapeau déjà enregistré. Silencieux si
 // le drapeau n'existe pas : `localize` ne doit jamais être la raison d'une panique
 // au démarrage.
+// providerNames rend les fournisseurs ENREGISTRÉS, dans l'ordre du registre.
+func providerNames() string {
+	noms := make([]string, 0, 8)
+	for _, p := range provider.All() {
+		noms = append(noms, p.Name())
+	}
+	return strings.Join(noms, ", ")
+}
+
 func setUsage(c *cobra.Command, name, usage string) {
 	if f := c.Flags().Lookup(name); f != nil {
 		f.Usage = usage
@@ -69,12 +79,18 @@ func localize() {
 	rootCmd.Short = tr(
 		"Pépin — trouve les pépins de votre cloud souverain",
 		"Pepin — finds the flaws in your sovereign cloud")
+	// La liste des clouds est DÉRIVÉE du registre, jamais écrite à la main.
+	//
+	// Elle l'était, et elle avait dérivé : la première phrase qu'un nouvel utilisateur
+	// lit annonçait OVH — qui est une entrée de feuille de route, pas un fournisseur —
+	// et omettait Kubernetes, qui en est un. Une liste recopiée se périme au premier
+	// fournisseur ajouté ou retiré, et personne ne relit une phrase d'accueil.
 	rootCmd.Long = tr(
 		"Pépin — CSPM multi-cloud souverain.\n\n"+
-			"Évalue la posture d'un cloud (OVH, Scaleway, Exoscale, Outscale…) contre un\n"+
+			"Évalue la posture d'un cloud ("+providerNames()+") contre un\n"+
 			"référentiel commun ancré sur SCSL, SecNumCloud, CIS et ISO.",
 		"Pepin — sovereign multi-cloud CSPM.\n\n"+
-			"Assesses the posture of a cloud (OVH, Scaleway, Exoscale, Outscale…) against a\n"+
+			"Assesses the posture of a cloud ("+providerNames()+") against a\n"+
 			"common reference anchored on SCSL, SecNumCloud, CIS and ISO.")
 	if f := rootCmd.PersistentFlags().Lookup("lang"); f != nil {
 		f.Usage = tr(

--- a/cmd/scsl.go
+++ b/cmd/scsl.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -21,11 +22,24 @@ var scslIndex string
 // Pépin non encore couvertes.
 var scslCmd = &cobra.Command{
 	Use:   "scsl",
-	Short: "Vérifier la cohérence avec l'index SCSL et piloter la roadmap",
+	Short: "Vérifier la cohérence avec l'index SCSL et piloter la roadmap (maintenance)",
 	// Aucune sous-commande : tout argument est donc une faute de frappe, et l'ignorer
 	// ferait exécuter autre chose que ce qui a été tapé.
 	Args: noArgs(),
 	RunE: func(_ *cobra.Command, _ []string) error {
+		if scslIndex == "" {
+			return errors.New(tr(
+				"--index est requis : chemin de l'API statique du framework SCSL (api/v1/exigences.json).\n"+
+					"  Cette commande confronte le référentiel de Pépin à l'index SCSL GELÉ, et cet index\n"+
+					"  vit dans le dépôt du framework, pas ici. C'est un outil de MAINTENANCE : un scan\n"+
+					"  n'en a pas besoin.\n"+
+					"  Exemple : pepin scsl --index ../framework-scsl/api/v1/exigences.json",
+				"--index is required: path to the SCSL framework's static API (api/v1/exigences.json).\n"+
+					"  This command confronts Pépin's reference with the FROZEN SCSL index, and that index\n"+
+					"  lives in the framework's repository, not here. It is a MAINTENANCE tool: a scan does\n"+
+					"  not need it.\n"+
+					"  Example: pepin scsl --index ../framework-scsl/api/v1/exigences.json"))
+		}
 		exs, err := referentiel.ParseCLDExigences(scslIndex)
 		if err != nil {
 			return err
@@ -309,6 +323,13 @@ var scslCmd = &cobra.Command{
 }
 
 func init() {
-	scslCmd.Flags().StringVar(&scslIndex, "index", "../framework-scsl/api/v1/exigences.json",
-		"chemin de l'API SCSL (api/v1/exigences.json du framework)")
+	// Aucune valeur par DÉFAUT. Elle valait `../framework-scsl/api/v1/exigences.json`,
+	// un chemin relatif qui remonte hors du répertoire courant vers un dépôt dont le
+	// lecteur n'a jamais entendu parler : la disposition locale d'un mainteneur
+	// échappée dans un binaire publié. L'erreur était juste et ne disait rien —
+	// impossible de savoir si `framework-scsl` était à installer, un sous-module
+	// oublié, ou un projet interne inaccessible.
+	scslCmd.Flags().StringVar(&scslIndex, "index", "",
+		tr("chemin de l'index SCSL gelé (api/v1/exigences.json du framework, REQUIS)",
+			"path to the frozen SCSL index (api/v1/exigences.json of the framework, REQUIRED)"))
 }

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -77,7 +77,7 @@ concerné. La même précaution vaut pour l'empreinte d'un bundle scellé : voir
 ```text
 Pépin — CSPM multi-cloud souverain.
 
-Évalue la posture d'un cloud (OVH, Scaleway, Exoscale, Outscale…) contre un
+Évalue la posture d'un cloud (exoscale, kubernetes, outscale, scaleway) contre un
 référentiel commun ancré sur SCSL, SecNumCloud, CIS et ISO.
 
 pepin [flags]
@@ -328,7 +328,7 @@ pepin scsl [flags]
 
 Drapeaux:
   -h, --help           aide pour scsl
-      --index string   chemin de l'API SCSL (api/v1/exigences.json du framework) (default "../framework-scsl/api/v1/exigences.json")
+      --index string   chemin de l'API SCSL (api/v1/exigences.json du framework)
 
 Drapeaux globaux:
       --lang string   langue de l'interface : fr | en (défaut : PEPIN_LANG, puis LC_ALL/LANG, sinon en)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -76,7 +76,7 @@ bundle's digest: see [Evidence bundles](../guides/evidence-bundles.md#the-digest
 ```text
 Pepin — sovereign multi-cloud CSPM.
 
-Assesses the posture of a cloud (OVH, Scaleway, Exoscale, Outscale…) against a
+Assesses the posture of a cloud (exoscale, kubernetes, outscale, scaleway) against a
 common reference anchored on SCSL, SecNumCloud, CIS and ISO.
 
 pepin [flags]
@@ -327,7 +327,7 @@ pepin scsl [flags]
 
 Flags:
   -h, --help           help for scsl
-      --index string   path to the SCSL API (the framework's api/v1/exigences.json) (default "../framework-scsl/api/v1/exigences.json")
+      --index string   path to the SCSL API (the framework's api/v1/exigences.json)
 
 Global Flags:
       --lang string   interface language: fr | en (default: PEPIN_LANG, then LC_ALL/LANG, otherwise en)


### PR DESCRIPTION
Deux défauts de **première impression**, dans ce que l'outil dit de lui-même avant
d'avoir rien fait.

## #150 — la description annonçait un fournisseur qui n'existe pas

```
Évalue la posture d'un cloud (OVH, Scaleway, Exoscale, Outscale…)
```

OVH est une entrée de **feuille de route**, pas un fournisseur. Et Kubernetes, qui en
est un, était omis.

La liste est désormais **dérivée du registre** :

```
Évalue la posture d'un cloud (exoscale, kubernetes, outscale, scaleway)
```

Une liste recopiée se périme au premier fournisseur ajouté ou retiré, et **personne ne
relit une phrase d'accueil** — celle-ci était fausse depuis assez longtemps pour qu'il
faille un lecteur extérieur pour la voir.

## #154 — un chemin de mainteneur échappé dans un binaire publié

```
--index string   … (default "../framework-scsl/api/v1/exigences.json")
```

Un chemin relatif qui remonte hors du répertoire courant vers un dépôt dont le lecteur
n'a jamais entendu parler. Le code de sortie et le message étaient tous deux **corrects**
— c'est ce qui en faisait un défaut de première impression et non de correction : le
lecteur ne pouvait pas savoir si `framework-scsl` était à installer, un sous-module
oublié, ou un projet interne inaccessible.

Le drapeau est maintenant **requis**, et le message dit ce qu'est le fichier :

```
erreur : --index est requis : chemin de l'API statique du framework SCSL (api/v1/exigences.json).
  Cette commande confronte le référentiel de Pépin à l'index SCSL GELÉ, et cet index
  vit dans le dépôt du framework, pas ici. C'est un outil de MAINTENANCE : un scan
  n'en a pas besoin.
  Exemple : pepin scsl --index ../framework-scsl/api/v1/exigences.json
```

Le `Short` le dit aussi : la commande siège dans la même liste que `scan` et `verify`,
sans rien qui signale qu'elle ne s'adresse pas à celui qui vient d'installer l'outil.

## Deux de mes gardes étaient fausses, de la même façon

Trop strictes sur la mauvaise chose.

L'une lisait le registre des fournisseurs **depuis le processus de test**, où il est
vide — il se peuple à partir des descripteurs du dépôt. Elle lit maintenant la sortie du
binaire.

L'autre rejetait toute mention de `../framework-scsl`, **y compris l'exemple** — qui est
précisément la partie qui aide. Ce qui était fautif, c'est le **défaut**, pas la
mention.

Closes #150
Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
