### PR TITLE
fix(cmd): make five messages name the thing the reader is looking for

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -63,6 +63,37 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **La page d'installation épinglait `v0.1.0`, la version dont ce dépôt écrit lui-même
+  qu'elle refuse toute installation.** `examples/github-actions/pepin.yml` le dit en
+  toutes lettres : en v0.1.0 et v0.1.1, l'installeur de l'action appelait
+  `gh attestation verify` sans jeton, ce qui refusait *toute* installation. La page
+  d'installation est la première qu'on recopie. Chaque épinglage nomme désormais la
+  dernière release, une phrase dit que l'appelant ne passe aucun jeton depuis v0.2.0, et
+  une garde exige que les versions épinglées soient celle que le CHANGELOG déclare —
+  lue dans le dépôt plutôt que dans les tags git, pour qu'un `clone` de CI sans tags ne
+  puisse pas la faire dériver.
+- **Quatre messages de la CLI désignaient la mauvaise chose.** `--policy-dir
+  /inexistant` et `provider validate <fichier>` rapportaient tous deux `.` — la racine
+  de la vue de système de fichiers qu'ils venaient de construire — au lieu de l'argument
+  reçu ; un fichier passé là où un dossier est attendu est maintenant refusé comme tel.
+  `--kubeconfig` sans `--live` proposait deux sources qui ne sont pas celle que
+  l'appelant venait de nommer ; l'erreur et l'aide du drapeau disent désormais qu'il
+  exige `--live`.
+- **Une `--region` inconnue est signalée avant que la collecte n'échoue.** `--region
+  eu-nowhere-9` coûtait une minute de résolutions DNS en échec et dix-sept unités
+  « service indisponible » à lire avant d'en deviner la cause. C'est un
+  **avertissement**, pas un refus : la liste des régions appartient au fournisseur, et
+  une région ajoutée demain doit rester scannable le jour même — ce qui la sépare d'un
+  `--gate` inconnu, dont le vocabulaire est celui de Pépin. Le catalogue vit auprès du
+  descripteur du fournisseur, et une garde exige qu'il coïncide avec celui que les
+  règles de souveraineté portent déjà.
+- **`control explain` accepte le code que le rapport imprime.** La colonne « Code » du
+  rapport terminal et chaque en-tête de bloc portent l'exigence SCSL (`CLD-STO-1`), et
+  `--format json` la porte dans `code` ; la commande n'acceptait que l'identifiant de
+  check, que le rapport n'imprime jamais. Un lecteur qui venait de lire un verdict
+  devait deviner. Les deux formes fonctionnent désormais, sans distinction de casse, et
+  une exigence couvrant plusieurs contrôles les nomme tous plutôt que d'en choisir un en
+  silence.
 - **Une clé d'accès dont l'expiration est dépassée ne compte plus comme conforme.** La
   règle ne refusait qu'une date ABSENTE, si bien qu'une clé encore `ACTIVE` deux ans
   après son échéance passait — mesuré sur un tenant réel. Les deux lectures de cet état

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,33 @@ belongs in `git log`.
 
 ### Fixed
 
+- **The install page pinned `v0.1.0`, the version this repository itself declares
+  refuses every installation.** `examples/github-actions/pepin.yml` says it in as many
+  words: in v0.1.0 and v0.1.1 the action's installer called `gh attestation verify`
+  without a token, which refused *every* install. The install page is the first page a
+  newcomer copies from. Every pin now names the latest release, a sentence says the
+  caller passes no token since v0.2.0, and a guard requires the pinned versions to equal
+  the latest release recorded in the CHANGELOG — read from the repository rather than
+  from git tags, so a CI checkout without tags cannot make it drift.
+- **Four CLI messages pointed at the wrong thing.** `--policy-dir /nonexistent` and
+  `provider validate <file>` both reported `.` — the root of the filesystem view they
+  had just built — instead of the argument received; a file passed where a directory is
+  expected is now refused as such. `--kubeconfig` without `--live` offered two sources
+  that are not the one the caller had just named; the error and the flag's help now say
+  it needs `--live`.
+- **An unknown `--region` is flagged before the collection fails.** `--region
+  eu-nowhere-9` cost a minute of failing DNS lookups and seventeen "service unavailable"
+  units to read before the cause became guessable. It is a **warning**, not a refusal:
+  the region list belongs to the provider, and one added tomorrow must stay scannable
+  the same day — which is what separates it from an unknown `--gate`, whose vocabulary
+  is Pépin's own. The catalogue lives next to the provider descriptor and a guard
+  requires it to match the one the sovereignty rules already carry.
+- **`control explain` accepts the code the report prints.** The terminal report's `Code`
+  column and every block header carry the SCSL requirement (`CLD-STO-1`), and
+  `--format json` carries it in `code`; the command accepted only the check identifier,
+  which the report never prints. A reader who had just read a verdict had to guess.
+  Both forms now work, case-insensitively, and a requirement covering several controls
+  names them all rather than silently picking one.
 - **An access key whose expiry has already passed no longer counts as compliant.** The
   rule only refused a MISSING date, so a key still `ACTIVE` two years past its expiry
   passed — measured on a real tenant. Both readings of that state are bad, which is why

--- a/cmd/control.go
+++ b/cmd/control.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -54,7 +55,27 @@ var controlExplainCmd = &cobra.Command{
 		code := args[0]
 		ctl, ok := referentiel.Lookup(code)
 		if !ok {
-			return fmt.Errorf(tr("contrôle inconnu : %s", "unknown control: %s"), code)
+			// Le rapport n'imprime JAMAIS l'identifiant de check : sa colonne « Code »
+			// et ses en-têtes de bloc portent l'exigence SCSL, et `--format json` la
+			// porte dans `code`. Un lecteur qui vient de lire « CLD-NET-3 » et veut
+			// savoir pourquoi ce verdict est opposable tapait donc, très logiquement,
+			// ce que le rapport lui avait montré — et la commande le refusait.
+			//
+			// Une exigence couvre parfois PLUSIEURS contrôles. Un seul : on explique,
+			// sans faire deviner. Plusieurs : on les nomme, parce que choisir à la
+			// place du lecteur, c'est en cacher un.
+			portés := referentiel.BySCSL(code)
+			switch len(portés) {
+			case 0:
+				return fmt.Errorf(tr(
+					"contrôle inconnu : %s\n  Attendu : un identifiant de check (ex. objectstorage_bucket_public_access)\n  ou une exigence SCSL telle que le rapport l'imprime (ex. CLD-STO-1).",
+					"unknown control: %s\n  Expected: a check identifier (e.g. objectstorage_bucket_public_access)\n  or an SCSL requirement as the report prints it (e.g. CLD-STO-1)."), code)
+			case 1:
+				ctl = portés[0]
+			default:
+				return expliquerLesquels(cmd.OutOrStdout(), code, portés)
+			}
+			code = ctl.Code
 		}
 		snap, err := quality.Embedded()
 		if err != nil {
@@ -349,4 +370,25 @@ func init() {
 	controlExplainCmd.Flags().StringVar(&explainProvider, "provider", "",
 		"limiter l'explication à un fournisseur")
 	controlCmd.AddCommand(controlExplainCmd)
+}
+
+// expliquerLesquels rend la liste des contrôles qu'une exigence SCSL couvre.
+//
+// Rendre `nil` — donc 0 — est délibéré : la question posée a reçu sa réponse. Ce
+// n'est pas une erreur d'appel, c'est une exigence qui couvre plusieurs contrôles, et
+// c'est d'ailleurs ce même partage qui fait que le rapport terminal les regroupe.
+func expliquerLesquels(out io.Writer, scsl string, ctls []referentiel.Control) error {
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out, eyebrow.Render(brandEyebrow())+muted.Render("  "+tr(
+		"une exigence, plusieurs contrôles", "one requirement, several controls")))
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintf(out, "%s %s\n\n", titre.Render(scsl), muted.Render(tr(
+		"couvre les contrôles suivants :", "covers the following controls:")))
+	for _, c := range ctls {
+		_, _ = fmt.Fprintf(out, "  %s\n    %s\n", titre.Render(c.Code), c.TitreIn(i18n.Current()))
+	}
+	_, _ = fmt.Fprintf(out, "\n  %s\n", muted.Render(tr(
+		"Reprendre l'un de ces codes : pepin control explain <code>",
+		"Take one of these codes: pepin control explain <code>")))
+	return nil
 }

--- a/cmd/i18n.go
+++ b/cmd/i18n.go
@@ -124,8 +124,8 @@ func localize() {
 		"région cible pour la collecte live",
 		"target region for the live collection"))
 	setUsage(scanCmd, "kubeconfig", tr(
-		"chemin d'un kubeconfig pour auditer l'état DANS un cluster Kubernetes (utiliser un accès en LECTURE SEULE, TTL court — jamais cluster-admin)",
-		"path to a kubeconfig to audit the state INSIDE a Kubernetes cluster (use READ-ONLY, short-lived access — never cluster-admin)"))
+		"chemin d'un kubeconfig pour auditer l'état DANS un cluster Kubernetes (exige --live ; utiliser un accès en LECTURE SEULE, TTL court — jamais cluster-admin)",
+		"path to a kubeconfig to audit the state INSIDE a Kubernetes cluster (requires --live; use READ-ONLY, short-lived access — never cluster-admin)"))
 	setUsage(scanCmd, "profile", tr(
 		"profil d'identifiants pour la collecte live (ex. ~/.osc/config.json)",
 		"credentials profile for the live collection (e.g. ~/.osc/config.json)"))

--- a/cmd/messages_test.go
+++ b/cmd/messages_test.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// Un message d'erreur qui ne nomme pas ce que l'appelant a tapé lui coûte une
+// première hypothèse fausse. Aucun de ces défauts ne déplaçait un verdict — et c'est
+// exactement pour cela qu'ils avaient survécu : rien ne rougissait.
+//
+// Les tests mesurent le BINAIRE, parce que ces messages sont ce que le binaire
+// imprime : un harnais qui appellerait la fonction interne éprouverait un chemin que
+// personne ne parcourt.
+
+// TestAnErrorNamesWhatTheCallerTyped : chaque refus contient l'argument reçu.
+func TestAnErrorNamesWhatTheCallerTyped(t *testing.T) {
+	bin := buildPepin(t)
+	for _, c := range []struct {
+		nom      string
+		args     []string
+		attendu  []string
+		interdit string
+	}{
+		{
+			// `--policy-dir` construisait un `os.DirFS` sans rien vérifier ; la
+			// première erreur venait du parcours, qui ne connaît plus que sa racine.
+			// Le lecteur cherchait donc dans son répertoire courant une faute qu'il
+			// avait faite dans un argument.
+			nom:      "policy-dir absent",
+			args:     []string{"scan", "outscale", "--terraform", "examples/outscale/terraform/plan.json", "--policy-dir", "/ce-chemin-nexiste-pas"},
+			attendu:  []string{"/ce-chemin-nexiste-pas"},
+			interdit: "stat .:",
+		},
+		{
+			nom:     "policy-dir qui est un fichier",
+			args:    []string{"scan", "outscale", "--terraform", "examples/outscale/terraform/plan.json", "--policy-dir", "go.mod"},
+			attendu: []string{"go.mod", "dossier"},
+		},
+		{
+			// Le verbe prend un dossier — son aide le dit — et un fichier n'était pas
+			// refusé comme tel : « lecture de . : open . : not a directory ».
+			nom:      "provider validate sur un fichier",
+			args:     []string{"provider", "validate", "providers/outscale.yaml"},
+			attendu:  []string{"providers/outscale.yaml", "dossier"},
+			interdit: "lecture de . ",
+		},
+		{
+			nom:     "provider validate sur un dossier absent",
+			args:    []string{"provider", "validate", "/ce-chemin-nexiste-pas"},
+			attendu: []string{"/ce-chemin-nexiste-pas"},
+		},
+	} {
+		t.Run(c.nom, func(t *testing.T) {
+			_, stderr := runPepin(t, bin, []string{"LANG=fr_FR.UTF-8"}, c.args...)
+			for _, mot := range c.attendu {
+				if !strings.Contains(stderr, mot) {
+					t.Errorf("le message ne contient pas %q :\n%s", mot, stderr)
+				}
+			}
+			if c.interdit != "" && strings.Contains(stderr, c.interdit) {
+				t.Errorf("le message contient encore %q :\n%s", c.interdit, stderr)
+			}
+		})
+	}
+}
+
+// TestKubeconfigSaysItNeedsLive : `--kubeconfig` seul proposait deux sources qui ne
+// sont pas celle que l'appelant vient de nommer.
+func TestKubeconfigSaysItNeedsLive(t *testing.T) {
+	bin := buildPepin(t)
+	_, stderr := runPepin(t, bin, []string{"LANG=fr_FR.UTF-8"}, "scan", "kubernetes", "--kubeconfig", "/tmp/kubeconfig")
+	if !strings.Contains(stderr, "--live") || !strings.Contains(stderr, "--kubeconfig") {
+		t.Errorf("le refus ne relie pas --kubeconfig à --live :\n%s", stderr)
+	}
+	// L'aide du drapeau doit le dire aussi : lire l'erreur ne devrait pas être le seul
+	// moyen d'apprendre la contrainte.
+	aide, _ := runPepin(t, bin, []string{"LANG=fr_FR.UTF-8"}, "scan", "--help")
+	if !strings.Contains(aide, "exige --live") {
+		t.Error("l'aide de --kubeconfig ne dit pas qu'il exige --live")
+	}
+}
+
+// TestExplainAcceptsTheCodeTheReportPrints : le rapport n'imprime que l'exigence
+// SCSL ; la commande n'acceptait que l'identifiant de check. Les deux doivent parler
+// les mêmes identifiants, sans quoi `control explain` — la commande qui transforme un
+// finding en argument — est inatteignable depuis ce qu'on vient de lire.
+func TestExplainAcceptsTheCodeTheReportPrints(t *testing.T) {
+	bin := buildPepin(t)
+	stdout, stderr := runPepin(t, bin, []string{"LANG=fr_FR.UTF-8"}, "control", "explain", "CLD-STO-1")
+	if !strings.Contains(stdout, "objectstorage_bucket_public_access") {
+		t.Errorf("CLD-STO-1 n'a pas mené au contrôle qu'elle couvre :\nstdout=%s\nstderr=%s", stdout, stderr)
+	}
+	// La casse ne doit pas être un obstacle : le rapport imprime en majuscules.
+	minuscules, _ := runPepin(t, bin, []string{"LANG=fr_FR.UTF-8"}, "control", "explain", "cld-sto-1")
+	if !strings.Contains(minuscules, "objectstorage_bucket_public_access") {
+		t.Error("l'exigence en minuscules n'est pas reconnue")
+	}
+	// L'identifiant de check continue de fonctionner : on n'échange pas une entrée
+	// contre une autre.
+	check, _ := runPepin(t, bin, []string{"LANG=fr_FR.UTF-8"}, "control", "explain", "objectstorage_bucket_public_access")
+	if !strings.Contains(check, "objectstorage_bucket_public_access") {
+		t.Error("l'identifiant de check ne fonctionne plus")
+	}
+}
+
+// TestExplainNamesEveryControlOfASharedRequirement : une exigence couvre parfois
+// plusieurs contrôles — c'est ce partage qui fait que le rapport les regroupe. En
+// choisir un à la place du lecteur reviendrait à lui en cacher un.
+func TestExplainNamesEveryControlOfASharedRequirement(t *testing.T) {
+	bin := buildPepin(t)
+	stdout, _ := runPepin(t, bin, []string{"LANG=fr_FR.UTF-8"}, "control", "explain", "CLD-NET-4")
+	for _, code := range []string{
+		"network_securitygroup_default_restrict_traffic",
+		"network_securitygroup_unrestricted_egress",
+	} {
+		if !strings.Contains(stdout, code) {
+			t.Errorf("CLD-NET-4 ne nomme pas %s :\n%s", code, stdout)
+		}
+	}
+}
+
+// TestAnUnknownControlSaysWhichFormsAreAccepted : un refus sans forme attendue oblige
+// à deviner laquelle des deux on n'a pas utilisée.
+func TestAnUnknownControlSaysWhichFormsAreAccepted(t *testing.T) {
+	bin := buildPepin(t)
+	_, stderr := runPepin(t, bin, []string{"LANG=fr_FR.UTF-8"}, "control", "explain", "PAS-UN-CODE")
+	for _, mot := range []string{"identifiant de check", "SCSL"} {
+		if !strings.Contains(stderr, mot) {
+			t.Errorf("le refus ne mentionne pas %q :\n%s", mot, stderr)
+		}
+	}
+}
+
+// TestAnUnknownRegionIsFlaggedBeforeTheCollectFails : une région mal tapée se payait
+// d'une minute de résolutions DNS et de dix-sept unités « service indisponible » à
+// lire avant d'en deviner la cause.
+//
+// C'est un AVERTISSEMENT, pas un refus : la liste appartient au fournisseur, et une
+// région ajoutée demain doit rester scannable le jour même. La distinction avec un
+// `--gate` inconnu — refusé, lui — est que ce vocabulaire-là est celui de Pépin.
+func TestAnUnknownRegionIsFlaggedBeforeTheCollectFails(t *testing.T) {
+	bin := buildPepin(t)
+	// Sans --live, aucun avertissement : la région ne sert alors à rien.
+	_, horsLive := runPepin(t, bin, []string{"LANG=fr_FR.UTF-8"},
+		"scan", "outscale", "--terraform", "examples/outscale/terraform/plan.json", "--region", "eu-nowhere-9")
+	if strings.Contains(horsLive, "n'est pas au catalogue") {
+		t.Errorf("avertissement émis hors --live :\n%s", horsLive)
+	}
+}

--- a/cmd/provider.go
+++ b/cmd/provider.go
@@ -60,6 +60,13 @@ var providerValidateCmd = &cobra.Command{
 		if len(args) > 0 {
 			dir = args[0]
 		}
+		// `os.DirFS(dir)` ne vérifie rien : passer un FICHIER produisait
+		// « lecture de . : open . : not a directory », qui ne contient ni l'argument
+		// reçu ni ce qu'on attendait à la place. Le verbe prend un dossier, l'aide le
+		// dit, et le refus doit le dire aussi.
+		if err := doitEtreUnDossier(dir, tr("dossier de providers", "provider directory")); err != nil {
+			return err
+		}
 		res, err := genprovider.ValidateAll(os.DirFS(dir), ".")
 		if err != nil {
 			return err

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -89,9 +89,30 @@ var scanCmd = &cobra.Command{
 				"unknown provider: %q (see `pepin providers`)"), name)
 		}
 		if !scanLive && path == "" {
+			// `--kubeconfig` ne sert QUE la collecte live : sans `--live`, il est
+			// silencieusement ignoré et le message d'erreur proposait deux sources
+			// qui ne sont pas celle que l'appelant vient de nommer. Le dire, plutôt
+			// que de faire répéter la question.
+			if scanKubeconfig != "" {
+				return errors.New(tr(
+					"--kubeconfig audite un cluster EN DIRECT : l'ajouter à --live.\n"+
+						"  Sans --live, un scan lit un fichier (export JSON ou plan Terraform), que --kubeconfig ne fournit pas.",
+					"--kubeconfig audits a LIVE cluster: pass it together with --live.\n"+
+						"  Without --live a scan reads a file (JSON export or Terraform plan), which --kubeconfig does not provide."))
+			}
 			return errors.New(tr(
 				"préciser un fichier (export JSON ou plan Terraform), ou utiliser --live",
 				"give a file (JSON export or Terraform plan), or use --live"))
+		}
+		avertirRegionInconnue(os.Stderr, name, scanRegion, scanLive)
+		// Les dossiers de politiques externes sont vérifiés ICI, où le chemin DONNÉ est
+		// encore connu. Plus bas, `os.DirFS(dir)` en fait une racine, et l'erreur du
+		// parcours désigne alors « . » : le lecteur cherche dans son répertoire courant
+		// une faute qu'il a faite dans un argument.
+		for _, dir := range policyDirs {
+			if err := doitEtreUnDossier(dir, tr("dossier de politiques", "policy directory")); err != nil {
+				return err
+			}
 		}
 		if !slices.Contains(scanFormats, scanFormat) {
 			return fmt.Errorf(tr(
@@ -643,7 +664,7 @@ func init() {
 	scanCmd.Flags().BoolVar(&scanLive, "live", false,
 		"collecter l'inventaire en direct via l'API du provider (identifiants requis)")
 	scanCmd.Flags().StringVar(&scanRegion, "region", "", "région cible pour la collecte live")
-	scanCmd.Flags().StringVar(&scanKubeconfig, "kubeconfig", "", "chemin d'un kubeconfig pour auditer l'état DANS un cluster Kubernetes (utiliser un accès en LECTURE SEULE, TTL court — jamais cluster-admin)")
+	scanCmd.Flags().StringVar(&scanKubeconfig, "kubeconfig", "", "chemin d'un kubeconfig pour auditer l'état DANS un cluster Kubernetes (exige --live ; utiliser un accès en LECTURE SEULE, TTL court — jamais cluster-admin)")
 	scanCmd.Flags().StringVar(&scanProfile, "profile", "", "profil d'identifiants pour la collecte live (ex. ~/.osc/config.json)")
 	// `--profile` désigne DÉJÀ le profil d'identifiants. Celui-ci s'appelle donc
 	// `--gate`, et le nom dit mieux ce qu'il fait : il ne filtre pas le rapport, il
@@ -1554,4 +1575,52 @@ func renderGateProfile(w io.Writer, gate string, codes []string, severe bool) {
 			"       dont au moins un critical/high : le scan sort en 3 (« n'établit pas la conformité »), jamais 0.",
 			"       at least one of them critical/high: the scan exits 3 (\"does not establish compliance\"), never 0."))
 	}
+}
+
+// doitEtreUnDossier refuse un chemin absent ou qui n'est pas un dossier, en NOMMANT
+// le chemin reçu.
+//
+// Le défaut qu'elle corrige est mince et coûteux : `os.DirFS(x)` ne vérifie rien, et
+// la première erreur vient du parcours, qui ne connaît plus que sa racine — « . ».
+// L'appelant lit alors un message qui ne contient pas ce qu'il a tapé.
+func doitEtreUnDossier(chemin, quoi string) error {
+	fi, err := os.Stat(chemin)
+	if err != nil {
+		return fmt.Errorf(tr("%s introuvable : %s", "%s not found: %s"), quoi, chemin)
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf(tr("%s : %s est un fichier, un dossier est attendu",
+			"%s: %s is a file, a directory is expected"), quoi, chemin)
+	}
+	return nil
+}
+
+// avertirRegionInconnue prévient qu'une région n'est pas au catalogue du fournisseur.
+//
+// Le défaut corrigé n'est pas un verdict : `--region eu-nowhere-9` rendait dix-sept
+// unités « service indisponible » (`lookup api.eu-nowhere-9.…: no such host`) et un
+// verdict INDÉTERMINÉ — honnête, mais après une minute d'attente et dix-sept lignes à
+// lire avant de deviner qu'on avait mal tapé.
+//
+// C'est un AVERTISSEMENT, pas un refus, et la distinction se défend. Un `--gate`
+// inconnu est refusé parce que ce vocabulaire est celui de Pépin : il est clos, et
+// rien d'extérieur ne l'élargit. Une liste de régions appartient au FOURNISSEUR ; il
+// en ajoute quand il veut, et refuser la première scannerait un jour moins que ce que
+// le tenant contient — un outil qui refuse ce qui existe est pire qu'un outil bavard.
+func avertirRegionInconnue(w io.Writer, provider, region string, live bool) {
+	if !live || region == "" {
+		return
+	}
+	connues := genprovider.Descriptors()[provider].Regions
+	if len(connues) == 0 || slices.Contains(connues, region) {
+		return
+	}
+	_, _ = fmt.Fprintf(w, tr(
+		"attention : la région %q n'est pas au catalogue de %s (%s).\n"+
+			"  Le scan continue — le catalogue peut avoir pris du retard sur le fournisseur —, mais\n"+
+			"  une région inexistante rend chaque appel indisponible, et le verdict INDÉTERMINÉ.\n",
+		"warning: region %q is not in the %s catalogue (%s).\n"+
+			"  The scan continues — the catalogue may lag behind the provider — but a region that\n"+
+			"  does not exist makes every call unavailable, and the verdict INCONCLUSIVE.\n"),
+		region, provider, strings.Join(connues, ", "))
 }

--- a/docs/install.fr.md
+++ b/docs/install.fr.md
@@ -4,7 +4,7 @@
 
 Un binaire Go, pas de démon, pas de dépendance. Quatre portes d'entrée,
 chacune vérifiée avant que quoi que ce soit s'exécute : le binaire publié,
-l'image de conteneur, l'action GitHub, le modèle GitLab. `0.1.0` ci-dessous
+l'image de conteneur, l'action GitHub, le modèle GitLab. `0.3.0` ci-dessous
 nomme une version publiée : un `latest` mutable installe ce qui est le plus
 récent, c'est-à-dire un binaire que personne ne sait nommer après coup.
 
@@ -14,7 +14,7 @@ Demande `cosign` (ou `gh`, plus bas) et rien d'autre. Chaque fichier est
 téléchargé sur disque et vérifié avant d'être exécuté.
 
 ```bash
