### PR TITLE
fix(rules): name which of the two findings the operator actually did

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -278,6 +278,30 @@ l'une ni l'autre appartient au `git log`.
 
 ### Modifié
 
+- **Les deux findings d'un réseau tout juste créé disent maintenant lequel vient de
+  l'exploitant.** Sur un Net Outscale neuf, un scan live signalait un `high` sur le
+  security group « default » — « porte une règle entrante » — et l'exploitant allait
+  chercher une règle qu'il aurait écrite. La règle trouvée est celle que le provider crée
+  avec le réseau : sa seule source admise est le groupe lui-même. L'écart subsiste (deux
+  ressources démarrées sans SG explicite y atterrissent et communiquent librement, ce que
+  CLD-NET-4 refuse), mais il nomme désormais la forme qu'il a trouvée et porte
+  `confidence: contextual` au lieu de `confirmed`. La distinction est **observée**, pas
+  déduite d'un CIDR absent : une règle entrante admet une source par CIDR **ou** par
+  groupe, et la source par groupe est maintenant collectée
+  (`peer_security_group_ids`). Là où le champ manque, la règle retombe sur la formulation
+  générale et sur `confirmed` — ne pas savoir ne doit pas faire sortir un écart d'une
+  porte de CI.
+- **La sortie non restreinte est `contextual`, plus `confirmed`.** L'étiquette venait du
+  constructeur partagé, dont la justification porte sur l'entrée : il n'existe pas de
+  raison légitime d'ouvrir SSH à tout Internet. Cet argument ne vaut pas pour la sortie.
+  Une sortie ouverte est un chemin d'exfiltration réel, mais des architectures
+  défendables la laissent ouverte et filtrent en aval — passerelle, mandataire, pare-feu
+  périmétrique — sur un plan que le scan ne voit pas. Le finding garde son code, sa
+  sévérité `medium` et sa catégorie `security` ; il quitte `--gate security` sans quitter
+  le rapport. **Le comportement par défaut ne bouge pas** : `--gate all` rend toujours `1`.
+- Les messages d'exposition choisissent leur préposition selon la direction de la règle.
+  Une règle sortante n'accepte rien « depuis » Internet, et un lecteur qui corrige ce que
+  la phrase décrit cherchait au mauvais endroit.
 - **La souveraineté se mesure désormais sur les ressources qui hébergent des données,
   et sur elles seules.** Le contrôle de localisation UE concluait depuis une *voisine* :
   une seule ressource portant une région ouvrait le `pass` à toutes les autres, y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,29 @@ belongs in `git log`.
 
 ### Changed
 
+- **The two findings a freshly created network produced now say which of them the
+  operator did.** On a brand-new Outscale Net, a live scan reported a `high` on the
+  default security group — "carries an inbound rule" — and the operator went looking for
+  a rule they had written. The rule found is the one the provider creates with the
+  network: its only accepted source is the group itself. The finding stands (two
+  resources started without an explicit SG land in it and talk freely, which is what
+  CLD-NET-4 refuses), but it now names the shape it found, and carries
+  `confidence: contextual` rather than `confirmed`. The distinction is **observed**, not
+  deduced from a missing CIDR: an inbound rule accepts a source by CIDR **or** by group,
+  and the group source is now collected (`peer_security_group_ids`). Where the field is
+  absent the rule falls back to the general wording and to `confirmed` — not knowing must
+  not take a deviation out of a CI gate.
+- **Unrestricted egress is `contextual`, not `confirmed`.** The label was inherited from
+  the shared constructor, whose justification is about ingress: there is no legitimate
+  reason to open SSH to the whole internet. That argument does not transfer to the way
+  out. An open egress is a real exfiltration path, but defensible architectures leave it
+  open and filter downstream — gateway, proxy, perimeter firewall — on a plane the scan
+  does not see. The finding keeps its code, its `medium` severity and its `security`
+  category; it leaves `--gate security` without leaving the report. **Default behaviour
+  is unchanged**: `--gate all` still exits `1`.
+- Exposure messages now pick their preposition from the rule's direction. An outbound
+  rule accepts nothing "from" the internet, and a reader who corrects what the sentence
+  describes was looking in the wrong place.
 - **Sovereignty is now measured on the resources that host data, and only those.** The
   EU-location control asserted compliance from a *neighbour*: one resource carrying a
   region opened a `pass` for every other, including types the rule never examines — an

