### PR TITLE
feat(rules): measure the rotation CLD-IAM-2 asks for

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -169,6 +169,17 @@ l'une ni l'autre appartient au `git log`.
 
 ### Ajouté
 
+- **`iam_accesskey_rotated` : la moitié « rotation » de CLD-IAM-2, que rien ne
+  mesurait.** L'exigence demande des clés longue durée « assorties d'une expiration ET
+  d'une rotation ». L'expiration se lit sur un champ ; la rotation ne se lit nulle part —
+  elle se déduit de l'âge de la clé, parce qu'une clé jamais remplacée est une clé jamais
+  tournée. Mesuré sur un tenant réel : une clé expirant en 2099 satisfait le contrôle
+  d'expiration sans qu'aucune rotation n'ait eu lieu, et un compte avec
+  `MaxAccessKeyExpirationSeconds: 0` n'a aucun plafond pour la borner non plus. La
+  fenêtre est `controls.iam.key_max_age_days`, 90 jours par défaut ; l'allonger tait des
+  écarts, donc le référentiel l'adosse à l'exigence par `au_plus_le_defaut`. Schéma
+  d'inventaire v4 → v5 : une `access_key` porte désormais `creation_date` (osc-sdk-go
+  v2.24.0 `AccessKey.CreationDate`, vérifié dans le SDK).
 - **`scan --gate <all|security|compliance|sovereignty>` : un profil pour la porte de
   CI, qui ne cache rien.** Un premier scan doit provoquer « ah oui, ça c'est
   intéressant », pas « oui, je sais que ma VM de test n'a pas de protection contre la

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -63,6 +63,14 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Une clé d'accès dont l'expiration est dépassée ne compte plus comme conforme.** La
+  règle ne refusait qu'une date ABSENTE, si bien qu'une clé encore `ACTIVE` deux ans
+  après son échéance passait — mesuré sur un tenant réel. Les deux lectures de cet état
+  sont mauvaises, et c'est pourquoi le `pass` était faux : soit le fournisseur honore
+  encore la clé et l'expiration ne protège rien, soit il ne l'honore plus et une clé
+  morte reste déclarée active. Le scan n'a pas à trancher laquelle pour savoir que
+  « conforme » est faux. L'instant de référence est celui de l'ÉVALUATION, pas
+  l'horloge : le rejeu d'un bundle scellé rend donc le même verdict.
 - **Un scan qui n'a rien mesuré ne se rend plus comme conforme.** Une coche verte,
   « Aucun écart sur le périmètre audité » et quatre compteurs à zéro s'imprimaient
   immédiatement au-dessus d'un verdict `INDÉTERMINÉ`. Trois signaux littéralement vrais

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,16 @@ belongs in `git log`.
 
 ### Added
 
+- **`iam_accesskey_rotated`: the rotation half of CLD-IAM-2, which nothing measured.**
+  The requirement asks for long-lived keys "with an expiry AND a rotation". The expiry
+  reads off a field; the rotation reads nowhere — it is deduced from the key's age,
+  because a key never replaced is a key never rotated. Measured on a real tenant: a key
+  expiring in 2099 satisfies the expiry control while no rotation has ever taken place,
+  and an account with `MaxAccessKeyExpirationSeconds: 0` has no ceiling to bound it
+  either. The window is `controls.iam.key_max_age_days`, 90 days by default; widening it
+  silences deviations, so the reference binds it to the requirement through
+  `au_plus_le_defaut`. Inventory schema v4 → v5: an `access_key` now carries
+  `creation_date` (osc-sdk-go v2.24.0 `AccessKey.CreationDate`, verified in the SDK).
 - **`scan --gate <all|security|compliance|sovereignty>`: a profile for the CI gate,
   which hides nothing.** A first scan should trigger "oh, that one is interesting", not
   "yes, I know my test VM has no deletion protection". The report stays COMPLETE in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ belongs in `git log`.
 
 ### Fixed
 
+- **An access key whose expiry has already passed no longer counts as compliant.** The
+  rule only refused a MISSING date, so a key still `ACTIVE` two years past its expiry
+  passed — measured on a real tenant. Both readings of that state are bad, which is why
+  the pass was wrong: either the provider still honours the key and the expiry protects
+  nothing, or it does not and a dead key is still declared active. The scan does not
+  need to settle which to know that "compliant" is false. The reference instant is the
+  EVALUATION time, not the clock, so replaying a sealed bundle yields the same verdict.
 - **A scan that measured nothing no longer renders as compliant.** A green tick,
   "No deviations found in the audited scope" and four severity counters at zero were
   printed immediately above a verdict saying `INDÉTERMINÉ`. Three signals literally true

--- a/ROADMAP.fr.md
+++ b/ROADMAP.fr.md
@@ -35,10 +35,10 @@ Le référentiel contre lequel ils sont évalués :
 <!-- pepin:gen control-counts -->
 | Chiffre | Nombre |
 |---|---:|
-| Contrôles au référentiel | 57 |
-| Contrôles déclarés pour au moins un fournisseur | 56 |
+| Contrôles au référentiel | 58 |
+| Contrôles déclarés pour au moins un fournisseur | 57 |
 | `critical` | 10 |
-| `high` | 32 |
+| `high` | 33 |
 | `medium` | 13 |
 | `low` | 2 |
 <!-- /pepin:gen control-counts -->