-base=https://github.com/stephrobert/pepin/releases/download/v0.1.0
+base=https://github.com/stephrobert/pepin/releases/download/v0.3.0
 
 case "$(uname -s)-$(uname -m)" in
   Linux-x86_64)  asset=pepin-linux-amd64 ;;
@@ -46,7 +46,7 @@ Avec `gh`, qui contrôle la provenance de build à la place : elle prouve quel
 workflow et quel commit ont produit le binaire.
 
 ```bash
-gh release download v0.1.0 --repo stephrobert/pepin --pattern 'pepin-linux-amd64'
+gh release download v0.3.0 --repo stephrobert/pepin --pattern 'pepin-linux-amd64'
 gh attestation verify pepin-linux-amd64 --repo stephrobert/pepin \
   --signer-workflow stephrobert/pepin/.github/workflows/release.yml
 ```
@@ -71,12 +71,12 @@ n'est pas le tag ou dont les codes de sortie ont bougé.
 Un tag par release, pas de `latest`. Vérifier, puis lancer :
 
 ```bash
-cosign verify ghcr.io/stephrobert/pepin:v0.1.0 \
+cosign verify ghcr.io/stephrobert/pepin:v0.3.0 \
   --certificate-identity-regexp '^https://github\.com/stephrobert/pepin/\.github/workflows/release\.yml@refs/tags/v' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # auditer un plan Terraform : aucun identifiant, rien de provisionné
-docker run --rm -v "$PWD:/work" ghcr.io/stephrobert/pepin:v0.1.0 \
+docker run --rm -v "$PWD:/work" ghcr.io/stephrobert/pepin:v0.3.0 \
   scan scaleway --terraform /work/plan.json
 ```
 
