### PR TITLE
fix(report): a scan that measured nothing does not render as compliant

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -63,6 +63,16 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Un scan qui n'a rien mesuré ne se rend plus comme conforme.** Une coche verte,
+  « Aucun écart sur le périmètre audité » et quatre compteurs à zéro s'imprimaient
+  immédiatement au-dessus d'un verdict `INDÉTERMINÉ`. Trois signaux littéralement vrais
+  et collectivement trompeurs : « aucun écart trouvé » et « rien n'a été regardé » se
+  rendaient à l'identique. Le code de sortie était déjà 3, donc l'automatisation se
+  comportait correctement — le mode d'échec était la personne qui survole un terminal,
+  ou la capture collée dans un ticket. Le marqueur est désormais neutre, la ligne nomme
+  la cause, et les compteurs sont tus. Un scan réellement conforme garde les trois, et
+  le test le vérifie aussi : rendre les deux cas identiques n'aurait fait que déplacer
+  la confusion.
 - **La description racine nomme les fournisseurs qui existent.** La première phrase
   qu'un nouvel utilisateur lit annonçait OVH — une entrée de feuille de route, pas un
   fournisseur — et omettait Kubernetes, qui en est un. La liste est désormais dérivée du

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,15 @@ belongs in `git log`.
 
 ### Fixed
 
+- **A scan that measured nothing no longer renders as compliant.** A green tick,
+  "No deviations found in the audited scope" and four severity counters at zero were
+  printed immediately above a verdict saying `INDÉTERMINÉ`. Three signals literally true
+  and collectively misleading: "no deviation was found" and "nothing was looked at"
+  rendered identically. The exit code was already 3, so automation behaved correctly —
+  the failure mode was the person skimming a terminal, or the screenshot pasted into a
+  ticket. The marker is now neutral, the line names the cause, and the counters are
+  omitted. A genuinely compliant scan keeps all three, and the test asserts that too:
+  making the two cases identical would only have moved the confusion.
 - **The root description names the providers that exist.** The first sentence a new
   user reads advertised OVH — a roadmap entry, not a provider — and omitted Kubernetes,
   which is one. The list is now derived from the registry: a copied list goes stale at

--- a/cmd/args_test.go
+++ b/cmd/args_test.go
@@ -213,3 +213,51 @@ func TestAnUnknownFormatIsRefused(t *testing.T) {
 		}
 	}
 }