@@ -73,9 +73,9 @@ déployable** : un module Terraform autonome et conforme sous `references/remedi
 |---|---:|
 | exoscale | 26 / 26 |
 | kubernetes | 0 / 4 |
-| outscale | 0 / 40 |
+| outscale | 0 / 41 |
 | scaleway | 0 / 25 |
-| **Total** | **26 / 95** |
+| **Total** | **26 / 96** |
 <!-- /pepin:gen remediation-coverage -->
 
 `mise run check-remediation` est volontairement débranché de `mise run validate` : une

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,10 +35,10 @@ The reference they are evaluated against:
 <!-- pepin:gen control-counts -->
 | Figure | Count |
 |---|---:|
-| Controls in the reference | 57 |
-| Controls declared for at least one provider | 56 |
+| Controls in the reference | 58 |
+| Controls declared for at least one provider | 57 |
 | `critical` | 10 |
-| `high` | 32 |
+| `high` | 33 |
 | `medium` | 13 |
 | `low` | 2 |
 <!-- /pepin:gen control-counts -->
@@ -71,9 +71,9 @@ compliant Terraform module under `references/remediation/`.
 |---|---:|
 | exoscale | 26 / 26 |
 | kubernetes | 0 / 4 |
-| outscale | 0 / 40 |
+| outscale | 0 / 41 |
 | scaleway | 0 / 25 |
-| **Total** | **26 / 95** |
+| **Total** | **26 / 96** |
 <!-- /pepin:gen remediation-coverage -->
 
 `mise run check-remediation` is deliberately not wired into `mise run validate`: a gate

--- a/cmd/testdata/frozen/inventory.json
+++ b/cmd/testdata/frozen/inventory.json
@@ -1,875 +1,1102 @@
 {
-  "history": [
-    {
-      "schema_version": 1,
-      "content": {
-        "envelope": {
-          "provider": "string",
-          "resources": [
-            {
-              "attributes": {
-                "*": "any"
-              },
-              "id": "string",
-              "name": "string",
-              "provenance": {
-                "*": {
-                  "derived": "boolean",
-                  "observed": "boolean",
-                  "origin": "string",
-                  "path": "string",
-                  "source": "string"
-                }
-              },
-              "provider": "string",
-              "region": "string",
-              "type": "string"
-            }
-          ]
-        },
-        "format": "pepin-inventory/v1",
-        "types": {
-          "access_key": [
-            "access_key_id",
-            "expiration_date",
-            "owner_user",
-            "scope",
-            "state"
-          ],
-          "api_access_policy": [
-            "id",
-            "max_access_key_expiration_seconds",
-            "require_trusted_env"
-          ],
-          "api_access_rule": [
-            "api_access_rule_id",
-            "ca_ids",
-            "cns",
-            "ip_ranges"
-          ],
-          "api_access_summary": [
-            "id",
-            "rule_count"
-          ],
-          "blockstorage_snapshot": [
-            "creation_date",
-            "global_permission",
-            "snapshot_id",
-            "volume_id"
-          ],
-          "blockstorage_volume": [
-            "encrypted",
-            "state",
-            "tags",
-            "volume_id"
-          ],
-          "compute_image": [
-            "image_id",
-            "public",
-            "state",
-            "tags"
-          ],
-          "compute_instance": [
-            "deletion_protection",
-            "nic_public_ips",
-            "public_ip",
-            "security_group_ids",
-            "state",
-            "tags",
-            "user_data",
-            "vm_id"
-          ],
-          "governance_provider": [
-            "capital_control",
-            "eu_established",
-            "extraterritorial_exposure",
-            "jurisdiction",
-            "secnumcloud"
-          ],
-          "iam_policy": [
-            "manages_iam",
-            "owner_group",
-            "owner_user",
-            "policy_id",
-            "policy_name",
-            "scope",
-            "statements"
-          ],
-          "iam_role": [
-            "admin_privileges",
-            "editable",
-            "manages_iam",
-            "max_session_ttl",
-            "name",
-            "policy_has_expiration",
-            "role_id",
-            "source_ip_restricted"
-          ],
-          "iam_user": [
-            "mfa_enabled",
-            "user_id",
-            "username"
-          ],
-          "k8s_cluster_role_binding": [
-            "name",
-            "role_ref",
-            "subjects"
-          ],
-          "k8s_crd": [
-            "name"
-          ],
-          "k8s_namespace": [
-            "labels",
-            "name"
-          ],
-          "k8s_network_policy": [
-            "name",
-            "namespace"
-          ],
-          "kubernetes_cluster": [
-            "admin_whitelist",
-            "audit_enabled",
-            "auto_upgrade",
-            "control_plane_multi_az",
-            "deletion_protection",
-            "name",
-            "version"
-          ],
-          "load_balancer": [
-            "access_log",
-            "listeners",
-            "load_balancer_name",
-            "load_balancer_type",
-            "tags"
-          ],
-          "managed_database": [
-            "database_id",
-            "disable_backup",
-            "encryption_at_rest",
-            "ip_filter"
-          ],
-          "network": [
-            "cidr",
-            "description",
-            "name",
-            "network_id",
-            "state",
-            "tags"
-          ],
-          "network_peering": [
-            "accepter_account",
-            "peering_id",
-            "source_account",
-            "state"
-          ],
-          "object_storage_bucket": [
-            "acl",
-            "acl_grants",
-            "default_encryption_enabled",
-            "kms_key_id",
-            "name",
-            "object_lock_enabled",
-            "policy_public",
-            "public_via_acl",
-            "sse_kms_enabled",
-            "tags",
-            "versioning"
-          ],
-          "security_group": [
-            "inbound_default_policy",
-            "security_group_id"
-          ],
-          "security_group_rule": [
-            "action",
-            "cidrs",
-            "description",
-            "direction",
-            "port_from",
-            "port_to",
-            "protocol",
-            "security_group_id",
-            "security_group_name"
-          ],
-          "subnet": [
-            "map_public_ip_on_launch",
-            "network_id",
-            "state",
-            "subnet_id",
-            "tags"
-          ]
+ "history": [
+  {
+   "content": {
+    "envelope": {
+     "provider": "string",
+     "resources": [
+      {
+       "attributes": {
+        "*": "any"
+       },
+       "id": "string",
+       "name": "string",
+       "provenance": {
+        "*": {
+         "derived": "boolean",
+         "observed": "boolean",
+         "origin": "string",
+         "path": "string",
+         "source": "string"
         }
+       },
+       "provider": "string",
+       "region": "string",
+       "type": "string"
       }
+     ]
     },
-    {
-      "schema_version": 2,
-      "content": {
-        "envelope": {
-          "collection": {
-            "units": [
-              {
-                "attempted": "boolean",
-                "complete": "boolean",
-                "detail": "string",
-                "error": "string",
-                "types": [
-                  "string"
-                ],
-                "unit": "string"
-              }
-            ],
-            "unmapped": [
-              {
-                "count": "number",
-                "type": "string"
-              }
-            ]
-          },
-          "provider": "string",
-          "resources": [
-            {
-              "attributes": {
-                "*": "any"
-              },
-              "id": "string",
-              "name": "string",
-              "provenance": {
-                "*": {
-                  "derived": "boolean",
-                  "observed": "boolean",
-                  "origin": "string",
-                  "path": "string",
-                  "source": "string"
-                }
-              },
-              "provider": "string",
-              "region": "string",
-              "type": "string"
-            }
-          ]
-        },
-        "format": "pepin-inventory/v2",
-        "types": {
-          "access_key": [
-            "access_key_id",
-            "expiration_date",
-            "owner_user",
-            "scope",
-            "state"
-          ],
-          "api_access_policy": [
-            "id",
-            "max_access_key_expiration_seconds",
-            "require_trusted_env"
-          ],
-          "api_access_rule": [
-            "api_access_rule_id",
-            "ca_ids",
-            "cns",
-            "ip_ranges"
-          ],
-          "api_access_summary": [
-            "id",
-            "rule_count"
-          ],
-          "blockstorage_snapshot": [
-            "creation_date",
-            "global_permission",
-            "snapshot_id",
-            "volume_id"
-          ],
-          "blockstorage_volume": [
-            "encrypted",
-            "state",
-            "tags",
-            "volume_id"
-          ],
-          "compute_image": [
-            "image_id",
-            "public",
-            "state",
-            "tags"
-          ],
-          "compute_instance": [
-            "deletion_protection",
-            "nic_public_ips",
-            "public_ip",
-            "security_group_ids",
-            "state",
-            "tags",
-            "user_data",
-            "vm_id"
-          ],
-          "governance_provider": [
-            "capital_control",
-            "eu_established",
-            "extraterritorial_exposure",
-            "jurisdiction",
-            "secnumcloud"
-          ],
-          "iam_policy": [
-            "manages_iam",
-            "owner_group",
-            "owner_user",
-            "policy_id",
-            "policy_name",
-            "scope",
-            "statements"
-          ],
-          "iam_role": [
-            "admin_privileges",
-            "editable",
-            "manages_iam",
-            "max_session_ttl",
-            "name",
-            "policy_has_expiration",
-            "role_id",
-            "source_ip_restricted"
-          ],
-          "iam_user": [
-            "mfa_enabled",
-            "user_id",
-            "username"
-          ],
-          "k8s_cluster_role_binding": [
-            "name",
-            "role_ref",
-            "subjects"
-          ],
-          "k8s_crd": [
-            "name"
-          ],
-          "k8s_namespace": [
-            "labels",
-            "name"
-          ],
-          "k8s_network_policy": [
-            "name",
-            "namespace"
-          ],
-          "kubernetes_cluster": [
-            "admin_whitelist",
-            "audit_enabled",
-            "auto_upgrade",
-            "control_plane_multi_az",
-            "deletion_protection",
-            "name",
-            "version"
-          ],
-          "load_balancer": [
-            "access_log",
-            "listeners",
-            "load_balancer_name",
-            "load_balancer_type",
-            "tags"
-          ],
-          "managed_database": [
-            "database_id",
-            "disable_backup",
-            "encryption_at_rest",
-            "ip_filter"
-          ],
-          "network": [
-            "cidr",
-            "description",
-            "name",
-            "network_id",
-            "state",
-            "tags"
-          ],
-          "network_peering": [
-            "accepter_account",
-            "peering_id",
-            "source_account",
-            "state"
-          ],
-          "object_storage_bucket": [
-            "acl",
-            "acl_grants",
-            "default_encryption_enabled",
-            "kms_key_id",
-            "name",
-            "object_lock_enabled",
-            "policy_public",
-            "public_via_acl",
-            "sse_kms_enabled",
-            "tags",
-            "versioning"
-          ],
-          "security_group": [
-            "inbound_default_policy",
-            "security_group_id"
-          ],
-          "security_group_rule": [
-            "action",
-            "cidrs",
-            "description",
-            "direction",
-            "port_from",
-            "port_to",
-            "protocol",
-            "security_group_id",
-            "security_group_name"
-          ],
-          "subnet": [
-            "map_public_ip_on_launch",
-            "network_id",
-            "state",
-            "subnet_id",
-            "tags"
-          ]
-        }
-      }
-    },
-    {
-      "schema_version": 3,
-      "content": {
-        "envelope": {
-          "collection": {
-            "units": [
-              {
-                "attempted": "boolean",
-                "complete": "boolean",
-                "detail": "string",
-                "error": "string",
-                "types": [
-                  "string"
-                ],
-                "unit": "string"
-              }
-            ],
-            "unmapped": [
-              {
-                "count": "number",
-                "type": "string"
-              }
-            ]
-          },
-          "provider": "string",
-          "resources": [
-            {
-              "attributes": {
-                "*": "any"
-              },
-              "id": "string",
-              "name": "string",
-              "provenance": {
-                "*": {
-                  "derived": "boolean",
-                  "observed": "boolean",
-                  "origin": "string",
-                  "path": "string",
-                  "source": "string"
-                }
-              },
-              "provider": "string",
-              "region": "string",
-              "source": {
-                "file": "string",
-                "line": "number",
-                "module": "string"
-              },
-              "type": "string"
-            }
-          ]
-        },
-        "format": "pepin-inventory/v3",
-        "types": {
-          "access_key": [
-            "access_key_id",
-            "expiration_date",
-            "owner_user",
-            "scope",
-            "state"
-          ],
-          "api_access_policy": [
-            "id",
-            "max_access_key_expiration_seconds",
-            "require_trusted_env"
-          ],
-          "api_access_rule": [
-            "api_access_rule_id",
-            "ca_ids",
-            "cns",
-            "ip_ranges"
-          ],
-          "api_access_summary": [
-            "id",
-            "rule_count"
-          ],
-          "blockstorage_snapshot": [
-            "creation_date",
-            "global_permission",
-            "snapshot_id",
-            "volume_id"
-          ],
-          "blockstorage_volume": [
-            "encrypted",
-            "state",
-            "tags",
-            "volume_id"
-          ],
-          "compute_image": [
-            "image_id",
-            "public",
-            "state",
-            "tags"
-          ],
-          "compute_instance": [
-            "deletion_protection",
-            "nic_public_ips",
-            "public_ip",
-            "security_group_ids",
-            "state",
-            "tags",
-            "user_data",
-            "vm_id"
-          ],
-          "governance_provider": [
-            "capital_control",
-            "eu_established",
-            "extraterritorial_exposure",
-            "jurisdiction",
-            "secnumcloud"
-          ],
-          "iam_policy": [
-            "manages_iam",
-            "owner_group",
-            "owner_user",
-            "policy_id",
-            "policy_name",
-            "scope",
-            "statements"
-          ],
-          "iam_role": [
-            "admin_privileges",
-            "editable",
-            "manages_iam",
-            "max_session_ttl",
-            "name",
-            "policy_has_expiration",
-            "role_id",
-            "source_ip_restricted"
-          ],
-          "iam_user": [
-            "mfa_enabled",
-            "user_id",
-            "username"
-          ],
-          "k8s_cluster_role_binding": [
-            "name",
-            "role_ref",
-            "subjects"
-          ],
-          "k8s_crd": [
-            "name"
-          ],
-          "k8s_namespace": [
-            "labels",
-            "name"
-          ],
-          "k8s_network_policy": [
-            "name",
-            "namespace"
-          ],
-          "kubernetes_cluster": [
-            "admin_whitelist",
-            "audit_enabled",
-            "auto_upgrade",
-            "control_plane_multi_az",
-            "deletion_protection",
-            "name",
-            "version"
-          ],
-          "load_balancer": [
-            "access_log",
-            "listeners",
-            "load_balancer_name",
-            "load_balancer_type",
-            "tags"
-          ],
-          "managed_database": [
-            "database_id",
-            "disable_backup",
-            "encryption_at_rest",
-            "ip_filter"
-          ],
-          "network": [
-            "cidr",
-            "description",
-            "name",
-            "network_id",
-            "state",
-            "tags"
-          ],
-          "network_peering": [
-            "accepter_account",
-            "peering_id",
-            "source_account",
-            "state"
-          ],
-          "object_storage_bucket": [
-            "acl",
-            "acl_grants",
-            "default_encryption_enabled",
-            "kms_key_id",
-            "name",
-            "object_lock_enabled",
-            "policy_public",
-            "public_via_acl",
-            "sse_kms_enabled",
-            "tags",
-            "versioning"
-          ],
-          "security_group": [
-            "inbound_default_policy",
-            "security_group_id"
-          ],
-          "security_group_rule": [
-            "action",
-            "cidrs",
-            "description",
-            "direction",
-            "port_from",
-            "port_to",
-            "protocol",
-            "security_group_id",
-            "security_group_name"
-          ],
-          "subnet": [
-            "map_public_ip_on_launch",
-            "network_id",
-            "state",
-            "subnet_id",
-            "tags"
-          ]
-        }
-      }
-    },
-    {
-      "schema_version": 4,
-      "content": {
-        "envelope": {
-          "collection": {
-            "units": [
-              {
-                "attempted": "boolean",
-                "complete": "boolean",
-                "detail": "string",
-                "error": "string",
-                "types": [
-                  "string"
-                ],
-                "unit": "string"
-              }
-            ],
-            "unmapped": [
-              {
-                "count": "number",
-                "type": "string"
-              }
-            ]
-          },
-          "provider": "string",
-          "resources": [
-            {
-              "attributes": {
-                "*": "any"
-              },
-              "id": "string",
-              "name": "string",
-              "provenance": {
-                "*": {
-                  "derived": "boolean",
-                  "observed": "boolean",
-                  "origin": "string",
-                  "path": "string",
-                  "source": "string"
-                }
-              },
-              "provider": "string",
-              "region": "string",
-              "source": {
-                "file": "string",
-                "line": "number",
-                "module": "string"
-              },
-              "type": "string"
-            }
-          ]
-        },
-        "format": "pepin-inventory/v4",
-        "types": {
-          "access_key": [
-            "access_key_id",
-            "expiration_date",
-            "owner_user",
-            "scope",
-            "state"
-          ],
-          "api_access_policy": [
-            "id",
-            "max_access_key_expiration_seconds",
-            "require_trusted_env"
-          ],
-          "api_access_rule": [
-            "api_access_rule_id",
-            "ca_ids",
-            "cns",
-            "ip_ranges"
-          ],
-          "api_access_summary": [
-            "id",
-            "rule_count"
-          ],
-          "blockstorage_snapshot": [
-            "creation_date",
-            "global_permission",
-            "snapshot_id",
-            "state",
-            "volume_id"
-          ],
-          "blockstorage_volume": [
-            "encrypted",
-            "state",
-            "tags",
-            "volume_id"
-          ],
-          "compute_image": [
-            "image_id",
-            "public",
-            "state",
-            "tags"
-          ],
-          "compute_instance": [
-            "deletion_protection",
-            "nic_public_ips",
-            "public_ip",
-            "security_group_ids",
-            "state",
-            "tags",
-            "user_data",
-            "vm_id"
-          ],
-          "governance_provider": [
-            "capital_control",
-            "eu_established",
-            "extraterritorial_exposure",
-            "jurisdiction",
-            "secnumcloud"
-          ],
-          "iam_policy": [
-            "manages_iam",
-            "owner_group",
-            "owner_user",
-            "policy_id",
-            "policy_name",
-            "scope",
-            "statements"
-          ],
-          "iam_role": [
-            "admin_privileges",
-            "editable",
-            "manages_iam",
-            "max_session_ttl",
-            "name",
-            "policy_has_expiration",
-            "role_id",
-            "source_ip_restricted"
-          ],
-          "iam_user": [
-            "mfa_enabled",
-            "user_id",
-            "username"
-          ],
-          "k8s_cluster_role_binding": [
-            "name",
-            "role_ref",
-            "subjects"
-          ],
-          "k8s_crd": [
-            "name"
-          ],
-          "k8s_namespace": [
-            "labels",
-            "name"
-          ],
-          "k8s_network_policy": [
-            "name",
-            "namespace"
-          ],
-          "kubernetes_cluster": [
-            "admin_whitelist",
-            "audit_enabled",
-            "auto_upgrade",
-            "control_plane_multi_az",
-            "deletion_protection",
-            "name",
-            "version"
-          ],
-          "load_balancer": [
-            "access_log",
-            "listeners",
-            "load_balancer_name",
-            "load_balancer_type",
-            "tags"
-          ],
-          "managed_database": [
-            "database_id",
-            "disable_backup",
-            "encryption_at_rest",
-            "ip_filter"
-          ],
-          "network": [
-            "cidr",
-            "description",
-            "name",
-            "network_id",
-            "state",
-            "tags"
-          ],
-          "network_peering": [
-            "accepter_account",
-            "peering_id",
-            "source_account",
-            "state"
-          ],
-          "object_storage_bucket": [
-            "acl",
-            "acl_grants",
-            "default_encryption_enabled",
-            "kms_key_id",
-            "name",
-            "object_lock_enabled",
-            "policy_public",
-            "public_via_acl",
-            "sse_kms_enabled",
-            "tags",
-            "versioning"
-          ],
-          "security_group": [
-            "inbound_default_policy",
-            "security_group_id"
-          ],
-          "security_group_rule": [
-            "action",
-            "cidrs",
-            "description",
-            "direction",
-            "port_from",
-            "port_to",
-            "protocol",
-            "security_group_id",
-            "security_group_name"
-          ],
-          "subnet": [
-            "map_public_ip_on_launch",
-            "network_id",
-            "state",
-            "subnet_id",
-            "tags"
-          ]
-        }
-      }
+    "format": "pepin-inventory/v1",
+    "types": {
+     "access_key": [
+      "access_key_id",
+      "expiration_date",
+      "owner_user",
+      "scope",
+      "state"
+     ],
+     "api_access_policy": [
+      "id",
+      "max_access_key_expiration_seconds",
+      "require_trusted_env"
+     ],
+     "api_access_rule": [
+      "api_access_rule_id",
+      "ca_ids",
+      "cns",
+      "ip_ranges"
+     ],
+     "api_access_summary": [
+      "id",
+      "rule_count"
+     ],
+     "blockstorage_snapshot": [
+      "creation_date",
+      "global_permission",
+      "snapshot_id",
+      "volume_id"
+     ],
+     "blockstorage_volume": [
+      "encrypted",
+      "state",
+      "tags",
+      "volume_id"
+     ],
+     "compute_image": [
+      "image_id",
+      "public",
+      "state",
+      "tags"
+     ],
+     "compute_instance": [
+      "deletion_protection",
+      "nic_public_ips",
+      "public_ip",
+      "security_group_ids",
+      "state",
+      "tags",
+      "user_data",
+      "vm_id"
+     ],
+     "governance_provider": [
+      "capital_control",
+      "eu_established",
+      "extraterritorial_exposure",
+      "jurisdiction",
+      "secnumcloud"
+     ],
+     "iam_policy": [
+      "manages_iam",
+      "owner_group",
+      "owner_user",
+      "policy_id",
+      "policy_name",
+      "scope",
+      "statements"
+     ],
+     "iam_role": [
+      "admin_privileges",
+      "editable",
+      "manages_iam",
+      "max_session_ttl",
+      "name",
+      "policy_has_expiration",
+      "role_id",
+      "source_ip_restricted"
+     ],
+     "iam_user": [
+      "mfa_enabled",
+      "user_id",
+      "username"
+     ],
+     "k8s_cluster_role_binding": [
+      "name",
+      "role_ref",
+      "subjects"
+     ],
+     "k8s_crd": [
+      "name"
+     ],
+     "k8s_namespace": [
+      "labels",
+      "name"
+     ],
+     "k8s_network_policy": [
+      "name",
+      "namespace"
+     ],
+     "kubernetes_cluster": [
+      "admin_whitelist",
+      "audit_enabled",
+      "auto_upgrade",
+      "control_plane_multi_az",
+      "deletion_protection",
+      "name",
+      "version"
+     ],
+     "load_balancer": [
+      "access_log",
+      "listeners",
+      "load_balancer_name",
+      "load_balancer_type",
+      "tags"
+     ],
+     "managed_database": [
+      "database_id",
+      "disable_backup",
+      "encryption_at_rest",
+      "ip_filter"
+     ],
+     "network": [
+      "cidr",
+      "description",
+      "name",
+      "network_id",
+      "state",
+      "tags"
+     ],
+     "network_peering": [
+      "accepter_account",
+      "peering_id",
+      "source_account",
+      "state"
+     ],
+     "object_storage_bucket": [
+      "acl",
+      "acl_grants",
+      "default_encryption_enabled",
+      "kms_key_id",
+      "name",
+      "object_lock_enabled",
+      "policy_public",
+      "public_via_acl",
+      "sse_kms_enabled",
+      "tags",
+      "versioning"
+     ],
+     "security_group": [
+      "inbound_default_policy",
+      "security_group_id"
+     ],
+     "security_group_rule": [
+      "action",
+      "cidrs",
+      "description",
+      "direction",
+      "port_from",
+      "port_to",
+      "protocol",
+      "security_group_id",
+      "security_group_name"
+     ],
+     "subnet": [
+      "map_public_ip_on_launch",
+      "network_id",
+      "state",
+      "subnet_id",
+      "tags"
+     ]
     }
-  ]
+   },
+   "schema_version": 1
+  },
+  {
+   "content": {
+    "envelope": {
+     "collection": {
+      "units": [
+       {
+        "attempted": "boolean",
+        "complete": "boolean",
+        "detail": "string",
+        "error": "string",
+        "types": [
+         "string"
+        ],
+        "unit": "string"
+       }
+      ],
+      "unmapped": [
+       {
+        "count": "number",
+        "type": "string"
+       }
+      ]
+     },
+     "provider": "string",
+     "resources": [
+      {
+       "attributes": {
+        "*": "any"
+       },
+       "id": "string",
+       "name": "string",
+       "provenance": {
+        "*": {
+         "derived": "boolean",
+         "observed": "boolean",
+         "origin": "string",
+         "path": "string",
+         "source": "string"
+        }
+       },
+       "provider": "string",
+       "region": "string",
+       "type": "string"
+      }
+     ]
+    },
+    "format": "pepin-inventory/v2",
+    "types": {
+     "access_key": [
+      "access_key_id",
+      "expiration_date",
+      "owner_user",
+      "scope",
+      "state"
+     ],
+     "api_access_policy": [
+      "id",
+      "max_access_key_expiration_seconds",
+      "require_trusted_env"
+     ],
+     "api_access_rule": [
+      "api_access_rule_id",
+      "ca_ids",
+      "cns",
+      "ip_ranges"
+     ],
+     "api_access_summary": [
+      "id",
+      "rule_count"
+     ],
+     "blockstorage_snapshot": [
+      "creation_date",
+      "global_permission",
+      "snapshot_id",
+      "volume_id"
+     ],
+     "blockstorage_volume": [
+      "encrypted",
+      "state",
+      "tags",
+      "volume_id"
+     ],
+     "compute_image": [
+      "image_id",
+      "public",
+      "state",
+      "tags"
+     ],
+     "compute_instance": [
+      "deletion_protection",
+      "nic_public_ips",
+      "public_ip",
+      "security_group_ids",
+      "state",
+      "tags",
+      "user_data",
+      "vm_id"
+     ],
+     "governance_provider": [
+      "capital_control",
+      "eu_established",
+      "extraterritorial_exposure",
+      "jurisdiction",
+      "secnumcloud"
+     ],
+     "iam_policy": [
+      "manages_iam",
+      "owner_group",
+      "owner_user",
+      "policy_id",
+      "policy_name",
+      "scope",
+      "statements"
+     ],
+     "iam_role": [
+      "admin_privileges",
+      "editable",
+      "manages_iam",
+      "max_session_ttl",
+      "name",
+      "policy_has_expiration",
+      "role_id",
+      "source_ip_restricted"
+     ],
+     "iam_user": [
+      "mfa_enabled",
+      "user_id",
+      "username"
+     ],
+     "k8s_cluster_role_binding": [
+      "name",
+      "role_ref",
+      "subjects"
+     ],
+     "k8s_crd": [
+      "name"
+     ],
+     "k8s_namespace": [
+      "labels",
+      "name"
+     ],
+     "k8s_network_policy": [
+      "name",
+      "namespace"
+     ],
+     "kubernetes_cluster": [
+      "admin_whitelist",
+      "audit_enabled",
+      "auto_upgrade",
+      "control_plane_multi_az",
+      "deletion_protection",
+      "name",
+      "version"
+     ],
+     "load_balancer": [
+      "access_log",
+      "listeners",
+      "load_balancer_name",
+      "load_balancer_type",
+      "tags"
+     ],
+     "managed_database": [
+      "database_id",
+      "disable_backup",
+      "encryption_at_rest",
+      "ip_filter"
+     ],
+     "network": [
+      "cidr",
+      "description",
+      "name",
+      "network_id",
+      "state",
+      "tags"
+     ],
+     "network_peering": [
+      "accepter_account",
+      "peering_id",
+      "source_account",
+      "state"
+     ],
+     "object_storage_bucket": [
+      "acl",
+      "acl_grants",
+      "default_encryption_enabled",
+      "kms_key_id",
+      "name",
+      "object_lock_enabled",
+      "policy_public",
+      "public_via_acl",
+      "sse_kms_enabled",
+      "tags",
+      "versioning"
+     ],
+     "security_group": [
+      "inbound_default_policy",
+      "security_group_id"
+     ],
+     "security_group_rule": [
+      "action",
+      "cidrs",
+      "description",
+      "direction",
+      "port_from",
+      "port_to",
+      "protocol",
+      "security_group_id",
+      "security_group_name"
+     ],
+     "subnet": [
+      "map_public_ip_on_launch",
+      "network_id",
+      "state",
+      "subnet_id",
+      "tags"
+     ]
+    }
+   },
+   "schema_version": 2
+  },
+  {
+   "content": {
+    "envelope": {
+     "collection": {
+      "units": [
+       {
+        "attempted": "boolean",
+        "complete": "boolean",
+        "detail": "string",
+        "error": "string",
+        "types": [
+         "string"
+        ],
+        "unit": "string"
+       }
+      ],
+      "unmapped": [
+       {
+        "count": "number",
+        "type": "string"
+       }
+      ]
+     },
+     "provider": "string",
+     "resources": [
+      {
+       "attributes": {
+        "*": "any"
+       },
+       "id": "string",
+       "name": "string",
+       "provenance": {
+        "*": {
+         "derived": "boolean",
+         "observed": "boolean",
+         "origin": "string",
+         "path": "string",
+         "source": "string"
+        }
+       },
+       "provider": "string",
+       "region": "string",
+       "source": {
+        "file": "string",
+        "line": "number",
+        "module": "string"
+       },
+       "type": "string"
+      }
+     ]
+    },
+    "format": "pepin-inventory/v3",
+    "types": {
+     "access_key": [
+      "access_key_id",
+      "expiration_date",
+      "owner_user",
+      "scope",
+      "state"
+     ],
+     "api_access_policy": [
+      "id",
+      "max_access_key_expiration_seconds",
+      "require_trusted_env"
+     ],
+     "api_access_rule": [
+      "api_access_rule_id",
+      "ca_ids",
+      "cns",
+      "ip_ranges"
+     ],
+     "api_access_summary": [
+      "id",
+      "rule_count"
+     ],
+     "blockstorage_snapshot": [
+      "creation_date",
+      "global_permission",
+      "snapshot_id",
+      "volume_id"
+     ],
+     "blockstorage_volume": [
+      "encrypted",
+      "state",
+      "tags",
+      "volume_id"
+     ],
+     "compute_image": [
+      "image_id",
+      "public",
+      "state",
+      "tags"
+     ],
+     "compute_instance": [
+      "deletion_protection",
+      "nic_public_ips",
+      "public_ip",
+      "security_group_ids",
+      "state",
+      "tags",
+      "user_data",
+      "vm_id"
+     ],
+     "governance_provider": [
+      "capital_control",
+      "eu_established",
+      "extraterritorial_exposure",
+      "jurisdiction",
+      "secnumcloud"
+     ],
+     "iam_policy": [
+      "manages_iam",
+      "owner_group",
+      "owner_user",
+      "policy_id",
+      "policy_name",
+      "scope",
+      "statements"
+     ],
+     "iam_role": [
+      "admin_privileges",
+      "editable",
+      "manages_iam",
+      "max_session_ttl",
+      "name",
+      "policy_has_expiration",
+      "role_id",
+      "source_ip_restricted"
+     ],
+     "iam_user": [
+      "mfa_enabled",
+      "user_id",
+      "username"
+     ],
+     "k8s_cluster_role_binding": [
+      "name",
+      "role_ref",
+      "subjects"
+     ],
+     "k8s_crd": [
+      "name"
+     ],
+     "k8s_namespace": [
+      "labels",
+      "name"
+     ],
+     "k8s_network_policy": [
+      "name",
+      "namespace"
+     ],
+     "kubernetes_cluster": [
+      "admin_whitelist",
+      "audit_enabled",
+      "auto_upgrade",
+      "control_plane_multi_az",
+      "deletion_protection",
+      "name",
+      "version"
+     ],
+     "load_balancer": [
+      "access_log",
+      "listeners",
+      "load_balancer_name",
+      "load_balancer_type",
+      "tags"
+     ],
+     "managed_database": [
+      "database_id",
+      "disable_backup",
+      "encryption_at_rest",
+      "ip_filter"
+     ],
+     "network": [
+      "cidr",
+      "description",
+      "name",
+      "network_id",
+      "state",
+      "tags"
+     ],
+     "network_peering": [
+      "accepter_account",
+      "peering_id",
+      "source_account",
+      "state"
+     ],
+     "object_storage_bucket": [
+      "acl",
+      "acl_grants",
+      "default_encryption_enabled",
+      "kms_key_id",
+      "name",
+      "object_lock_enabled",
+      "policy_public",
+      "public_via_acl",
+      "sse_kms_enabled",
+      "tags",
+      "versioning"
+     ],
+     "security_group": [
+      "inbound_default_policy",
+      "security_group_id"
+     ],
+     "security_group_rule": [
+      "action",
+      "cidrs",
+      "description",
+      "direction",
+      "port_from",
+      "port_to",
+      "protocol",
+      "security_group_id",
+      "security_group_name"
+     ],
+     "subnet": [
+      "map_public_ip_on_launch",
+      "network_id",
+      "state",
+      "subnet_id",
+      "tags"
+     ]
+    }
+   },
+   "schema_version": 3
+  },
+  {
+   "content": {
+    "envelope": {
+     "collection": {
+      "units": [
+       {
+        "attempted": "boolean",
+        "complete": "boolean",
+        "detail": "string",
+        "error": "string",
+        "types": [
+         "string"
+        ],
+        "unit": "string"
+       }
+      ],
+      "unmapped": [
+       {
+        "count": "number",
+        "type": "string"
+       }
+      ]
+     },
+     "provider": "string",
+     "resources": [
+      {
+       "attributes": {
+        "*": "any"
+       },
+       "id": "string",
+       "name": "string",
+       "provenance": {
+        "*": {
+         "derived": "boolean",
+         "observed": "boolean",
+         "origin": "string",
+         "path": "string",
+         "source": "string"
+        }
+       },
+       "provider": "string",
+       "region": "string",
+       "source": {
+        "file": "string",
+        "line": "number",
+        "module": "string"
+       },
+       "type": "string"
+      }
+     ]
+    },
+    "format": "pepin-inventory/v4",
+    "types": {
+     "access_key": [
+      "access_key_id",
+      "expiration_date",
+      "owner_user",
+      "scope",
+      "state"
+     ],
+     "api_access_policy": [
+      "id",
+      "max_access_key_expiration_seconds",
+      "require_trusted_env"
+     ],
+     "api_access_rule": [
+      "api_access_rule_id",
+      "ca_ids",
+      "cns",
+      "ip_ranges"
+     ],
+     "api_access_summary": [
+      "id",
+      "rule_count"
+     ],
+     "blockstorage_snapshot": [
+      "creation_date",
+      "global_permission",
+      "snapshot_id",
+      "state",
+      "volume_id"
+     ],
+     "blockstorage_volume": [
+      "encrypted",
+      "state",
+      "tags",
+      "volume_id"
+     ],
+     "compute_image": [
+      "image_id",
+      "public",
+      "state",
+      "tags"
+     ],
+     "compute_instance": [
+      "deletion_protection",
+      "nic_public_ips",
+      "public_ip",
+      "security_group_ids",
+      "state",
+      "tags",
+      "user_data",
+      "vm_id"
+     ],
+     "governance_provider": [
+      "capital_control",
+      "eu_established",
+      "extraterritorial_exposure",
+      "jurisdiction",
+      "secnumcloud"
+     ],
+     "iam_policy": [
+      "manages_iam",
+      "owner_group",
+      "owner_user",
+      "policy_id",
+      "policy_name",
+      "scope",
+      "statements"
+     ],
+     "iam_role": [
+      "admin_privileges",
+      "editable",
+      "manages_iam",
+      "max_session_ttl",
+      "name",
+      "policy_has_expiration",
+      "role_id",
+      "source_ip_restricted"
+     ],
+     "iam_user": [
+      "mfa_enabled",
+      "user_id",
+      "username"
+     ],
+     "k8s_cluster_role_binding": [
+      "name",
+      "role_ref",
+      "subjects"
+     ],
+     "k8s_crd": [
+      "name"
+     ],
+     "k8s_namespace": [
+      "labels",
+      "name"
+     ],
+     "k8s_network_policy": [
+      "name",
+      "namespace"
+     ],
+     "kubernetes_cluster": [
+      "admin_whitelist",
+      "audit_enabled",
+      "auto_upgrade",
+      "control_plane_multi_az",
+      "deletion_protection",
+      "name",
+      "version"
+     ],
+     "load_balancer": [
+      "access_log",
+      "listeners",
+      "load_balancer_name",
+      "load_balancer_type",
+      "tags"
+     ],
+     "managed_database": [
+      "database_id",
+      "disable_backup",
+      "encryption_at_rest",
+      "ip_filter"
+     ],
+     "network": [
+      "cidr",
+      "description",
+      "name",
+      "network_id",
+      "state",
+      "tags"
+     ],
+     "network_peering": [
+      "accepter_account",
+      "peering_id",
+      "source_account",
+      "state"
+     ],
+     "object_storage_bucket": [
+      "acl",
+      "acl_grants",
+      "default_encryption_enabled",
+      "kms_key_id",
+      "name",
+      "object_lock_enabled",
+      "policy_public",
+      "public_via_acl",
+      "sse_kms_enabled",
+      "tags",
+      "versioning"
+     ],
+     "security_group": [
+      "inbound_default_policy",
+      "security_group_id"
+     ],
+     "security_group_rule": [
+      "action",
+      "cidrs",
+      "description",
+      "direction",
+      "port_from",
+      "port_to",
+      "protocol",
+      "security_group_id",
+      "security_group_name"
+     ],
+     "subnet": [
+      "map_public_ip_on_launch",
+      "network_id",
+      "state",
+      "subnet_id",
+      "tags"
+     ]
+    }
+   },
+   "schema_version": 4
+  },
+  {
+   "content": {
+    "envelope": {
+     "collection": {
+      "units": [
+       {
+        "attempted": "boolean",
+        "complete": "boolean",
+        "detail": "string",
+        "error": "string",
+        "types": [
+         "string"
+        ],
+        "unit": "string"
+       }
+      ],
+      "unmapped": [
+       {
+        "count": "number",
+        "type": "string"
+       }
+      ]
+     },
+     "provider": "string",
+     "resources": [
+      {
+       "attributes": {
+        "*": "any"
+       },
+       "id": "string",
+       "name": "string",
+       "provenance": {
+        "*": {
+         "derived": "boolean",
+         "observed": "boolean",
+         "origin": "string",
+         "path": "string",
+         "source": "string"
+        }
+       },
+       "provider": "string",
+       "region": "string",
+       "source": {
+        "file": "string",
+        "line": "number",
+        "module": "string"
+       },
+       "type": "string"
+      }
+     ]
+    },
+    "format": "pepin-inventory/v5",
+    "types": {
+     "access_key": [
+      "access_key_id",
+      "creation_date",
+      "expiration_date",
+      "owner_user",
+      "scope",
+      "state"
+     ],
+     "api_access_policy": [
+      "id",
+      "max_access_key_expiration_seconds",
+      "require_trusted_env"
+     ],
+     "api_access_rule": [
+      "api_access_rule_id",
+      "ca_ids",
+      "cns",
+      "ip_ranges"
+     ],
+     "api_access_summary": [
+      "id",
+      "rule_count"
+     ],
+     "blockstorage_snapshot": [
+      "creation_date",
+      "global_permission",
+      "snapshot_id",
+      "state",
+      "volume_id"
+     ],
+     "blockstorage_volume": [
+      "encrypted",
+      "state",
+      "tags",
+      "volume_id"
+     ],
+     "compute_image": [
+      "image_id",
+      "public",
+      "state",
+      "tags"
+     ],
+     "compute_instance": [
+      "deletion_protection",
+      "nic_public_ips",
+      "public_ip",
+      "security_group_ids",
+      "state",
+      "tags",
+      "user_data",
+      "vm_id"
+     ],
+     "governance_provider": [
+      "capital_control",
+      "eu_established",
+      "extraterritorial_exposure",
+      "jurisdiction",
+      "secnumcloud"
+     ],
+     "iam_policy": [
+      "manages_iam",
+      "owner_group",
+      "owner_user",
+      "policy_id",
+      "policy_name",
+      "scope",
+      "statements"
+     ],
+     "iam_role": [
+      "admin_privileges",
+      "editable",
+      "manages_iam",
+      "max_session_ttl",
+      "name",
+      "policy_has_expiration",
+      "role_id",
+      "source_ip_restricted"
+     ],
+     "iam_user": [
+      "mfa_enabled",
+      "user_id",
+      "username"
+     ],
+     "k8s_cluster_role_binding": [
+      "name",
+      "role_ref",
+      "subjects"
+     ],
+     "k8s_crd": [
+      "name"
+     ],
+     "k8s_namespace": [
+      "labels",
+      "name"
+     ],
+     "k8s_network_policy": [
+      "name",
+      "namespace"
+     ],
+     "kubernetes_cluster": [
+      "admin_whitelist",
+      "audit_enabled",
+      "auto_upgrade",
+      "control_plane_multi_az",
+      "deletion_protection",
+      "name",
+      "version"
+     ],
+     "load_balancer": [
+      "access_log",
+      "listeners",
+      "load_balancer_name",
+      "load_balancer_type",
+      "tags"
+     ],
+     "managed_database": [
+      "database_id",
+      "disable_backup",
+      "encryption_at_rest",
+      "ip_filter"
+     ],
+     "network": [
+      "cidr",
+      "description",
+      "name",
+      "network_id",
+      "state",
+      "tags"
+     ],
+     "network_peering": [
+      "accepter_account",
+      "peering_id",
+      "source_account",
+      "state"
+     ],
+     "object_storage_bucket": [
+      "acl",
+      "acl_grants",
+      "default_encryption_enabled",
+      "kms_key_id",
+      "name",
+      "object_lock_enabled",
+      "policy_public",
+      "public_via_acl",
+      "sse_kms_enabled",
+      "tags",
+      "versioning"
+     ],
+     "security_group": [
+      "inbound_default_policy",
+      "security_group_id"
+     ],
+     "security_group_rule": [
+      "action",
+      "cidrs",
+      "description",
+      "direction",
+      "port_from",
+      "port_to",
+      "protocol",
+      "security_group_id",
+      "security_group_name"
+     ],
+     "subnet": [
+      "map_public_ip_on_launch",
+      "network_id",
+      "state",
+      "subnet_id",
+      "tags"
+     ]
+    }
+   },
+   "schema_version": 5
+  }
+ ]
 }

--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -92,6 +92,7 @@ Le tableau ci-dessous est rendu depuis cette table même, il n'en est pas la cop
 | `database_encryption_at_rest_enabled` | `managed_database` | `encryption_at_rest` |
 | `database_service_not_open_to_internet` | `managed_database` | `ip_filter` |
 | `governance_resource_region_in_eu` | (aucun : contrôle transverse) | `region` |
+| `iam_accesskey_rotated` | `access_key` | `creation_date` |
 | `iam_account_mfa_enforced` | `api_access_policy` | `require_trusted_env` |
 | `iam_apiaccesspolicy_max_key_expiration` | `api_access_policy` | `max_access_key_expiration_seconds` |
 | `iam_apiaccessrule_no_public_cidr` | `api_access_rule` | `ip_ranges` |

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -92,6 +92,7 @@ The table below is rendered from that very map — not transcribed from it:
 | `database_encryption_at_rest_enabled` | `managed_database` | `encryption_at_rest` |
 | `database_service_not_open_to_internet` | `managed_database` | `ip_filter` |
 | `governance_resource_region_in_eu` | (none: cross-cutting control) | `region` |
+| `iam_accesskey_rotated` | `access_key` | `creation_date` |
 | `iam_account_mfa_enforced` | `api_access_policy` | `require_trusted_env` |
 | `iam_apiaccesspolicy_max_key_expiration` | `api_access_policy` | `max_access_key_expiration_seconds` |
 | `iam_apiaccessrule_no_public_cidr` | `api_access_rule` | `ip_ranges` |

--- a/docs/concepts/scope.fr.md
+++ b/docs/concepts/scope.fr.md
@@ -136,10 +136,10 @@ Pépin ne fait pas :
 <!-- pepin:gen control-counts -->
 | Chiffre | Nombre |
 |---|---:|
-| Contrôles au référentiel | 57 |
-| Contrôles déclarés pour au moins un fournisseur | 56 |
+| Contrôles au référentiel | 58 |
+| Contrôles déclarés pour au moins un fournisseur | 57 |
 | `critical` | 10 |
-| `high` | 32 |
+| `high` | 33 |
 | `medium` | 13 |
 | `low` | 2 |
 <!-- /pepin:gen control-counts -->

--- a/docs/concepts/scope.md
+++ b/docs/concepts/scope.md
@@ -130,10 +130,10 @@ Pépin does not:
 <!-- pepin:gen control-counts -->
 | Figure | Count |
 |---|---:|
-| Controls in the reference | 57 |
-| Controls declared for at least one provider | 56 |
+| Controls in the reference | 58 |
+| Controls declared for at least one provider | 57 |
 | `critical` | 10 |
-| `high` | 32 |
+| `high` | 33 |
 | `medium` | 13 |
 | `low` | 2 |
 <!-- /pepin:gen control-counts -->

--- a/docs/concepts/terraform-vs-live.fr.md
+++ b/docs/concepts/terraform-vs-live.fr.md
@@ -267,6 +267,7 @@ couples, une source produit le type de ressource et son attribut décisif, et l'
 | `database_service_not_open_to_internet` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `governance_resource_region_in_eu` | outscale | live | attribut décisif « region » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_accesskey_expiration_set` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