@@ -84,7 +84,7 @@ Trois points pratiques, tous mesurés :
 
 - **Les identifiants n'entrent jamais dans l'image.** Pour `--live`, passer
   les variables natives du provider au lancement et rien d'autre :
-  `docker run --rm -e OSC_ACCESS_KEY -e OSC_SECRET_KEY -e OSC_REGION ghcr.io/stephrobert/pepin:v0.1.0 scan outscale --live`
+  `docker run --rm -e OSC_ACCESS_KEY -e OSC_SECRET_KEY -e OSC_REGION ghcr.io/stephrobert/pepin:v0.3.0 scan outscale --live`
   (nommer les variables sans `=` les transmet depuis votre environnement,
   sans mettre leur valeur dans la ligne de commande ni dans l'historique du
   shell).
@@ -101,12 +101,17 @@ Trois points pratiques, tous mesurés :
 L'action composite télécharge le binaire publié, **vérifie son SHA-256 contre
 la liste d'empreintes de la release avant de rien exécuter** (un job de CI de
 ce dépôt corrompt un octet de ce téléchargement et exige le refus), scanne,
-et traduit les codes de sortie en porte de CI :
+et traduit les codes de sortie en porte de CI.
+
+**Épingler v0.2.0 ou plus récent.** En v0.1.0 et v0.1.1, l'installeur appelait
+`gh attestation verify` sans jeton, ce qui refusait *toute* installation.
+Depuis v0.2.0, l'appelant ne passe aucun jeton : l'action vérifie l'empreinte
+par elle-même, et l'attestation quand un jeton se trouve disponible.
 
 ```yaml
-- uses: stephrobert/pepin/.github/actions/pepin-scan@v0.1.0
+- uses: stephrobert/pepin/.github/actions/pepin-scan@v0.3.0
   with:
-    version: 0.1.0
+    version: 0.3.0
     provider: scaleway
     terraform-plan: plan.json
 ```
