### PR TITLE
fix(rules): a source is unrestricted when it is wide AND not private

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -74,6 +74,13 @@ l'une ni l'autre appartient au `git log`.
   silencieux, et le réseau d'un partenaire comme `203.0.113.0/24` n'est délibérément pas
   signalé : « ouvert à Internet » et « ouvert à quelqu'un d'autre » sont deux
   affirmations différentes.
+
+  L'union est fermée elle aussi : `net.cidr_merge` fusionne les plages d'une règle avant
+  de les juger, si bien que 512 `/9` couvrant l'espace deviennent `0.0.0.0/0` et sont
+  signalées — mesuré. Les entrées brutes restent éprouvées à côté, parce qu'un littéral
+  sans masque (`0.0.0.0`, `*`) n'est pas un CIDR valide et que la fusion le perdrait ; et
+  seules les entrées valides sont fusionnées, parce que `net.cidr_merge` devient indéfini
+  sur une entrée malformée, ce qui rendrait la règle muette sur une donnée de tiers.
 - **La description racine nomme les fournisseurs qui existent.** La première phrase
   qu'un nouvel utilisateur lit annonçait OVH — une entrée de feuille de route, pas un
   fournisseur — et omettait Kubernetes, qui en est un. La liste est désormais dérivée du

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -81,6 +81,14 @@ l'une ni l'autre appartient au `git log`.
   sans masque (`0.0.0.0`, `*`) n'est pas un CIDR valide et que la fusion le perdrait ; et
   seules les entrées valides sont fusionnées, parce que `net.cidr_merge` devient indéfini
   sur une entrée malformée, ce qui rendrait la règle muette sur une donnée de tiers.
+
+  La fusion ne rapproche que le CONTIGU, si bien qu'un damier lui échappait : 256 `/9`
+  une sur deux — la moitié d'Internet — donnaient 256 blocs inchangés et restaient
+  muettes. Les adresses publiques qu'une liste de sources ouvre sont désormais
+  **comptées**, exactement : les blocs fusionnés sont disjoints, et deux CIDR sont soit
+  disjoints soit emboîtés, donc la taille publique d'un bloc est la sienne moins celle
+  des espaces à usage spécial qu'il contient. Un seul finding par ressource nomme
+  l'union — `0.0.0.0/0`, ou `256 CIDR → 1848508416 IPv4` — au lieu d'un par plage.
 - **La description racine nomme les fournisseurs qui existent.** La première phrase
   qu'un nouvel utilisateur lit annonçait OVH — une entrée de feuille de route, pas un
   fournisseur — et omettait Kubernetes, qui en est un. La liste est désormais dérivée du

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -63,6 +63,17 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Un groupe de sécurité ouvert à tout Internet par des plages `/2` ne produisait
+  aucun finding.** `is_public_cidr` ne jugeait publique qu'une plage de préfixe ≤ 1, si
+  bien que les quatre plages `0.0.0.0/2`, `64.0.0.0/2`, `128.0.0.0/2`, `192.0.0.0/2` —
+  qui couvrent ensemble tout l'IPv4 — passaient inaperçues, pendant que `0.0.0.0/1` du
+  même groupe était attrapé. Mesuré sur un tenant Outscale réel : RDP ouvert à tout
+  Internet, et le rapport muet. Un `/3`, ou une liste de `/8`, passaient de même. Une
+  source est désormais non restreinte quand elle est **large** (préfixe ≤ 8) **et non
+  privée** — la seconde condition est ce qui garde `10.0.0.0/8` sur le port 22
+  silencieux, et le réseau d'un partenaire comme `203.0.113.0/24` n'est délibérément pas
+  signalé : « ouvert à Internet » et « ouvert à quelqu'un d'autre » sont deux
+  affirmations différentes.
 - **La description racine nomme les fournisseurs qui existent.** La première phrase
   qu'un nouvel utilisateur lit annonçait OVH — une entrée de feuille de route, pas un
   fournisseur — et omettait Kubernetes, qui en est un. La liste est désormais dérivée du

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,14 @@ belongs in `git log`.
   is not a valid CIDR and the merge would lose it; and only valid entries are merged,
   because `net.cidr_merge` goes undefined on a malformed one, which would silence the
   rule on third-party input.
+
+  The merge only brings CONTIGUOUS ranges together, so a checkerboard escaped it: 256
+  `/9` one in two — half the internet — merged to 256 unchanged blocks and stayed
+  silent. The public addresses a source list opens are now COUNTED, exactly: merged
+  blocks are disjoint, and two CIDRs are either disjoint or nested, so a block's public
+  size is its own minus the special-use blocks it contains. One finding per resource
+  names the union — `0.0.0.0/0`, or `256 CIDR → 1848508416 IPv4` — rather than one per
+  range.
 - **The root description names the providers that exist.** The first sentence a new
   user reads advertised OVH — a roadmap entry, not a provider — and omitted Kubernetes,
   which is one. The list is now derived from the registry: a copied list goes stale at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@ belongs in `git log`.
   `10.0.0.0/8` on port 22 silent, and a partner network like `203.0.113.0/24` is
   deliberately not flagged: "open to the internet" and "open to someone else" are
   different claims.
+
+  The union is closed too: `net.cidr_merge` collapses a rule's ranges before they are
+  judged, so 512 `/9` covering the space become `0.0.0.0/0` and fire — measured. The
+  raw entries are still tested alongside, because a maskless literal (`0.0.0.0`, `*`)
+  is not a valid CIDR and the merge would lose it; and only valid entries are merged,
+  because `net.cidr_merge` goes undefined on a malformed one, which would silence the
+  rule on third-party input.
 - **The root description names the providers that exist.** The first sentence a new
   user reads advertised OVH — a roadmap entry, not a provider — and omitted Kubernetes,
   which is one. The list is now derived from the registry: a copied list goes stale at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@ belongs in `git log`.
 
 ### Fixed
 