+| `iam_accesskey_rotated` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
 | `iam_account_mfa_enforced` | outscale | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccessrule_defined` | outscale | live | cette source ne produit aucune ressource de type « api_access_summary » |

--- a/docs/concepts/terraform-vs-live.md
+++ b/docs/concepts/terraform-vs-live.md
@@ -262,6 +262,7 @@ source produces the resource type and its deciding attribute, and the other does
 | `database_service_not_open_to_internet` | scaleway | terraform | this source produces no resource of type "managed_database" |
 | `governance_resource_region_in_eu` | outscale | live | deciding attribute "region" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_accesskey_expiration_set` | outscale | live | this source produces no resource of type "access_key" |
+| `iam_accesskey_rotated` | outscale | live | this source produces no resource of type "access_key" |
 | `iam_account_mfa_enforced` | outscale | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccessrule_defined` | outscale | live | this source produces no resource of type "api_access_summary" |

--- a/docs/controls/iam_accesskey_rotated.fr.md
+++ b/docs/controls/iam_accesskey_rotated.fr.md
@@ -1,0 +1,112 @@
+> [🇬🇧 English](iam_accesskey_rotated.md) · 🇫🇷 Français
+
+<!-- PAGE GÉNÉRÉE : ne pas éditer à la main. Régénérer avec `mise run gen-docs`. -->
+
+# `iam_accesskey_rotated`
+
+**Clé d'accès jamais renouvelée**
+
+[Retour au catalogue](index.fr.md)
+
+| Champ | Valeur |
+|---|---|
+| Code | `iam_accesskey_rotated` |
+| Famille | `iam` |
+| Sévérité | `high` |
+| Exigence SCSL (index gelé) | `CLD-IAM-2` |
+| Type de ressource lu | `access_key` |
+| Attribut décisif | `creation_date` |
+| État | actif |
+| Déclaré pour | `outscale` |
+| Preuves de remédiation | 0 / 1 |
+
+## Le risque
+
+Une clé d'accès longue durée n'a pas été remplacée depuis plus longtemps que la fenêtre de rotation : une expiration lointaine satisfait le contrôle d'expiration sans qu'aucune rotation n'ait jamais eu lieu, et un compte sans plafond d'expiration ne borne rien.
+
+Cette description vient du référentiel : c'est le texte que le rapport cite, dans la
+langue du lecteur.
+
+## Correspondances normatives
+
+Reprises telles quelles du référentiel. L'exigence SCSL provient de l'index **gelé** :
+un contrôle se rattache à une exigence existante, jamais à une exigence créée pour lui.
+Ces correspondances sont **indicatives** : un rapport Pépin n'est pas une preuve de
+qualification.
+
+| Cadre | Références |
+|---|---|
+| `scsl` | `CLD-IAM-2` |
+| `iso_27001_2022` | `A.5.17`, `A.8.2` |
+| `secnumcloud_3_2` | `9.5`, `10.5` |
+
+## Où Pépin sait le mesurer
+
+Une case ✅ signifie que la source produit le type visé, que le contrat du fournisseur
+le déclare `verifie` et que l'attribut décisif est projeté. ◐ signifie « Pépin ne peut
+pas décider depuis cette source », ∅ « non testable, avec justification », ✗ « non
+déclaré, ou type absent de cette source ».
+
+| Fournisseur | Plan Terraform | Collecte live |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | sans objet | ✗ |
+
+Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
+porte son motif :
+
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « access_key » |
+
+## Ce que Pépin peut conclure
+
+| Statut | Ce que le statut affirme | Atteignable depuis |
+|---|---|---|
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+
+Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
+contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
+
+## Comment enquêter
+
+- Type de ressource normalisé lu par la règle : `access_key`
+- Attribut dont la décision dépend : `creation_date`
+- Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
+
+## Comment corriger
+
+Émettre une nouvelle clé, migrer les consommateurs, puis révoquer l'ancienne ; automatiser la rotation. Préférer une identité courte (OIDC) à un secret statique.
+
+| Fournisseur | Montage déployable |
+|---|---|
+| outscale | _aucune preuve déposée à ce jour_ |
+
+Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
+tel quel, ou une note ancrée sur la documentation officielle. Voir
+[le guide de remédiation](../guides/remediation.fr.md).
+
+## Comment vérifier la correction
+
+```bash
+# depuis l'API du fournisseur : configuration effective
+./pepin scan outscale --live --format assessment
+```
+
+Dans la sortie `assessment`, chercher `"control": "iam_accesskey_rotated"` : son `status` doit être
+`pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
+correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+## Voir aussi
+
+- [Le modèle d'assessment](../concepts/assessment-model.fr.md) : ce que chaque statut affirme.
+- [Matrice de couverture](../coverage.fr.md) : la même information, tous contrôles confondus.
+- [Plan Terraform ou scan live](../concepts/terraform-vs-live.fr.md) : choisir la source.
+- [Ajouter un contrôle](../contributing/adding-a-control.fr.md) : la procédure de bout en bout.

--- a/docs/controls/iam_accesskey_rotated.md
+++ b/docs/controls/iam_accesskey_rotated.md
@@ -1,0 +1,111 @@
+> 🇬🇧 English · [🇫🇷 Français](iam_accesskey_rotated.fr.md)
+
+<!-- GENERATED PAGE — do not edit by hand. Regenerate with `mise run gen-docs`. -->
+
+# `iam_accesskey_rotated`
+
+**Access key never renewed**
+
+[Back to the catalogue](index.md)
+
+| Field | Value |
+|---|---|
+| Code | `iam_accesskey_rotated` |
+| Family | `iam` |
+| Severity | `high` |
+| SCSL requirement (frozen index) | `CLD-IAM-2` |
+| Resource type read | `access_key` |
+| Deciding attribute | `creation_date` |
+| State | active |
+| Declared for | `outscale` |
+| Remediation proofs | 0 / 1 |
+
+## The risk
+
+A long-lived access key has not been replaced for longer than the rotation window: a distant expiry satisfies the expiry control while no rotation has ever taken place, and an account with no expiry ceiling bounds nothing.
+
+This description comes from the reference: it is the text the report quotes, in the
+reader's language.
+
+## Normative mappings
+
+Taken verbatim from the reference. The SCSL requirement comes from the **frozen** index:
+a control maps onto an existing requirement, never onto one created for it. These mappings
+are **indicative**: a Pépin report is not proof of qualification.
+
+| Framework | References |
+|---|---|
+| `scsl` | `CLD-IAM-2` |
+| `iso_27001_2022` | `A.5.17`, `A.8.2` |
+| `secnumcloud_3_2` | `9.5`, `10.5` |
+
+## Where Pépin can measure it
+
+A ✅ cell means the source produces the targeted type, the provider contract marks it
+`verifie`, and the deciding attribute is projected. ◐ means "Pépin cannot decide from this
+source", ∅ "not testable, with justification", ✗ "not declared, or type absent from this
+source".
+
+| Provider | Terraform plan | Live collection |
+|---|:-:|:-:|
+| exoscale | ✗ | ✗ |
+| outscale | ✗ | ✅ |
+| scaleway | ✗ | ✗ |
+| kubernetes | n/a | ✗ |
+
+Every cell that is not ✅ **while the control is declared for that provider** carries its
+reason:
+
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "access_key" |
+
+## What Pépin can conclude
+
+| Status | What the status asserts | Reachable from |
+|---|---|---|
+| `fail` | a deviation was detected on a real resource | outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `not-applicable` | the provider contract declares the control untestable, with its justification | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+
+An observable control still returns `not-evaluated` on an inventory that contains no
+resource of the targeted type: "nothing to look at" is not "compliant".
+
+## How to investigate
+
+- Normalized resource type the rule reads: `access_key`
+- Attribute the decision depends on: `creation_date`
+- Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
+
+## How to remediate
+
+Issue a new key, migrate its consumers, then revoke the old one; automate the rotation. Prefer a short-lived identity (OIDC) over a static secret.
+
+| Provider | Deployable setup |
+|---|---|
+| outscale | _no proof filed yet_ |
+
+A remediation proof is a self-contained, **compliant** Terraform module that deploys as
+is, or a note anchored on the official documentation. See
+[the remediation guide](../guides/remediation.md).
+
+## How to verify the fix
+
+```bash
+# from the provider API: effective configuration
+./pepin scan outscale --live --format assessment
+```
+
+In the `assessment` output, look for `"control": "iam_accesskey_rotated"`: its `status` must be `pass`.
+If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
+demonstrated: the reasons table above says why.
+
+## See also
+
+- [The assessment model](../concepts/assessment-model.md): what each status asserts.
+- [Coverage matrix](../coverage.md): the same information, across every control.
+- [Terraform plan or live scan](../concepts/terraform-vs-live.md): choosing the source.
+- [Adding a control](../contributing/adding-a-control.md): the end-to-end procedure.

--- a/docs/controls/index.fr.md
+++ b/docs/controls/index.fr.md
@@ -16,14 +16,14 @@ vue d'ensemble par fournisseur et par source, voir la [matrice de couverture](..
 
 | Chiffre | Nombre |
 |---|---:|
-| Contrôles au référentiel | 57 |
-| Contrôles actifs | 56 |
+| Contrôles au référentiel | 58 |
+| Contrôles actifs | 57 |
 | Contrôles dormants | 1 |
 | `critical` | 10 |
-| `high` | 32 |
+| `high` | 33 |
 | `medium` | 13 |
 | `low` | 2 |
-| Preuves de remédiation déployables | 26 / 95 |
+| Preuves de remédiation déployables | 26 / 96 |
 
 ## Comment lire ce catalogue
 
@@ -43,6 +43,7 @@ vue d'ensemble par fournisseur et par source, voir la [matrice de couverture](..
 | Contrôle | Sévérité | SCSL | Actif pour | Preuves |
 |---|---|---|---|---|
 | [`iam_accesskey_expiration_set`](iam_accesskey_expiration_set.fr.md) Clé d'accès sans expiration ni rotation | critical | `CLD-IAM-2` | `outscale`, `scaleway` | 0 / 2 |
+| [`iam_accesskey_rotated`](iam_accesskey_rotated.fr.md) Clé d'accès jamais renouvelée | high | `CLD-IAM-2` | `outscale` | 0 / 1 |
 | [`iam_account_mfa_enforced`](iam_account_mfa_enforced.fr.md) MFA non imposée au niveau du compte | high | `CLD-IAM-3` | `outscale` | 0 / 1 |
 | [`iam_apiaccesspolicy_max_key_expiration`](iam_apiaccesspolicy_max_key_expiration.fr.md) Politique d'accès API sans expiration maximale des clés | medium | `CLD-IAM-2` | `outscale` | 0 / 1 |
 | [`iam_apiaccessrule_defined`](iam_apiaccessrule_defined.fr.md) Aucune règle d'accès API définie | high | `CLD-IAM-4` | `outscale` | 0 / 1 |

--- a/docs/controls/index.md
+++ b/docs/controls/index.md
@@ -16,14 +16,14 @@ overview per provider and per source, see the [coverage matrix](../coverage.md).
 
 | Figure | Count |
 |---|---:|
-| Controls in the reference | 57 |
-| Active controls | 56 |
+| Controls in the reference | 58 |
+| Active controls | 57 |
 | Dormant controls | 1 |
 | `critical` | 10 |
-| `high` | 32 |
+| `high` | 33 |
 | `medium` | 13 |
 | `low` | 2 |
-| Deployable remediation proofs | 26 / 95 |
+| Deployable remediation proofs | 26 / 96 |
 
 ## How to read this catalogue
 
@@ -43,6 +43,7 @@ overview per provider and per source, see the [coverage matrix](../coverage.md).
 | Control | Severity | SCSL | Active for | Proofs |
 |---|---|---|---|---|
 | [`iam_accesskey_expiration_set`](iam_accesskey_expiration_set.md) Access key without expiry or rotation | critical | `CLD-IAM-2` | `outscale`, `scaleway` | 0 / 2 |
+| [`iam_accesskey_rotated`](iam_accesskey_rotated.md) Access key never renewed | high | `CLD-IAM-2` | `outscale` | 0 / 1 |
 | [`iam_account_mfa_enforced`](iam_account_mfa_enforced.md) MFA not enforced at the account level | high | `CLD-IAM-3` | `outscale` | 0 / 1 |
 | [`iam_apiaccesspolicy_max_key_expiration`](iam_apiaccesspolicy_max_key_expiration.md) API access policy without a maximum key expiry | medium | `CLD-IAM-2` | `outscale` | 0 / 1 |
 | [`iam_apiaccessrule_defined`](iam_apiaccessrule_defined.md) No API access rule defined | high | `CLD-IAM-4` | `outscale` | 0 / 1 |

--- a/docs/coverage.fr.md
+++ b/docs/coverage.fr.md
@@ -46,7 +46,7 @@ et le rapport le dit à chaque scan, contrôle par contrôle, avec le motif.
 | `chiffrement` | 7 | ✅ 1 · ◐ 0 · ∅ 3 · ✗ 3 | ✅ 2 · ◐ 0 · ∅ 3 · ✗ 2 | ✅ 2 · ◐ 0 · ∅ 1 · ✗ 4 |
 | `compute` | 9 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 5 | ✅ 7 · ◐ 0 · ∅ 0 · ✗ 2 | ✅ 2 · ◐ 0 · ∅ 0 · ✗ 7 |
 | `gouvernance` | 3 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 |
-| `iam` | 14 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 10 | ✅ 10 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 3 · ◐ 1 · ∅ 0 · ✗ 10 |
+| `iam` | 15 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 | ✅ 11 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 3 · ◐ 1 · ∅ 0 · ✗ 11 |
 | `journalisation` | 2 | ✅ 1 · ◐ 0 · ∅ 1 · ✗ 0 | ✅ 1 · ◐ 0 · ∅ 0 · ✗ 1 | ✅ 0 · ◐ 0 · ∅ 0 · ✗ 2 |
 | `reseau` | 15 | ✅ 9 · ◐ 0 · ∅ 0 · ✗ 6 | ✅ 11 · ◐ 0 · ∅ 0 · ✗ 4 | ✅ 9 · ◐ 1 · ∅ 0 · ✗ 5 |
 | `stockage` | 7 | ✅ 4 · ◐ 0 · ∅ 1 · ✗ 2 | ✅ 6 · ◐ 0 · ∅ 0 · ✗ 1 | ✅ 4 · ◐ 0 · ∅ 1 · ✗ 2 |
@@ -70,6 +70,7 @@ et le rapport le dit à chaque scan, contrôle par contrôle, avec le motif.
 | `governance_resource_region_in_eu` | high | CLD-GVN-3 | ✅ | ✅ | ◐ | ✅ | ✅ | ✅ |
 | `governance_resource_required_tags` | medium | CLD-GVN-1 | ◐ | ◐ | ◐ | ◐ | ◐ | ◐ |
 | `iam_accesskey_expiration_set` | critical | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✅ | ✅ |
+| `iam_accesskey_rotated` | high | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_account_mfa_enforced` | high | CLD-IAM-3 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccesspolicy_max_key_expiration` | medium | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccessrule_defined` | high | CLD-IAM-4 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
@@ -145,6 +146,7 @@ ici : la matrice les montre déjà, et elles n'apprennent rien de plus.
 | `governance_resource_required_tags` | scaleway | terraform | ◐ `partial` | aucun type de ressource visé et le contrôle ne lit pas le descripteur du fournisseur : le verrou du « pass » ne peut pas être levé, le scan rend « not-evaluated » tant qu'aucun écart n'est détecté |
 | `governance_resource_required_tags` | scaleway | live | ◐ `partial` | aucun type de ressource visé et le contrôle ne lit pas le descripteur du fournisseur : le verrou du « pass » ne peut pas être levé, le scan rend « not-evaluated » tant qu'aucun écart n'est détecté |
 | `iam_accesskey_expiration_set` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « access_key » |
+| `iam_accesskey_rotated` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « access_key » |
 | `iam_account_mfa_enforced` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccessrule_defined` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_summary » |
@@ -207,10 +209,10 @@ deux ne peut couvrir la portée de l'autre. Une seule source : la collecte live 
 
 | Fournisseur | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---|---:|---:|---:|---:|
-| exoscale | terraform | 21 | 1 | 5 | 30 |
-| exoscale | live | 25 | 1 | 5 | 26 |
-| outscale | terraform | 17 | 4 | 4 | 32 |
-| outscale | live | 39 | 1 | 4 | 13 |
-| scaleway | terraform | 18 | 6 | 2 | 31 |
-| scaleway | live | 16 | 3 | 2 | 36 |
-| kubernetes | live | 4 | 0 | 0 | 53 |
+| exoscale | terraform | 21 | 1 | 5 | 31 |
+| exoscale | live | 25 | 1 | 5 | 27 |
+| outscale | terraform | 17 | 4 | 4 | 33 |
+| outscale | live | 40 | 1 | 4 | 13 |
+| scaleway | terraform | 18 | 6 | 2 | 32 |
+| scaleway | live | 16 | 3 | 2 | 37 |
+| kubernetes | live | 4 | 0 | 0 | 54 |

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -45,7 +45,7 @@ and the report says so on every scan, control by control, with the reason.
 | `chiffrement` | 7 | ✅ 1 · ◐ 0 · ∅ 3 · ✗ 3 | ✅ 2 · ◐ 0 · ∅ 3 · ✗ 2 | ✅ 2 · ◐ 0 · ∅ 1 · ✗ 4 |
 | `compute` | 9 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 5 | ✅ 7 · ◐ 0 · ∅ 0 · ✗ 2 | ✅ 2 · ◐ 0 · ∅ 0 · ✗ 7 |
 | `gouvernance` | 3 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 |
-| `iam` | 14 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 10 | ✅ 10 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 3 · ◐ 1 · ∅ 0 · ✗ 10 |
+| `iam` | 15 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 | ✅ 11 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 3 · ◐ 1 · ∅ 0 · ✗ 11 |
 | `journalisation` | 2 | ✅ 1 · ◐ 0 · ∅ 1 · ✗ 0 | ✅ 1 · ◐ 0 · ∅ 0 · ✗ 1 | ✅ 0 · ◐ 0 · ∅ 0 · ✗ 2 |
 | `reseau` | 15 | ✅ 9 · ◐ 0 · ∅ 0 · ✗ 6 | ✅ 11 · ◐ 0 · ∅ 0 · ✗ 4 | ✅ 9 · ◐ 1 · ∅ 0 · ✗ 5 |
 | `stockage` | 7 | ✅ 4 · ◐ 0 · ∅ 1 · ✗ 2 | ✅ 6 · ◐ 0 · ∅ 0 · ✗ 1 | ✅ 4 · ◐ 0 · ∅ 1 · ✗ 2 |
@@ -69,6 +69,7 @@ and the report says so on every scan, control by control, with the reason.
 | `governance_resource_region_in_eu` | high | CLD-GVN-3 | ✅ | ✅ | ◐ | ✅ | ✅ | ✅ |
 | `governance_resource_required_tags` | medium | CLD-GVN-1 | ◐ | ◐ | ◐ | ◐ | ◐ | ◐ |
 | `iam_accesskey_expiration_set` | critical | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✅ | ✅ |
+| `iam_accesskey_rotated` | high | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_account_mfa_enforced` | high | CLD-IAM-3 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccesspolicy_max_key_expiration` | medium | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccessrule_defined` | high | CLD-IAM-4 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
@@ -144,6 +145,7 @@ already shows them, and they add nothing.
 | `governance_resource_required_tags` | scaleway | terraform | ◐ `partial` | no targeted resource type, and the control does not read the provider descriptor: the "pass" lock cannot be lifted, so the scan returns "not-evaluated" as long as no deviation is detected |
 | `governance_resource_required_tags` | scaleway | live | ◐ `partial` | no targeted resource type, and the control does not read the provider descriptor: the "pass" lock cannot be lifted, so the scan returns "not-evaluated" as long as no deviation is detected |
 | `iam_accesskey_expiration_set` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "access_key" |
+| `iam_accesskey_rotated` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "access_key" |
 | `iam_account_mfa_enforced` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccessrule_defined` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_summary" |
@@ -206,10 +208,10 @@ the other's scope. One source only: live collection through a kubeconfig.
 
 | Provider | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---|---:|---:|---:|---:|
-| exoscale | terraform | 21 | 1 | 5 | 30 |
-| exoscale | live | 25 | 1 | 5 | 26 |
-| outscale | terraform | 17 | 4 | 4 | 32 |
-| outscale | live | 39 | 1 | 4 | 13 |
-| scaleway | terraform | 18 | 6 | 2 | 31 |
-| scaleway | live | 16 | 3 | 2 | 36 |
-| kubernetes | live | 4 | 0 | 0 | 53 |
+| exoscale | terraform | 21 | 1 | 5 | 31 |
+| exoscale | live | 25 | 1 | 5 | 27 |
+| outscale | terraform | 17 | 4 | 4 | 33 |
+| outscale | live | 40 | 1 | 4 | 13 |
+| scaleway | terraform | 18 | 6 | 2 | 32 |
+| scaleway | live | 16 | 3 | 2 | 37 |
+| kubernetes | live | 4 | 0 | 0 | 54 |

--- a/docs/detection-quality.fr.md
+++ b/docs/detection-quality.fr.md
@@ -15,19 +15,19 @@ référence, relevés de canari. Aucun n'est saisi.
 pourcentage sans mesure derrière est un faux vert déplacé dans un tableau de
 bord, et il y est pire qu'ailleurs : personne ne relit un tableau de bord.
 
-Les chiffres sont donc laids, et c'est le point. « 57 contrôles » ne dit rien de
-la qualité d'une détection ; « 83 verdicts prouvés sur 458 » dit où en est le
+Les chiffres sont donc laids, et c'est le point. « 58 contrôles » ne dit rien de
+la qualité d'une détection ; « 86 verdicts prouvés sur 461 » dit où en est le
 produit, et rétrécit dans le bon sens à chaque scénario écrit.
 
 ## Les chiffres
 
 | Chiffre | Nombre |
 |---|---:|
-| Contrôles au référentiel | 57 |
-| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 178 |
-| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 24 |
-| Verdicts à prouver au total | 458 |
-| Verdicts prouvés | 83 |
+| Contrôles au référentiel | 58 |
+| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 179 |
+| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 25 |
+| Verdicts à prouver au total | 461 |
+| Verdicts prouvés | 86 |
 
 ## Couverture de véracité, par verdict
 
@@ -37,11 +37,11 @@ demanderait d'inventer une non-applicabilité.
 
 | Verdict | Ce qu'il met en scène | À prouver | Prouvés | % |
 |---|---|---:|---:|---:|
-| `fail` | une configuration vulnérable est détectée | 140 | 21 | 15 |
-| `pass` | une configuration réellement correcte est confirmée | 140 | 33 | 23 |
-| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 156 | 18 | 11 |
+| `fail` | une configuration vulnérable est détectée | 141 | 22 | 15 |
+| `pass` | une configuration réellement correcte est confirmée | 141 | 34 | 24 |
+| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 157 | 19 | 12 |
 | `not-applicable` | le contrat du fournisseur déclare le mécanisme inexistant | 22 | 11 | 50 |
-| **Total** | | **458** | **83** | **18** |
+| **Total** | | **461** | **86** | **18** |
 
 ## Validé en live
 
@@ -56,7 +56,7 @@ relevé authentifié, il montera tout seul.
 
 | Chiffre | Nombre |
 |---|---:|
-| Chemins dont la source est une collecte live | 100 |
+| Chemins dont la source est une collecte live | 101 |
 | Validé en live | **0 %** |
 
 ## Ce que les vrais plans de contrôle ont répondu
@@ -84,9 +84,9 @@ n'en ont pas encore sont comptés dans
 
 | Chiffre | Nombre |
 |---|---:|
-| Contrôles high/critical actifs | 42 |
-| Dont un chemin de détection est prouvé de bout en bout | 18 |
-| Dont un contre-exemple légitime est prouvé | 16 |
+| Contrôles high/critical actifs | 43 |
+| Dont un chemin de détection est prouvé de bout en bout | 19 |
+| Dont un contre-exemple légitime est prouvé | 17 |
 | Faux positifs mesurés sur les contre-témoins | 0 |
 
 Il n'y a pas de ligne « faux négatifs », et son absence est le chiffre le plus

--- a/docs/detection-quality.md
+++ b/docs/detection-quality.md
@@ -15,19 +15,19 @@ tenants, canary records. None is typed in.
 with no measurement behind it is a false green moved into a dashboard, and it is
 worse there than anywhere else: nobody re-reads a dashboard.
 
-The figures are therefore ugly, and that is the point. "57 controls" says nothing
-about the quality of a detection; "83 verdicts proven out of 458" says where the
+The figures are therefore ugly, and that is the point. "58 controls" says nothing
+about the quality of a detection; "86 verdicts proven out of 461" says where the
 product stands, and shrinks the right way with every scenario written.
 
 ## The figures
 
 | Figure | Count |
 |---|---:|
-| Controls in the reference | 57 |
-| Control x provider x source paths on which Pépin concludes | 178 |
-| Paths whose EVERY reachable verdict is proven end to end | 24 |
-| Verdicts to prove in total | 458 |
-| Verdicts proven | 83 |
+| Controls in the reference | 58 |
+| Control x provider x source paths on which Pépin concludes | 179 |
+| Paths whose EVERY reachable verdict is proven end to end | 25 |
+| Verdicts to prove in total | 461 |
+| Verdicts proven | 86 |
 
 ## Veracity coverage, by verdict
 
@@ -37,11 +37,11 @@ inventing a non-applicability.
 
 | Verdict | What it stages | To prove | Proven | % |
 |---|---|---:|---:|---:|
-| `fail` | a vulnerable configuration is detected | 140 | 21 | 15 |
-| `pass` | a genuinely correct configuration is confirmed | 140 | 33 | 23 |
-| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 156 | 18 | 11 |
+| `fail` | a vulnerable configuration is detected | 141 | 22 | 15 |
+| `pass` | a genuinely correct configuration is confirmed | 141 | 34 | 24 |
+| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 157 | 19 | 12 |
 | `not-applicable` | the provider's contract declares the mechanism non-existent | 22 | 11 | 50 |
-| **Total** | | **458** | **83** | **18** |
+| **Total** | | **461** | **86** | **18** |
 
 ## Validated live
 
@@ -56,7 +56,7 @@ will rise on its own.
 
 | Figure | Count |
 |---|---:|
-| Paths whose source is a live collection | 100 |
+| Paths whose source is a live collection | 101 |
 | Validated live | **0 %** |
 
 ## What the real control planes answered
@@ -83,9 +83,9 @@ in `internal/veracity/testdata/counterexamples-debt.txt`.
 
 | Figure | Count |
 |---|---:|
-| Active high/critical controls | 42 |
-| Of which a detection path is proven end to end | 18 |
-| Of which a legitimate counterexample is proven | 16 |
+| Active high/critical controls | 43 |
+| Of which a detection path is proven end to end | 19 |
+| Of which a legitimate counterexample is proven | 17 |
 | False positives measured on the counter-witnesses | 0 |
 
 There is no "false negatives" row, and its absence is the most honest figure on

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -58,7 +58,7 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v4",
+  "inventory_schema": "pepin-inventory/v5",
   "disclaimer": "Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -56,7 +56,7 @@ raises a version number and gets a CHANGELOG line.
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v4",
+  "inventory_schema": "pepin-inventory/v5",
   "disclaimer": "This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/guides/remediation.fr.md
+++ b/docs/guides/remediation.fr.md
@@ -208,9 +208,9 @@ couples (contrôle, fournisseur) que le référentiel déclare réellement :
 |---|---:|
 | exoscale | 26 / 26 |
 | kubernetes | 0 / 4 |
-| outscale | 0 / 40 |
+| outscale | 0 / 41 |
 | scaleway | 0 / 25 |
-| **Total** | **26 / 95** |
+| **Total** | **26 / 96** |
 <!-- /pepin:gen remediation-coverage -->
 
 Ce tableau compte des **preuves déployables**, pas des remédiations. La remédiation

--- a/docs/guides/remediation.md
+++ b/docs/guides/remediation.md
@@ -204,9 +204,9 @@ provider) pairs the reference actually declares:
 |---|---:|
 | exoscale | 26 / 26 |
 | kubernetes | 0 / 4 |