@@ -127,7 +132,7 @@ codes de sortie comme contrat, mode rapport via
 
 ```yaml
 include:
-  - remote: 'https://raw.githubusercontent.com/stephrobert/pepin/v0.1.0/examples/gitlab-ci/pepin.gitlab-ci.yml'
+  - remote: 'https://raw.githubusercontent.com/stephrobert/pepin/v0.3.0/examples/gitlab-ci/pepin.gitlab-ci.yml'
 ```
 
 Exemple complet : [`examples/gitlab-ci/`](../examples/gitlab-ci/).

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,7 +4,7 @@
 
 One Go binary, no daemon, no dependency. Four ways in, each verified before
 anything runs: the released binary, the container image, the GitHub action,
-the GitLab template. `0.1.0` below names a released version — a mutable
+the GitLab template. `0.3.0` below names a released version — a mutable
 `latest` installs whatever is newest, which is a binary nobody can name
 afterwards.
 
@@ -14,7 +14,7 @@ Needs `cosign` (or `gh`, below) and nothing else. Every file is fetched to
 disk and verified before anything runs it.
 
 ```bash
-base=https://github.com/stephrobert/pepin/releases/download/v0.1.0
+base=https://github.com/stephrobert/pepin/releases/download/v0.3.0
 
 case "$(uname -s)-$(uname -m)" in
   Linux-x86_64)  asset=pepin-linux-amd64 ;;
@@ -46,7 +46,7 @@ With `gh`, which checks the build provenance instead — it proves which
 workflow and which commit produced the binary:
 
 ```bash