+
+// TestNothingMeasuredNeverRendersAsCompliant — l'issue #158.
+//
+// Quand rien n'a pu être mesuré, le rapport montrait une coche VERTE, « aucun écart sur
+// le périmètre audité », et quatre compteurs à zéro — immédiatement au-dessus d'un
+// verdict INDÉTERMINÉ qui disait l'inverse. Trois signaux littéralement vrais et
+// collectivement trompeurs.
+//
+// Le mode d'échec est HUMAIN, pas machine : le code de sortie était déjà 3, et une
+// automatisation se comportait correctement. C'est la personne qui survole un terminal,
+// ou la capture collée dans un ticket, qui voit une coche et une rangée de zéros.
+//
+// Les deux sens sont éprouvés. Un cas RÉELLEMENT conforme doit garder sa coche : une
+// correction qui les rendrait identiques n'aurait fait que déplacer la confusion.
+func TestNothingMeasuredNeverRendersAsCompliant(t *testing.T) {
+	bin := buildPepin(t)
+
+	// Rien de mesuré : un plan dont aucune ressource n'entre dans un contrôle.
+	vide, _ := runPepin(t, bin, []string{"LANG=fr_FR.UTF-8"},
+		"scan", "scaleway", "--terraform", "references/tenants/scaleway/kubic/plan.json")
+	if strings.Contains(vide, "✓") {
+		t.Error("la coche verte subsiste alors que rien n'a été mesuré : c'est ce que l'œil retient")
+	}
+	if strings.Contains(vide, "Aucun écart") {
+		t.Error("« aucun écart » subsiste alors que rien n'a été regardé")
+	}
+	if strings.Contains(vide, "CRITICAL") {
+		t.Error("les compteurs subsistent : quatre zéros se lisent comme un feu vert")
+	}
+	if !strings.Contains(vide, "Aucun contrôle n'a pu être mesuré") {
+		t.Errorf("le rendu ne nomme pas la cause :\n%s", vide)
+	}
+	// Le code de sortie et le rendu doivent dire la MÊME chose : c'est leur divergence
+	// qui faisait le défaut.
+	if code := exitCodeOfArgs(t, bin, "scan", "scaleway", "--terraform",
+		"references/tenants/scaleway/kubic/plan.json"); code != exitStrict {
+		t.Errorf("code %d, attendu %d : le rendu et la porte ne disent plus la même chose", code, exitStrict)
+	}
+
+	// Et le cas RÉELLEMENT conforme garde tout ce qui le distingue.
+	ok, _ := runPepin(t, bin, []string{"LANG=fr_FR.UTF-8"},
+		"scan", "scaleway", "examples/scaleway/inventory-ok.json")
+	for _, want := range []string{"✓", "Aucun écart", "CRITICAL"} {
+		if !strings.Contains(ok, want) {
+			t.Errorf("le cas conforme a perdu %q : la correction a rendu les deux cas identiques", want)
+		}
+	}
+}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -286,6 +286,12 @@ var scanCmd = &cobra.Command{
 		res := scoring.Summarize(deviations)
 		gate := scoring.Summarize(open)
 		opts.SummaryHeadline = verdictHeadline(res, gate, asmt, exReport, asmt.Run.Source, len(degraded), len(cfg.Relaxations))
+		// RIEN n'a été mesuré. Le rendu et le code de sortie tirent la même conclusion
+		// du MÊME calcul : deux conditions écrites séparément finiraient par diverger,
+		// et celle qui divergerait serait celle qu'on lit — une coche verte au-dessus
+		// d'un verdict INDÉTERMINÉ, ce qui est exactement le défaut corrigé ici.
+		rienMesure := evaluatedNonGov(asmt) == 0
+		opts.Inconclusive = rienMesure
 
 		switch scanFormat {
 		case "json":
@@ -331,7 +337,7 @@ var scanCmd = &cobra.Command{
 		// rien de la posture : identifiants expirés, droits insuffisants, région vide ou
 		// inventaire tronqué rendraient une porte de CI verte sur un périmètre jamais regardé.
 		// Le bandeau annonce déjà « INDÉTERMINÉ » dans ce cas — le code de sortie doit le suivre.
-		if evaluatedNonGov(asmt) == 0 {
+		if rienMesure {
 			os.Exit(exitStrict)
 		}
 		// Un écart critical/high MIS DE CÔTÉ par le profil : jamais 0. Le scan a
@@ -1455,9 +1461,15 @@ func scanReportOptions(provName, path string) screport.Options {
 		// traduction inachevée et dessert le contenu. Le vocabulaire vit ICI :
 		// scankit n'a pas à connaître les langues de ses consommateurs (§9).
 		Labels: screport.Labels{
-			Mode:            tr("Mode", "Mode"),
-			Source:          tr("Source", "Source"),
-			NoDeviations:    tr("Aucun écart sur le périmètre audité.", "No deviations found in the audited scope."),
+			Mode:         tr("Mode", "Mode"),
+			Source:       tr("Source", "Source"),
+			NoDeviations: tr("Aucun écart sur le périmètre audité.", "No deviations found in the audited scope."),
+			// Il NOMME la cause. « Aucun écart » et « rien de mesuré » se lisent pareil,
+			// et c'est précisément ce qu'il faut séparer : le verdict placé dessous dit
+			// déjà les bons mots, le bloc au-dessus le contredisait.
+			NothingMeasured: tr(
+				"Aucun contrôle n'a pu être mesuré : le périmètre évalué est vide ou n'a pas été collecté.",
+				"No control could be measured: the evaluated scope is empty or was not collected."),
 			ImmediateAction: tr("⚡ Action immédiate — les %d écarts les plus graves", "⚡ Immediate action — top %d most severe deviations"),
 			TotalDeviations: tr("Écarts au total :", "Total deviations:"),
 			Details:         tr("Détail :", "Details:"),

--- a/docs/reference/exit-codes.fr.md
+++ b/docs/reference/exit-codes.fr.md
@@ -133,11 +133,11 @@ qu'il faille demander `--strict`.
 ```console
 $ ./pepin scan scaleway empty-inventory.json
 […]
+──────────────────────────────────────────────────────────────────────────────
  Synthèse
 
  Verdict : INDÉTERMINÉ — aucun contrôle mesuré sur des ressources (le périmètre évalué est vide ou non collecté)
 
- 🔴 CRITICAL 0   🟠 HIGH 0   🟡 MEDIUM 0   🔵 LOW 0
 ──────────────────────────────────────────────────────────────────────────────
 $ echo $?
 3

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -132,11 +132,11 @@ for `--strict`.
 ```console
 $ ./pepin scan scaleway empty-inventory.json
 […]
+──────────────────────────────────────────────────────────────────────────────
  Summary
 
  Verdict: UNDETERMINED — no control measured on any resource (the assessed scope is empty or was not collected)
 
- 🔴 CRITICAL 0   🟠 HIGH 0   🟡 MEDIUM 0   🔵 LOW 0
 ──────────────────────────────────────────────────────────────────────────────
 $ echo $?
 3

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/sirupsen/logrus v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10
-	github.com/stephrobert/scankit v0.3.2
+	github.com/stephrobert/scankit v0.3.3
 	github.com/tchap/go-patricia/v2 v2.3.3 // indirect
 	github.com/valyala/fastjson v1.6.10 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.36 // indirect

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stephrobert/scankit v0.3.2 h1:KcQbCdM3Lx32ABKnZX0Le3jWmmedFdn6FjTQaSi4Hn4=
-github.com/stephrobert/scankit v0.3.2/go.mod h1:ujhvahsG9HgtJC75QBgVsKRhepGvdo9Ey6RtJ6va6lM=
+github.com/stephrobert/scankit v0.3.3 h1:kXEUIgXb+0/DwC0pMANyb3tlPcEDhOx6MI5d1C/nr2M=
+github.com/stephrobert/scankit v0.3.3/go.mod h1:ujhvahsG9HgtJC75QBgVsKRhepGvdo9Ey6RtJ6va6lM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=


### PR DESCRIPTION
## Le défaut

```
  ✓ Aucun écart sur le périmètre audité.
──────────────────────────────────────────────
 Synthèse
 Verdict : INDÉTERMINÉ — aucun contrôle mesuré sur des ressources
 🔴 CRITICAL 0   🟠 HIGH 0   🟡 MEDIUM 0   🔵 LOW 0
```

Une coche **verte**, « aucun écart », et quatre compteurs à zéro — immédiatement au-dessus
d'un verdict qui dit l'inverse. **Trois signaux littéralement vrais et collectivement
trompeurs** : « aucun écart trouvé » et « rien n'a été regardé » se rendaient à
l'identique.

## Ce qui était déjà juste, et que la présentation desservait

Le comportement en dessous est ce que ce produit a de meilleur : refuser de dire
« conforme » quand rien n'a été mesuré, et porter ce refus jusque dans un code de sortie
dédié. Le verdict disait déjà les bons mots.

**Le mode d'échec est une personne, pas un script.** L'automatisation lit le code 3 et se
comporte correctement. C'est l'humain qui survole un terminal, ou la capture collée dans
un ticket, qui voit une coche et une rangée de zéros et s'arrête là.

## Après

```
  ○ Aucun contrôle n'a pu être mesuré : le périmètre évalué est vide ou n'a pas été collecté.
──────────────────────────────────────────────
 Synthèse
 Verdict : INDÉTERMINÉ — aucun contrôle mesuré sur des ressources
```

## Où le correctif vit

Le rendu est partagé, donc la capacité est arrivée dans **scankit 0.3.3**
([PR #29](https://github.com/stephrobert/scankit/pull/29)) sous `Options.Inconclusive` :
la distinction entre « rien trouvé » et « rien inspecté » appartient à **tout** scanner,
pas à un produit. Pépin fournit le drapeau et les mots.

## Un seul calcul

Le drapeau et le code de sortie viennent désormais de **la même variable**. Deux
conditions écrites séparément finissent par diverger, et celle qui diverge est celle
qu'on lit — ce qui est *exactement* ce défaut : une coche verte au-dessus d'un verdict
INDÉTERMINÉ.

## Les deux sens sont éprouvés

Un scan **réellement conforme** garde sa coche, sa ligne et ses compteurs. Rendre les
deux cas identiques n'aurait fait que déplacer la confusion.

| | Coche | Ligne | Compteurs | Code |
|---|---|---|---|---|
| conforme | `✓` | « Aucun écart » | affichés | 0 |
| rien mesuré | `○` | nomme la cause | tus | 3 |

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