-| outscale | 0 / 40 |
+| outscale | 0 / 41 |
 | scaleway | 0 / 25 |
-| **Total** | **26 / 95** |
+| **Total** | **26 / 96** |
 <!-- /pepin:gen remediation-coverage -->
 
 Read that table for what it is: it counts **deployable proofs**, not remediations. The

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -91,6 +91,7 @@ pas.
 | `database_service_not_open_to_internet` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `governance_resource_region_in_eu` | outscale | live | attribut décisif « region » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_accesskey_expiration_set` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
+| `iam_accesskey_rotated` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
 | `iam_account_mfa_enforced` | outscale | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccessrule_defined` | outscale | live | cette source ne produit aucune ressource de type « api_access_summary » |
@@ -145,13 +146,13 @@ Par fournisseur et par source, sur l'ensemble des contrôles du référentiel :
 <!-- pepin:gen coverage-totals -->
 | Fournisseur | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---|---:|---:|---:|---:|
-| exoscale | terraform | 21 | 1 | 5 | 30 |
-| exoscale | live | 25 | 1 | 5 | 26 |
-| outscale | terraform | 17 | 4 | 4 | 32 |
-| outscale | live | 39 | 1 | 4 | 13 |
-| scaleway | terraform | 18 | 6 | 2 | 31 |
-| scaleway | live | 16 | 3 | 2 | 36 |
-| kubernetes | live | 4 | 0 | 0 | 53 |
+| exoscale | terraform | 21 | 1 | 5 | 31 |
+| exoscale | live | 25 | 1 | 5 | 27 |
+| outscale | terraform | 17 | 4 | 4 | 33 |
+| outscale | live | 40 | 1 | 4 | 13 |
+| scaleway | terraform | 18 | 6 | 2 | 32 |
+| scaleway | live | 16 | 3 | 2 | 37 |
+| kubernetes | live | 4 | 0 | 0 | 54 |
 <!-- /pepin:gen coverage-totals -->
 
 Le détail par contrôle, avec le motif de chaque case qui n'est pas pleinement supportée, est la