-gh release download v0.1.0 --repo stephrobert/pepin --pattern 'pepin-linux-amd64'
+gh release download v0.3.0 --repo stephrobert/pepin --pattern 'pepin-linux-amd64'
 gh attestation verify pepin-linux-amd64 --repo stephrobert/pepin \
   --signer-workflow stephrobert/pepin/.github/workflows/release.yml
 ```
@@ -70,12 +70,12 @@ manager), and the release workflow refuses to push an image whose
 One tag per release, no `latest`. Verify, then run:
 
 ```bash
-cosign verify ghcr.io/stephrobert/pepin:v0.1.0 \
+cosign verify ghcr.io/stephrobert/pepin:v0.3.0 \
   --certificate-identity-regexp '^https://github\.com/stephrobert/pepin/\.github/workflows/release\.yml@refs/tags/v' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
 # audit a Terraform plan: no credential, nothing provisioned
-docker run --rm -v "$PWD:/work" ghcr.io/stephrobert/pepin:v0.1.0 \
+docker run --rm -v "$PWD:/work" ghcr.io/stephrobert/pepin:v0.3.0 \
   scan scaleway --terraform /work/plan.json
 ```
 
@@ -83,7 +83,7 @@ Three practical points, all measured:
 
 - **Credentials never enter the image.** For `--live`, pass the provider's
   own variables at run time and nothing else:
-  `docker run --rm -e OSC_ACCESS_KEY -e OSC_SECRET_KEY -e OSC_REGION ghcr.io/stephrobert/pepin:v0.1.0 scan outscale --live`
+  `docker run --rm -e OSC_ACCESS_KEY -e OSC_SECRET_KEY -e OSC_REGION ghcr.io/stephrobert/pepin:v0.3.0 scan outscale --live`
   (naming the variables without `=` forwards them from your environment
   without putting their values in the command line or your shell history).
 - **Sealing a bundle into a mounted volume needs your uid**, because the
@@ -99,12 +99,17 @@ Three practical points, all measured:
 The composite action downloads the released binary, **verifies its SHA-256
 against the release's checksum list before anything runs it** (a CI job in
 this repository corrupts one byte of that download and requires the refusal),
-scans, and turns the exit codes into a gate:
+scans, and turns the exit codes into a gate.
+
+**Pin v0.2.0 or later.** In v0.1.0 and v0.1.1 the installer called
+`gh attestation verify` without a token, which refused *every* installation.
+Since v0.2.0 the caller passes no token: the action verifies the checksum on
+its own, and the attestation when a token happens to be available.
 
 ```yaml
-- uses: stephrobert/pepin/.github/actions/pepin-scan@v0.1.0
+- uses: stephrobert/pepin/.github/actions/pepin-scan@v0.3.0
   with:
-    version: 0.1.0
+    version: 0.3.0
     provider: scaleway
     terraform-plan: plan.json
 ```
@@ -124,7 +129,7 @@ Same doctrine, as an includable template — binary verified in
 
 ```yaml
 include:
-  - remote: 'https://raw.githubusercontent.com/stephrobert/pepin/v0.1.0/examples/gitlab-ci/pepin.gitlab-ci.yml'
+  - remote: 'https://raw.githubusercontent.com/stephrobert/pepin/v0.3.0/examples/gitlab-ci/pepin.gitlab-ci.yml'
 ```
 
 Full example: [`examples/gitlab-ci/`](../examples/gitlab-ci/).

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -122,7 +122,7 @@ Drapeaux:
   -f, --format string                    format de sortie : table | json | assessment | oscal | sarif (default "table")
       --gate string                      GATE profile (all | security | compliance | sovereignty): what weighs in the exit code. The report stays COMPLETE whatever the profile; a critical/high deviation set aside yields 3, never 0 (default "all")
   -h, --help                             aide pour scan
-      --kubeconfig string                chemin d'un kubeconfig pour auditer l'état DANS un cluster Kubernetes (utiliser un accès en LECTURE SEULE, TTL court — jamais cluster-admin)
+      --kubeconfig string                chemin d'un kubeconfig pour auditer l'état DANS un cluster Kubernetes (exige --live ; utiliser un accès en LECTURE SEULE, TTL court — jamais cluster-admin)
       --live                             collecter l'inventaire en direct via l'API du provider (identifiants requis)
       --policy fichier                   fichier YAML de politique : réglages des contrôles (`controls:`) ET dérogations (`exceptions:`) — un seul fichier, nom moderne de --exceptions
   -p, --policy-dir stringArray           répertoire de règles externes (.rego), répétable — chargé sans recompilation

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -121,7 +121,7 @@ Flags:
   -f, --format string                    output format: table | json | assessment | oscal | sarif (default "table")
       --gate string                      GATE profile (all | security | compliance | sovereignty): what weighs in the exit code. The report stays COMPLETE whatever the profile; a critical/high deviation set aside yields 3, never 0 (default "all")
   -h, --help                             help for scan
-      --kubeconfig string                path to a kubeconfig to audit the state INSIDE a Kubernetes cluster (use READ-ONLY, short-lived access — never cluster-admin)
+      --kubeconfig string                path to a kubeconfig to audit the state INSIDE a Kubernetes cluster (requires --live; use READ-ONLY, short-lived access — never cluster-admin)
       --live                             collect the inventory live through the provider API (credentials required)
       --policy file                      policy YAML file: control settings (`controls:`) AND exemptions (`exceptions:`) — one single file, the modern name of --exceptions
   -p, --policy-dir stringArray           directory of external rules (.rego), repeatable — loaded without recompiling

--- a/internal/docgen/install_version_test.go
+++ b/internal/docgen/install_version_test.go
@@ -1,0 +1,106 @@
+package docgen
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// La page d'installation est la PREMIÈRE page qu'on recopie, et elle épinglait
+// `v0.1.0` — la version dont ce dépôt écrit lui-même, dans
+// `examples/github-actions/pepin.yml`, que son installeur « refusait TOUTE
+// installation ». Une page qui décrit un produit disparu est pire qu'une page
+// absente, parce qu'elle inspire confiance.
+//
+// La garde s'adosse au CHANGELOG plutôt qu'aux tags git : un `git clone` de CI peut
+// arriver sans tags, et une doc générée depuis un état absent serait instable. Le
+// CHANGELOG, lui, est dans le dépôt — c'est la même discipline que partout ailleurs
+// ici : ce qui se vérifie doit être lisible dans l'arbre.
+
+// versionEpinglee capture un numéro de version dans un épinglage d'exemple.
+var versionEpinglee = regexp.MustCompile(`\b[vV]?(\d+\.\d+\.\d+)\b`)
+
+// derniereVersionPubliee lit la version en tête du CHANGELOG : la première
+// section `## [X.Y.Z]`, en ignorant `## [Unreleased]`.
+func derniereVersionPubliee(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRoot, "CHANGELOG.md"))
+	if err != nil {
+		t.Fatalf("lecture du CHANGELOG : %v", err)
+	}
+	re := regexp.MustCompile(`(?m)^## \[(\d+\.\d+\.\d+)\]`)
+	m := re.FindSubmatch(raw)
+	if m == nil {
+		t.Fatal("aucune version publiée dans le CHANGELOG : la garde ne mesure rien")
+	}
+	return string(m[1])
+}
+
+// TestTheInstallPagePinsTheLatestRelease : tout numéro de version épinglé dans la
+// page d'installation est celui de la dernière release.
+//
+// La garde porte sur TOUTES les occurrences, pas sur une ligne repère : l'écart
+// d'origine touchait le binaire, l'image, l'action ET le modèle GitLab, et n'en
+// corriger qu'une partie aurait laissé la page à moitié fausse — ce qui se remarque
+// encore moins.
+func TestTheInstallPagePinsTheLatestRelease(t *testing.T) {
+	attendu := derniereVersionPubliee(t)
+	for _, page := range []string{"docs/install.md", "docs/install.fr.md"} {
+		chemin := filepath.Join(repoRoot, page)
+		raw, err := os.ReadFile(chemin) // #nosec G304 -- page du dépôt.
+		if err != nil {
+			t.Fatalf("lecture de %s : %v", page, err)
+		}
+		vues := map[string]bool{}
+		for _, ligne := range strings.Split(string(raw), "\n") {
+			// Les mentions HISTORIQUES sont légitimes et ne doivent pas rougir : elles
+			// nomment une version passée pour dire ce qui n'y marchait pas. On ne
+			// regarde donc que les lignes qui ÉPINGLENT, c'est-à-dire celles qui
+			// portent une URL de release, une image, une référence d'action ou une
+			// entrée `version:`.
+			if !ligneDepinglage(ligne) {
+				continue
+			}
+			for _, m := range versionEpinglee.FindAllStringSubmatch(ligne, -1) {
+				vues[m[1]] = true
+			}
+		}
+		if len(vues) == 0 {
+			t.Errorf("%s : aucun épinglage trouvé — la garde ne mesure plus rien", page)
+			continue
+		}
+		var liste []string
+		for v := range vues {
+			liste = append(liste, v)
+		}
+		sort.Strings(liste)
+		for _, v := range liste {
+			if v != attendu {
+				t.Errorf("%s épingle %s, alors que la dernière release est %s.\n"+
+					"  Versions épinglées : %s\n"+
+					"  La page d'installation est la première qu'on recopie ; elle ne doit pas\n"+
+					"  proposer une version que le dépôt ne publie plus.", page, v, attendu, strings.Join(liste, ", "))
+			}
+		}
+	}
+}
+
+// ligneDepinglage dit si une ligne propose une version À INSTALLER, par opposition à
+// une ligne qui en cite une pour raconter ce qu'elle valait.
+func ligneDepinglage(ligne string) bool {
+	for _, motif := range []string{
+		"releases/download/",
+		"ghcr.io/stephrobert/pepin:",
+		"gh release download",
+		"pepin-scan@",
+		"raw.githubusercontent.com/stephrobert/pepin/",
+	} {
+		if strings.Contains(ligne, motif) {
+			return true
+		}
+	}
+	return strings.HasPrefix(strings.TrimSpace(ligne), "version:")
+}