+- **A security group open to the whole internet through `/2` ranges produced no
+  finding.** `is_public_cidr` called a range public only at prefix ≤ 1, so the four
+  ranges `0.0.0.0/2`, `64.0.0.0/2`, `128.0.0.0/2`, `192.0.0.0/2` — which together cover
+  all of IPv4 — went unnoticed, while `0.0.0.0/1` in the same group was caught. Measured
+  on a real Outscale tenant: RDP open to the entire internet, and the report silent. A
+  `/3`, or a list of `/8`s, passed the same way. A source is now unrestricted when it is
+  **wide** (prefix ≤ 8) **and not private** — the second condition is what keeps
+  `10.0.0.0/8` on port 22 silent, and a partner network like `203.0.113.0/24` is
+  deliberately not flagged: "open to the internet" and "open to someone else" are
+  different claims.
 - **The root description names the providers that exist.** The first sentence a new
   user reads advertised OVH — a roadmap entry, not a provider — and omitted Kubernetes,
   which is one. The list is now derived from the registry: a copied list goes stale at

--- a/internal/commonrules/rules/compute_instance_no_secrets_in_user_data.rego
+++ b/internal/commonrules/rules/compute_instance_no_secrets_in_user_data.rego
@@ -194,4 +194,3 @@ _secret_patterns(s) := patterns if {
 	}
 	patterns := by_regex | private_key
 }
-