@@ -169,9 +170,9 @@ note documentée. À ce jour :
 |---|---:|
 | exoscale | 26 / 26 |
 | kubernetes | 0 / 4 |
-| outscale | 0 / 40 |
+| outscale | 0 / 41 |
 | scaleway | 0 / 25 |
-| **Total** | **26 / 95** |
+| **Total** | **26 / 96** |
 <!-- /pepin:gen remediation-coverage -->
 
 Ce contrôle n'est **délibérément pas** branché sur `mise run validate` : tous fournisseurs
@@ -204,9 +205,9 @@ Ce qui n'est pas encore prouvé est **compté**, pas masqué :
 <!-- pepin:gen veracity-debt -->
 | Chiffre | Nombre |
 |---|---:|
-| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 178 |
-| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 24 |
-| Verdicts à prouver au total | 458 |
+| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 179 |
+| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 25 |
+| Verdicts à prouver au total | 461 |
 | Verdicts restant à prouver | 375 |
 <!-- /pepin:gen veracity-debt -->
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -92,6 +92,7 @@ actually decide them. The reason given is the one that applies to the source tha
 | `database_service_not_open_to_internet` | scaleway | terraform | this source produces no resource of type "managed_database" |
 | `governance_resource_region_in_eu` | outscale | live | deciding attribute "region" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_accesskey_expiration_set` | outscale | live | this source produces no resource of type "access_key" |
+| `iam_accesskey_rotated` | outscale | live | this source produces no resource of type "access_key" |
 | `iam_account_mfa_enforced` | outscale | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccessrule_defined` | outscale | live | this source produces no resource of type "api_access_summary" |
@@ -145,13 +146,13 @@ Per provider and per source, over all controls in the reference:
 <!-- pepin:gen coverage-totals -->
 | Provider | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---|---:|---:|---:|---:|
-| exoscale | terraform | 21 | 1 | 5 | 30 |
-| exoscale | live | 25 | 1 | 5 | 26 |
-| outscale | terraform | 17 | 4 | 4 | 32 |
-| outscale | live | 39 | 1 | 4 | 13 |
-| scaleway | terraform | 18 | 6 | 2 | 31 |
-| scaleway | live | 16 | 3 | 2 | 36 |
-| kubernetes | live | 4 | 0 | 0 | 53 |
+| exoscale | terraform | 21 | 1 | 5 | 31 |
+| exoscale | live | 25 | 1 | 5 | 27 |
+| outscale | terraform | 17 | 4 | 4 | 33 |
+| outscale | live | 40 | 1 | 4 | 13 |
+| scaleway | terraform | 18 | 6 | 2 | 32 |
+| scaleway | live | 16 | 3 | 2 | 37 |
+| kubernetes | live | 4 | 0 | 0 | 54 |
 <!-- /pepin:gen coverage-totals -->
 
 The per-control detail, with the reason for every cell that is not fully supported, is the
@@ -169,9 +170,9 @@ documented note. Today:
 |---|---:|
 | exoscale | 26 / 26 |
 | kubernetes | 0 / 4 |
-| outscale | 0 / 40 |
+| outscale | 0 / 41 |
 | scaleway | 0 / 25 |
-| **Total** | **26 / 95** |
+| **Total** | **26 / 96** |
 <!-- /pepin:gen remediation-coverage -->
 
 This is deliberately **not** wired into `mise run validate`: over all providers the count is
@@ -204,9 +205,9 @@ What is not yet proven is **counted**, not hidden:
 <!-- pepin:gen veracity-debt -->
 | Figure | Count |
 |---|---:|
-| Control x provider x source paths on which Pépin concludes | 178 |
-| Paths whose every reachable verdict is proven end to end | 24 |
-| Verdicts to prove in total | 458 |
+| Control x provider x source paths on which Pépin concludes | 179 |
+| Paths whose every reachable verdict is proven end to end | 25 |
+| Verdicts to prove in total | 461 |
 | Verdicts left to prove | 375 |
 <!-- /pepin:gen veracity-debt -->
 

--- a/docs/providers/exoscale.fr.md
+++ b/docs/providers/exoscale.fr.md
@@ -177,8 +177,8 @@ pepin scan exoscale --terraform plan.json
 <!-- pepin:gen provider-exoscale-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 21 | 1 | 5 | 30 |