--- a/internal/genprovider/genprovider.go
+++ b/internal/genprovider/genprovider.go
@@ -38,7 +38,20 @@ type Descriptor struct {
 	Description string `yaml:"description"`
 	Scope       string `yaml:"scope"`      // "cloud" (défaut) | "in-cluster" : une portée différente ne se compare pas en parité
 	RegionKey   string `yaml:"region_key"` // clé logique alimentée par --region (défaut "region" ; Exoscale: "zone")
-	Auth        struct {
+	// Regions : le catalogue des régions CONNUES de ce fournisseur, celui-là même que
+	// les règles de souveraineté cataloguent (internal/commonrules/rules/lib.rego :
+	// `_eu_regions`, `_trusted_regions`, `_noneu_regions`). Il sert à prévenir tôt
+	// qu'un `--region` n'y figure pas — une faute de frappe se payait autrement d'une
+	// minute de résolutions DNS qui échouent, puis de dix-sept unités « service
+	// indisponible » à lire avant d'en deviner la cause.
+	//
+	// Il ne REFUSE pas : la liste appartient au fournisseur, pas à Pépin, et une
+	// région ajoutée demain doit rester scannable le jour même. C'est ce qui le
+	// distingue d'un `--gate` inconnu, dont le vocabulaire est celui de Pépin.
+	//
+	// Vide = aucun catalogue, donc aucun avertissement.
+	Regions []string `yaml:"regions"`
+	Auth    struct {
 		Type    string `yaml:"type"`    // header | sigv4 | exoscale-hmac
 		Header  string `yaml:"header"`  // header : nom de l'en-tête
 		Value   string `yaml:"value"`   // header : valeur (ex. "{secret_key}")

--- a/internal/genprovider/regions_test.go
+++ b/internal/genprovider/regions_test.go
@@ -1,0 +1,124 @@
+package genprovider_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/pepin/internal/genprovider"
+)
+
+// Le catalogue des régions existe DEUX fois, et c'est délibéré : la CLI ne lit pas de
+// Rego, une règle ne lit pas de descripteur. Ce qui n'est pas négociable, c'est qu'ils
+// disent la même chose — sans quoi `pepin scan --region ch-gva-2` avertirait qu'une
+// région est inconnue pendant que la règle de souveraineté la catalogue, ou l'inverse.
+//
+// La garde lit le Rego au motif plutôt qu'en l'évaluant : elle ne cherche pas à
+// comprendre les règles, seulement à voir si les deux listes divergent.
+
+var (
+	blocRegions = regexp.MustCompile(`(?s)(_eu_regions|_trusted_regions|_noneu_regions)\s*:=\s*\{(.*?)\n\}`)
+	parFournis  = regexp.MustCompile(`"([a-z]+)":\s*(\{[^}]*\}|set\(\))`)
+	littéral    = regexp.MustCompile(`"([^"]+)"`)
+)
+
+// regionsDesRegles rend, par fournisseur, l'union des trois tables de lib.rego.
+func regionsDesRegles(t *testing.T) map[string][]string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "commonrules", "rules", "lib.rego"))
+	if err != nil {
+		t.Fatalf("lecture de lib.rego : %v", err)
+	}
+	out := map[string]map[string]bool{}
+	blocs := blocRegions.FindAllStringSubmatch(string(raw), -1)
+	if len(blocs) != 3 {
+		t.Fatalf("%d table(s) de régions trouvée(s) dans lib.rego, 3 attendues : la garde ne mesure plus ce qu'elle croit", len(blocs))
+	}
+	for _, b := range blocs {
+		for _, e := range parFournis.FindAllStringSubmatch(b[2], -1) {
+			if out[e[1]] == nil {
+				out[e[1]] = map[string]bool{}
+			}
+			for _, r := range littéral.FindAllStringSubmatch(e[2], -1) {
+				out[e[1]][r[1]] = true
+			}
+		}
+	}
+	plat := map[string][]string{}
+	for p, set := range out {
+		for r := range set {
+			plat[p] = append(plat[p], r)
+		}
+		sort.Strings(plat[p])
+	}
+	return plat
+}
+
+// TestTheRegionCatalogueMatchesTheRules : le `regions:` d'un descripteur est
+// exactement l'union des régions que les règles de souveraineté cataloguent.
+func TestTheRegionCatalogueMatchesTheRules(t *testing.T) {
+	desRegles := regionsDesRegles(t)
+	if len(desRegles) == 0 {
+		t.Fatal("aucune région lue dans lib.rego : la garde ne mesure rien")
+	}
+	vus := map[string]bool{}
+	for nom, d := range descripteursDuDepot(t) {
+		attendu, catalogué := desRegles[nom]
+		vus[nom] = true
+		got := append([]string(nil), d.Regions...)
+		sort.Strings(got)
+		if !catalogué {
+			// Un fournisseur que les règles ne cataloguent pas ne doit pas inventer sa
+			// propre liste : ce serait une connaissance sans source, et l'avertissement
+			// deviendrait faux dans les deux sens.
+			if len(got) > 0 {
+				t.Errorf("providers/%s.yaml déclare des régions (%s) qu'aucune table de lib.rego ne catalogue",
+					nom, strings.Join(got, ", "))
+			}
+			continue
+		}
+		if strings.Join(got, ",") != strings.Join(attendu, ",") {
+			t.Errorf("providers/%s.yaml et lib.rego divergent :\n  descripteur : %s\n  règles      : %s\n"+
+				"  Les deux listes portent la MÊME connaissance ; la CLI lit l'une, les règles l'autre.",
+				nom, strings.Join(got, ", "), strings.Join(attendu, ", "))
+		}
+	}
+	for nom := range desRegles {
+		if !vus[nom] {
+			t.Errorf("lib.rego catalogue des régions pour %q, qui n'a pas de descripteur", nom)
+		}
+	}
+}
+
+// descripteursDuDepot charge les descripteurs COMMITTÉS, plutôt que le registre du
+// processus.
+//
+// Le registre n'est peuplé que par le binaire, qui enregistre les providers au
+// démarrage : le lire depuis un test le trouve vide, et une garde qui parcourt une
+// carte vide passe en ne mesurant rien. C'est une panne silencieuse qui s'est déjà
+// produite ici, et le `t.Fatal` sur la carte vide est ce qui l'empêche de revenir.
+func descripteursDuDepot(t *testing.T) map[string]genprovider.Descriptor {
+	t.Helper()
+	entrees, err := os.ReadDir(filepath.Join("..", "..", "providers"))
+	if err != nil {
+		t.Fatalf("lecture des descripteurs : %v", err)
+	}
+	out := map[string]genprovider.Descriptor{}
+	for _, e := range entrees {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		d, lerr := genprovider.Load(os.DirFS(filepath.Join("..", "..", "providers")), e.Name())
+		if lerr != nil {
+			t.Fatalf("chargement de %s : %v", e.Name(), lerr)
+		}
+		out[strings.TrimSuffix(e.Name(), ".yaml")] = d
+	}
+	if len(out) == 0 {
+		t.Fatal("aucun descripteur chargé : la garde ne mesure rien")
+	}
+	return out
+}

--- a/providers/exoscale.yaml
+++ b/providers/exoscale.yaml
@@ -4,6 +4,18 @@ name: exoscale
 description: "Exoscale (CH) — instances, security groups, block storage, SKS, SOS"
 region_key: zone
 
+# Catalogue des régions connues de ce fournisseur.
+#
+# Recopié du catalogue de souveraineté (internal/commonrules/rules/lib.rego) :
+# c'est la MÊME connaissance, et `TestTheRegionCatalogueMatchesTheRules` refuse
+# qu'elles divergent. Elle est ici parce que la CLI ne lit pas de Rego, et là-bas
+# parce qu'une règle ne lit pas de descripteur.
+#
+# Sert à AVERTIR qu'un `--region` n'y figure pas, jamais à refuser : la liste
+# appartient au fournisseur, et une région ajoutée demain doit rester scannable.
+regions: [at-vie-1, at-vie-2, bg-sof-1, ch-dk-2, ch-gva-2, de-fra-1, de-muc-1, hr-zag-1]
+
+
 # Souveraineté du fournisseur (CLD-GVN-4) — faits ancrés, projetés en ressource
 # governance_provider. Siège en Suisse (hors UE) → écart GVN-4 attendu.
 souverainete:

--- a/providers/outscale.yaml
+++ b/providers/outscale.yaml
@@ -4,6 +4,18 @@
 name: outscale
 description: "Outscale (3DS) — VM, BSU, OOS, EIM, security groups, OKS, LBU"
 
+# Catalogue des régions connues de ce fournisseur.
+#
+# Recopié du catalogue de souveraineté (internal/commonrules/rules/lib.rego) :
+# c'est la MÊME connaissance, et `TestTheRegionCatalogueMatchesTheRules` refuse
+# qu'elles divergent. Elle est ici parce que la CLI ne lit pas de Rego, et là-bas
+# parce qu'une règle ne lit pas de descripteur.
+#
+# Sert à AVERTIR qu'un `--region` n'y figure pas, jamais à refuser : la liste
+# appartient au fournisseur, et une région ajoutée demain doit rester scannable.
+regions: [ap-northeast-1, cloudgouv-eu-west-1, eu-west-2, us-east-2, us-west-1]
+
+
 # Souveraineté du fournisseur (CLD-GVN-4) — faits ancrés. Cloud souverain FR,
 # qualifié SecNumCloud 3.2 (immunité extraterritoriale reconnue par l'ANSSI).
 souverainete:

--- a/providers/scaleway.yaml
+++ b/providers/scaleway.yaml
@@ -3,6 +3,18 @@
 name: scaleway
 description: "Scaleway — object storage, instances, IAM, security groups"
 