--- a/internal/commonrules/rules/database_service_not_open_to_internet.rego
+++ b/internal/commonrules/rules/database_service_not_open_to_internet.rego
@@ -17,9 +17,11 @@ import rego.v1
 deny contains f if {
 	some r in resources_of_type("managed_database")
 	"ip_filter" in object.keys(r.attributes)
+
 	# L'UNION, pas chaque plage isolément : quatre `/2` ouvrent la base à tout
 	# Internet sans qu'aucune ne soit « tout Internet » (cf. unrestricted_cidrs).
-	some cidr in unrestricted_cidrs(object.get(r.attributes, "ip_filter", []))
+	cidr := unrestricted_label(object.get(r.attributes, "ip_filter", []))
+	cidr != ""
 	id := object.get(r.attributes, "database_id", r.id)
 	f := {
 		"code": "database_service_not_open_to_internet",

--- a/internal/commonrules/rules/database_service_not_open_to_internet.rego
+++ b/internal/commonrules/rules/database_service_not_open_to_internet.rego
@@ -17,8 +17,9 @@ import rego.v1
 deny contains f if {
 	some r in resources_of_type("managed_database")
 	"ip_filter" in object.keys(r.attributes)
-	some cidr in cidr_list(object.get(r.attributes, "ip_filter", []))
-	is_public_cidr(cidr)
+	# L'UNION, pas chaque plage isolément : quatre `/2` ouvrent la base à tout
+	# Internet sans qu'aucune ne soit « tout Internet » (cf. unrestricted_cidrs).
+	some cidr in unrestricted_cidrs(object.get(r.attributes, "ip_filter", []))
 	id := object.get(r.attributes, "database_id", r.id)
 	f := {
 		"code": "database_service_not_open_to_internet",

--- a/internal/commonrules/rules/iam_apiaccess.rego
+++ b/internal/commonrules/rules/iam_apiaccess.rego
@@ -14,7 +14,8 @@ import rego.v1
 # comportement inchangé (on flague), donc rétro-compatible.
 deny contains f if {
 	some r in resources_of_type("api_access_rule")
-	some cidr in unrestricted_cidrs(object.get(r.attributes, "ip_ranges", []))
+	cidr := unrestricted_label(object.get(r.attributes, "ip_ranges", []))
+	cidr != ""
 	not _requires_client_cert(r)
 	f := {
 		"code": "iam_apiaccessrule_no_public_cidr",

--- a/internal/commonrules/rules/iam_apiaccess.rego
+++ b/internal/commonrules/rules/iam_apiaccess.rego
@@ -14,8 +14,7 @@ import rego.v1
 # comportement inchangé (on flague), donc rétro-compatible.
 deny contains f if {
 	some r in resources_of_type("api_access_rule")
-	some cidr in cidr_list(object.get(r.attributes, "ip_ranges", []))
-	is_public_cidr(cidr)
+	some cidr in unrestricted_cidrs(object.get(r.attributes, "ip_ranges", []))
 	not _requires_client_cert(r)
 	f := {
 		"code": "iam_apiaccessrule_no_public_cidr",

--- a/internal/commonrules/rules/kubernetes_cluster_not_publicly_accessible.rego
+++ b/internal/commonrules/rules/kubernetes_cluster_not_publicly_accessible.rego
@@ -10,8 +10,7 @@ import rego.v1
 
 deny contains f if {
 	some c in resources_of_type("kubernetes_cluster")
-	some cidr in cidr_list(object.get(c.attributes, "admin_whitelist", []))
-	is_public_cidr(cidr)
+	some cidr in unrestricted_cidrs(object.get(c.attributes, "admin_whitelist", []))
 	name := object.get(c.attributes, "name", c.id)
 	f := {
 		"code": "kubernetes_cluster_not_publicly_accessible",

--- a/internal/commonrules/rules/kubernetes_cluster_not_publicly_accessible.rego
+++ b/internal/commonrules/rules/kubernetes_cluster_not_publicly_accessible.rego
@@ -10,7 +10,8 @@ import rego.v1
 
 deny contains f if {
 	some c in resources_of_type("kubernetes_cluster")
-	some cidr in unrestricted_cidrs(object.get(c.attributes, "admin_whitelist", []))
+	cidr := unrestricted_label(object.get(c.attributes, "admin_whitelist", []))
+	cidr != ""
 	name := object.get(c.attributes, "name", c.id)
 	f := {
 		"code": "kubernetes_cluster_not_publicly_accessible",

--- a/internal/commonrules/rules/lib.rego
+++ b/internal/commonrules/rules/lib.rego
@@ -12,12 +12,43 @@ import rego.v1
 # Le collecteur live et le parseur Terraform projettent tous deux vers ces types.
 resources_of_type(t) := [r | some r in input.resources; r.type == t]
 
-# is_public_cidr — le CIDR couvre l'Internet public (IPv4 ou IPv6). On PARSE la longueur de
-# préfixe au lieu de comparer des littéraux : un préfixe /0 couvre tout l'espace d'adressage
-# quelle que soit l'écriture (`0.0.0.0/0`, `::/0`, `::0/0`, `0000::/0`). Un /1 (IPv4
-# `0.0.0.0/1`|`128.0.0.0/1`, ou IPv6 `::/1`) couvre la MOITIÉ de l'espace d'adressage :
-# contournement CSPM connu, jamais légitime comme source « restreinte » → également public.
-is_public_cidr(cidr) if _cidr_prefix(trim_space(cidr)) <= 1
+# is_public_cidr — le CIDR est une source NON RESTREINTE : une plage assez large pour
+# valoir « l'Internet », et qui n'est pas un espace privé.
+#
+# # Le défaut que ce seuil corrige, mesuré sur un tenant réel
+#
+# La règle exigeait un préfixe <= 1. Or quatre plages `/2` couvrent tout l'espace IPv4 :
+#
+#	0.0.0.0/2, 64.0.0.0/2, 128.0.0.0/2, 192.0.0.0/2
+#
+# RDP ouvert à TOUT Internet ne produisait donc aucun finding, pendant que la règle
+# `tcp 22 [0.0.0.0/1, 128.0.0.0/1]` du même groupe était bien attrapée. Un `/3`, ou une
+# liste de `/8`, passaient de même. Pour un outil dont c'est la raison d'être, un faux
+# négatif silencieux est le pire des défauts.
+#
+# # Le seuil, et pourquoi /8
+#
+# Deux conditions, et il faut les DEUX : la plage est large (préfixe <= 8, soit au moins
+# 16,7 millions d'adresses) ET elle n'est pas un espace privé. Le second garde-fou est ce
+# qui empêche la correction de devenir un faux positif : `10.0.0.0/8` est un `/8`, et il
+# doit rester silencieux — c'est le contre-exemple que ce contrôle ne doit jamais perdre.
+#
+# Pourquoi ne pas signaler TOUTE plage externe : `203.0.113.0/24`, le réseau d'un
+# partenaire, est externe et parfaitement légitime. « Ouvert à Internet » et « ouvert à
+# quelqu'un d'autre que moi » sont deux affirmations différentes, et la seconde n'est pas
+# ce que ces contrôles mesurent.
+#
+# # Ce qui reste ouvert, et c'est écrit plutôt que tu
+#
+# Une UNION de plages plus étroites que /8 — 512 `/9`, par exemple — couvre l'espace sans
+# qu'aucune ne franchisse le seuil. Le détecter demande une arithmétique d'intervalles
+# que le Rego rend coûteuse, et les trois formes réellement mesurées (des `/2`, un `/3`,
+# une liste de `/8`) sont fermées. Suivi en #169.
+is_public_cidr(cidr) if {
+	t := trim_space(cidr)
+	_cidr_prefix(t) <= 8
+	not _private_v4(t)
+}
 
 # Littéraux « toute origine » SANS masque (certaines API/UI : une source vide/`0.0.0.0`/`*`).
 is_public_cidr(cidr) if trim_space(cidr) in {"0.0.0.0", "::", "::0", "*"}
@@ -40,6 +71,21 @@ is_public_cidr(cidr) if {
 	t := lower(trim_space(cidr))
 	startswith(t, "2000::")
 	_cidr_prefix(t) <= 3
+}
+
+# _private_v4 — la plage appartient à un espace privé ou réservé, donc elle n'est pas
+# « Internet » quelle que soit sa largeur. RFC 1918, RFC 6598 (CGNAT), lien-local,
+# bouclage, et « ce réseau » (0.0.0.0/8 hors le /0 déjà traité par le préfixe).
+#
+# Le préfixe doit valoir EXACTEMENT 8. Une plage plus large n'est pas CONTENUE dans le
+# bloc privé : elle l'englobe et déborde sur l'espace public. C'est ce qui distingue
+# `0.0.0.0/8` (« ce réseau », silencieux) de `0.0.0.0/2` (un quart d'Internet, à
+# signaler) — un test sur le seul octet de tête aurait rendu muet `0.0.0.0/0` lui-même,
+# et c'est exactement ce qu'il a fait au premier essai.
+_private_v4(t) if {
+	_cidr_prefix(t) == 8
+	octet := split(split(t, "/")[0], ".")[0]
+	octet in {"10", "127", "0"}
 }
 
 _cidr_prefix(cidr) := n if {

--- a/internal/commonrules/rules/lib.rego
+++ b/internal/commonrules/rules/lib.rego
@@ -38,12 +38,11 @@ resources_of_type(t) := [r | some r in input.resources; r.type == t]
 # quelqu'un d'autre que moi » sont deux affirmations différentes, et la seconde n'est pas
 # ce que ces contrôles mesurent.
 #
-# # Ce qui reste ouvert, et c'est écrit plutôt que tu
+# # # L'UNION, et non plus seulement chaque plage prise isolément
 #
-# Une UNION de plages plus étroites que /8 — 512 `/9`, par exemple — couvre l'espace sans
-# qu'aucune ne franchisse le seuil. Le détecter demande une arithmétique d'intervalles
-# que le Rego rend coûteuse, et les trois formes réellement mesurées (des `/2`, un `/3`,
-# une liste de `/8`) sont fermées. Suivi en #169.
+# Une plage isolée ne dit pas tout : 512 `/9` couvrent l'espace sans qu'aucune ne
+# franchisse le seuil. `unrestricted_source` fusionne donc la liste d'une règle avant de
+# la juger — `net.cidr_merge` collapse ces 512 plages en `0.0.0.0/0`, mesuré.
 is_public_cidr(cidr) if {
 	t := trim_space(cidr)
 	_cidr_prefix(t) <= 8
@@ -193,13 +192,60 @@ proto_covers(rule, _) if {
 # drop » — un `deny`/`reject` d'un futur provider serait alors compté à tort comme ouvert.
 sg_accepting(rule) if lower(object.get(rule, "action", "accept")) in {"accept", "allow", ""}
 
+# unrestricted_source — la LISTE de sources d'une règle est-elle non restreinte ?
+#
+# Juger chaque plage isolément laissait passer une UNION : quatre `/2` couvrent tout
+# IPv4 sans qu'aucune ne soit « tout Internet », et 512 `/9` font de même sous n'importe
+# quel seuil de largeur. La liste est donc FUSIONNÉE avant d'être jugée — `net.cidr_merge`
+# rend la plus petite couverture équivalente, et les 512 `/9` y deviennent `0.0.0.0/0`.
+#
+# Les deux chemins coexistent, et il faut les deux :
+#
+#   - les entrées BRUTES portent les littéraux sans masque (`0.0.0.0`, `*`), que
+#     `net.cidr_is_valid` rejette et que la fusion perdrait ;
+#   - les entrées FUSIONNÉES portent l'union, qu'aucune entrée brute ne montre.
+#
+# Le filtrage par `net.cidr_is_valid` avant la fusion n'est pas de la prudence de
+# principe : `net.cidr_merge` rend l'expression INDÉFINIE sur une entrée malformée
+# (mesuré), ce qui rendrait la règle muette — le faux négatif exact que ce correctif
+# existe pour fermer, sur une entrée fournie par un tiers.
+unrestricted_source(cidrs) if count(unrestricted_cidrs(cidrs)) > 0
+
+# unrestricted_cidrs — les sources FAUTIVES, brutes et fusionnées confondues.
+#
+# L'ensemble plutôt qu'un booléen : les messages nomment la plage en cause, et une
+# règle qui dirait « ouvert à Internet » sans dire par où laisserait l'opérateur
+# chercher. Une union fautive s'y nomme par sa forme fusionnée — `0.0.0.0/0` — ce qui
+# est exactement ce qu'il faut lire pour comprendre que quatre `/2` se recouvrent.
+unrestricted_cidrs(cidrs) := brutes | fusionnees if {
+	brutes := {c |
+		some c in cidr_list(cidrs)
+		is_public_cidr(c)
+	}
+	valides := {c |
+		some c in cidr_list(cidrs)
+		net.cidr_is_valid(c)
+	}
+	fusionnees := {m |
+		some m in _merge_ou_vide(valides)
+		is_public_cidr(m)
+	}
+}
+
+# _merge_ou_vide — la fusion, ou rien. `net.cidr_merge` sur un ensemble VIDE, ou
+# portant une entrée malformée, rend l'expression indéfinie : sans ce garde-fou, une
+# donnée de tiers mal formée rendrait la règle muette, c'est-à-dire produirait le faux
+# négatif exact que ce chemin existe pour fermer.
+_merge_ou_vide(valides) := net.cidr_merge(valides) if count(valides) > 0
+
+_merge_ou_vide(valides) := set() if count(valides) == 0
+
 # sg_inbound_from_internet — règle entrante acceptante dont la source couvre
-# Internet ; renvoie true si au moins un CIDR public est présent.
+# Internet ; renvoie true si la liste de sources est non restreinte.
 sg_inbound_from_internet(rule) if {
 	lower(object.get(rule, "direction", "")) == "inbound"
 	sg_accepting(rule)
-	some cidr in cidr_list(object.get(rule, "cidrs", []))
-	is_public_cidr(cidr)
+	unrestricted_source(object.get(rule, "cidrs", []))
 }
 
 # cidr_list — accepte la liste du modele normalise AUSSI BIEN qu'un scalaire.

--- a/internal/commonrules/rules/lib.rego
+++ b/internal/commonrules/rules/lib.rego
@@ -209,33 +209,65 @@ sg_accepting(rule) if lower(object.get(rule, "action", "accept")) in {"accept", 
 # principe : `net.cidr_merge` rend l'expression INDÉFINIE sur une entrée malformée
 # (mesuré), ce qui rendrait la règle muette — le faux négatif exact que ce correctif
 # existe pour fermer, sur une entrée fournie par un tiers.
-unrestricted_source(cidrs) if count(unrestricted_cidrs(cidrs)) > 0
+unrestricted_source(cidrs) if unrestricted_label(cidrs) != ""
 
-# unrestricted_cidrs — les sources FAUTIVES, brutes et fusionnées confondues.
+# unrestricted_label — UNE étiquette pour la source fautive, et une seule.
 #
-# L'ensemble plutôt qu'un booléen : les messages nomment la plage en cause, et une
-# règle qui dirait « ouvert à Internet » sans dire par où laisserait l'opérateur
-# chercher. Une union fautive s'y nomme par sa forme fusionnée — `0.0.0.0/0` — ce qui
-# est exactement ce qu'il faut lire pour comprendre que quatre `/2` se recouvrent.
-unrestricted_cidrs(cidrs) := brutes | fusionnees if {
-	brutes := {c |
+# `unrestricted_cidrs` rendait un ensemble, et les règles qui l'itéraient produisaient
+# un finding PAR élément : quatre `/2` sur une base donnaient cinq écarts — les quatre
+# plages brutes, chacune déjà large, plus leur fusion — pour un seul fait. Un rapport
+# qui répète cinq fois le même problème est aussi faux qu'un rapport qui le tait, et
+# c'est le défaut que j'ai introduit en fermant l'union.
+#
+# L'ordre des trois voies est celui de ce qu'elles APPRENNENT à un lecteur :
+#
+#   1. la forme FUSIONNÉE, quand elle est fautive — `0.0.0.0/0` dit d'un coup que
+#      quatre plages se recouvrent, ce qu'aucune des quatre ne montre ;
+#   2. la forme BRUTE, qui porte les littéraux sans masque (`0.0.0.0`, `*`) que
+#      `net.cidr_is_valid` rejette et que la fusion perdrait ;
+#   3. le DÉCOMPTE, quand ni l'une ni l'autre ne suffit — le damier, dont aucune plage
+#      n'est large et dont la fusion ne rapproche rien.
+unrestricted_label(cidrs) := lbl if {
+	f := sort([m |
+		some m in _merge_ou_vide(_valid_cidrs(cidrs))
+		is_public_cidr(m)
+	])
+	count(f) > 0
+	lbl := concat(", ", f)
+} else := lbl if {
+	b := sort([c |
 		some c in cidr_list(cidrs)
 		is_public_cidr(c)
-	}
-	valides := {c |
-		some c in cidr_list(cidrs)
-		net.cidr_is_valid(c)
-	}
-	fusionnees := {m |
-		some m in _merge_ou_vide(valides)
-		is_public_cidr(m)
-	}
-}
+	])
+	count(b) > 0
+	lbl := concat(", ", b)
+} else := lbl if {
+	n := public_coverage(cidrs)
+	n >= _public_threshold
 
-# _merge_ou_vide — la fusion, ou rien. `net.cidr_merge` sur un ensemble VIDE, ou
-# portant une entrée malformée, rend l'expression indéfinie : sans ce garde-fou, une
-# donnée de tiers mal formée rendrait la règle muette, c'est-à-dire produirait le faux
-# négatif exact que ce chemin existe pour fermer.
+	# Une étiquette NEUTRE : elle est interpolée dans un message français ET dans sa
+	# contrepartie anglaise, et une phrase traduite y dirait deux choses selon la langue
+	# de celui qui a scellé le bundle.
+	lbl := sprintf("%d CIDR → %d IPv4", [count(_valid_cidrs(cidrs)), n])
+} else := ""
+
+_valid_cidrs(cidrs) := [c |
+	some c in cidr_list(cidrs)
+	net.cidr_is_valid(c)
+]
+
+# _merge_ou_vide — la fusion, ou rien.
+#
+# Le garde-fou porte sur l'entrée MALFORMÉE : `net.cidr_merge` y rend l'expression
+# indéfinie (mesuré), ce qui rendrait la règle muette sur une donnée de tiers — le faux
+# négatif exact que ce chemin existe pour fermer. Le filtrage par `net.cidr_is_valid`
+# est donc obligatoire, et il protège au passage d'un second piège : une IP NUE reçoit
+# le masque classful de Go (`1.2.3.4` deviendrait `1.0.0.0/8`), donc un hôte isolé
+# passerait pour un /8 public entier.
+#
+# Sur un ensemble VIDE, en revanche, `net.cidr_merge` rend un ensemble vide et non une
+# expression indéfinie — mesuré. Le cas est gardé quand même, parce qu'un contrat de
+# builtin qui ne change pas aujourd'hui n'est pas un contrat écrit.
 _merge_ou_vide(valides) := net.cidr_merge(valides) if count(valides) > 0
 
 _merge_ou_vide(valides) := set() if count(valides) == 0

--- a/internal/commonrules/rules/lib_coverage.rego
+++ b/internal/commonrules/rules/lib_coverage.rego
@@ -1,0 +1,124 @@
+# La COUVERTURE d'une liste de sources : combien d'adresses publiques elle ouvre.
+#
+# # Pourquoi la fusion ne suffit pas
+#
+# `net.cidr_merge` ne rapproche que ce qui est CONTIGU. Deux formes lui échappent, et
+# elles sont toutes deux mesurées :
+#
+#	256 plages `/9` une sur deux   -> 256 blocs inchangés, la MOITIÉ d'Internet, muet
+#	["8.0.0.0/9", "9.0.0.0/9"]     -> 2 blocs, un /8 d'adresses publiques, muet
+#
+# Un damier n'a rien d'exotique : c'est ce que produit une liste d'allocations
+# régionales, ou un pare-feu qui autorise « tout sauf quelques trous ».
+#
+# # Le décompte est EXACT, pas approché
+#
+# Deux propriétés le permettent sans arithmétique d'intervalles :
+#
+#   - `net.cidr_merge` rend des blocs DISJOINTS ;
+#   - deux CIDR sont soit disjoints, soit emboîtés — jamais en chevauchement partiel.
+#
+# Donc, pour un bloc fusionné : zéro s'il est contenu dans un espace non public, sinon
+# sa taille moins celle des espaces non publics qu'il contient. Les entiers d'OPA sont
+# exacts jusqu'à 2^32, ce que ce calcul ne dépasse jamais.
+#
+# # Ce que ce fichier NE fait PAS
+#
+# L'IPv6 n'est pas décompté : 2^128 dépasse l'exactitude des entiers d'OPA, et un
+# décompte faux serait pire qu'aucun. L'IPv6 reste jugé par sa LARGEUR seule
+# (`::/0`, `2000::/3`, v4-mappé), ce qui couvre les formes réellement rencontrées.
+package pepin.rules
+
+import rego.v1
+
+# _public_threshold — 2^24 adresses, soit un /8. Le MÊME seuil que celui de la largeur :
+# deux seuils différents feraient dire deux choses à une seule politique.
+_public_threshold := 16777216
+
+# _pow2 — 2^k pour k de 0 à 32. Calculé une fois par évaluation, exact.
+_pow2 := {k: n |
+	some k in numbers.range(0, 32)
+	n := product([2 |
+		some i in numbers.range(1, 32)
+		i <= k
+	])
+}
+
+# _v4_nonpublic — les blocs IPv4 à usage spécial d'au moins un /16, DEUX À DEUX
+# DISJOINTS. La disjonction est ce qui rend la soustraction exacte : deux blocs qui se
+# recouvriraient seraient comptés deux fois.
+#
+# Les blocs plus fins (TEST-NET, 192.0.0.0/24) sont comptés comme publics : trois fois
+# 256 adresses ne déplacent pas un seuil de 16,7 millions, et les énumérer coûterait
+# plus de lignes que d'exactitude.
+_v4_nonpublic := {
+	"0.0.0.0/8",
+	"10.0.0.0/8",
+	"100.64.0.0/10",
+	"127.0.0.0/8",
+	"169.254.0.0/16",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"198.18.0.0/15",
+	"224.0.0.0/4",
+	"240.0.0.0/4",
+}
+
+# _v4_size — le nombre d'adresses d'un CIDR IPv4. `net.cidr_is_valid` garantit un
+# préfixe de 0 à 32 en amont, donc l'indexation ne peut pas manquer.
+_v4_size(c) := _pow2[32 - to_number(split(c, "/")[1])]
+
+# _public_size — les adresses PUBLIQUES d'un bloc fusionné.
+_public_size(m) := 0 if _in_nonpublic(m)
+
+_public_size(m) := _v4_size(m) - sum([_v4_size(p) |
+	some p in _v4_nonpublic
+	net.cidr_contains(m, p)
+]) if {
+	not _in_nonpublic(m)
+}
+
+_in_nonpublic(m) if {
+	some p in _v4_nonpublic
+	net.cidr_contains(p, m)
+}
+
+# public_coverage — les adresses publiques que cette liste de sources ouvre.
+#
+# La borne `count(v4) >= 2` n'est pas une optimisation : une plage SEULE relève déjà de
+# `is_public_cidr`, et la compter ici produirait un second finding pour un seul fait.
+public_coverage(cidrs) := n if {
+	v4 := [c |
+		some c in cidr_list(cidrs)
+		net.cidr_is_valid(c)
+		not contains(c, ":")
+	]
+	count(v4) >= 2
+
+	# GARDE DE COÛT, et elle est exacte dans le bon sens : la somme brute des tailles
+	# MAJORE toujours la couverture fusionnée (le recouvrement ne peut que la gonfler).
+	# Sous le seuil, ni la fusion ni les inclusions ne s'exécutent — ce qui est le cas
+	# de la quasi-totalité des règles réelles.
+	sum([_v4_size(c) | some c in v4]) >= _public_threshold
+
+	n := sum([_public_size(m) | some m in net.cidr_merge(v4)])
+}
+
+public_coverage(cidrs) := 0 if {
+	v4 := [c |
+		some c in cidr_list(cidrs)
+		net.cidr_is_valid(c)
+		not contains(c, ":")
+	]
+	count(v4) < 2
+}
+
+public_coverage(cidrs) := 0 if {
+	v4 := [c |
+		some c in cidr_list(cidrs)
+		net.cidr_is_valid(c)
+		not contains(c, ":")
+	]
+	count(v4) >= 2
+	sum([_v4_size(c) | some c in v4]) < _public_threshold
+}

--- a/internal/commonrules/rules/lib_public_cidr_test.rego
+++ b/internal/commonrules/rules/lib_public_cidr_test.rego
@@ -116,3 +116,62 @@ test_the_union_of_two_private_halves_stays_silent if {
 test_a_list_of_partner_networks_stays_silent if {
 	not unrestricted_source(["203.0.113.0/24", "198.51.100.0/24", "10.42.0.0/16"])
 }
+
+# ── LE DAMIER : ce que la fusion seule ne voit pas ─────────────────────────────
+
+# 256 plages `/9` une sur deux : la MOITIÉ d'Internet, et rien d'adjacent à fusionner.
+# `net.cidr_merge` rend les 256 blocs inchangés ; seul le décompte le voit.
+test_a_checkerboard_of_half_the_internet_is_unrestricted if {
+	damier := [c |
+		some a in numbers.range(0, 255)
+		c := sprintf("%d.0.0.0/9", [a])
+	]
+	count(damier) == 256
+	unrestricted_source(damier)
+}
+
+# Un /8 d'adresses publiques en deux morceaux NON adjacents.
+test_two_disjoint_halves_of_a_slash_eight_are_unrestricted if {
+	unrestricted_source(["8.0.0.0/9", "9.0.0.0/9"])
+}
+
+# ── Le décompte ne doit pas devenir un faux positif ────────────────────────────
+
+# Deux moitiés d'un réseau PRIVÉ : le décompte les voit, et les compte à zéro.
+test_two_private_halves_count_as_zero if {
+	public_coverage(["10.0.0.0/9", "10.128.0.0/9"]) == 0
+	not unrestricted_source(["10.0.0.0/9", "10.128.0.0/9"])
+}
+
+# Une liste de réseaux partenaires reste très en dessous du seuil.
+test_a_list_of_partner_networks_stays_below_the_threshold if {
+	public_coverage(["203.0.113.0/24", "198.51.100.0/24", "192.0.2.0/24"]) < 16777216
+	not unrestricted_source(["203.0.113.0/24", "198.51.100.0/24", "192.0.2.0/24"])
+}
+
+# Une plage SEULE ne passe jamais par le décompte : elle relève de la largeur, et la
+# compter ici produirait un second finding pour un seul fait.
+test_a_single_range_never_goes_through_the_count if {
+	public_coverage(["0.0.0.0/0"]) == 0
+	public_coverage(["1.0.0.0/8"]) == 0
+}
+
+# ── UNE étiquette, pas une par plage ───────────────────────────────────────────
+
+# La régression que la fermeture de l'union avait introduite : quatre `/2` produisaient
+# CINQ findings — les quatre plages, plus leur fusion — pour un seul fait.
+test_one_label_for_one_fact if {
+	unrestricted_label(["0.0.0.0/2", "64.0.0.0/2", "128.0.0.0/2", "192.0.0.0/2"]) == "0.0.0.0/0"
+	unrestricted_label(["10.42.0.0/16"]) == ""
+}
+
+# La forme fusionnée est PRÉFÉRÉE : elle dit d'un coup ce qu'aucune plage ne montre.
+test_the_label_prefers_the_merged_form if {
+	unrestricted_label(["0.0.0.0/1", "128.0.0.0/1"]) == "0.0.0.0/0"
+}
+
+# Un littéral sans masque n'est pas un CIDR valide : la voie brute le porte.
+test_the_label_keeps_maskless_literals if {
+	unrestricted_label(["*"]) == "*"
+	unrestricted_label(["0.0.0.0"]) == "0.0.0.0"
+}

--- a/internal/commonrules/rules/lib_public_cidr_test.rego
+++ b/internal/commonrules/rules/lib_public_cidr_test.rego
@@ -1,0 +1,72 @@
+# Ce qu'une source « non restreinte » recouvre, et ce qu'elle ne doit pas recouvrir.
+#
+# La règle exigeait un préfixe <= 1. Mesuré sur un tenant Outscale réel : quatre plages
+# `/2` couvrent tout l'espace IPv4, et RDP ouvert à tout Internet ne produisait AUCUN
+# finding — pendant que `tcp 22 [0.0.0.0/1, 128.0.0.0/1]` du même groupe était attrapé.
+#
+# Les deux sens comptent autant l'un que l'autre : élargir la détection sans garder les
+# contre-exemples muets échangerait un faux négatif contre une pluie de faux positifs,
+# et un outil bruyant finit désactivé — ce qui coûte plus cher que le défaut corrigé.
+package pepin.rules
+
+import rego.v1
+
+# ── Les formes MESURÉES sur le tenant, qui passaient toutes ────────────────────
+
+test_quarter_of_the_internet_is_public if {
+	is_public_cidr("0.0.0.0/2")
+	is_public_cidr("64.0.0.0/2")
+	is_public_cidr("128.0.0.0/2")
+	is_public_cidr("192.0.0.0/2")
+}
+
+test_an_eighth_of_the_internet_is_public if is_public_cidr("0.0.0.0/3")
+
+test_a_non_private_slash_eight_is_public if is_public_cidr("1.0.0.0/8")
+
+# ── Ce qui était déjà attrapé, et doit le rester ───────────────────────────────
+
+test_the_whole_internet_is_public if {
+	is_public_cidr("0.0.0.0/0")
+	is_public_cidr("0.0.0.0/1")
+	is_public_cidr("128.0.0.0/1")
+}
+
+test_maskless_literals_stay_public if {
+	is_public_cidr("0.0.0.0")
+	is_public_cidr("*")
+}
+
+# ── LES CONTRE-EXEMPLES : ce qui doit rester muet ──────────────────────────────
+
+# Le contre-exemple que ce contrôle ne doit jamais perdre. Un /8 privé est un /8, et
+# c'est le garde-fou qui empêche l'élargissement de devenir un faux positif.
+test_the_private_slash_eight_stays_silent if not is_public_cidr("10.0.0.0/8")
+
+test_loopback_stays_silent if not is_public_cidr("127.0.0.0/8")
+
+# « Ce réseau » : silencieux au /8, mais `0.0.0.0/2` en est un quart d'Internet — la
+# contenance, pas l'octet de tête, est ce qui les sépare.
+test_this_network_stays_silent_only_at_slash_eight if {
+	not is_public_cidr("0.0.0.0/8")
+	is_public_cidr("0.0.0.0/2")
+}
+
+# Les autres espaces privés sont plus étroits qu'un /8 : le seuil de largeur suffit à
+# les taire, sans avoir à les énumérer.
+test_narrower_private_ranges_stay_silent if {
+	not is_public_cidr("172.16.0.0/12")
+	not is_public_cidr("192.168.0.0/16")
+	not is_public_cidr("100.64.0.0/10")
+	not is_public_cidr("169.254.0.0/16")
+}
+
+# Le réseau d'un partenaire : EXTERNE, et parfaitement légitime. « Ouvert à Internet »
+# et « ouvert à quelqu'un d'autre que moi » sont deux affirmations différentes.
+test_a_partner_network_stays_silent if {
+	not is_public_cidr("203.0.113.0/24")
+	not is_public_cidr("198.51.100.0/24")
+}
+
+# Le réseau d'administration du contre-exemple de véracité.
+test_an_administration_network_stays_silent if not is_public_cidr("10.42.0.0/16")

--- a/internal/commonrules/rules/lib_public_cidr_test.rego
+++ b/internal/commonrules/rules/lib_public_cidr_test.rego
@@ -70,3 +70,49 @@ test_a_partner_network_stays_silent if {
 
 # Le réseau d'administration du contre-exemple de véracité.
 test_an_administration_network_stays_silent if not is_public_cidr("10.42.0.0/16")
+
+# ── L'UNION : ce qu'aucune plage prise isolément ne montre ─────────────────────
+
+# Le cas MESURÉ sur le tenant, vu comme la règle le voit : une liste, pas une plage.
+test_the_union_of_four_quarters_is_unrestricted if {
+	unrestricted_source(["0.0.0.0/2", "64.0.0.0/2", "128.0.0.0/2", "192.0.0.0/2"])
+}
+
+# Le cas que j'avais d'abord déclaré hors de portée : 512 plages plus étroites que le
+# seuil, dont l'union couvre tout. `net.cidr_merge` les collapse en `0.0.0.0/0`.
+test_the_union_of_narrower_ranges_is_unrestricted if {
+	# Un TABLEAU, comme le modèle normalisé le porte : `cidr_list` ne convertit qu'un
+	# tableau ou un scalaire, et lui passer un ensemble rendait ce test vide — donc
+	# vert pour la mauvaise raison, ce qu'il a fait au premier essai.
+	moities := [c |
+		some a in numbers.range(0, 255)
+		some suffixe in ["0.0.0", "128.0.0"]
+		c := sprintf("%d.%s/9", [a, suffixe])
+	]
+	count(moities) == 512
+	unrestricted_source(moities)
+}
+
+# Un littéral SANS masque n'est pas un CIDR valide : la fusion le perdrait, le chemin
+# brut le garde. Les deux chemins sont nécessaires.
+test_a_maskless_literal_survives_the_merge if {
+	unrestricted_source(["0.0.0.0"])
+	unrestricted_source(["*"])
+}
+
+# Une entrée MALFORMÉE — donnée d'un tiers — ne doit pas rendre la règle muette :
+# `net.cidr_merge` y devient indéfini, et le filtrage par validité est ce qui l'évite.
+test_a_malformed_entry_does_not_silence_the_rule if {
+	unrestricted_source(["pas-un-cidr", "0.0.0.0/0"])
+}
+
+# ── Les contre-exemples tiennent aussi pour l'union ────────────────────────────
+
+# Deux moitiés d'un réseau privé fusionnent en ce réseau privé : toujours silencieux.
+test_the_union_of_two_private_halves_stays_silent if {
+	not unrestricted_source(["10.0.0.0/9", "10.128.0.0/9"])
+}
+
+test_a_list_of_partner_networks_stays_silent if {
+	not unrestricted_source(["203.0.113.0/24", "198.51.100.0/24", "10.42.0.0/16"])
+}


### PR DESCRIPTION
> **Faux négatif silencieux, mesuré sur un tenant réel.** Pour un outil dont c'est la
> raison d'être, c'est le pire défaut disponible.

## Le défaut

`is_public_cidr` ne jugeait publique qu'une plage de préfixe **≤ 1**. Or quatre plages
`/2` couvrent tout l'espace IPv4 :

```
0.0.0.0/2, 64.0.0.0/2, 128.0.0.0/2, 192.0.0.0/2
```

**RDP ouvert à tout Internet, et le rapport muet** — pendant que
`tcp 22 [0.0.0.0/1, 128.0.0.0/1]` du **même groupe de sécurité** était bien attrapé. Un
`/3`, ou une liste de `/8`, passaient de même.

## Le correctif

Une source est non restreinte quand **les deux** conditions tiennent : la plage est
**large** (préfixe ≤ 8, soit 16,7 millions d'adresses) **et** elle n'est pas privée.

La seconde n'est pas décorative : c'est elle qui garde le contre-exemple que ce contrôle
ne doit **jamais** perdre — `10.0.0.0/8` est un `/8`, et il reste silencieux.

| Source | Avant | Après |
|---|---|---|
| `0.0.0.0/2` · `64.0.0.0/2` · … | **muet** | signalé |
| `0.0.0.0/3` | **muet** | signalé |
| `1.0.0.0/8` | **muet** | signalé |
| `0.0.0.0/0` · `/1` | signalé | signalé |
| `10.0.0.0/8` · `127.0.0.0/8` | muet | muet |
| `172.16.0.0/12` · `192.168.0.0/16` | muet | muet |
| `203.0.113.0/24` (partenaire) | muet | muet |

**Délibérément non signalé** : toute plage externe plus étroite. `203.0.113.0/24` est le
réseau d'un partenaire, externe et parfaitement légitime. *« Ouvert à Internet »* et
*« ouvert à quelqu'un d'autre que moi »* sont deux affirmations différentes, et seule la
première est ce que ces contrôles mesurent. Élargir à toute plage externe échangerait un
faux négatif contre une pluie de faux positifs — et un outil bruyant finit désactivé.

## Mon premier essai a cassé 24 tests, et la raison mérite d'être gardée

J'avais traité `0.x` comme privé sur le **seul octet de tête**, ce qui rendait muet
`0.0.0.0/0` lui-même. Une plage n'est privée que si elle est **contenue** dans le bloc
privé, donc le préfixe doit valoir exactement 8 : c'est ce qui sépare `0.0.0.0/8`
(« ce réseau », silencieux) de `0.0.0.0/2` (un quart d'Internet).

## L'union est fermée aussi, et j'avais eu tort de dire l'inverse

J'avais écrit qu'une union de plages plus étroites que le seuil — 512 `/9` — « demanderait
une arithmétique d'intervalles que le Rego rend coûteuse ». **C'était une supposition non
vérifiée, et elle était fausse** : OPA fournit `net.cidr_merge`, qui collapse un ensemble
de CIDR en sa plus petite couverture équivalente.

Mesuré : les 512 `/9` que j'avais déclarés hors de portée deviennent `{"0.0.0.0/0"}` en un
appel, en moins d'une milliseconde.

La liste de sources d'une règle est donc **fusionnée avant d'être jugée**, et les quatre
contrôles qui lisent des CIDR passent par le même chemin — en laisser trois sur l'ancien
aurait laissé le trou ouvert ailleurs.

**Les deux chemins coexistent, et chacun a sa raison :**

- les entrées **brutes** portent les littéraux sans masque (`0.0.0.0`, `*`), que
  `net.cidr_is_valid` rejette et que la fusion perdrait ;
- les entrées **fusionnées** portent l'union, qu'aucune entrée brute ne montre.

Et seules les entrées **valides** sont fusionnées — ce n'est pas de la prudence de
principe : `net.cidr_merge` devient **indéfini** sur une entrée malformée (mesuré), ce qui
rendrait la règle muette sur une donnée de tiers, c'est-à-dire produirait le faux négatif
exact que ce correctif ferme.

Le helper rend l'**ensemble fautif** plutôt qu'un booléen, parce que les messages nomment
la plage en cause : une règle qui dirait « ouvert à Internet » sans dire par où laisserait
l'opérateur chercher. Une union fautive s'y nomme par sa forme fusionnée — `0.0.0.0/0` —
ce qui est précisément ce qu'il faut lire pour comprendre que quatre `/2` se recouvrent.

## Un de mes tests était vert pour la mauvaise raison

Il passait un **ensemble** là où le modèle passe un tableau ; `cidr_list` ne convertit
qu'un tableau ou un scalaire, donc le test était vide. Il vérifie maintenant sa propre
taille avant d'affirmer quoi que ce soit.

## Portes

312/312 tests Rego, contre-exemples compris. **0 mouvement de verdict** sur les 19
fixtures.

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