--- a/cmd/testdata/frozen/inventory.json
+++ b/cmd/testdata/frozen/inventory.json
@@ -1,1102 +1,1330 @@
 {
- "history": [
-  {
-   "content": {
-    "envelope": {
-     "provider": "string",
-     "resources": [
-      {
-       "attributes": {
-        "*": "any"
-       },
-       "id": "string",
-       "name": "string",
-       "provenance": {
-        "*": {
-         "derived": "boolean",
-         "observed": "boolean",
-         "origin": "string",
-         "path": "string",
-         "source": "string"
+  "history": [
+    {
+      "schema_version": 1,
+      "content": {
+        "envelope": {
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v1",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "expiration_date",
+            "owner_user",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "inbound_default_policy",
+            "security_group_id"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
         }
-       },
-       "provider": "string",
-       "region": "string",
-       "type": "string"
       }
-     ]
     },
-    "format": "pepin-inventory/v1",
-    "types": {
-     "access_key": [
-      "access_key_id",
-      "expiration_date",
-      "owner_user",
-      "scope",
-      "state"
-     ],
-     "api_access_policy": [
-      "id",
-      "max_access_key_expiration_seconds",
-      "require_trusted_env"
-     ],
-     "api_access_rule": [
-      "api_access_rule_id",
-      "ca_ids",
-      "cns",
-      "ip_ranges"
-     ],
-     "api_access_summary": [
-      "id",
-      "rule_count"
-     ],
-     "blockstorage_snapshot": [
-      "creation_date",
-      "global_permission",
-      "snapshot_id",
-      "volume_id"
-     ],
-     "blockstorage_volume": [
-      "encrypted",
-      "state",
-      "tags",
-      "volume_id"
-     ],
-     "compute_image": [
-      "image_id",
-      "public",
-      "state",
-      "tags"
-     ],
-     "compute_instance": [
-      "deletion_protection",
-      "nic_public_ips",
-      "public_ip",
-      "security_group_ids",
-      "state",
-      "tags",
-      "user_data",
-      "vm_id"
-     ],
-     "governance_provider": [
-      "capital_control",
-      "eu_established",
-      "extraterritorial_exposure",
-      "jurisdiction",
-      "secnumcloud"
-     ],
-     "iam_policy": [
-      "manages_iam",
-      "owner_group",
-      "owner_user",
-      "policy_id",
-      "policy_name",
-      "scope",
-      "statements"
-     ],
-     "iam_role": [
-      "admin_privileges",
-      "editable",
-      "manages_iam",
-      "max_session_ttl",
-      "name",
-      "policy_has_expiration",
-      "role_id",
-      "source_ip_restricted"
-     ],
-     "iam_user": [
-      "mfa_enabled",
-      "user_id",
-      "username"
-     ],
-     "k8s_cluster_role_binding": [
-      "name",
-      "role_ref",
-      "subjects"
-     ],
-     "k8s_crd": [
-      "name"
-     ],
-     "k8s_namespace": [
-      "labels",
-      "name"
-     ],
-     "k8s_network_policy": [
-      "name",
-      "namespace"
-     ],
-     "kubernetes_cluster": [
-      "admin_whitelist",
-      "audit_enabled",
-      "auto_upgrade",
-      "control_plane_multi_az",
-      "deletion_protection",
-      "name",
-      "version"
-     ],
-     "load_balancer": [
-      "access_log",
-      "listeners",
-      "load_balancer_name",
-      "load_balancer_type",
-      "tags"
-     ],
-     "managed_database": [
-      "database_id",
-      "disable_backup",
-      "encryption_at_rest",
-      "ip_filter"
-     ],
-     "network": [
-      "cidr",
-      "description",
-      "name",
-      "network_id",
-      "state",
-      "tags"
-     ],
-     "network_peering": [
-      "accepter_account",
-      "peering_id",
-      "source_account",
-      "state"
-     ],
-     "object_storage_bucket": [
-      "acl",
-      "acl_grants",
-      "default_encryption_enabled",
-      "kms_key_id",
-      "name",
-      "object_lock_enabled",
-      "policy_public",
-      "public_via_acl",
-      "sse_kms_enabled",
-      "tags",
-      "versioning"
-     ],
-     "security_group": [
-      "inbound_default_policy",
-      "security_group_id"
-     ],
-     "security_group_rule": [
-      "action",
-      "cidrs",
-      "description",
-      "direction",
-      "port_from",
-      "port_to",
-      "protocol",
-      "security_group_id",
-      "security_group_name"
-     ],
-     "subnet": [
-      "map_public_ip_on_launch",
-      "network_id",
-      "state",
-      "subnet_id",
-      "tags"
-     ]
-    }
-   },
-   "schema_version": 1
-  },
-  {
-   "content": {
-    "envelope": {
-     "collection": {
-      "units": [
-       {
-        "attempted": "boolean",
-        "complete": "boolean",
-        "detail": "string",
-        "error": "string",
-        "types": [
-         "string"
-        ],
-        "unit": "string"
-       }
-      ],
-      "unmapped": [
-       {
-        "count": "number",
-        "type": "string"
-       }
-      ]
-     },
-     "provider": "string",
-     "resources": [
-      {
-       "attributes": {
-        "*": "any"
-       },
-       "id": "string",
-       "name": "string",
-       "provenance": {
-        "*": {
-         "derived": "boolean",
-         "observed": "boolean",
-         "origin": "string",
-         "path": "string",
-         "source": "string"
+    {
+      "schema_version": 2,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v2",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "expiration_date",
+            "owner_user",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "inbound_default_policy",
+            "security_group_id"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
         }
-       },
-       "provider": "string",
-       "region": "string",
-       "type": "string"
       }
-     ]
     },
-    "format": "pepin-inventory/v2",
-    "types": {
-     "access_key": [
-      "access_key_id",
-      "expiration_date",
-      "owner_user",
-      "scope",
-      "state"
-     ],
-     "api_access_policy": [
-      "id",
-      "max_access_key_expiration_seconds",
-      "require_trusted_env"
-     ],
-     "api_access_rule": [
-      "api_access_rule_id",
-      "ca_ids",
-      "cns",
-      "ip_ranges"
-     ],
-     "api_access_summary": [
-      "id",
-      "rule_count"
-     ],
-     "blockstorage_snapshot": [
-      "creation_date",
-      "global_permission",
-      "snapshot_id",
-      "volume_id"
-     ],
-     "blockstorage_volume": [
-      "encrypted",
-      "state",
-      "tags",
-      "volume_id"
-     ],
-     "compute_image": [
-      "image_id",
-      "public",
-      "state",
-      "tags"
-     ],
-     "compute_instance": [
-      "deletion_protection",
-      "nic_public_ips",
-      "public_ip",
-      "security_group_ids",
-      "state",
-      "tags",
-      "user_data",
-      "vm_id"
-     ],
-     "governance_provider": [
-      "capital_control",
-      "eu_established",
-      "extraterritorial_exposure",
-      "jurisdiction",
-      "secnumcloud"
-     ],
-     "iam_policy": [
-      "manages_iam",
-      "owner_group",
-      "owner_user",
-      "policy_id",
-      "policy_name",
-      "scope",
-      "statements"
-     ],
-     "iam_role": [
-      "admin_privileges",
-      "editable",
-      "manages_iam",
-      "max_session_ttl",
-      "name",
-      "policy_has_expiration",
-      "role_id",
-      "source_ip_restricted"
-     ],
-     "iam_user": [
-      "mfa_enabled",
-      "user_id",
-      "username"
-     ],
-     "k8s_cluster_role_binding": [
-      "name",
-      "role_ref",
-      "subjects"
-     ],
-     "k8s_crd": [
-      "name"
-     ],
-     "k8s_namespace": [
-      "labels",
-      "name"
-     ],
-     "k8s_network_policy": [
-      "name",
-      "namespace"
-     ],
-     "kubernetes_cluster": [
-      "admin_whitelist",
-      "audit_enabled",
-      "auto_upgrade",
-      "control_plane_multi_az",
-      "deletion_protection",
-      "name",
-      "version"
-     ],
-     "load_balancer": [
-      "access_log",
-      "listeners",
-      "load_balancer_name",
-      "load_balancer_type",
-      "tags"
-     ],
-     "managed_database": [
-      "database_id",
-      "disable_backup",
-      "encryption_at_rest",
-      "ip_filter"
-     ],
-     "network": [
-      "cidr",
-      "description",
-      "name",
-      "network_id",
-      "state",
-      "tags"
-     ],
-     "network_peering": [
-      "accepter_account",
-      "peering_id",
-      "source_account",
-      "state"
-     ],
-     "object_storage_bucket": [
-      "acl",
-      "acl_grants",
-      "default_encryption_enabled",
-      "kms_key_id",
-      "name",
-      "object_lock_enabled",
-      "policy_public",
-      "public_via_acl",
-      "sse_kms_enabled",
-      "tags",
-      "versioning"
-     ],
-     "security_group": [
-      "inbound_default_policy",
-      "security_group_id"
-     ],
-     "security_group_rule": [
-      "action",
-      "cidrs",
-      "description",
-      "direction",
-      "port_from",
-      "port_to",
-      "protocol",
-      "security_group_id",
-      "security_group_name"
-     ],
-     "subnet": [
-      "map_public_ip_on_launch",
-      "network_id",
-      "state",
-      "subnet_id",
-      "tags"
-     ]
-    }
-   },
-   "schema_version": 2
-  },
-  {
-   "content": {
-    "envelope": {
-     "collection": {
-      "units": [
-       {
-        "attempted": "boolean",
-        "complete": "boolean",
-        "detail": "string",
-        "error": "string",
-        "types": [
-         "string"
-        ],
-        "unit": "string"
-       }
-      ],
-      "unmapped": [
-       {
-        "count": "number",
-        "type": "string"
-       }
-      ]
-     },
-     "provider": "string",
-     "resources": [
-      {
-       "attributes": {
-        "*": "any"
-       },
-       "id": "string",
-       "name": "string",
-       "provenance": {
-        "*": {
-         "derived": "boolean",
-         "observed": "boolean",
-         "origin": "string",
-         "path": "string",
-         "source": "string"
+    {
+      "schema_version": 3,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "source": {
+                "file": "string",
+                "line": "number",
+                "module": "string"
+              },
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v3",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "expiration_date",
+            "owner_user",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "inbound_default_policy",
+            "security_group_id"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
         }
-       },
-       "provider": "string",
-       "region": "string",
-       "source": {
-        "file": "string",
-        "line": "number",
-        "module": "string"
-       },
-       "type": "string"
       }
-     ]
     },
-    "format": "pepin-inventory/v3",
-    "types": {
-     "access_key": [
-      "access_key_id",
-      "expiration_date",
-      "owner_user",
-      "scope",
-      "state"
-     ],
-     "api_access_policy": [
-      "id",
-      "max_access_key_expiration_seconds",
-      "require_trusted_env"
-     ],
-     "api_access_rule": [
-      "api_access_rule_id",
-      "ca_ids",
-      "cns",
-      "ip_ranges"
-     ],
-     "api_access_summary": [
-      "id",
-      "rule_count"
-     ],
-     "blockstorage_snapshot": [
-      "creation_date",
-      "global_permission",
-      "snapshot_id",
-      "volume_id"
-     ],
-     "blockstorage_volume": [
-      "encrypted",
-      "state",
-      "tags",
-      "volume_id"
-     ],
-     "compute_image": [
-      "image_id",
-      "public",
-      "state",
-      "tags"
-     ],
-     "compute_instance": [
-      "deletion_protection",
-      "nic_public_ips",
-      "public_ip",
-      "security_group_ids",
-      "state",
-      "tags",
-      "user_data",
-      "vm_id"
-     ],
-     "governance_provider": [
-      "capital_control",
-      "eu_established",
-      "extraterritorial_exposure",
-      "jurisdiction",
-      "secnumcloud"
-     ],
-     "iam_policy": [
-      "manages_iam",
-      "owner_group",
-      "owner_user",
-      "policy_id",
-      "policy_name",
-      "scope",
-      "statements"
-     ],
-     "iam_role": [
-      "admin_privileges",
-      "editable",
-      "manages_iam",
-      "max_session_ttl",
-      "name",
-      "policy_has_expiration",
-      "role_id",
-      "source_ip_restricted"
-     ],
-     "iam_user": [
-      "mfa_enabled",
-      "user_id",
-      "username"
-     ],
-     "k8s_cluster_role_binding": [
-      "name",
-      "role_ref",
-      "subjects"
-     ],
-     "k8s_crd": [
-      "name"
-     ],
-     "k8s_namespace": [
-      "labels",
-      "name"
-     ],
-     "k8s_network_policy": [
-      "name",
-      "namespace"
-     ],
-     "kubernetes_cluster": [
-      "admin_whitelist",
-      "audit_enabled",
-      "auto_upgrade",
-      "control_plane_multi_az",
-      "deletion_protection",
-      "name",
-      "version"
-     ],
-     "load_balancer": [
-      "access_log",
-      "listeners",
-      "load_balancer_name",
-      "load_balancer_type",
-      "tags"
-     ],
-     "managed_database": [
-      "database_id",
-      "disable_backup",
-      "encryption_at_rest",
-      "ip_filter"
-     ],
-     "network": [
-      "cidr",
-      "description",
-      "name",
-      "network_id",
-      "state",
-      "tags"
-     ],
-     "network_peering": [
-      "accepter_account",
-      "peering_id",
-      "source_account",
-      "state"
-     ],
-     "object_storage_bucket": [
-      "acl",
-      "acl_grants",
-      "default_encryption_enabled",
-      "kms_key_id",
-      "name",
-      "object_lock_enabled",
-      "policy_public",
-      "public_via_acl",
-      "sse_kms_enabled",
-      "tags",
-      "versioning"
-     ],
-     "security_group": [
-      "inbound_default_policy",
-      "security_group_id"
-     ],
-     "security_group_rule": [
-      "action",
-      "cidrs",
-      "description",
-      "direction",
-      "port_from",
-      "port_to",
-      "protocol",
-      "security_group_id",
-      "security_group_name"
-     ],
-     "subnet": [
-      "map_public_ip_on_launch",
-      "network_id",
-      "state",
-      "subnet_id",
-      "tags"
-     ]
-    }
-   },
-   "schema_version": 3
-  },
-  {
-   "content": {
-    "envelope": {
-     "collection": {
-      "units": [
-       {
-        "attempted": "boolean",
-        "complete": "boolean",
-        "detail": "string",
-        "error": "string",
-        "types": [
-         "string"
-        ],
-        "unit": "string"
-       }
-      ],
-      "unmapped": [
-       {
-        "count": "number",
-        "type": "string"
-       }
-      ]
-     },
-     "provider": "string",
-     "resources": [
-      {
-       "attributes": {
-        "*": "any"
-       },
-       "id": "string",
-       "name": "string",
-       "provenance": {
-        "*": {
-         "derived": "boolean",
-         "observed": "boolean",
-         "origin": "string",
-         "path": "string",
-         "source": "string"
+    {
+      "schema_version": 4,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "source": {
+                "file": "string",
+                "line": "number",
+                "module": "string"
+              },
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v4",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "expiration_date",
+            "owner_user",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "state",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "inbound_default_policy",
+            "security_group_id"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
         }
-       },
-       "provider": "string",
-       "region": "string",
-       "source": {
-        "file": "string",
-        "line": "number",
-        "module": "string"
-       },
-       "type": "string"
       }
-     ]
     },
-    "format": "pepin-inventory/v4",
-    "types": {
-     "access_key": [
-      "access_key_id",
-      "expiration_date",
-      "owner_user",
-      "scope",
-      "state"
-     ],
-     "api_access_policy": [
-      "id",
-      "max_access_key_expiration_seconds",
-      "require_trusted_env"
-     ],
-     "api_access_rule": [
-      "api_access_rule_id",
-      "ca_ids",
-      "cns",
-      "ip_ranges"
-     ],
-     "api_access_summary": [
-      "id",
-      "rule_count"
-     ],
-     "blockstorage_snapshot": [
-      "creation_date",
-      "global_permission",
-      "snapshot_id",
-      "state",
-      "volume_id"
-     ],
-     "blockstorage_volume": [
-      "encrypted",
-      "state",
-      "tags",
-      "volume_id"
-     ],
-     "compute_image": [
-      "image_id",
-      "public",
-      "state",
-      "tags"
-     ],
-     "compute_instance": [
-      "deletion_protection",
-      "nic_public_ips",
-      "public_ip",
-      "security_group_ids",
-      "state",
-      "tags",
-      "user_data",
-      "vm_id"
-     ],
-     "governance_provider": [
-      "capital_control",
-      "eu_established",
-      "extraterritorial_exposure",
-      "jurisdiction",
-      "secnumcloud"
-     ],
-     "iam_policy": [
-      "manages_iam",
-      "owner_group",
-      "owner_user",
-      "policy_id",
-      "policy_name",
-      "scope",
-      "statements"
-     ],
-     "iam_role": [
-      "admin_privileges",
-      "editable",
-      "manages_iam",
-      "max_session_ttl",
-      "name",
-      "policy_has_expiration",
-      "role_id",
-      "source_ip_restricted"
-     ],
-     "iam_user": [
-      "mfa_enabled",
-      "user_id",
-      "username"
-     ],
-     "k8s_cluster_role_binding": [
-      "name",
-      "role_ref",
-      "subjects"
-     ],
-     "k8s_crd": [
-      "name"
-     ],
-     "k8s_namespace": [
-      "labels",
-      "name"
-     ],
-     "k8s_network_policy": [
-      "name",
-      "namespace"
-     ],
-     "kubernetes_cluster": [
-      "admin_whitelist",
-      "audit_enabled",
-      "auto_upgrade",
-      "control_plane_multi_az",
-      "deletion_protection",
-      "name",
-      "version"
-     ],
-     "load_balancer": [
-      "access_log",
-      "listeners",
-      "load_balancer_name",
-      "load_balancer_type",
-      "tags"
-     ],
-     "managed_database": [
-      "database_id",
-      "disable_backup",
-      "encryption_at_rest",
-      "ip_filter"
-     ],
-     "network": [
-      "cidr",
-      "description",
-      "name",
-      "network_id",
-      "state",
-      "tags"
-     ],
-     "network_peering": [
-      "accepter_account",
-      "peering_id",
-      "source_account",
-      "state"
-     ],
-     "object_storage_bucket": [
-      "acl",
-      "acl_grants",
-      "default_encryption_enabled",
-      "kms_key_id",
-      "name",
-      "object_lock_enabled",
-      "policy_public",
-      "public_via_acl",
-      "sse_kms_enabled",
-      "tags",
-      "versioning"
-     ],
-     "security_group": [
-      "inbound_default_policy",
-      "security_group_id"
-     ],
-     "security_group_rule": [
-      "action",
-      "cidrs",
-      "description",
-      "direction",
-      "port_from",
-      "port_to",
-      "protocol",
-      "security_group_id",
-      "security_group_name"
-     ],
-     "subnet": [
-      "map_public_ip_on_launch",
-      "network_id",
-      "state",
-      "subnet_id",
-      "tags"
-     ]
-    }
-   },
-   "schema_version": 4
-  },
-  {
-   "content": {
-    "envelope": {
-     "collection": {
-      "units": [
-       {
-        "attempted": "boolean",
-        "complete": "boolean",
-        "detail": "string",
-        "error": "string",
-        "types": [
-         "string"
-        ],
-        "unit": "string"
-       }
-      ],
-      "unmapped": [
-       {
-        "count": "number",
-        "type": "string"
-       }
-      ]
-     },
-     "provider": "string",
-     "resources": [
-      {
-       "attributes": {
-        "*": "any"
-       },
-       "id": "string",
-       "name": "string",
-       "provenance": {
-        "*": {
-         "derived": "boolean",
-         "observed": "boolean",
-         "origin": "string",
-         "path": "string",
-         "source": "string"
+    {
+      "schema_version": 5,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "source": {
+                "file": "string",
+                "line": "number",
+                "module": "string"
+              },
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v5",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "creation_date",
+            "expiration_date",
+            "owner_user",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "state",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "inbound_default_policy",
+            "security_group_id"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
         }
-       },
-       "provider": "string",
-       "region": "string",
-       "source": {
-        "file": "string",
-        "line": "number",
-        "module": "string"
-       },
-       "type": "string"
       }
-     ]
     },
-    "format": "pepin-inventory/v5",
-    "types": {
-     "access_key": [
-      "access_key_id",
-      "creation_date",
-      "expiration_date",
-      "owner_user",
-      "scope",
-      "state"
-     ],
-     "api_access_policy": [
-      "id",
-      "max_access_key_expiration_seconds",
-      "require_trusted_env"
-     ],
-     "api_access_rule": [
-      "api_access_rule_id",
-      "ca_ids",
-      "cns",
-      "ip_ranges"
-     ],
-     "api_access_summary": [
-      "id",
-      "rule_count"
-     ],
-     "blockstorage_snapshot": [
-      "creation_date",
-      "global_permission",
-      "snapshot_id",
-      "state",
-      "volume_id"
-     ],
-     "blockstorage_volume": [
-      "encrypted",
-      "state",
-      "tags",
-      "volume_id"
-     ],
-     "compute_image": [
-      "image_id",
-      "public",
-      "state",
-      "tags"
-     ],
-     "compute_instance": [
-      "deletion_protection",
-      "nic_public_ips",
-      "public_ip",
-      "security_group_ids",
-      "state",
-      "tags",
-      "user_data",
-      "vm_id"
-     ],
-     "governance_provider": [
-      "capital_control",
-      "eu_established",
-      "extraterritorial_exposure",
-      "jurisdiction",
-      "secnumcloud"
-     ],
-     "iam_policy": [
-      "manages_iam",
-      "owner_group",
-      "owner_user",
-      "policy_id",
-      "policy_name",
-      "scope",
-      "statements"
-     ],
-     "iam_role": [
-      "admin_privileges",
-      "editable",
-      "manages_iam",
-      "max_session_ttl",
-      "name",
-      "policy_has_expiration",
-      "role_id",
-      "source_ip_restricted"
-     ],
-     "iam_user": [
-      "mfa_enabled",
-      "user_id",
-      "username"
-     ],
-     "k8s_cluster_role_binding": [
-      "name",
-      "role_ref",
-      "subjects"
-     ],
-     "k8s_crd": [
-      "name"
-     ],
-     "k8s_namespace": [
-      "labels",
-      "name"
-     ],
-     "k8s_network_policy": [
-      "name",
-      "namespace"
-     ],
-     "kubernetes_cluster": [
-      "admin_whitelist",
-      "audit_enabled",
-      "auto_upgrade",
-      "control_plane_multi_az",
-      "deletion_protection",
-      "name",
-      "version"
-     ],
-     "load_balancer": [
-      "access_log",
-      "listeners",
-      "load_balancer_name",
-      "load_balancer_type",
-      "tags"
-     ],
-     "managed_database": [
-      "database_id",
-      "disable_backup",
-      "encryption_at_rest",
-      "ip_filter"
-     ],
-     "network": [
-      "cidr",
-      "description",
-      "name",
-      "network_id",
-      "state",
-      "tags"
-     ],
-     "network_peering": [
-      "accepter_account",
-      "peering_id",
-      "source_account",
-      "state"
-     ],
-     "object_storage_bucket": [
-      "acl",
-      "acl_grants",
-      "default_encryption_enabled",
-      "kms_key_id",
-      "name",
-      "object_lock_enabled",
-      "policy_public",
-      "public_via_acl",
-      "sse_kms_enabled",
-      "tags",
-      "versioning"
-     ],
-     "security_group": [
-      "inbound_default_policy",
-      "security_group_id"
-     ],
-     "security_group_rule": [
-      "action",
-      "cidrs",
-      "description",
-      "direction",
-      "port_from",
-      "port_to",
-      "protocol",
-      "security_group_id",
-      "security_group_name"
-     ],
-     "subnet": [
-      "map_public_ip_on_launch",
-      "network_id",
-      "state",
-      "subnet_id",
-      "tags"
-     ]
+    {
+      "schema_version": 6,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "source": {
+                "file": "string",
+                "line": "number",
+                "module": "string"
+              },
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v6",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "creation_date",
+            "expiration_date",
+            "owner_user",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "state",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "inbound_default_policy",
+            "security_group_id"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "peer_security_group_ids",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
+        }
+      }
     }
-   },
-   "schema_version": 5
-  }
- ]
+  ]
 }

--- a/cmd/testdata/lang/scan-fr.stdout
+++ b/cmd/testdata/lang/scan-fr.stdout
@@ -79,7 +79,7 @@
 
   Détail :
       HIGH  fr-par/11111111-1111-1111-1111-111111111111 — ACL autorisant un CIDR public (0.0.0.0/0) — service exposé à Internet.
-      HIGH  scaleway_instance_security_group.web — SSH (port 22) accepté depuis/vers Internet.
+      HIGH  scaleway_instance_security_group.web — SSH (port 22) accepté depuis Internet.
 
   Remédiation
     Restreindre l'ACL de la base aux seuls CIDR applicatifs (réseau privé quand disponible) ; retirer 0.0.0.0/0.

--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -434,7 +434,7 @@ exception, c'est-à-dire le même faux vert avec une étape de plus.
 {
   "control": "network_securitygroup_allow_ingress_from_internet_to_tcp_port_22",
   "evidence": {
-    "observed": "SSH (port 22) accepté depuis/vers Internet.",
+    "observed": "SSH (port 22) accepté depuis Internet.",
     "source": "export"
   },
   "labels": {

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -429,7 +429,7 @@ with one more step.
 {
   "control": "network_securitygroup_allow_ingress_from_internet_to_tcp_port_22",
   "evidence": {
-    "observed": "Security group \"sg-bastion\": SSH (port 22) accepted from/to the internet.",
+    "observed": "Security group \"sg-bastion\": SSH (port 22) accepted from the internet.",
     "source": "export"
   },
   "labels": {

--- a/docs/detection-quality.fr.md
+++ b/docs/detection-quality.fr.md
@@ -16,7 +16,7 @@ pourcentage sans mesure derrière est un faux vert déplacé dans un tableau de
 bord, et il y est pire qu'ailleurs : personne ne relit un tableau de bord.
 
 Les chiffres sont donc laids, et c'est le point. « 58 contrôles » ne dit rien de
-la qualité d'une détection ; « 86 verdicts prouvés sur 461 » dit où en est le
+la qualité d'une détection ; « 89 verdicts prouvés sur 461 » dit où en est le
 produit, et rétrécit dans le bon sens à chaque scénario écrit.
 
 ## Les chiffres
@@ -25,9 +25,9 @@ produit, et rétrécit dans le bon sens à chaque scénario écrit.
 |---|---:|
 | Contrôles au référentiel | 58 |
 | Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 179 |
-| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 25 |
+| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 26 |
 | Verdicts à prouver au total | 461 |
-| Verdicts prouvés | 86 |
+| Verdicts prouvés | 89 |
 
 ## Couverture de véracité, par verdict
 
@@ -37,11 +37,11 @@ demanderait d'inventer une non-applicabilité.
 
 | Verdict | Ce qu'il met en scène | À prouver | Prouvés | % |
 |---|---|---:|---:|---:|
-| `fail` | une configuration vulnérable est détectée | 141 | 22 | 15 |
-| `pass` | une configuration réellement correcte est confirmée | 141 | 34 | 24 |
-| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 157 | 19 | 12 |
+| `fail` | une configuration vulnérable est détectée | 141 | 23 | 16 |
+| `pass` | une configuration réellement correcte est confirmée | 141 | 35 | 24 |
+| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 157 | 20 | 12 |
 | `not-applicable` | le contrat du fournisseur déclare le mécanisme inexistant | 22 | 11 | 50 |
-| **Total** | | **461** | **86** | **18** |
+| **Total** | | **461** | **89** | **19** |
 
 ## Validé en live
 
@@ -85,8 +85,8 @@ n'en ont pas encore sont comptés dans
 | Chiffre | Nombre |
 |---|---:|
 | Contrôles high/critical actifs | 43 |
-| Dont un chemin de détection est prouvé de bout en bout | 19 |
-| Dont un contre-exemple légitime est prouvé | 17 |
+| Dont un chemin de détection est prouvé de bout en bout | 20 |
+| Dont un contre-exemple légitime est prouvé | 18 |
 | Faux positifs mesurés sur les contre-témoins | 0 |
 
 Il n'y a pas de ligne « faux négatifs », et son absence est le chiffre le plus

--- a/docs/detection-quality.md
+++ b/docs/detection-quality.md
@@ -16,7 +16,7 @@ with no measurement behind it is a false green moved into a dashboard, and it is
 worse there than anywhere else: nobody re-reads a dashboard.
 
 The figures are therefore ugly, and that is the point. "58 controls" says nothing
-about the quality of a detection; "86 verdicts proven out of 461" says where the
+about the quality of a detection; "89 verdicts proven out of 461" says where the
 product stands, and shrinks the right way with every scenario written.
 
 ## The figures
@@ -25,9 +25,9 @@ product stands, and shrinks the right way with every scenario written.
 |---|---:|
 | Controls in the reference | 58 |
 | Control x provider x source paths on which Pépin concludes | 179 |
-| Paths whose EVERY reachable verdict is proven end to end | 25 |
+| Paths whose EVERY reachable verdict is proven end to end | 26 |
 | Verdicts to prove in total | 461 |
-| Verdicts proven | 86 |
+| Verdicts proven | 89 |
 
 ## Veracity coverage, by verdict
 
@@ -37,11 +37,11 @@ inventing a non-applicability.
 
 | Verdict | What it stages | To prove | Proven | % |
 |---|---|---:|---:|---:|
-| `fail` | a vulnerable configuration is detected | 141 | 22 | 15 |
-| `pass` | a genuinely correct configuration is confirmed | 141 | 34 | 24 |
-| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 157 | 19 | 12 |
+| `fail` | a vulnerable configuration is detected | 141 | 23 | 16 |
+| `pass` | a genuinely correct configuration is confirmed | 141 | 35 | 24 |
+| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 157 | 20 | 12 |
 | `not-applicable` | the provider's contract declares the mechanism non-existent | 22 | 11 | 50 |
-| **Total** | | **461** | **86** | **18** |
+| **Total** | | **461** | **89** | **19** |
 
 ## Validated live
 
@@ -84,8 +84,8 @@ in `internal/veracity/testdata/counterexamples-debt.txt`.
 | Figure | Count |
 |---|---:|
 | Active high/critical controls | 43 |
-| Of which a detection path is proven end to end | 19 |
-| Of which a legitimate counterexample is proven | 17 |
+| Of which a detection path is proven end to end | 20 |
+| Of which a legitimate counterexample is proven | 18 |
 | False positives measured on the counter-witnesses | 0 |
 
 There is no "false negatives" row, and its absence is the most honest figure on

--- a/docs/getting-started/understanding-a-scan.fr.md
+++ b/docs/getting-started/understanding-a-scan.fr.md
@@ -129,7 +129,7 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
 
   Détail :
       HIGH  fr-par/11111111-1111-1111-1111-111111111111 — ACL autorisant un CIDR public (0.0.0.0/0) — service exposé à Internet.
-      HIGH  scaleway_instance_security_group.web — SSH (port 22) accepté depuis/vers Internet.
+      HIGH  scaleway_instance_security_group.web — SSH (port 22) accepté depuis Internet.
 
   Remédiation
     Restreindre l'ACL de la base aux seuls CIDR applicatifs (réseau privé quand disponible) ; retirer 0.0.0.0/0.

--- a/docs/getting-started/understanding-a-scan.md
+++ b/docs/getting-started/understanding-a-scan.md
@@ -130,7 +130,7 @@ large tenant, you want to know the tool started. The closing line is
 
   Details:
       HIGH  fr-par/11111111-1111-1111-1111-111111111111 — Managed database "fr-par/11111111-1111-1111-1111-111111111111": ACL allowing a public CIDR (0.0.0.0/0) — the service is exposed to the internet.
-      HIGH  scaleway_instance_security_group.web — Security group "scaleway_instance_security_group.web": SSH (port 22) accepted from/to the internet.
+      HIGH  scaleway_instance_security_group.web — Security group "scaleway_instance_security_group.web": SSH (port 22) accepted from the internet.
 
   Remediation
     Restrict the database ACL to the application CIDRs only (a private network where one is available); remove 0.0.0.0/0.

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -58,7 +58,7 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v5",
+  "inventory_schema": "pepin-inventory/v6",
   "disclaimer": "Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -56,7 +56,7 @@ raises a version number and gets a CHANGELOG line.
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v5",
+  "inventory_schema": "pepin-inventory/v6",
   "disclaimer": "This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -206,9 +206,9 @@ Ce qui n'est pas encore prouvé est **compté**, pas masqué :
 | Chiffre | Nombre |
 |---|---:|
 | Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 179 |
-| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 25 |
+| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 26 |
 | Verdicts à prouver au total | 461 |
-| Verdicts restant à prouver | 375 |
+| Verdicts restant à prouver | 372 |
 <!-- /pepin:gen veracity-debt -->
 
 Le reste est listé chemin par chemin dans `internal/veracity/testdata/debt.txt`. Ce registre est

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -206,9 +206,9 @@ What is not yet proven is **counted**, not hidden:
 | Figure | Count |
 |---|---:|
 | Control x provider x source paths on which Pépin concludes | 179 |
-| Paths whose every reachable verdict is proven end to end | 25 |
+| Paths whose every reachable verdict is proven end to end | 26 |
 | Verdicts to prove in total | 461 |
-| Verdicts left to prove | 375 |
+| Verdicts left to prove | 372 |
 <!-- /pepin:gen veracity-debt -->
 
 The remainder is listed path by path in `internal/veracity/testdata/debt.txt`. That ledger is a

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -43,7 +43,7 @@ séparément :
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v5** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v6** |
 <!-- /pepin:gen surface-versions -->
 
 Un numéro monte à **tout** changement de forme, ajout compris : il signifie « la surface a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,7 +43,7 @@ independently:
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v5** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v6** |
 <!-- /pepin:gen surface-versions -->
 
 A version rises on **any** shape change, additions included: the number means "the surface has

--- a/docs/reference/inventory.fr.md
+++ b/docs/reference/inventory.fr.md
@@ -12,7 +12,7 @@ gelée, avec les mêmes égards que la surface CLI.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v5
+pepin-inventory/v6
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -172,7 +172,7 @@ code.
 | `network_peering` | `accepter_account` `peering_id` `source_account` `state` |
 | `object_storage_bucket` | `acl` `acl_grants` `default_encryption_enabled` `kms_key_id` `name` `object_lock_enabled` `policy_public` `public_via_acl` `sse_kms_enabled` `tags` `versioning` |
 | `security_group` | `inbound_default_policy` `security_group_id` |
-| `security_group_rule` | `action` `cidrs` `description` `direction` `port_from` `port_to` `protocol` `security_group_id` `security_group_name` |
+| `security_group_rule` | `action` `cidrs` `description` `direction` `peer_security_group_ids` `port_from` `port_to` `protocol` `security_group_id` `security_group_name` |
 | `subnet` | `map_public_ip_on_launch` `network_id` `state` `subnet_id` `tags` |
 <!-- /pepin:gen inventory-types -->
 

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -12,7 +12,7 @@ with the same regard as the CLI surface.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v5
+pepin-inventory/v6
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -164,7 +164,7 @@ descriptors and from the Go collectors — never a hand-kept list beside the cod
 | `network_peering` | `accepter_account` `peering_id` `source_account` `state` |
 | `object_storage_bucket` | `acl` `acl_grants` `default_encryption_enabled` `kms_key_id` `name` `object_lock_enabled` `policy_public` `public_via_acl` `sse_kms_enabled` `tags` `versioning` |
 | `security_group` | `inbound_default_policy` `security_group_id` |
-| `security_group_rule` | `action` `cidrs` `description` `direction` `port_from` `port_to` `protocol` `security_group_id` `security_group_name` |
+| `security_group_rule` | `action` `cidrs` `description` `direction` `peer_security_group_ids` `port_from` `port_to` `protocol` `security_group_id` `security_group_name` |
 | `subnet` | `map_public_ip_on_launch` `network_id` `state` `subnet_id` `tags` |
 <!-- /pepin:gen inventory-types -->
 

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -30,7 +30,7 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v5** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v6** |
 <!-- /pepin:gen surface-versions -->
 
 « Gelé » signifie qu'un test échoue quand la forme bouge sans que sa version ait suivi : les

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -30,7 +30,7 @@ See [Exit codes](exit-codes.md).
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v5** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v6** |
 <!-- /pepin:gen surface-versions -->
 
 "Frozen" means a test fails when the shape moves and its version has not: field paths and JSON

--- a/internal/commonrules/rules/network_securitygroup_default_restrict_traffic.rego
+++ b/internal/commonrules/rules/network_securitygroup_default_restrict_traffic.rego
@@ -7,6 +7,25 @@
 # Contrat : type normalisé agnostique `security_group_rule` ; attributs
 #   security_group_name (nom natif du SG) et direction. Nom absent ⇒ pas de finding
 #   (garde de capacité) : l'assessment rend « non évalué » plutôt qu'un faux vert.
+#
+# # Ce que la règle NOMME, et pourquoi
+#
+# Sur un réseau tout juste créé, le provider fabrique lui-même le SG « default » et lui
+# donne une règle entrante auto-référencée : la seule source admise est le groupe
+# lui-même. Le constat reste juste — deux ressources démarrées sans SG explicite y
+# atterrissent et se parlent librement, ce qui est exactement ce que CLD-NET-4 refuse —
+# mais le message, lui, ne l'était pas : il annonçait « porte une règle entrante » à un
+# exploitant qui allait chercher une règle qu'il aurait écrite, et n'en trouvait aucune.
+#
+# La règle distingue donc les deux formes, et elle les distingue en les OBSERVANT. La
+# source par groupe est un champ collecté (`peer_security_group_ids`), pas une déduction
+# tirée de l'absence de CIDR : sans ce champ, « pas de CIDR » ne dirait pas si la règle
+# n'admet personne ou si elle admet un groupe qu'on n'a pas lu (ADR-0014).
+#
+# Quand le champ manque — un provider qui ne l'expose pas, une source qui ne le porte
+# pas —, la règle retombe sur la formulation générale et sur `confirmed`. Le repli penche
+# vers la SÉVÉRITÉ : une caractérisation impossible ne doit pas faire sortir l'écart
+# d'une porte de CI (même raisonnement qu'à l'ADR-0019 pour un label absent).
 package pepin.rules
 
 import rego.v1
@@ -16,18 +35,62 @@ deny contains f if {
 	lower(object.get(r.attributes, "security_group_name", "")) == "default"
 	lower(object.get(r.attributes, "direction", "")) == "inbound"
 	sg := object.get(r.attributes, "security_group_id", r.id)
+	forme := _forme_default(r.attributes, sg)
 	f := {
 		"code": "network_securitygroup_default_restrict_traffic",
 		"severity": "high",
 		"subject": sg,
-		"message": sprintf("Security group « default » (%s) : porte une règle entrante — il s'applique d'office à toute ressource créée sans SG explicite.", [sg]),
-		"remediation": "Vider le security group « default » de toutes ses règles ; attacher explicitement un SG dédié et restrictif à chaque ressource.",
+		"message": forme.message,
+		"remediation": forme.remediation,
 		"labels": {
 			"provider": provider_of(r),
 			"category": "security",
-			"confidence": "confirmed",
-			"message_en": sprintf("Security group \"default\" (%s) carries an inbound rule — it applies automatically to every resource created without an explicit SG.", [sg]),
-			"remediation_en": "Empty the \"default\" security group of all its rules; explicitly attach a dedicated, restrictive SG to every resource.",
+			"confidence": forme.confidence,
+			"message_en": forme.message_en,
+			"remediation_en": forme.remediation_en,
 		},
+	}
+}
+
+# _forme_default : la règle d'usine auto-référencée, OBSERVÉE.
+#
+# `contextual` parce que ce que cette forme fait courir dépend d'un contexte que le scan
+# ne regarde pas : si rien ne démarre jamais sans SG explicite, le groupe reste vide et
+# la règle ne s'applique à personne. L'écart reste au rapport et compte dans la porte par
+# défaut ; il cesse seulement de casser une chaîne `--gate security`, ce qui est
+# précisément ce que cette dimension existe pour permettre.
+_forme_default(attrs, sg) := forme if {
+	_regle_dusine(attrs, sg)
+	forme := {
+		"confidence": "contextual",
+		"message": sprintf("Security group « default » (%s) : sa seule source admise est le groupe lui-même — c'est la règle d'usine, créée avec le réseau, non une règle écrite par l'exploitant. Elle reste un écart : deux ressources démarrées sans SG explicite y atterrissent et communiquent librement.", [sg]),
+		"remediation": "Ne rien laisser atterrir dans le groupe « default » : attacher explicitement un SG dédié et restrictif à chaque ressource. Vider ensuite ses règles, la règle d'usine comprise.",
+		"message_en": sprintf("Security group \"default\" (%s): its only accepted source is the group itself — this is the factory rule, created with the network, not a rule an operator wrote. It remains a deviation: two resources started without an explicit SG land in it and talk to each other freely.", [sg]),
+		"remediation_en": "Let nothing land in the \"default\" group: explicitly attach a dedicated, restrictive SG to every resource. Then empty its rules, the factory rule included.",
+	}
+}
+
+# _forme_default : tout le reste — une source qu'il a fallu écrire, ou une forme que la
+# collecte ne permet pas de caractériser. Formulation générale, `confirmed`.
+_forme_default(attrs, sg) := forme if {
+	not _regle_dusine(attrs, sg)
+	forme := {
+		"confidence": "confirmed",
+		"message": sprintf("Security group « default » (%s) : porte une règle entrante — il s'applique d'office à toute ressource créée sans SG explicite.", [sg]),
+		"remediation": "Vider le security group « default » de toutes ses règles ; attacher explicitement un SG dédié et restrictif à chaque ressource.",
+		"message_en": sprintf("Security group \"default\" (%s) carries an inbound rule — it applies automatically to every resource created without an explicit SG.", [sg]),
+		"remediation_en": "Empty the \"default\" security group of all its rules; explicitly attach a dedicated, restrictive SG to every resource.",
+	}
+}
+
+# _regle_dusine : vrai quand la seule source admise est le groupe lui-même. Écrit une
+# fois, employé par les deux clauses, pour qu'elles ne puissent pas diverger — deux
+# corps qui se contrediraient rendraient la règle indéfinie, et donc muette.
+_regle_dusine(attrs, sg) if {
+	count(cidr_list(object.get(attrs, "cidrs", []))) == 0
+	pairs := [p | some p in cidr_list(object.get(attrs, "peer_security_group_ids", []))]
+	count(pairs) > 0
+	every p in pairs {
+		p == sg
 	}
 }

--- a/internal/commonrules/rules/network_securitygroup_default_restrict_traffic_test.rego
+++ b/internal/commonrules/rules/network_securitygroup_default_restrict_traffic_test.rego
@@ -4,6 +4,8 @@ import rego.v1
 
 _default_sgr(attrs) := {"resources": [{"provider": "outscale", "type": "security_group_rule", "id": "sg-1", "attributes": attrs}]}
 
+_default_findings(attrs) := {f | some f in deny with input as _default_sgr(attrs); f.code == "network_securitygroup_default_restrict_traffic"}
+
 # ✗ Le SG « default » porte une règle entrante : elle s'applique d'office aux ressources
 # créées sans groupe explicite, donc sans décision de l'exploitant.
 test_default_sg_inbound_denied if {
@@ -13,16 +15,99 @@ test_default_sg_inbound_denied if {
 
 # ✓ Un SG nommé autrement n'est pas concerné : il est attaché explicitement.
 test_named_sg_inbound_ok if {
-	count({f | some f in deny; f.code == "network_securitygroup_default_restrict_traffic"}) == 0 with input as _default_sgr({"security_group_id": "sg-2", "security_group_name": "web", "direction": "inbound", "protocol": "tcp", "cidrs": ["10.0.0.0/8"]})
+	count(_default_findings({"security_group_id": "sg-2", "security_group_name": "web", "direction": "inbound", "protocol": "tcp", "cidrs": ["10.0.0.0/8"]})) == 0
 }
 
 # ✓ Une règle SORTANTE du SG default n'est pas visée ici (l'egress a son propre contrôle) :
 # sinon chaque SG produirait un doublon, la règle sortante par défaut étant systématique.
 test_default_sg_outbound_ok if {
-	count({f | some f in deny; f.code == "network_securitygroup_default_restrict_traffic"}) == 0 with input as _default_sgr({"security_group_id": "sg-1", "security_group_name": "default", "direction": "outbound", "protocol": "all", "cidrs": ["0.0.0.0/0"]})
+	count(_default_findings({"security_group_id": "sg-1", "security_group_name": "default", "direction": "outbound", "protocol": "all", "cidrs": ["0.0.0.0/0"]})) == 0
 }
 
 # ✓ Nom non collecté (provider ne l'exposant pas) → garde de capacité, aucun verdict inventé.
 test_default_sg_name_uncollected_silent if {
-	count({f | some f in deny; f.code == "network_securitygroup_default_restrict_traffic"}) == 0 with input as _default_sgr({"security_group_id": "sg-1", "direction": "inbound", "protocol": "tcp"})
+	count(_default_findings({"security_group_id": "sg-1", "direction": "inbound", "protocol": "tcp"})) == 0
+}
+
+# ── CE QUE LA RÈGLE NOMME : l'usine contre l'exploitant ────────────────────────
+
+# La forme MESURÉE sur un réseau neuf : la seule source admise est le groupe lui-même.
+# Le finding subsiste — c'est bien l'écart que CLD-NET-4 vise —, mais il dit de QUOI il
+# parle, et sa confiance cesse d'affirmer plus que ce que le scan établit.
+test_the_factory_self_reference_is_named_and_contextual if {
+	fs := _default_findings({"security_group_id": "sg-1", "security_group_name": "default", "direction": "inbound", "protocol": "all", "peer_security_group_ids": ["sg-1"]})
+	count(fs) == 1
+	some f in fs
+	f.labels.confidence == "contextual"
+	contains(f.message, "groupe lui-même")
+	contains(f.labels.message_en, "the group itself")
+}
+
+# LE CONTRE-EXEMPLE qui empêche la caractérisation de tout absoudre : une règle du SG
+# « default » ouverte à un CIDR est une décision d'exploitant, et elle reste `confirmed`.
+test_a_cidr_source_stays_confirmed if {
+	fs := _default_findings({"security_group_id": "sg-1", "security_group_name": "default", "direction": "inbound", "protocol": "tcp", "cidrs": ["0.0.0.0/0"]})
+	count(fs) == 1
+	some f in fs
+	f.labels.confidence == "confirmed"
+	not contains(f.message, "groupe lui-même")
+}
+
+# Un AUTRE groupe admis n'est pas la règle d'usine : quelqu'un l'a écrite.
+test_a_peer_group_that_is_not_itself_stays_confirmed if {
+	fs := _default_findings({"security_group_id": "sg-1", "security_group_name": "default", "direction": "inbound", "protocol": "all", "peer_security_group_ids": ["sg-99"]})
+	some f in fs
+	f.labels.confidence == "confirmed"
+}
+
+# Le groupe lui-même ET un autre : il ne suffit pas qu'un membre soit l'auto-référence.
+test_itself_plus_another_group_stays_confirmed if {
+	fs := _default_findings({"security_group_id": "sg-1", "security_group_name": "default", "direction": "inbound", "protocol": "all", "peer_security_group_ids": ["sg-1", "sg-99"]})
+	some f in fs
+	f.labels.confidence == "confirmed"
+}
+
+# Une auto-référence assortie d'un CIDR n'est plus l'usine : le CIDR est le fait qui compte.
+test_self_reference_with_a_cidr_stays_confirmed if {
+	fs := _default_findings({"security_group_id": "sg-1", "security_group_name": "default", "direction": "inbound", "protocol": "all", "peer_security_group_ids": ["sg-1"], "cidrs": ["0.0.0.0/0"]})
+	some f in fs
+	f.labels.confidence == "confirmed"
+}
+
+# LE REPLI. Sans le champ des membres — un provider qui ne l'expose pas, une source qui
+# ne le porte pas —, la règle ne caractérise pas : elle retombe sur la formulation
+# générale et sur `confirmed`. Ne pas savoir ne doit pas faire sortir l'écart de la porte.
+test_an_uncollected_peer_field_falls_back_to_confirmed if {
+	fs := _default_findings({"security_group_id": "sg-1", "security_group_name": "default", "direction": "inbound", "protocol": "all"})
+	count(fs) == 1
+	some f in fs
+	f.labels.confidence == "confirmed"
+}
+
+# Un champ collecté mais VIDE dit « aucune source par groupe », pas « auto-référence ».
+test_an_empty_peer_list_falls_back_to_confirmed if {
+	fs := _default_findings({"security_group_id": "sg-1", "security_group_name": "default", "direction": "inbound", "protocol": "all", "peer_security_group_ids": []})
+	some f in fs
+	f.labels.confidence == "confirmed"
+}
+
+# UNE seule forme s'applique, jamais les deux : deux corps concurrents rendraient la
+# fonction indéfinie, donc la règle MUETTE — l'inverse exact de ce qu'on cherche.
+test_exactly_one_finding_per_rule_whatever_the_shape if {
+	count(_default_findings({"security_group_id": "sg-1", "security_group_name": "default", "direction": "inbound", "protocol": "all", "peer_security_group_ids": ["sg-1"]})) == 1
+	count(_default_findings({"security_group_id": "sg-1", "security_group_name": "default", "direction": "inbound", "protocol": "all", "peer_security_group_ids": ["sg-9"]})) == 1
+	count(_default_findings({"security_group_id": "sg-1", "security_group_name": "default", "direction": "inbound", "protocol": "all"})) == 1
+}
+
+# La sévérité ne bouge PAS. Nommer la forme précise le message et la confiance ; cela ne
+# rend pas l'écart moins grave, et le rétrograder ferait passer au vert des chaînes qui
+# rougissent aujourd'hui sans que personne ne l'ait décidé.
+test_the_severity_never_moves if {
+	every attrs in [
+		{"security_group_id": "sg-1", "security_group_name": "default", "direction": "inbound", "protocol": "all", "peer_security_group_ids": ["sg-1"]},
+		{"security_group_id": "sg-1", "security_group_name": "default", "direction": "inbound", "protocol": "tcp", "cidrs": ["0.0.0.0/0"]},
+	] {
+		some f in _default_findings(attrs)
+		f.severity == "high"
+	}
 }

--- a/internal/commonrules/rules/network_securitygroup_ingress.rego
+++ b/internal/commonrules/rules/network_securitygroup_ingress.rego
@@ -63,7 +63,10 @@ deny contains f if {
 	lower(object.get(r.attributes, "protocol", "")) == "all"
 	some cidr in cidr_list(object.get(r.attributes, "cidrs", []))
 	is_public_cidr(cidr)
-	f := _sg_finding(r, "network_securitygroup_unrestricted_egress", "medium", "tout le trafic sortant", "all outbound traffic")
+	f := _avec_confiance(
+		_sg_finding(r, "network_securitygroup_unrestricted_egress", "medium", "tout le trafic sortant", "all outbound traffic"),
+		"contextual",
+	)
 }
 
 # _sg_finding : finding commun des règles d'exposition. `what` nomme CE QUI est
@@ -74,18 +77,52 @@ _sg_finding(r, code, sev, what, what_en) := {
 	"code": code,
 	"severity": sev,
 	"subject": object.get(r.attributes, "security_group_id", r.id),
-	"message": sprintf("Security group « %s » : %s accepté depuis/vers Internet.", [object.get(r.attributes, "security_group_id", r.id), what]),
+	"message": sprintf("Security group « %s » : %s accepté %s Internet.", [object.get(r.attributes, "security_group_id", r.id), what, _sens_fr(r.attributes)]),
 	"remediation": "Restreindre la règle à des sources/destinations et ports légitimes (CIDR d'administration, bastion, VPN) ; ne jamais exposer un service sensible à 0.0.0.0/0.",
 	"labels": {
 		"provider": provider_of(r),
 		"category": "security",
-		# CONFIRMÉ pour toutes les règles d'exposition que ce constructeur sert : une
-		# origine `0.0.0.0/0` sur un port sensible est OBSERVÉE dans la configuration,
-		# pas inférée. Le contexte n'y change rien — il n'existe pas de raison
-		# légitime d'ouvrir SSH ou RDP à tout Internet, seulement des raisons
-		# temporaires, qui se posent en dérogation datée.
+		# CONFIRMÉ pour les règles d'ENTRÉE que ce constructeur sert : une origine
+		# `0.0.0.0/0` sur un port sensible est OBSERVÉE dans la configuration, pas
+		# inférée. Le contexte n'y change rien — il n'existe pas de raison légitime
+		# d'ouvrir SSH ou RDP à tout Internet, seulement des raisons temporaires, qui
+		# se posent en dérogation datée.
+		#
+		# Cet argument ne vaut PAS pour la sortie, et l'egress se réétiquette donc
+		# `contextual` chez l'appelant. Une sortie ouverte est un chemin
+		# d'exfiltration réel, mais des architectures parfaitement défendables la
+		# laissent ouverte et filtrent en aval — passerelle, mandataire, pare-feu
+		# périmétrique — sur un plan que le scan ne voit pas. C'est la définition même
+		# de `contextual` ici, et la porte `--gate security` la met de côté sans que
+		# l'écart quitte le rapport (ADR-0019).
 		"confidence": "confirmed",
-		"message_en": sprintf("Security group \"%s\": %s accepted from/to the internet.", [object.get(r.attributes, "security_group_id", r.id), what_en]),
+		"message_en": sprintf("Security group \"%s\": %s accepted %s the internet.", [object.get(r.attributes, "security_group_id", r.id), what_en, _sens_en(r.attributes)]),
 		"remediation_en": "Restrict the rule to legitimate sources/destinations and ports (administration CIDR, bastion, VPN); never expose a sensitive service to 0.0.0.0/0.",
 	},
 }
+
+# _avec_confiance : remplace la seule confiance d'un finding, en laissant le reste des
+# étiquettes intact. Écrit plutôt que recopié dans le constructeur, parce qu'un
+# constructeur qui prendrait la confiance en paramètre obligerait les six appelants à la
+# répéter — et une valeur répétée six fois est une valeur qui finit par diverger.
+_avec_confiance(f, c) := object.union(f, {"labels": object.union(f.labels, {"confidence": c})})
+
+# _sens_fr, _sens_en : la préposition suit la DIRECTION de la règle.
+#
+# Le constructeur écrivait « depuis/vers Internet » pour les six règles, ce qui rendait
+# la phrase fausse d'un côté à chaque fois : une règle sortante n'accepte rien « depuis »
+# Internet. Un lecteur qui corrige ce que la phrase décrit va chercher au mauvais
+# endroit, et c'est exactement le défaut de précision que ce lot traite.
+#
+# Le repli garde les deux prépositions : sans direction lue, on ne CHOISIT pas.
+_sens_fr(attrs) := "depuis" if lower(object.get(attrs, "direction", "")) == "inbound"
+
+_sens_fr(attrs) := "vers" if lower(object.get(attrs, "direction", "")) == "outbound"
+
+_sens_fr(attrs) := "depuis/vers" if not lower(object.get(attrs, "direction", "")) in {"inbound", "outbound"}
+
+_sens_en(attrs) := "from" if lower(object.get(attrs, "direction", "")) == "inbound"
+
+_sens_en(attrs) := "to" if lower(object.get(attrs, "direction", "")) == "outbound"
+
+_sens_en(attrs) := "from/to" if not lower(object.get(attrs, "direction", "")) in {"inbound", "outbound"}

--- a/internal/commonrules/rules/network_securitygroup_ingress_test.rego
+++ b/internal/commonrules/rules/network_securitygroup_ingress_test.rego
@@ -140,3 +140,54 @@ test_provider_from_resource if {
 	f.code == _ssh
 	f.labels.provider == "scaleway"
 }
+
+# ── La confiance de la SORTIE n'est pas celle de l'ENTRÉE ──────────────────────
+
+# Une sortie ouverte est un chemin d'exfiltration réel, mais des architectures
+# défendables la laissent ouverte et filtrent en aval, sur un plan que le scan ne voit
+# pas. L'écart reste au rapport et dans la porte par défaut ; il cesse de casser une
+# chaîne `--gate security`, ce que la dimension de confiance existe pour permettre.
+test_egress_is_contextual_not_confirmed if {
+	some f in deny with input as _sgr({"direction": "outbound", "action": "accept", "protocol": "all", "cidrs": ["0.0.0.0/0"], "security_group_id": "sg-1"})
+	f.code == _egr
+	f.labels.confidence == "contextual"
+}
+
+# LE CONTRE-EXEMPLE : l'entrée, elle, ne bouge pas. Il n'existe pas d'architecture qui
+# rende SSH ouvert à tout Internet défendable, et réétiqueter la sortie ne doit pas
+# emporter l'entrée avec elle — c'est exactement ce qu'un constructeur partagé rend
+# facile, et ce que ce test empêche.
+test_ingress_stays_confirmed if {
+	every code in [_ssh, _rdp, _all] {
+		some f in deny with input as _sgr({"direction": "inbound", "action": "accept", "protocol": "all", "cidrs": ["0.0.0.0/0"], "port_from": 0, "port_to": 65535, "security_group_id": "sg-1"})
+		f.code == code
+		f.labels.confidence == "confirmed"
+	}
+}
+
+# La sévérité et le code de la sortie ne bougent pas : seule l'étiquette de confiance
+# change, et un consommateur qui filtre sur le code lit la même chose qu'avant.
+test_egress_keeps_its_code_and_severity if {
+	some f in deny with input as _sgr({"direction": "outbound", "action": "accept", "protocol": "all", "cidrs": ["0.0.0.0/0"], "security_group_id": "sg-1"})
+	f.code == _egr
+	f.severity == "medium"
+	f.labels.category == "security"
+}
+
+# La préposition suit la direction. Écrit dans les DEUX sens : une règle sortante
+# n'accepte rien « depuis » Internet, et une règle entrante rien « vers ».
+test_the_preposition_follows_the_direction if {
+	some f in deny with input as _sgr({"direction": "outbound", "action": "accept", "protocol": "all", "cidrs": ["0.0.0.0/0"], "security_group_id": "sg-1"})
+	f.code == _egr
+	contains(f.message, "accepté vers Internet")
+	contains(f.labels.message_en, "accepted to the internet")
+	not contains(f.message, "depuis")
+}
+
+test_an_inbound_rule_says_depuis if {
+	some f in deny with input as _sgr({"direction": "inbound", "action": "accept", "protocol": "tcp", "cidrs": ["0.0.0.0/0"], "port_from": 22, "port_to": 22, "security_group_id": "sg-1"})
+	f.code == _ssh
+	contains(f.message, "accepté depuis Internet")
+	contains(f.labels.message_en, "accepted from the internet")
+	not contains(f.message, "vers")
+}

--- a/internal/model/schema.go
+++ b/internal/model/schema.go
@@ -91,7 +91,19 @@ import (
 //	ROTATION ne se lit nulle part : CLD-IAM-2 demande « une expiration ET une
 //	rotation », l'expiration se lit sur un champ, la rotation se déduit de l'âge.
 //	Un consommateur qui l'ignore ne perd rien de ce qu'il lisait déjà.
-const InventoryFormat = "pepin-inventory/v5"
+//
+// v6 : une `security_group_rule` ENTRANTE porte `peer_security_group_ids`, les groupes
+//
+//	dont les membres sont admis comme source (osc-sdk-go v2.24.0
+//	SecurityGroupRule.SecurityGroupsMembers, vérifié dans
+//	model_security_groups_member.go). Ajout PUR — aucun champ existant ne bouge.
+//	Une règle entrante admet une source par CIDR OU par groupe ; sans ce champ,
+//	« pas de CIDR » ne dit pas si la règle n'admet personne ou si elle admet un
+//	groupe qu'on n'a pas lu. Le contrôle du SG « default » a besoin de la
+//	différence pour nommer ce qu'il a trouvé, et la DÉDUIRE d'une absence serait la
+//	fabrication que l'ADR-0014 refuse. Mappé sur l'entrant seul : rien ne lit la
+//	contrepartie sortante.
+const InventoryFormat = "pepin-inventory/v6"
 
 // InventorySchemaVersion extrait le N du suffixe `/vN`. Comme pour le bundle, la
 // constante et le signal sur le fil sont la même chose : impossible de faire

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -1,13 +1,13 @@
 {
   "controls": 58,
   "paths": 179,
-  "paths_proven": 25,
+  "paths_proven": 26,
   "obligations": 461,
-  "proven": 86,
+  "proven": 89,
   "verdicts": {
     "fail": {
       "required": 141,
-      "proven": 22
+      "proven": 23
     },
     "not-applicable": {
       "required": 22,
@@ -15,11 +15,11 @@
     },
     "not-evaluated": {
       "required": 157,
-      "proven": 19
+      "proven": 20
     },
     "pass": {
       "required": 141,
-      "proven": 34
+      "proven": 35
     }
   },
   "live_paths": 101,
@@ -2199,6 +2199,11 @@
             "fail",
             "pass",
             "not-evaluated"
+          ],
+          "proven": [
+            "fail",
+            "pass",
+            "not-evaluated"
           ]
         },
         {
@@ -2212,6 +2217,9 @@
             "not-evaluated"
           ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/default-sg-restrict-outscale-live.yaml"
       ],
       "tenants": [
         "outscale/ztiac-two-tier"
@@ -2592,8 +2600,8 @@
   },
   "precision": {
     "controls": 43,
-    "detection_proven": 19,
-    "with_counterexample": 17,
+    "detection_proven": 20,
+    "with_counterexample": 18,
     "false_positives": 0,
     "counterwitnesses": 2
   }

--- a/internal/veracity/testdata/counterexamples-debt.txt
+++ b/internal/veracity/testdata/counterexamples-debt.txt
@@ -10,7 +10,7 @@
 # contre-exemple est une règle high/critical ajoutée sans sa preuve de
 # précision, et la CI la refuse.
 #
-# high/critical actifs : 43 · avec contre-exemple : 17 · restants : 26
+# high/critical actifs : 43 · avec contre-exemple : 18 · restants : 25
 
 blockstorage_snapshot_not_public
 blockstorage_volume_encryption
@@ -36,5 +36,4 @@ kubernetes_cluster_control_plane_highly_available
 kubernetes_cluster_not_publicly_accessible
 loadbalancer_ssl_listeners
 network_peering_cross_organization
-network_securitygroup_default_restrict_traffic
 objectstorage_bucket_default_encryption

--- a/internal/veracity/testdata/debt.txt
+++ b/internal/veracity/testdata/debt.txt
@@ -8,7 +8,7 @@
 # Une ligne qui disparaît est une dette payée. Une ligne qui apparaît sans
 # scénario est un contrôle ajouté sans sa preuve, et la CI la refuse.
 #
-# chemins : 179 · entierement prouves : 25 · obligations : 461 · restantes : 375
+# chemins : 179 · entierement prouves : 26 · obligations : 461 · restantes : 372
 
 blockstorage_snapshot_not_public exoscale live not-applicable
 blockstorage_snapshot_not_public outscale live fail,pass,not-evaluated
@@ -141,7 +141,6 @@ network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389 outscale terr
 network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389 scaleway live fail,pass,not-evaluated
 network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389 scaleway terraform fail,pass,not-evaluated
 network_securitygroup_default_deny scaleway terraform not-evaluated
-network_securitygroup_default_restrict_traffic outscale live fail,pass,not-evaluated
 network_securitygroup_unrestricted_egress exoscale live fail,pass,not-evaluated
 network_securitygroup_unrestricted_egress exoscale terraform fail,not-evaluated
 network_securitygroup_unrestricted_egress outscale live fail,pass,not-evaluated

--- a/internal/veracity/testdata/scenarios/default-sg-restrict-outscale-live.yaml
+++ b/internal/veracity/testdata/scenarios/default-sg-restrict-outscale-live.yaml
@@ -1,0 +1,53 @@
+# Le security group « default » d'un réseau, sur une collecte live Outscale.
+#
+# Le chemin traverse le collecteur RÉEL : `/ReadSecurityGroups`, le mapping déclaratif du
+# descripteur (`SecurityGroupName` du SG parent → `security_group_name`,
+# `SecurityGroupsMembers` → `peer_security_group_ids`), le verrou de capacité, la règle,
+# puis l'assessment. C'est l'entrée exigée par le contrat : le type
+# `security_group_rule` est produit par la spec `collecte`, donc un scénario `live` ne
+# peut pas passer par `inventory:`.
+#
+# Ce qui est en jeu ici est précisément le MAPPING. La règle sait déjà distinguer la
+# règle d'usine auto-référencée d'une règle écrite par l'exploitant ; ce qu'aucun test
+# Rego ne prouve, c'est que le collecteur lui apporte de quoi le faire. Un
+# `SecurityGroupsMembers` non projeté rendrait la distinction muette sans rien casser :
+# la règle retomberait sur son repli, et personne ne verrait la différence.
+control: network_securitygroup_default_restrict_traffic
+provider: outscale
+source: live
+
+scenarios:
+  - expect: fail
+    why: "reseau neuf : le SG default porte la regle d'usine auto-referencee, et c'est un ecart"
+    api:
+      /ReadSecurityGroups: |
+        {"SecurityGroups": [{"SecurityGroupId": "sg-default-1",
+                             "SecurityGroupName": "default",
+                             "NetId": "vpc-1",
+                             "InboundRules": [{"IpProtocol": "-1",
+                                               "SecurityGroupsMembers": [{"SecurityGroupId": "sg-default-1",
+                                                                          "SecurityGroupName": "default"}]}],
+                             "OutboundRules": [{"IpProtocol": "-1", "IpRanges": ["0.0.0.0/0"]}]}]}
+
+  - expect: pass
+    why: "le meme reseau une fois la remediation appliquee : le SG default n'a plus de regle entrante"
+    api:
+      /ReadSecurityGroups: |
+        {"SecurityGroups": [{"SecurityGroupId": "sg-default-1",
+                             "SecurityGroupName": "default",
+                             "NetId": "vpc-1",
+                             "InboundRules": [],
+                             "OutboundRules": [{"IpProtocol": "-1", "IpRanges": ["0.0.0.0/0"]}]},
+                            {"SecurityGroupId": "sg-web-1",
+                             "SecurityGroupName": "web",
+                             "NetId": "vpc-1",
+                             "InboundRules": [{"IpProtocol": "tcp",
+                                               "FromPortRange": 443,
+                                               "ToPortRange": 443,
+                                               "IpRanges": ["0.0.0.0/0"]}],
+                             "OutboundRules": []}]}
+
+  - expect: not-evaluated
+    why: "le droit api:Read* manque : l'unite est incomplete, et rien ne se conclut d'une lecture refusee"
+    deny:
+      - /ReadSecurityGroups

--- a/providers/outscale.yaml
+++ b/providers/outscale.yaml
@@ -180,11 +180,22 @@ collecte:
         security_group_name: _parent.SecurityGroupName
         protocol: IpProtocol
         cidrs: IpRanges
+        # Une règle entrante admet une source par CIDR (`IpRanges`) OU par GROUPE
+        # (`SecurityGroupsMembers`). Sans ce second champ, une règle sans CIDR est un
+        # trou : on ne sait pas si elle n'admet personne, ou si elle admet un groupe
+        # qu'on n'a pas lu. Le contrôle du SG « default » a besoin de la différence pour
+        # nommer ce qu'il a trouvé, et la DÉDUIRE d'une absence serait la fabrication que
+        # l'ADR-0014 refuse. Contrat : osc-sdk-go v2.24.0
+        # SecurityGroupRule.SecurityGroupsMembers []SecurityGroupsMember{SecurityGroupId}.
+        # Mappé sur l'ENTRANT seul : rien ne lit la contrepartie sortante, et le dépôt ne
+        # collecte pas un attribut que personne ne relit.
+        peer_security_group_ids: SecurityGroupsMembers
         port_from: FromPortRange
         port_to: ToPortRange
       transforms:
         protocol: [lower, { "-1": all, any: all, "": all, "1": icmp, "6": tcp, "17": udp }]
         cidrs: list
+        peer_security_group_ids: pluck:SecurityGroupId
     - type: security_group_rule
       path: /ReadSecurityGroups
       method: POST
@@ -576,7 +587,9 @@ contrat:
         port_from: FromPortRange (*int32)
         port_to: ToPortRange (*int32)
         cidrs: IpRanges (*[]string)
+        peer_security_group_ids: SecurityGroupsMembers (*[]SecurityGroupsMember) → pluck SecurityGroupId ; ENTRANT seulement
         security_group_id: SecurityGroupId
+        security_group_name: SecurityGroupName (du SG parent)
     compute_instance:
       etat: verifie
       source: Vm


### PR DESCRIPTION
## The two findings a fresh Net produced

On a brand-new Outscale Net, before any operator action, a live scan reported two
things nobody chose. **Neither is a false positive** — CIS asks that the default
security group restrict all traffic, and both findings are defensible. They are a
*precision* defect, which is what this milestone is about.

### 1. The default SG finding pointed at the wrong author

It said *"porte une règle entrante"*, and the operator went looking for a rule
they had written. The rule found is the one the **provider** creates with the
network: its only accepted source is the group itself.

The deviation stands — two resources started without an explicit SG land in it
and talk to each other freely — but the sentence now names the shape it found:

| shape | message | confidence |
|---|---|---|
| factory self-reference (`peer_security_group_ids: [itself]`, no CIDR) | "sa seule source admise est le groupe lui-même — c'est la règle d'usine, créée avec le réseau" | `contextual` |
| a source someone wrote (a CIDR, or another group) | unchanged | `confirmed` |
| the field was not collected | unchanged | `confirmed` |

**The distinction is observed, not deduced.** An inbound rule accepts a source by
CIDR **or** by group. Without the second field, "no CIDR" cannot say whether the
rule admits nobody or admits a group we never read — and deducing it from the
absence is the fabrication ADR-0014 refuses. So `SecurityGroupsMembers` is now
collected (osc-sdk-go v2.24.0, verified in `model_security_groups_member.go`) and
mapped on the **inbound** rule alone: nothing reads the outbound counterpart, and
this repo does not collect an attribute nobody reads.

The fallback leans toward **severity** on purpose. Failing to characterise must
not take a deviation out of a CI gate — the same reasoning ADR-0019 applies to a
missing label.

### 2. The egress label was inherited, not reasoned

`confirmed` comes from the shared constructor, whose justification is written
there and is about **ingress**: *"il n'existe pas de raison légitime d'ouvrir SSH
ou RDP à tout Internet"*. True — and it does not transfer to the way out. An open
egress is a real exfiltration path, but defensible architectures leave it open and
filter downstream (gateway, proxy, perimeter firewall) on a plane the scan does
not see. That is the definition of `contextual` in this repo.

Same code, same `medium`, same `security` category. It leaves `--gate security`
without leaving the report.

### 3. An outbound rule accepts nothing "from" the internet

The constructor wrote *"accepté depuis/vers Internet"* for all six exposure rules,
making the sentence half-wrong every time. The preposition now follows the
direction. This is the same defect class the issue reports, in the very sentence
it reports it on.

## What I did NOT do, and why

The issue suggested **one finding per Net** and category **`hygiene`**. I declined
both, and would rather say so than do it quietly:

- **Aggregating to the Net moves the finding's `subject`.** A derogation matches
  on `(control, subject)` (`internal/exempt/apply.go`). One could no longer except
  a single security group — only the whole network. SARIF and OSCAL lose the same
  granularity, irreversibly, in artefacts meant to be reopened by a third party.
- **`hygiene` in this repo means traceability** — tags, flow matrix, network
  mapping. Unrestricted egress is a filtering weakness mapped to CLD-NET-4, not a
  documentation gap. Moving it there would take it out of the security gate for
  the wrong reason; `contextual` takes it out for the right one.
- **ADR-0019 already decided this.** *"La demande d'un premier scan moins irritant
  est réelle, mais elle se traite par le REGROUPEMENT des findings, pas par leur
  disparition."* And the terminal already collapses these into one block with a
  count — the eleven lines are eleven `Détail :` rows, not eleven blocks. #117
  aggregates one subject with several causes, which is a different shape.

## Measured

On the binary, with a Net carrying both findings:

```
--gate all       → exit 1     (unchanged: the default behaviour does not move)
--gate security  → exit 3     (set aside — never 0, per ADR-0019)
```

Verdict movement across the reference corpus: **zero**. Detection is unchanged;
only the wording and the labels moved.

The French reference output moved by **exactly one line**, and only because I
decided it — the guard has no auto-update, which is the point:

```
- SSH (port 22) accepté depuis/vers Internet.
+ SSH (port 22) accepté depuis Internet.
```

## Veracity

The new scenario enters through the **real collector**, because what needed
proving is the mapping, not the rule. An unprojected `SecurityGroupsMembers` would
have silenced the distinction *without breaking anything*: the rule would have
fallen back to its general form and nobody would have seen the difference. Three
cases — factory rule (`fail`), rules emptied (`pass`), `api:Read*` refused
(`not-evaluated`, via `deny:`, the degradation an operator actually hits).

Ledgers: paths fully proven **25 → 26**, counterexamples **17 → 18**, remaining
obligations **375 → 372**.

## Impact ADR

- **ADR-0014** (an absent datum is not fabricated) — the reason the collector
  change exists rather than inferring the shape from a missing CIDR.
- **ADR-0019** (a profile filters the gate, never the report) — respected and
  measured: default unchanged, set-aside `high` → 3, never 0. Its rejected
  alternative ("solve first-scan irritation by removing findings") is the reason
  the aggregation suggestion was declined.
- **ADR-0013** (a control code is not renamed) — no code moves.
- **ADR-0003** (frozen inventory contract) — v5 → v6, justified in the history.

No ADR reopened, none needed.

## Gates

`mise run prepush` green. 353 Rego tests (was 351 before the preposition tests,
339 at the start).

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