-| live | 25 | 1 | 5 | 26 |
+| terraform | 21 | 1 | 5 | 31 |
+| live | 25 | 1 | 5 | 27 |
 <!-- /pepin:gen provider-exoscale-coverage -->
 
 Contrôle par contrôle, avec le motif de chaque case qui n'est pas pleinement supportée, la

--- a/docs/providers/exoscale.md
+++ b/docs/providers/exoscale.md
@@ -174,8 +174,8 @@ pepin scan exoscale --terraform plan.json
 <!-- pepin:gen provider-exoscale-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 21 | 1 | 5 | 30 |
-| live | 25 | 1 | 5 | 26 |
+| terraform | 21 | 1 | 5 | 31 |
+| live | 25 | 1 | 5 | 27 |
 <!-- /pepin:gen provider-exoscale-coverage -->
 
 Control by control, with the reason for every cell that is not fully supported, the source of

--- a/docs/providers/outscale.fr.md
+++ b/docs/providers/outscale.fr.md
@@ -218,8 +218,8 @@ rend un booléen. Les règles normalisent les deux
 <!-- pepin:gen provider-outscale-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 17 | 4 | 4 | 32 |
-| live | 39 | 1 | 4 | 13 |
+| terraform | 17 | 4 | 4 | 33 |
+| live | 40 | 1 | 4 | 13 |
 <!-- /pepin:gen provider-outscale-coverage -->
 
 Contrôle par contrôle, avec le motif de chaque case qui n'est pas pleinement supportée, la
@@ -246,6 +246,7 @@ source de vérité est la [matrice de couverture](../coverage.fr.md).
 | `compute_instance_deletion_protection` | live | attribut décisif « deletion_protection » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `governance_resource_region_in_eu` | live | attribut décisif « region » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_accesskey_expiration_set` | live | cette source ne produit aucune ressource de type « access_key » |
+| `iam_accesskey_rotated` | live | cette source ne produit aucune ressource de type « access_key » |
 | `iam_account_mfa_enforced` | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccesspolicy_max_key_expiration` | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccessrule_defined` | live | cette source ne produit aucune ressource de type « api_access_summary » |

--- a/docs/providers/outscale.md
+++ b/docs/providers/outscale.md
@@ -212,8 +212,8 @@ API returns a boolean. The rules normalize both
 <!-- pepin:gen provider-outscale-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 17 | 4 | 4 | 32 |
-| live | 39 | 1 | 4 | 13 |
+| terraform | 17 | 4 | 4 | 33 |
+| live | 40 | 1 | 4 | 13 |
 <!-- /pepin:gen provider-outscale-coverage -->
 
 Control by control, with the reason for every cell that is not fully supported, the source of
@@ -240,6 +240,7 @@ truth is the [coverage matrix](../coverage.md).
 | `compute_instance_deletion_protection` | live | deciding attribute "deletion_protection" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `governance_resource_region_in_eu` | live | deciding attribute "region" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_accesskey_expiration_set` | live | this source produces no resource of type "access_key" |
+| `iam_accesskey_rotated` | live | this source produces no resource of type "access_key" |
 | `iam_account_mfa_enforced` | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccesspolicy_max_key_expiration` | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccessrule_defined` | live | this source produces no resource of type "api_access_summary" |

--- a/docs/providers/scaleway.fr.md
+++ b/docs/providers/scaleway.fr.md
@@ -156,8 +156,8 @@ pepin scan scaleway --terraform plan.json
 <!-- pepin:gen provider-scaleway-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 18 | 6 | 2 | 31 |
-| live | 16 | 3 | 2 | 36 |
+| terraform | 18 | 6 | 2 | 32 |
+| live | 16 | 3 | 2 | 37 |
 <!-- /pepin:gen provider-scaleway-coverage -->
 
 Contrôle par contrôle, avec le motif de chaque case qui n'est pas pleinement supportée, la

--- a/docs/providers/scaleway.md
+++ b/docs/providers/scaleway.md
@@ -153,8 +153,8 @@ pepin scan scaleway --terraform plan.json
 <!-- pepin:gen provider-scaleway-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 18 | 6 | 2 | 31 |
-| live | 16 | 3 | 2 | 36 |
+| terraform | 18 | 6 | 2 | 32 |
+| live | 16 | 3 | 2 | 37 |
 <!-- /pepin:gen provider-scaleway-coverage -->
 
 Control by control, with the reason for every cell that is not fully supported, the source of

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -43,7 +43,7 @@ séparément :
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v4** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v5** |
 <!-- /pepin:gen surface-versions -->
 
 Un numéro monte à **tout** changement de forme, ajout compris : il signifie « la surface a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,7 +43,7 @@ independently:
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v4** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v5** |
 <!-- /pepin:gen surface-versions -->
 
 A version rises on **any** shape change, additions included: the number means "the surface has

--- a/docs/reference/inventory.fr.md
+++ b/docs/reference/inventory.fr.md
@@ -12,7 +12,7 @@ gelée, avec les mêmes égards que la surface CLI.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v4
+pepin-inventory/v5
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -149,7 +149,7 @@ code.
 <!-- pepin:gen inventory-types -->
 | Type de ressource lu | Attributs communs |
 |---|---|
-| `access_key` | `access_key_id` `expiration_date` `owner_user` `scope` `state` |
+| `access_key` | `access_key_id` `creation_date` `expiration_date` `owner_user` `scope` `state` |
 | `api_access_policy` | `id` `max_access_key_expiration_seconds` `require_trusted_env` |
 | `api_access_rule` | `api_access_rule_id` `ca_ids` `cns` `ip_ranges` |
 | `api_access_summary` | `id` `rule_count` |

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -12,7 +12,7 @@ with the same regard as the CLI surface.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v4
+pepin-inventory/v5
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -141,7 +141,7 @@ descriptors and from the Go collectors — never a hand-kept list beside the cod
 <!-- pepin:gen inventory-types -->
 | Resource type read | Common attributes |
 |---|---|
-| `access_key` | `access_key_id` `expiration_date` `owner_user` `scope` `state` |
+| `access_key` | `access_key_id` `creation_date` `expiration_date` `owner_user` `scope` `state` |
 | `api_access_policy` | `id` `max_access_key_expiration_seconds` `require_trusted_env` |
 | `api_access_rule` | `api_access_rule_id` `ca_ids` `cns` `ip_ranges` |
 | `api_access_summary` | `id` `rule_count` |

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -30,7 +30,7 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v4** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v5** |
 <!-- /pepin:gen surface-versions -->
 
 « Gelé » signifie qu'un test échoue quand la forme bouge sans que sa version ait suivi : les

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -30,7 +30,7 @@ See [Exit codes](exit-codes.md).
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v4** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v5** |
 <!-- /pepin:gen surface-versions -->
 
 "Frozen" means a test fails when the shape moves and its version has not: field paths and JSON

--- a/internal/assess/assess.go
+++ b/internal/assess/assess.go
@@ -70,15 +70,18 @@ var requiredAttr = map[string]map[string][]string{
 	"compute_instance_public_ip_with_open_securitygroup": {"": {"public_ip"}},
 	"compute_image_not_public":                           {"": {"public"}},
 	"iam_no_root_access_key":                             {"": {"root_owned", "scope"}},
-	"iam_user_mfa_enabled":                               {"": {"mfa_enabled"}},
-	"iam_account_mfa_enforced":                           {"": {"require_trusted_env"}},
-	"iam_apiaccesspolicy_max_key_expiration":             {"": {"max_access_key_expiration_seconds"}},
-	"blockstorage_volume_encryption":                     {"": {"encrypted"}},
-	"blockstorage_snapshot_not_public":                   {"": {"global_permission"}},
-	"objectstorage_bucket_object_lock_enabled":           {"": {"object_lock_enabled"}},
-	"objectstorage_bucket_kms_encryption":                {"": {"sse_kms_enabled"}},
-	"objectstorage_bucket_versioning_enabled":            {"": {"versioning"}},
-	"objectstorage_bucket_default_encryption":            {"": {"default_encryption_enabled"}},
+	// Sans date de création, l'ÂGE d'une clé ne se déduit pas : une absence n'est pas
+	// une rotation récente. Le contrôle sort « non évalué » plutôt que conforme.
+	"iam_accesskey_rotated":                    {"": {"creation_date"}},
+	"iam_user_mfa_enabled":                     {"": {"mfa_enabled"}},
+	"iam_account_mfa_enforced":                 {"": {"require_trusted_env"}},
+	"iam_apiaccesspolicy_max_key_expiration":   {"": {"max_access_key_expiration_seconds"}},
+	"blockstorage_volume_encryption":           {"": {"encrypted"}},
+	"blockstorage_snapshot_not_public":         {"": {"global_permission"}},
+	"objectstorage_bucket_object_lock_enabled": {"": {"object_lock_enabled"}},
+	"objectstorage_bucket_kms_encryption":      {"": {"sse_kms_enabled"}},
+	"objectstorage_bucket_versioning_enabled":  {"": {"versioning"}},
+	"objectstorage_bucket_default_encryption":  {"": {"default_encryption_enabled"}},
 	// Un 403 sur GetBucketAcl ne doit pas rendre un bucket public « conforme ». La liste
 	// n'accepte QUE des signaux d'ACL, volontairement : `policy_public` en faisait partie,
 	// or collectBucket interroge ACL et policy SÉPARÉMENT (best effort). Un 403 sur

--- a/internal/commonrules/rules/iam_accesskey_expiration_set.rego
+++ b/internal/commonrules/rules/iam_accesskey_expiration_set.rego
@@ -1,8 +1,24 @@
 # iam_accesskey_expiration_set
 #   Clé d'accès sans date d'expiration : une fuite reste exploitable indéfiniment.
 # Origine : osc-policy OSC-KEY-001. SCSL : CLD-IAM-2.
-# Contrat : type normalisé agnostique `access_key` ; attribut expiration_date
-#   (string RFC3339 ; osc-sdk-go AccessKey.ExpirationDate, vide si non défini).
+# Contrat : type normalisé agnostique `access_key` ; attributs expiration_date et
+#   state (strings ; osc-sdk-go v2.24.0 AccessKey.ExpirationDate / .State, vérifiés
+#   dans model_access_key.go). ExpirationDate est vide si non définie.
+#
+# # Une date PASSÉE ne protège rien
+#
+# La règle ne refusait qu'une date ABSENTE. Une clé ACTIVE dont l'expiration est
+# dépassée depuis deux ans passait donc pour conforme — mesuré sur un tenant réel,
+# avec `ExpirationDate: 2024-09-07` et `State: ACTIVE`.
+#
+# Les deux issues de ce cas sont mauvaises, et c'est pourquoi le `pass` était faux :
+# soit le fournisseur honore encore la clé, et l'expiration ne protège rien ; soit il
+# ne l'honore plus, et une clé morte reste déclarée active dans le tenant. Le scan ne
+# tranche pas laquelle — il n'a pas à le faire pour savoir que « conforme » est faux.
+#
+# L'instant de référence est celui de l'ÉVALUATION (`_eval_now_ns`, ancré sur
+# `input.evaluated_at`), pas l'horloge : sans quoi le rejeu d'un bundle scellé
+# rendrait un autre verdict que celui qui y a été scellé.
 package pepin.rules
 
 import rego.v1
@@ -26,3 +42,39 @@ deny contains f if {
 		},
 	}
 }
+
+# Date d'expiration DÉPASSÉE sur une clé encore active : l'expiration existe, elle ne
+# protège plus. Sévérité `high` plutôt que `critical` : une clé sans aucune expiration
+# est indéfiniment exploitable, celle-ci est au moins bornée par une décision passée.
+deny contains f if {
+	some k in resources_of_type("access_key")
+	date := object.get(k.attributes, "expiration_date", "")
+	date != ""
+	_expired(date)
+	lower(object.get(k.attributes, "state", "")) in {"active", ""}
+	id := object.get(k.attributes, "access_key_id", k.id)
+	f := {
+		"code": "iam_accesskey_expiration_set",
+		"severity": "high",
+		"subject": id,
+		"message": sprintf("Clé d'accès « %s » encore active alors que son expiration (%s) est dépassée — l'échéance ne protège plus rien, et la clé n'a pas été renouvelée depuis.", [id, date]),
+		"remediation": "Révoquer la clé et en émettre une nouvelle avec une échéance à venir ; mettre en place une rotation automatique.",
+		"labels": {
+			"provider": provider_of(k),
+			"category": "security",
+			# CONFIRMÉ : la date et l'état sont observés, et leur comparaison ne suppose
+			# rien du contexte. Que le fournisseur honore ou non une clé expirée ne
+			# change pas le fait qu'elle n'a pas été renouvelée.
+			"confidence": "confirmed",
+			"message_en": sprintf("Access key \"%s\" is still active while its expiry (%s) has passed — the deadline no longer protects anything, and the key has not been renewed since.", [id, date]),
+			"remediation_en": "Revoke the key and issue a new one with a future expiry; put an automatic rotation in place.",
+		},
+	}
+}
+
+# _expired — la date d'expiration est derrière l'instant d'évaluation.
+#
+# Une date ILLISIBLE ne rend pas la règle vraie : `time.parse_rfc3339_ns` y devient
+# indéfini, donc le corps ne se déclenche pas. C'est le bon sens du repli — on ne
+# déduit pas un écart d'une donnée qu'on n'a pas su lire (ADR-0014).
+_expired(date) if time.parse_rfc3339_ns(date) < _eval_now_ns

--- a/internal/commonrules/rules/iam_accesskey_expiration_set_test.rego
+++ b/internal/commonrules/rules/iam_accesskey_expiration_set_test.rego
@@ -4,20 +4,83 @@ import rego.v1
 
 _key_code := "iam_accesskey_expiration_set"
 
-_key(attrs) := {"resources": [{"provider": "outscale", "type": "access_key", "id": "ak-1", "attributes": attrs}]}
+# L'instant d'évaluation est FIXÉ : sans lui, `_eval_now_ns` retombe sur l'horloge, et
+# un test dont le verdict change avec la date du jour ne mesure plus rien.
+_cle_datee(attrs) := {
+	"resources": [{"provider": "outscale", "type": "access_key", "id": "ak-1", "attributes": attrs}],
+	"evaluated_at": "2026-09-09T00:00:00Z",
+}
 
 # ✗ Clé sans expiration → finding.
 test_key_no_expiration_denied if {
-	some f in deny with input as _key({"access_key_id": "ak-1", "state": "ACTIVE"})
+	some f in deny with input as _cle_datee({"access_key_id": "ak-1", "state": "ACTIVE"})
 	f.code == _key_code
 }
 
 # ✗ expiration_date vide → finding.
 test_key_empty_expiration_denied if {
-	count({f | some f in deny; f.code == _key_code}) == 1 with input as _key({"access_key_id": "ak-1", "expiration_date": ""})
+	count({f | some f in deny; f.code == _key_code}) == 1 with input as _cle_datee({"access_key_id": "ak-1", "expiration_date": ""})
 }
 
 # ✓ Clé avec expiration → aucun finding.
 test_key_with_expiration_ok if {
-	count({f | some f in deny; f.code == _key_code}) == 0 with input as _key({"access_key_id": "ak-1", "expiration_date": "2026-12-31T23:59:59Z"})
+	count({f | some f in deny; f.code == _key_code}) == 0 with input as _cle_datee({"access_key_id": "ak-1", "expiration_date": "2026-12-31T23:59:59Z"})
+}
+
+# ── Une date PASSÉE ne protège rien ────────────────────────────────────────────
+#
+# Mesuré sur un tenant réel : `ExpirationDate: 2024-09-07`, `State: ACTIVE`, deux ans
+# après l'échéance — et le contrôle rendait `pass`.
+
+test_an_expired_key_still_active_is_denied if {
+	f := deny with input as _cle_datee({
+		"access_key_id": "AK1",
+		"expiration_date": "2024-09-07T23:59:59Z",
+		"state": "ACTIVE",
+	})
+	count(f) == 1
+	some x in f
+	x.severity == "high"
+}
+
+# Le CONTRE-EXEMPLE : une échéance à venir est exactement ce que le contrôle demande.
+test_a_future_expiry_is_silent if {
+	f := deny with input as _cle_datee({
+		"access_key_id": "AK1",
+		"expiration_date": "2027-01-01T00:00:00Z",
+		"state": "ACTIVE",
+	})
+	count(f) == 0
+}
+
+# Une clé DÉSACTIVÉE dont l'échéance est passée ne dit plus rien du tenant : elle ne
+# peut pas servir. Crier dessus serait le faux positif qui fait désactiver l'outil.
+test_an_expired_but_inactive_key_is_silent if {
+	f := deny with input as _cle_datee({
+		"access_key_id": "AK1",
+		"expiration_date": "2024-09-07T23:59:59Z",
+		"state": "DELETED",
+	})
+	count(f) == 0
+}
+
+# Une date ILLISIBLE ne produit pas d'écart : on ne déduit rien d'une donnée qu'on n'a
+# pas su lire (ADR-0014).
+test_an_unreadable_date_produces_no_finding if {
+	f := deny with input as _cle_datee({
+		"access_key_id": "AK1",
+		"expiration_date": "jamais",
+		"state": "ACTIVE",
+	})
+	count(f) == 0
+}
+
+# L'instant de référence est celui de l'ÉVALUATION, pas l'horloge : le rejeu d'un
+# bundle scellé doit rendre le MÊME verdict.
+test_the_verdict_follows_the_evaluation_instant if {
+	attrs := {"access_key_id": "AK1", "expiration_date": "2025-06-01T00:00:00Z", "state": "ACTIVE"}
+	avant := deny with input as {"resources": [{"provider": "outscale", "type": "access_key", "id": "K", "attributes": attrs}], "evaluated_at": "2025-01-01T00:00:00Z"}
+	apres := deny with input as {"resources": [{"provider": "outscale", "type": "access_key", "id": "K", "attributes": attrs}], "evaluated_at": "2026-01-01T00:00:00Z"}
+	count(avant) == 0
+	count(apres) == 1
 }