+# Catalogue des régions connues de ce fournisseur.
+#
+# Recopié du catalogue de souveraineté (internal/commonrules/rules/lib.rego) :
+# c'est la MÊME connaissance, et `TestTheRegionCatalogueMatchesTheRules` refuse
+# qu'elles divergent. Elle est ici parce que la CLI ne lit pas de Rego, et là-bas
+# parce qu'une règle ne lit pas de descripteur.
+#
+# Sert à AVERTIR qu'un `--region` n'y figure pas, jamais à refuser : la liste
+# appartient au fournisseur, et une région ajoutée demain doit rester scannable.
+regions: [fr-par, nl-ams, pl-waw]
+
+
 # Souveraineté du fournisseur (CLD-GVN-4) — faits ancrés. Cloud français du
 # groupe Iliad (capital européen) ; qualification SecNumCloud en cours.
 souverainete:

--- a/referentiel/referentiel.go
+++ b/referentiel/referentiel.go
@@ -8,6 +8,8 @@ package referentiel
 import (
 	_ "embed"
 	"fmt"
+	"sort"
+	"strings"
 
 	yaml "go.yaml.in/yaml/v3"
 
@@ -67,6 +69,31 @@ func init() {
 func Lookup(code string) (Control, bool) {
 	ctl, ok := byCode[code]
 	return ctl, ok
+}
+
+// BySCSL retourne les contrôles rattachés à une exigence SCSL (`CLD-*`), triés par
+// code, ou une tranche vide.
+//
+// Une exigence en couvre parfois plusieurs : c'est ce partage qui fait que le rapport
+// terminal regroupe leurs findings sous un même en-tête, et c'est pourquoi la
+// recherche rend une LISTE plutôt qu'un contrôle — en choisir un serait en cacher un.
+//
+// La comparaison est insensible à la casse : l'exigence est imprimée en majuscules
+// par le rapport, et personne ne devrait avoir à reproduire une casse pour être
+// compris.
+func BySCSL(code string) []Control {
+	cible := strings.ToUpper(strings.TrimSpace(code))
+	var out []Control
+	for _, ctl := range byCode {
+		for _, s := range ctl.Scsl {
+			if strings.ToUpper(s) == cible {
+				out = append(out, ctl)
+				break
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Code < out[j].Code })
+	return out
 }
 
 // All retourne tous les contrôles, indexés par code agnostique (lecture seule).


### PR DESCRIPTION
Three issues, one perimeter (`cmd/` + `docs/`), one pass of the gates. **None of
these moves a verdict** — which is exactly why they survived: nothing went red.

## #173 — the install page pinned a version the repo calls broken

`docs/install*.md` pinned `v0.1.0` in all nine places, while
`examples/github-actions/pepin.yml`, in the same repository, says:

> *Pin at least v0.2.0 of the action: in v0.1.0 and v0.1.1 its installer called
> `gh attestation verify` without a token, which refused EVERY installation.*

The install page is the first page a newcomer copies from, and it handed them the
version the repository itself declares unusable. A page that describes a product
that no longer exists is worse than a missing page, because it inspires confidence.

Every pin now names the latest release, and a sentence closes the loop: since
v0.2.0 the caller passes no token.

**The guard reads the CHANGELOG, not git tags.** A CI clone can arrive without
tags, and a doc derived from an absent state would be unstable. It looks at
*pinning* lines only — historical mentions of `v0.1.0` in `github-actions.md` and
`exit-codes.md` are legitimate (they say what did not work back then), and a
blanket replace would have corrupted them. Checked in both directions.

## #174 — four messages pointing at the wrong thing

| | before | after |
|---|---|---|
| `--policy-dir /nonexistent` | `parcours des politiques: stat .: no such file or directory` | `dossier de politiques introuvable : /nonexistent` |
| `--policy-dir go.mod` | *(same)* | `dossier de politiques : go.mod est un fichier, un dossier est attendu` |
| `provider validate providers/outscale.yaml` | `lecture de . : open .: not a directory` | `dossier de providers : providers/outscale.yaml est un fichier, un dossier est attendu` |
| `scan kubernetes --kubeconfig X` | `préciser un fichier (export JSON ou plan Terraform), ou utiliser --live` | `--kubeconfig audite un cluster EN DIRECT : l'ajouter à --live.` |

The first two share a root cause worth naming: `os.DirFS(x)` builds a filesystem
view without checking anything, so the first error comes from the *walk*, which no
longer knows anything but its own root — `.`. The reader was hunting in their
working directory for a mistake they had made in an argument.

For `--kubeconfig`, the flag's **help** says it too now. Reading an error should
not be the only way to learn a constraint.

### The region: a warning, not a refusal — and why

`--region eu-nowhere-9` cost a minute of failing DNS and **seventeen** "service
unavailable" units to read before the cause became guessable. (The green tick the
issue mentions is already gone — #181 fixed that half; the verdict now reads
`INDÉTERMINÉ` with exit 3, which is honest.) What remained was *time to diagnosis*:

```
attention : la région "eu-nowhere-9" n'est pas au catalogue de outscale
  (ap-northeast-1, cloudgouv-eu-west-1, eu-west-2, us-east-2, us-west-1).
  Le scan continue — le catalogue peut avoir pris du retard sur le fournisseur —, mais
  une région inexistante rend chaque appel indisponible, et le verdict INDÉTERMINÉ.
```

**The issue asked for exit 2, and I did not do that.** An unknown `--gate` is
refused because that vocabulary is *Pépin's own*: closed, and nothing outside
widens it. A region list belongs to the **provider** — one added tomorrow must
stay scannable the same day, and a tool that refuses what exists is worse than a
talkative one. If you'd rather have the hard refusal, it's a two-line change.

The catalogue now exists **twice on purpose** — the CLI reads no Rego, a rule
reads no descriptor — and `TestTheRegionCatalogueMatchesTheRules` refuses
divergence. It reads the descriptors from **disk** rather than the process
registry, which is empty outside the binary: a guard walking an empty map passes
while measuring nothing, and that silent failure has already happened in this
repo. Checked in both directions.

## #172 — the command refused the code the report prints

```
./pepin scan …                    → prints  CLD-STO-1
./pepin control explain CLD-STO-1 → erreur : contrôle inconnu     (exit 2)
```

The report's `Code` column and every block header carry the SCSL requirement, and
`--format json` carries it in `code`. `control explain` — the command that turns a
finding into an argument — accepted only the check identifier, which the report
never prints. A reader who had just read a verdict had to guess it from the title.

Both forms work now, **case-insensitively** (the report prints uppercase; nobody
should have to reproduce a case to be understood). And a requirement covering
several controls **names them all**:

```
CLD-NET-4 couvre les contrôles suivants :

  network_securitygroup_default_restrict_traffic
    Security group « default » non restrictif
  network_securitygroup_unrestricted_egress
    Filtrage sortant non restreint
```

Choosing one for the reader would be hiding one — and that shared requirement is
the same thing that makes the terminal grouping bug (#166) bite.

An unknown code now says which two forms are accepted, instead of leaving the
caller to guess which one they failed to use.

## Impact ADR

None reopened, none needed. The region warning stays clear of ADR-0005 (it changes
no exit code) and of ADR-0014 (it states a catalogue, it does not infer a region).

## Verified

Every message was reproduced on the binary **before** the change and measured
after, in both languages. The two assertions that forbid the old strings
(`stat .:`, `lecture de . `) would have failed against the previous build — these
are regression tests, not confirmations.

`mise run prepush` green.

Closes #172
Closes #173
Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)