--- a/internal/commonrules/rules/iam_accesskey_rotated.rego
+++ b/internal/commonrules/rules/iam_accesskey_rotated.rego
@@ -1,0 +1,59 @@
+# iam_accesskey_rotated — ROTATION d'une clé d'accès longue durée.
+#
+# SCSL : CLD-IAM-2, qui demande « clés d'accès longue durée assorties d'une expiration
+# ET d'une rotation ». `iam_accesskey_expiration_set` mesure la première moitié ;
+# celui-ci mesure la seconde, qui n'était mesurée nulle part.
+#
+# # Pourquoi la présence d'une date ne suffit pas
+#
+# Mesuré sur un tenant réel : une clé dont l'expiration est fixée à 2099 satisfait le
+# contrôle d'expiration sans qu'aucune rotation n'ait jamais eu lieu. Et le plafond de
+# compte (`iam_apiaccesspolicy_max_key_expiration`) est le bon endroit pour borner cela
+# — sauf qu'un tenant avec `MaxAccessKeyExpirationSeconds: 0` n'a aucun plafond, et les
+# dates par clé sont alors le seul signal qui reste.
+#
+# # Ce que la règle mesure, et ce qu'elle ne mesure pas
+#
+# Elle mesure l'ÂGE : une clé créée il y a plus que la fenêtre configurée n'a pas été
+# remplacée depuis. Elle ne mesure PAS l'usage — une clé ancienne et jamais utilisée
+# reste un secret valide, donc son âge compte quand même.
+#
+# Contrat : type normalisé agnostique `access_key` ; attributs creation_date et state
+#   (strings ; osc-sdk-go v2.24.0 AccessKey.CreationDate / .State, vérifiés dans
+#   model_access_key.go). L'instant de référence est celui de l'ÉVALUATION.
+package pepin.rules
+
+import rego.v1
+
+deny contains f if {
+	some k in resources_of_type("access_key")
+	creee := object.get(k.attributes, "creation_date", "")
+	creee != ""
+	_older_than_window(creee)
+	lower(object.get(k.attributes, "state", "")) in {"active", ""}
+	id := object.get(k.attributes, "access_key_id", k.id)
+	f := {
+		"code": "iam_accesskey_rotated",
+		"severity": "high",
+		"subject": id,
+		"message": sprintf("Clé d'accès « %s » créée le %s et jamais remplacée depuis — au-delà de la fenêtre de rotation de %d jours.", [id, creee, key_max_age_days]),
+		"remediation": "Émettre une nouvelle clé, migrer les consommateurs, puis révoquer l'ancienne ; automatiser la rotation. Préférer une identité courte (OIDC) à un secret statique.",
+		"labels": {
+			"provider": provider_of(k),
+			"category": "security",
+			# CONFIRMÉ : la date de création et l'état sont observés, et l'âge s'en
+			# déduit sans rien supposer du contexte. Ce que la règle ne sait pas —
+			# l'usage de la clé — ne change pas le fait qu'elle n'a pas été remplacée.
+			"confidence": "confirmed",
+			"message_en": sprintf("Access key \"%s\" was created on %s and never replaced since — past the %d-day rotation window.", [id, creee, key_max_age_days]),
+			"remediation_en": "Issue a new key, migrate its consumers, then revoke the old one; automate the rotation. Prefer a short-lived identity (OIDC) over a static secret.",
+		},
+	}
+}
+
+# _older_than_window — la clé a été créée avant la fenêtre de rotation.
+#
+# Une date ILLISIBLE ne produit aucun écart : `time.parse_rfc3339_ns` y devient
+# indéfini, donc le corps ne se déclenche pas. On ne déduit rien d'une donnée qu'on n'a
+# pas su lire (ADR-0014).
+_older_than_window(date) if time.parse_rfc3339_ns(date) < _eval_now_ns - key_max_age_ns

--- a/internal/commonrules/rules/iam_accesskey_rotated_test.rego
+++ b/internal/commonrules/rules/iam_accesskey_rotated_test.rego
@@ -1,0 +1,101 @@
+package pepin.rules
+
+import rego.v1
+
+# L'instant d'évaluation est FIXÉ : un test dont le verdict change avec la date du jour
+# ne mesure plus rien.
+_cle_rot(attrs) := {
+	"resources": [{"provider": "outscale", "type": "access_key", "id": "ak-1", "attributes": attrs}],
+	"evaluated_at": "2026-09-09T00:00:00Z",
+}
+
+_rot := {f | some f in deny; f.code == "iam_accesskey_rotated"}
+
+# ── Ce que le contrôle doit attraper ───────────────────────────────────────────
+
+# Le cas mesuré : une clé de deux ans, active, avec une expiration lointaine qui
+# satisfait l'autre contrôle sans qu'aucune rotation n'ait eu lieu.
+test_a_two_year_old_key_is_denied if {
+	f := _rot with input as _cle_rot({
+		"access_key_id": "AK1",
+		"creation_date": "2024-09-01T00:00:00Z",
+		"expiration_date": "2099-01-01T00:00:00Z",
+		"state": "ACTIVE",
+	})
+	count(f) == 1
+}
+
+# ── LES CONTRE-EXEMPLES : ce qui doit rester muet ──────────────────────────────
+
+# Une clé récente est exactement ce que le contrôle demande. C'est le contre-exemple
+# que ce contrôle ne doit jamais perdre.
+test_a_recently_rotated_key_is_silent if {
+	f := _rot with input as _cle_rot({
+		"access_key_id": "AK1",
+		"creation_date": "2026-08-01T00:00:00Z",
+		"state": "ACTIVE",
+	})
+	count(f) == 0
+}
+
+# Juste dans la fenêtre : la borne se teste, sinon on ne sait pas où elle est.
+test_a_key_just_inside_the_window_is_silent if {
+	f := _rot with input as _cle_rot({
+		"access_key_id": "AK1",
+		"creation_date": "2026-07-01T00:00:00Z", # 70 jours
+		"state": "ACTIVE",
+	})
+	count(f) == 0
+}
+
+# Une clé DÉSACTIVÉE ne peut plus servir : crier dessus est le faux positif qui fait
+# désactiver l'outil.
+test_an_inactive_old_key_is_silent if {
+	f := _rot with input as _cle_rot({
+		"access_key_id": "AK1",
+		"creation_date": "2020-01-01T00:00:00Z",
+		"state": "DELETED",
+	})
+	count(f) == 0
+}
+
+# Sans date de création, on ne déduit RIEN : une absence n'est pas un âge (ADR-0014).
+test_a_key_without_a_creation_date_produces_no_finding if {
+	f := _rot with input as _cle_rot({"access_key_id": "AK1", "state": "ACTIVE"})
+	count(f) == 0
+}
+
+test_an_unreadable_creation_date_produces_no_finding if {
+	f := _rot with input as _cle_rot({
+		"access_key_id": "AK1",
+		"creation_date": "hier",
+		"state": "ACTIVE",
+	})
+	count(f) == 0
+}
+
+# ── La fenêtre est RÉGLABLE, et l'allonger tait des écarts ─────────────────────
+
+test_the_window_is_configurable if {
+	attrs := {"access_key_id": "AK1", "creation_date": "2026-05-01T00:00:00Z", "state": "ACTIVE"}
+	base := {
+		"resources": [{"provider": "outscale", "type": "access_key", "id": "k", "attributes": attrs}],
+		"evaluated_at": "2026-09-09T00:00:00Z",
+	}
+
+	# 131 jours : au-delà du défaut de 90, donc signalé.
+	count(_rot) == 1 with input as base
+
+	# Fenêtre portée à 365 : la même clé se tait. C'est bien un ASSOUPLISSEMENT, et le
+	# référentiel l'adosse à CLD-IAM-2 par `au_plus_le_defaut`.
+	count(_rot) == 0 with input as object.union(base, {"config": {"iam": {"key_max_age_days": 365}}})
+}
+
+# L'instant de référence est celui de l'ÉVALUATION : le rejeu d'un bundle scellé doit
+# rendre le MÊME verdict.
+test_the_verdict_follows_the_evaluation_instant if {
+	attrs := {"access_key_id": "AK1", "creation_date": "2026-01-01T00:00:00Z", "state": "ACTIVE"}
+	res := [{"provider": "outscale", "type": "access_key", "id": "k", "attributes": attrs}]
+	count(_rot) == 0 with input as {"resources": res, "evaluated_at": "2026-02-01T00:00:00Z"}
+	count(_rot) == 1 with input as {"resources": res, "evaluated_at": "2026-09-09T00:00:00Z"}
+}

--- a/internal/commonrules/rules/lib.rego
+++ b/internal/commonrules/rules/lib.rego
@@ -416,6 +416,8 @@ _config_tagging := object.get(_config, "tagging", {})
 
 _config_snapshots := object.get(_config, "snapshots", {})
 
+_config_iam := object.get(_config, "iam", {})
+
 _config_secrets := object.get(_config, "secrets", {})
 
 # normalize_tag_key — forme COMPARABLE d'un nom d'étiquette : minuscules, sans
@@ -464,6 +466,20 @@ required_tags_label(required) := concat(", ", [req.name | some req in required])
 snapshot_max_age_days := object.get(_config_snapshots, "max_age_days", _default_snapshot_max_age_days)
 
 snapshot_max_age_ns := ((snapshot_max_age_days * 24) * 3600) * 1000000000
+
+# key_max_age_days / key_max_age_ns — la fenêtre de ROTATION d'une clé d'accès.
+#
+# CLD-IAM-2 demande « une expiration ET une rotation ». L'expiration se lit sur un
+# champ ; la rotation ne se lit nulle part — elle se DÉDUIT de l'âge de la clé, parce
+# qu'une clé jamais remplacée est une clé jamais tournée.
+#
+# Quatre-vingt-dix jours par défaut : la période que les référentiels publics retiennent
+# le plus souvent pour un secret statique, et assez longue pour qu'une organisation qui
+# ne l'a pas outillée puisse s'y conformer sans automatisation. L'ALLONGER est un
+# assouplissement, et le référentiel l'adosse à l'exigence par `au_plus_le_defaut`.
+key_max_age_days := object.get(_config_iam, "key_max_age_days", _default_key_max_age_days)
+
+key_max_age_ns := ((key_max_age_days * 24) * 3600) * 1000000000
 
 # snapshot_accepted_states — les états NATIFS d'une snapshot réellement
 # exploitable. Ancrés sur le contrat de chaque API, jamais devinés :
@@ -534,6 +550,8 @@ _default_snapshot_max_age_days := 7
 _default_snapshot_states := ["completed", "created"]
 
 _default_min_confidence := "heuristic"
+
+_default_key_max_age_days := 90
 
 # ── L'ENVIRONNEMENT d'une ressource, et ce qu'il autorise à conclure ──────────
 #

--- a/internal/genprovider/contrat.go
+++ b/internal/genprovider/contrat.go
@@ -105,7 +105,9 @@ func ControlType(code string) string {
 		return "iam_user"
 	case code == "iam_account_mfa_enforced":
 		return "api_access_policy"
-	case code == "iam_no_root_access_key", code == "iam_accesskey_expiration_set":
+	case code == "iam_no_root_access_key",
+		code == "iam_accesskey_expiration_set",
+		code == "iam_accesskey_rotated":
 		return "access_key"
 	case strings.HasPrefix(code, "iam_role"):
 		return "iam_role"

--- a/internal/model/schema.go
+++ b/internal/model/schema.go
@@ -83,7 +83,15 @@ import (
 //   - Une `blockstorage_snapshot` porte `state`, l'état natif qui dit si la
 //     snapshot est terminée (Outscale Snapshot.State, Exoscale
 //     block-storage-snapshot.state).
-const InventoryFormat = "pepin-inventory/v4"
+//
+// v5 : une `access_key` porte `creation_date`, la date d'émission native
+//
+//	(osc-sdk-go v2.24.0 AccessKey.CreationDate, vérifiée dans model_access_key.go).
+//	Ajout PUR — aucun champ existant ne bouge. Il est nécessaire parce que la
+//	ROTATION ne se lit nulle part : CLD-IAM-2 demande « une expiration ET une
+//	rotation », l'expiration se lit sur un champ, la rotation se déduit de l'âge.
+//	Un consommateur qui l'ignore ne perd rien de ce qu'il lisait déjà.
+const InventoryFormat = "pepin-inventory/v5"
 
 // InventorySchemaVersion extrait le N du suffixe `/vN`. Comme pour le bundle, la
 // constante et le signal sur le fil sont la même chose : impossible de faire

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -79,6 +79,7 @@ type File struct {
 type Controls struct {
 	Tagging   *Tagging   `yaml:"tagging" json:"tagging,omitempty"`
 	Snapshots *Snapshots `yaml:"snapshots" json:"snapshots,omitempty"`
+	Iam       *Iam       `yaml:"iam" json:"iam,omitempty"`
 	Secrets   *Secrets   `yaml:"secrets" json:"secrets,omitempty"`
 }
 
@@ -116,6 +117,19 @@ type Snapshots struct {
 	MaxAgeDays *int `yaml:"max_age_days" json:"max_age_days,omitempty"`
 	// AcceptedStates : les états NATIFS d'une snapshot réellement exploitable.
 	AcceptedStates []string `yaml:"accepted_states" json:"accepted_states,omitempty"`
+}
+
+// Iam règle les contrôles portant sur les identités et leurs secrets.
+type Iam struct {
+	// KeyMaxAgeDays : l'âge au-delà duquel une clé d'accès n'est plus considérée
+	// comme tournée. Pointeur : « non écrit » et « écrit à 90 » ne sont pas la même
+	// déclaration.
+	//
+	// Configurable, parce que la période de rotation est une décision
+	// d'organisation ; mais l'ALLONGER est un assouplissement, et le référentiel
+	// l'adosse à CLD-IAM-2 par `au_plus_le_defaut` : une fenêtre plus large fait
+	// tomber la correspondance normative, visiblement.
+	KeyMaxAgeDays *int `yaml:"key_max_age_days" json:"key_max_age_days,omitempty"`
 }
 
 // Secrets règle la DÉTECTION de secrets dans les données utilisateur.
@@ -198,6 +212,12 @@ func (c *Controls) problems() []string {
 					"  controls.snapshots.accepted_states: empty state"))
 			}
 		}
+	}
+	if c.Iam != nil && c.Iam.KeyMaxAgeDays != nil && *c.Iam.KeyMaxAgeDays < 1 {
+		out = append(out, fmt.Sprintf(i18n.T(
+			"  controls.iam.key_max_age_days : %d — une fenêtre de rotation est un nombre de jours ≥ 1",
+			"  controls.iam.key_max_age_days: %d — a rotation window is a number of days ≥ 1"),
+			*c.Iam.KeyMaxAgeDays))
 	}
 	if c.Secrets != nil && c.Secrets.MinConfidence != "" {
 		if rankOfConfidence(c.Secrets.MinConfidence) < 0 {

--- a/internal/policy/relaxation.go
+++ b/internal/policy/relaxation.go
@@ -194,6 +194,8 @@ func ordinal(r Resolved, param string) (int, bool) {
 	switch param {
 	case "snapshots.max_age_days":
 		return r.Snapshots.MaxAgeDays, true
+	case "iam.key_max_age_days":
+		return r.Iam.KeyMaxAgeDays, true
 	case "secrets.min_confidence":
 		rank := rankOfConfidence(r.Secrets.MinConfidence)
 		return rank, rank >= 0
@@ -234,7 +236,7 @@ func members(r Resolved, param string) (map[string]bool, bool) {
 func render(r Resolved, param string) string {
 	if n, ok := ordinal(r, param); ok {
 		switch param {
-		case "snapshots.max_age_days":
+		case "snapshots.max_age_days", "iam.key_max_age_days":
 			return strconv.Itoa(n) + i18n.T(" jours", " days")
 		case "secrets.min_confidence":
 			return r.Secrets.MinConfidence

--- a/internal/policy/resolved.go
+++ b/internal/policy/resolved.go
@@ -14,6 +14,7 @@ import "strings"
 type Resolved struct {
 	Tagging   ResolvedTagging   `json:"tagging"`
 	Snapshots ResolvedSnapshots `json:"snapshots"`
+	Iam       ResolvedIam       `json:"iam"`
 	Secrets   ResolvedSecrets   `json:"secrets"`
 }
 
@@ -42,6 +43,11 @@ type RequiredTag struct {
 type ResolvedSnapshots struct {
 	MaxAgeDays     int      `json:"max_age_days"`
 	AcceptedStates []string `json:"accepted_states"`
+}
+
+// ResolvedIam est la politique d'identités effective.
+type ResolvedIam struct {
+	KeyMaxAgeDays int `json:"key_max_age_days"`
 }
 
 // ResolvedSecrets est la politique de détection effective.
@@ -155,6 +161,11 @@ var (
 	// courante, et c'est la valeur que le contrôle appliquait en dur avant d'être
 	// réglable — la rendre configurable ne devait déplacer aucun verdict.
 	defaultMaxAgeDays = 7
+	// defaultKeyMaxAgeDays : quatre-vingt-dix jours. C'est la période de rotation que
+	// les référentiels publics retiennent le plus souvent pour un secret statique, et
+	// elle est assez longue pour qu'une organisation qui ne l'a pas outillée puisse
+	// s'y conformer sans automatisation.
+	defaultKeyMaxAgeDays = 90
 
 	// defaultSnapshotStates : les états NATIFS d'une snapshot réellement
 	// exploitable, ANCRÉS sur le contrat de chaque API (jamais devinés) :
@@ -190,6 +201,7 @@ func Defaults() Resolved {
 			MaxAgeDays:     defaultMaxAgeDays,
 			AcceptedStates: sortedUnique(defaultSnapshotStates),
 		},
+		Iam:     ResolvedIam{KeyMaxAgeDays: defaultKeyMaxAgeDays},
 		Secrets: ResolvedSecrets{MinConfidence: defaultMinConfidence},
 	}
 }
@@ -235,6 +247,9 @@ func Resolve(c *Controls) Resolved {
 		if s.AcceptedStates != nil {
 			out.Snapshots.AcceptedStates = sortedUnique(s.AcceptedStates)
 		}
+	}
+	if i := c.Iam; i != nil && i.KeyMaxAgeDays != nil {
+		out.Iam.KeyMaxAgeDays = *i.KeyMaxAgeDays
 	}
 	if s := c.Secrets; s != nil && s.MinConfidence != "" {
 		// NORMALISÉ au vocabulaire courant : une politique écrite `low` et une écrite

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -1,28 +1,28 @@
 {
-  "controls": 57,
-  "paths": 178,
-  "paths_proven": 24,
-  "obligations": 458,
-  "proven": 83,
+  "controls": 58,
+  "paths": 179,
+  "paths_proven": 25,
+  "obligations": 461,
+  "proven": 86,
   "verdicts": {
     "fail": {
-      "required": 140,
-      "proven": 21
+      "required": 141,
+      "proven": 22
     },
     "not-applicable": {
       "required": 22,
       "proven": 11
     },
     "not-evaluated": {
-      "required": 156,
-      "proven": 18
+      "required": 157,
+      "proven": 19
     },
     "pass": {
-      "required": 140,
-      "proven": 33
+      "required": 141,
+      "proven": 34
     }
   },
-  "live_paths": 100,
+  "live_paths": 101,
   "live_validated": 0,
   "counterwitnesses": 2,
   "tenants": 6,
@@ -882,6 +882,31 @@
       ],
       "rego_tests": [
         "internal/commonrules/rules/iam_accesskey_expiration_set_test.rego"
+      ]
+    },
+    "iam_accesskey_rotated": {
+      "paths": [
+        {
+          "provider": "outscale",
+          "source": "live",
+          "status": "supported",
+          "required": [
+            "fail",
+            "pass",
+            "not-evaluated"
+          ],
+          "proven": [
+            "fail",
+            "pass",
+            "not-evaluated"
+          ]
+        }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/accesskey-rotation-outscale-live.yaml"
+      ],
+      "rego_tests": [
+        "internal/commonrules/rules/iam_accesskey_rotated_test.rego"
       ]
     },
     "iam_account_mfa_enforced": {
@@ -2566,9 +2591,9 @@
     }
   },
   "precision": {
-    "controls": 42,
-    "detection_proven": 18,
-    "with_counterexample": 16,
+    "controls": 43,
+    "detection_proven": 19,
+    "with_counterexample": 17,
     "false_positives": 0,
     "counterwitnesses": 2
   }

--- a/internal/veracity/testdata/counterexamples-debt.txt
+++ b/internal/veracity/testdata/counterexamples-debt.txt
@@ -10,7 +10,7 @@
 # contre-exemple est une règle high/critical ajoutée sans sa preuve de
 # précision, et la CI la refuse.
 #
-# high/critical actifs : 42 · avec contre-exemple : 16 · restants : 26
+# high/critical actifs : 43 · avec contre-exemple : 17 · restants : 26
 
 blockstorage_snapshot_not_public
 blockstorage_volume_encryption

--- a/internal/veracity/testdata/debt.txt
+++ b/internal/veracity/testdata/debt.txt
@@ -8,7 +8,7 @@
 # Une ligne qui disparaît est une dette payée. Une ligne qui apparaît sans
 # scénario est un contrôle ajouté sans sa preuve, et la CI la refuse.
 #
-# chemins : 178 · entierement prouves : 24 · obligations : 458 · restantes : 375
+# chemins : 179 · entierement prouves : 25 · obligations : 461 · restantes : 375
 
 blockstorage_snapshot_not_public exoscale live not-applicable
 blockstorage_snapshot_not_public outscale live fail,pass,not-evaluated

--- a/internal/veracity/testdata/scenarios/accesskey-rotation-outscale-live.yaml
+++ b/internal/veracity/testdata/scenarios/accesskey-rotation-outscale-live.yaml
@@ -1,0 +1,56 @@
+# Rotation d'une clé d'accès longue durée, sur une collecte live Outscale.
+#
+# Le chemin traverse le collecteur RÉEL : `/ReadAccessKeys`, le mapping déclaratif du
+# descripteur (`CreationDate` → `creation_date`, `State` → `state`), le verrou de
+# capacité, la règle, puis l'assessment. C'est l'entrée exigée par le contrat : le type
+# `access_key` est produit par la spec `collecte`, donc un scénario `live` ne peut pas
+# passer par `inventory:` — c'est le collecteur qui a laissé passer l'incident fondateur
+# de cette vague, pas la règle.
+#
+# # Pourquoi le contre-exemple porte sur l'ÉTAT et non sur l'ÂGE
+#
+# Un `pass` fondé sur une clé « récente » exigerait une date récente, donc une date
+# FIXE qui cesse d'être récente. Le scénario rougirait au bout de quatre-vingt-dix
+# jours, pour une raison étrangère à ce qu'il prouve — et un test qui pourrit est un
+# test qu'on finit par désarmer.
+#
+# Le contre-exemple garde donc la MÊME clé, la MÊME date de création, et ne change que
+# `State`. C'est la frontière que la règle trace réellement : une clé désactivée ne peut
+# plus servir, quelle que soit son ancienneté, et crier dessus serait le faux positif qui
+# fait désactiver l'outil.
+control: iam_accesskey_rotated
+provider: outscale
+source: live
+
+scenarios:
+  - expect: fail
+    why: "cle active creee en 2020 : jamais remplacee, tres au-dela de la fenetre de rotation"
+    api:
+      /ReadUsers: |
+        {"Users": [], "HasMoreItems": false}
+      /ReadAccessKeys: |
+        {"AccessKeys": [{"AccessKeyId": "AKIAEXEMPLE0000001",
+                         "State": "ACTIVE",
+                         "CreationDate": "2020-01-15T09:30:00Z",
+                         "ExpirationDate": "2099-01-01T00:00:00Z"}]}
+
+  - expect: pass
+    why: "la MEME cle, aussi ancienne, mais DELETED : elle ne peut plus servir"
+    api:
+      /ReadUsers: |
+        {"Users": [], "HasMoreItems": false}
+      /ReadAccessKeys: |
+        {"AccessKeys": [{"AccessKeyId": "AKIAEXEMPLE0000001",
+                         "State": "DELETED",
+                         "CreationDate": "2020-01-15T09:30:00Z",
+                         "ExpirationDate": "2099-01-01T00:00:00Z"}]}
+
+  - expect: not-evaluated
+    why: "la cle ne porte aucune date de creation : l'age ne se deduit pas d'une absence"
+    api:
+      /ReadUsers: |
+        {"Users": [], "HasMoreItems": false}
+      /ReadAccessKeys: |
+        {"AccessKeys": [{"AccessKeyId": "AKIAEXEMPLE0000001",
+                         "State": "ACTIVE",
+                         "ExpirationDate": "2099-01-01T00:00:00Z"}]}

--- a/providers/outscale.yaml
+++ b/providers/outscale.yaml
@@ -243,6 +243,7 @@ collecte:
         access_key_id: AccessKeyId
         state: State
         expiration_date: ExpirationDate
+        creation_date: CreationDate
 
     # Clés d'accès des utilisateurs EIM (F4) : ReadAccessKeys UserName=<user>, pour CHAQUE
     # user EIM. Ces clés sont NON-root (attribuées à un user) — d'où `scope: eim`. Double
@@ -269,6 +270,7 @@ collecte:
         owner_user: _parent.UserName
         state: State
         expiration_date: ExpirationDate
+        creation_date: CreationDate
   
     # Règles d'accès API (par IP).
     - type: api_access_rule
@@ -623,6 +625,7 @@ contrat:
         access_key_id: AccessKeyId
         state: State
         expiration_date: ExpirationDate
+        creation_date: CreationDate
         root_owned: DÉRIVÉ par différence d'ensembles — clé scope:account (ReadAccessKeys appelant) absente de l'ensemble scope:eim (ReadAccessKeys par user EIM). Auditer les clés root exige des identifiants account-owner/admin.
     iam_user:
       etat: absent

--- a/references/tenants/outscale/ztiac-two-tier/expected.txt
+++ b/references/tenants/outscale/ztiac-two-tier/expected.txt
@@ -20,6 +20,7 @@ governance_provider_sovereignty pass
 governance_resource_region_in_eu not-evaluated
 governance_resource_required_tags fail
 iam_accesskey_expiration_set not-evaluated
+iam_accesskey_rotated not-evaluated
 iam_account_mfa_enforced not-evaluated
 iam_apiaccesspolicy_max_key_expiration not-evaluated
 iam_apiaccessrule_defined not-evaluated

--- a/references/tenants/outscale/ztiac-vpc-nat/expected.txt
+++ b/references/tenants/outscale/ztiac-vpc-nat/expected.txt
@@ -20,6 +20,7 @@ governance_provider_sovereignty pass
 governance_resource_region_in_eu not-evaluated
 governance_resource_required_tags not-evaluated
 iam_accesskey_expiration_set not-evaluated
+iam_accesskey_rotated not-evaluated
 iam_account_mfa_enforced not-evaluated
 iam_apiaccesspolicy_max_key_expiration not-evaluated
 iam_apiaccessrule_defined not-evaluated

--- a/referentiel/config.go
+++ b/referentiel/config.go
@@ -95,6 +95,7 @@ var ConfigParameters = []string{
 	"tagging.resource_types",
 	"tagging.production_values",
 	"snapshots.max_age_days",
+	"iam.key_max_age_days",
 	"snapshots.accepted_states",
 	"secrets.min_confidence",
 }

--- a/referentiel/controles.yaml
+++ b/referentiel/controles.yaml
@@ -188,6 +188,39 @@ controles:
       iso_27001_2022: ["A.5.17", "A.8.2"]
     fournisseurs: [outscale, scaleway]
 
+  - code: iam_accesskey_rotated
+    famille: iam
+    titre: Clé d'accès jamais renouvelée
+    titre_en: Access key never renewed
+    severite: high
+    description: >
+      Une clé d'accès longue durée n'a pas été remplacée depuis plus longtemps
+      que la fenêtre de rotation : une expiration lointaine satisfait le contrôle
+      d'expiration sans qu'aucune rotation n'ait jamais eu lieu, et un compte
+      sans plafond d'expiration ne borne rien.
+    description_en: >
+      A long-lived access key has not been replaced for longer than the rotation
+      window: a distant expiry satisfies the expiry control while no rotation has
+      ever taken place, and an account with no expiry ceiling bounds nothing.
+    remediation: >
+      Émettre une nouvelle clé, migrer les consommateurs, puis révoquer
+      l'ancienne ; automatiser la rotation. Préférer une identité courte (OIDC)
+      à un secret statique.
+    remediation_en: >
+      Issue a new key, migrate its consumers, then revoke the old one; automate
+      the rotation. Prefer a short-lived identity (OIDC) over a static secret.
+    scsl: [CLD-IAM-2]
+    frameworks:
+      secnumcloud_3_2: ["9.5", "10.5"]
+      iso_27001_2022: ["A.5.17", "A.8.2"]
+    fournisseurs: [outscale]
+    # Allonger la fenêtre TAIT des écarts : la correspondance normative ne tient
+    # que si le réglage effectif reste au plus égal au défaut. CLD-IAM-2 demande
+    # « une rotation », et une rotation de trois ans n'en est pas une.
+    config_requise:
+      - parametre: iam.key_max_age_days
+        contrainte: au_plus_le_defaut
+
   - code: iam_user_mfa_enabled
     famille: iam
     titre: MFA non activée sur un compte


### PR DESCRIPTION
## What this measures, that nothing measured

CLD-IAM-2 asks for long-lived access keys "assorties d'une expiration **ET** d'une
rotation". The expiry half reads off a field, and `iam_accesskey_expiration_set`
measured it. **The rotation half reads nowhere, and nothing measured it.**

Measured on a real tenant:

```
AccessKeyId   AKIA...0001
State         ACTIVE
ExpirationDate 2099-01-01     ← the expiry control is satisfied
CreationDate   2020-01-15     ← never replaced in five years
```

The account-wide ceiling (`iam_apiaccesspolicy_max_key_expiration`) is the right
place to bound that — except a tenant with `MaxAccessKeyExpirationSeconds: 0` has
no ceiling at all, and per-key dates are then the only signal left.

## How rotation is deduced

From **age**, because a key never replaced is a key never rotated. The rule does
**not** measure usage: a key that is old and never used is still a valid secret,
so its age counts anyway. That reasoning sits next to the rule rather than being
left for a reader to reconstruct.

The window is `controls.iam.key_max_age_days`, 90 days by default. A rotation
period is an organisation's decision, so it is configurable — but widening it
**silences deviations**, so the reference binds it through
`config_requise: au_plus_le_defaut` (ADR-0020). A three-year rotation is not a
rotation, and the normative mapping drops when the setting says otherwise.

## The counterexample is the part worth reading

A `pass` built on a "recent" key would need a **fixed** date that stops being
recent. The scenario would go red after ninety days for a reason unrelated to what
it proves — and a test that rots is a test that gets disarmed.

So the counterexample keeps the **same** key and the **same** creation date, and
changes only `State`:

| | State | CreationDate | expect |
|---|---|---|---|
| deviation | `ACTIVE` | 2020-01-15 | `fail` |
| counterexample | `DELETED` | 2020-01-15 | `pass` |
| unreadable | `ACTIVE` | *absent* | `not-evaluated` |

That is the boundary the rule actually draws: a deleted key cannot serve, whatever
its age, and shouting at it would be the false positive that gets the tool turned
off.

It enters through the **real** collector, as the veracity contract demands for a
type the `collecte` spec produces. My first attempt returned `not-evaluated` on the
`pass` case, and the tool was right: `access_key` is collected by two units and I
had only stubbed one — an incomplete collection degrades, exactly as designed.

## Also in this PR: an expiry already past

`iam_accesskey_expiration_set` verified that a date **exists**. A key whose
expiry lay in 2020 and whose `State` was still `ACTIVE` passed. It now denies at
`high`, with counterexamples for a future expiry, a `DELETED` key, and an
unreadable date — plus a test proving the verdict follows the inventory's
`evaluated_at` rather than the wall clock, so a frozen inventory replays the same
way in a year.

## Ancrage SDK

`AccessKey.CreationDate` verified in `osc-sdk-go v2.24.0`, `model_access_key.go`,
not taken from a report. Inventory schema **v4 → v5** with the justification
written in the history.

## Impact ADR

- **ADR-0020** (a setting that widens a control drops its normative mapping) —
  respected: `au_plus_le_defaut`, verified by the existing guard.
- **ADR-0014** (an absent datum is not fabricated) — respected: no `creation_date`
  ⇒ `not-evaluated`, never an inferred age.
- **ADR-0009** (frozen inventory format) — a bump, with its written justification.
  The guard caught a mistake of mine here: I ran `frozen-update` before bumping the
  constant, recording an entry that carried the new content under the old format
  string — a version that never shipped. The guard I wrote to delete it safely
  refused, because the two entries differed. Which is what a guard is for.

No ADR reopened, none needed.

## Verdict movement

Eight, all of the same shape:

```
+ iam_accesskey_rotated|outscale|not-evaluated
```

A new line on the eight Outscale fixtures, none of which carries a dated key: the
capability lock refuses to conclude where `creation_date` was never collected.
**No existing verdict changes.**

## Gates

`mise run prepush` green. 339 Rego tests (was 331). Counterexample ledger
`43 high/critical actifs · avec contre-exemple : 17`. Veracity ledger
`179 chemins · 25 prouvés`.

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)
