### PR TITLE
fix(provider): pair exposure per NIC, and scope the qualification to its regions

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -63,6 +63,30 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Une VM publique par sa carte secondaire, SSH ouvert sur cette carte, ne produisait
+  aucun finding.** Le collecteur projetait l'union des IP publiques des cartes, donc la
+  machine comptait pour publique — mais il la confrontait à `Vm.SecurityGroups`, que
+  l'OAPI documente comme les groupes de la carte **primaire**. Mesuré sur un tenant
+  réel : SSH répondait sur l'adresse publique et le rapport ne disait rien. L'exposition
+  est une propriété de la **carte** : une ressource `network_interface` est désormais
+  collectée par NIC (`nic_id`, `vm_id`, `public_ip`, `security_group_ids`) et la règle
+  apparie une adresse avec les groupes **de la même carte**. L'aplatissement est fautif
+  dans les deux sens, et c'est pourquoi le correctif n'est pas une union plus large :
+  une carte publique au groupe fermé plus une carte privée au groupe ouvert se liraient,
+  une fois réunies, comme « publique et ouverte » — un écart que la machine ne porte
+  pas. Là où les cartes ne sont pas collectées (un plan Terraform), la machine reste
+  jugée sur ses propres attributs : un repli muet aurait fait DISPARAÎTRE des écarts.
+- **SecNumCloud était déclaré par fournisseur, alors qu'une qualification couvre un
+  périmètre de régions.** Celle d'Outscale couvre `cloudgouv-eu-west-1` et elle seule ;
+  un tenant en `eu-west-2` lisait « SecNumCloud qualifié » dans un `pass` de
+  souveraineté, ce qui est la première affirmation qu'un auditeur conteste. Le
+  descripteur déclare désormais le périmètre (`secnumcloud_regions`, sourcé), et
+  l'attribut `secnumcloud` est rendu **pour la région réellement scannée** : `qualifie`
+  dans le périmètre, `hors_perimetre` en dehors, `perimetre_inconnu` quand le scan n'a
+  pas de région — un scan qui ne sait pas où il porte ne tranche pas. La qualification ne
+  vaut donc plus immunité extraterritoriale hors de son périmètre, et la page du
+  fournisseur ne peut plus imprimer le statut sans lui. Aucun écart nouveau n'est émis,
+  aucun code de sortie ne bouge.
 - **La page d'installation épinglait `v0.1.0`, la version dont ce dépôt écrit lui-même
   qu'elle refuse toute installation.** `examples/github-actions/pepin.yml` le dit en
   toutes lettres : en v0.1.0 et v0.1.1, l'installeur de l'action appelait

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,28 @@ belongs in `git log`.
 
 ### Fixed
 
+- **A VM public through a secondary NIC, with SSH open on that NIC, produced no
+  finding.** The collector projected the union of the NICs' public IPs, so the machine
+  counted as public — but it confronted that with `Vm.SecurityGroups`, which the OAPI
+  documents as the **primary** NIC's groups. Measured on a real tenant: SSH answered on
+  the public address and the report said nothing. Exposure is a property of the
+  **interface**, so a `network_interface` resource is now collected per NIC (`nic_id`,
+  `vm_id`, `public_ip`, `security_group_ids`) and the rule pairs an address with the
+  groups **of the same card**. Flattening is wrong in both directions, which is why the
+  fix is not a wider union: a public NIC with a closed group plus a private NIC with an
+  open one would read, once merged, as "public and open" — a deviation the machine does
+  not carry. Where NICs are not collected (a Terraform plan), the machine is still judged
+  on its own attributes: a silent fallback would have made deviations disappear.
+- **SecNumCloud was declared per provider, while a qualification covers a scope of
+  regions.** Outscale's covers `cloudgouv-eu-west-1` and that one only; an `eu-west-2`
+  tenant read "SecNumCloud qualifié" inside a sovereignty `pass`, which is the first
+  claim an auditor contests. The descriptor now declares the scope
+  (`secnumcloud_regions`, sourced), and the `secnumcloud` attribute is rendered **for the
+  region actually scanned**: `qualifie` inside the scope, `hors_perimetre` outside it,
+  `perimetre_inconnu` when the scan has no region — a scan that does not know where it
+  applies does not decide. The qualification therefore no longer grants extraterritorial
+  immunity outside its scope, and the provider page can no longer print the status
+  without it. No new deviation is emitted and no exit code moves.
 - **The install page pinned `v0.1.0`, the version this repository itself declares
   refuses every installation.** `examples/github-actions/pepin.yml` says it in as many
   words: in v0.1.0 and v0.1.1 the action's installer called `gh attestation verify`

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -1266,10 +1266,14 @@ func withGovernance(p provider.Provider, input any) any {
 	if !ok {
 		return input
 	}
-	res, ok := gp.GovernanceResource()
+	// La région SCANNÉE entre dans la projection : c'est elle qui dit si le tenant
+	// se trouve dans le périmètre d'une qualification. Vide sur un plan Terraform,
+	// et le statut le dit alors plutôt que de trancher.
+	res, ok := gp.GovernanceResourceIn(scanRegion)
 	if !ok {
 		return input
 	}
+	res.Region = scanRegion
 	m, ok := input.(map[string]any)
 	if !ok {
 		return input

--- a/cmd/testdata/frozen/inventory.json
+++ b/cmd/testdata/frozen/inventory.json
@@ -1325,6 +1325,241 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 7,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "source": {
+                "file": "string",
+                "line": "number",
+                "module": "string"
+              },
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v7",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "creation_date",
+            "expiration_date",
+            "owner_user",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "state",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud",
+            "secnumcloud_regions"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_interface": [
+            "nic_id",
+            "public_ip",
+            "security_group_ids",
+            "vm_id"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "inbound_default_policy",
+            "security_group_id"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "peer_security_group_ids",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
+        }
+      }
     }
   ]
 }

--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -87,7 +87,7 @@ Le tableau ci-dessous est rendu depuis cette table même, il n'en est pas la cop
 | `compute_instance_deletion_protection` | `compute_instance` | `deletion_protection` |
 | `compute_instance_has_security_group` | `compute_instance` | `security_group_ids` |
 | `compute_instance_no_secrets_in_user_data` | `compute_instance` | `user_data` |
-| `compute_instance_public_ip_with_open_securitygroup` | `compute_instance` | `public_ip` |
+| `compute_instance_public_ip_with_open_securitygroup` | `compute_instance` | `nic_public_ips` ou `public_ip` |
 | `database_backup_enabled` | `managed_database` | `disable_backup` |
 | `database_encryption_at_rest_enabled` | `managed_database` | `encryption_at_rest` |
 | `database_service_not_open_to_internet` | `managed_database` | `ip_filter` |
@@ -344,7 +344,7 @@ pas touché : Pépin ne l'a pas collecté, il n'a donc rien à en attester.
 {
   "control": "compute_instance_public_ip_with_open_securitygroup",
   "evidence": {
-    "observed": "attribut « public_ip » non collecté sur les ressources de type « compute_instance » (garde de capacité)",
+    "observed": "attribut « nic_public_ips / public_ip » non collecté sur les ressources de type « compute_instance » (garde de capacité)",
     "source": "terraform-plan"
   },
   "references": [

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -87,7 +87,7 @@ The table below is rendered from that very map — not transcribed from it:
 | `compute_instance_deletion_protection` | `compute_instance` | `deletion_protection` |
 | `compute_instance_has_security_group` | `compute_instance` | `security_group_ids` |
 | `compute_instance_no_secrets_in_user_data` | `compute_instance` | `user_data` |
-| `compute_instance_public_ip_with_open_securitygroup` | `compute_instance` | `public_ip` |
+| `compute_instance_public_ip_with_open_securitygroup` | `compute_instance` | `nic_public_ips` or `public_ip` |
 | `database_backup_enabled` | `managed_database` | `disable_backup` |
 | `database_encryption_at_rest_enabled` | `managed_database` | `encryption_at_rest` |
 | `database_service_not_open_to_internet` | `managed_database` | `ip_filter` |
@@ -341,7 +341,7 @@ Pépin did not collect it, so it has nothing to attest about it.
 {
   "control": "compute_instance_public_ip_with_open_securitygroup",
   "evidence": {
-    "observed": "attribute \"public_ip\" not collected on the resources of type \"compute_instance\" (capability guard)",
+    "observed": "attribute \"nic_public_ips / public_ip\" not collected on the resources of type \"compute_instance\" (capability guard)",
     "source": "terraform-plan"
   },
   "references": [

--- a/docs/concepts/terraform-vs-live.fr.md
+++ b/docs/concepts/terraform-vs-live.fr.md
@@ -261,7 +261,7 @@ couples, une source produit le type de ressource et son attribut décisif, et l'
 | `blockstorage_volume_snapshots_exist` | outscale | live | cette source ne produit aucune ressource de type « blockstorage_volume » |
 | `compute_instance_deletion_protection` | outscale | live | attribut décisif « deletion_protection » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `compute_instance_no_secrets_in_user_data` | scaleway | terraform | attribut décisif « user_data » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
-| `compute_instance_public_ip_with_open_securitygroup` | scaleway | live | attribut décisif « public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| `compute_instance_public_ip_with_open_securitygroup` | scaleway | live | attribut décisif « nic_public_ips / public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `database_backup_enabled` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `database_encryption_at_rest_enabled` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `database_service_not_open_to_internet` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |

--- a/docs/concepts/terraform-vs-live.md
+++ b/docs/concepts/terraform-vs-live.md
@@ -256,7 +256,7 @@ source produces the resource type and its deciding attribute, and the other does
 | `blockstorage_volume_snapshots_exist` | outscale | live | this source produces no resource of type "blockstorage_volume" |
 | `compute_instance_deletion_protection` | outscale | live | deciding attribute "deletion_protection" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `compute_instance_no_secrets_in_user_data` | scaleway | terraform | deciding attribute "user_data" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
-| `compute_instance_public_ip_with_open_securitygroup` | scaleway | live | deciding attribute "public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| `compute_instance_public_ip_with_open_securitygroup` | scaleway | live | deciding attribute "nic_public_ips / public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `database_backup_enabled` | scaleway | terraform | this source produces no resource of type "managed_database" |
 | `database_encryption_at_rest_enabled` | scaleway | terraform | this source produces no resource of type "managed_database" |
 | `database_service_not_open_to_internet` | scaleway | terraform | this source produces no resource of type "managed_database" |

--- a/docs/controls/compute_instance_public_ip_with_open_securitygroup.fr.md
+++ b/docs/controls/compute_instance_public_ip_with_open_securitygroup.fr.md
@@ -15,7 +15,7 @@
 | Sévérité | `critical` |
 | Exigence SCSL (index gelé) | `CLD-NET-3` |
 | Type de ressource lu | `compute_instance` |
-| Attribut décisif | `public_ip` |
+| Attribut décisif | `nic_public_ips` / `public_ip` |
 | État | actif |
 | Déclaré pour | `exoscale`, `outscale`, `scaleway` |
 | Preuves de remédiation | 1 / 3 |
@@ -61,7 +61,7 @@ porte son motif :
 
 | Fournisseur | Source | Statut | Motif |
 |---|---|---|---|
-| scaleway | terraform | ◐ `partial` | attribut décisif « public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| scaleway | terraform | ◐ `partial` | attribut décisif « nic_public_ips / public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 
 ## Ce que Pépin peut conclure
 
@@ -78,7 +78,7 @@ contient aucune ressource du type visé : « rien à voir » n'est pas « confor
 ## Comment enquêter
 
 - Type de ressource normalisé lu par la règle : `compute_instance`
-- Attribut dont la décision dépend : `public_ip`
+- Attribut dont la décision dépend : `nic_public_ips` / `public_ip`
 - Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
 - Ce que chaque source projette se lit dans le descripteur : [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
 - La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.

--- a/docs/controls/compute_instance_public_ip_with_open_securitygroup.md
+++ b/docs/controls/compute_instance_public_ip_with_open_securitygroup.md
@@ -15,7 +15,7 @@
 | Severity | `critical` |
 | SCSL requirement (frozen index) | `CLD-NET-3` |
 | Resource type read | `compute_instance` |
-| Deciding attribute | `public_ip` |
+| Deciding attribute | `nic_public_ips` / `public_ip` |
 | State | active |
 | Declared for | `exoscale`, `outscale`, `scaleway` |
 | Remediation proofs | 1 / 3 |
@@ -60,7 +60,7 @@ reason:
 
 | Provider | Source | Status | Reason |
 |---|---|---|---|
-| scaleway | terraform | ◐ `partial` | deciding attribute "public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| scaleway | terraform | ◐ `partial` | deciding attribute "nic_public_ips / public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 
 ## What Pépin can conclude
 
@@ -77,7 +77,7 @@ resource of the targeted type: "nothing to look at" is not "compliant".
 ## How to investigate
 
 - Normalized resource type the rule reads: `compute_instance`
-- Attribute the decision depends on: `public_ip`
+- Attribute the decision depends on: `nic_public_ips` / `public_ip`
 - Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
 - What each source projects is readable in the descriptor: [`providers/exoscale.yaml`](../../providers/exoscale.yaml) · [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
 - The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.

--- a/docs/coverage.fr.md
+++ b/docs/coverage.fr.md
@@ -134,7 +134,7 @@ ici : la matrice les montre déjà, et elles n'apprennent rien de plus.
 | `blockstorage_volume_snapshots_exist` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « blockstorage_volume » |
 | `compute_instance_deletion_protection` | outscale | terraform | ◐ `partial` | attribut décisif « deletion_protection » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `compute_instance_no_secrets_in_user_data` | scaleway | live | ◐ `partial` | attribut décisif « user_data » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
-| `compute_instance_public_ip_with_open_securitygroup` | scaleway | terraform | ◐ `partial` | attribut décisif « public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| `compute_instance_public_ip_with_open_securitygroup` | scaleway | terraform | ◐ `partial` | attribut décisif « nic_public_ips / public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `database_backup_enabled` | scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « managed_database » |
 | `database_encryption_at_rest_enabled` | scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « managed_database » |
 | `database_service_not_open_to_internet` | scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « managed_database » |

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -133,7 +133,7 @@ already shows them, and they add nothing.
 | `blockstorage_volume_snapshots_exist` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "blockstorage_volume" |
 | `compute_instance_deletion_protection` | outscale | terraform | ◐ `partial` | deciding attribute "deletion_protection" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `compute_instance_no_secrets_in_user_data` | scaleway | live | ◐ `partial` | deciding attribute "user_data" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
-| `compute_instance_public_ip_with_open_securitygroup` | scaleway | terraform | ◐ `partial` | deciding attribute "public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| `compute_instance_public_ip_with_open_securitygroup` | scaleway | terraform | ◐ `partial` | deciding attribute "nic_public_ips / public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `database_backup_enabled` | scaleway | live | ✗ `unsupported` | this source produces no resource of type "managed_database" |
 | `database_encryption_at_rest_enabled` | scaleway | live | ✗ `unsupported` | this source produces no resource of type "managed_database" |
 | `database_service_not_open_to_internet` | scaleway | live | ✗ `unsupported` | this source produces no resource of type "managed_database" |

--- a/docs/detection-quality.fr.md
+++ b/docs/detection-quality.fr.md
@@ -16,7 +16,7 @@ pourcentage sans mesure derrière est un faux vert déplacé dans un tableau de
 bord, et il y est pire qu'ailleurs : personne ne relit un tableau de bord.
 
 Les chiffres sont donc laids, et c'est le point. « 58 contrôles » ne dit rien de
-la qualité d'une détection ; « 89 verdicts prouvés sur 461 » dit où en est le
+la qualité d'une détection ; « 92 verdicts prouvés sur 461 » dit où en est le
 produit, et rétrécit dans le bon sens à chaque scénario écrit.
 
 ## Les chiffres
@@ -25,9 +25,9 @@ produit, et rétrécit dans le bon sens à chaque scénario écrit.
 |---|---:|
 | Contrôles au référentiel | 58 |
 | Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 179 |
-| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 26 |
+| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 27 |
 | Verdicts à prouver au total | 461 |
-| Verdicts prouvés | 89 |
+| Verdicts prouvés | 92 |
 
 ## Couverture de véracité, par verdict
 
@@ -37,11 +37,11 @@ demanderait d'inventer une non-applicabilité.
 
 | Verdict | Ce qu'il met en scène | À prouver | Prouvés | % |
 |---|---|---:|---:|---:|
-| `fail` | une configuration vulnérable est détectée | 141 | 23 | 16 |
-| `pass` | une configuration réellement correcte est confirmée | 141 | 36 | 25 |
-| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 157 | 19 | 12 |
+| `fail` | une configuration vulnérable est détectée | 141 | 24 | 17 |
+| `pass` | une configuration réellement correcte est confirmée | 141 | 37 | 26 |
+| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 157 | 20 | 12 |
 | `not-applicable` | le contrat du fournisseur déclare le mécanisme inexistant | 22 | 11 | 50 |
-| **Total** | | **461** | **89** | **19** |
+| **Total** | | **461** | **92** | **19** |
 
 ## Validé en live
 

--- a/docs/detection-quality.md
+++ b/docs/detection-quality.md
@@ -16,7 +16,7 @@ with no measurement behind it is a false green moved into a dashboard, and it is
 worse there than anywhere else: nobody re-reads a dashboard.
 
 The figures are therefore ugly, and that is the point. "58 controls" says nothing
-about the quality of a detection; "89 verdicts proven out of 461" says where the
+about the quality of a detection; "92 verdicts proven out of 461" says where the
 product stands, and shrinks the right way with every scenario written.
 
 ## The figures
@@ -25,9 +25,9 @@ product stands, and shrinks the right way with every scenario written.
 |---|---:|
 | Controls in the reference | 58 |
 | Control x provider x source paths on which Pépin concludes | 179 |
-| Paths whose EVERY reachable verdict is proven end to end | 26 |
+| Paths whose EVERY reachable verdict is proven end to end | 27 |
 | Verdicts to prove in total | 461 |
-| Verdicts proven | 89 |
+| Verdicts proven | 92 |
 
 ## Veracity coverage, by verdict
 
@@ -37,11 +37,11 @@ inventing a non-applicability.
 
 | Verdict | What it stages | To prove | Proven | % |
 |---|---|---:|---:|---:|
-| `fail` | a vulnerable configuration is detected | 141 | 23 | 16 |
-| `pass` | a genuinely correct configuration is confirmed | 141 | 36 | 25 |
-| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 157 | 19 | 12 |
+| `fail` | a vulnerable configuration is detected | 141 | 24 | 17 |
+| `pass` | a genuinely correct configuration is confirmed | 141 | 37 | 26 |
+| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 157 | 20 | 12 |
 | `not-applicable` | the provider's contract declares the mechanism non-existent | 22 | 11 | 50 |
-| **Total** | | **461** | **89** | **19** |
+| **Total** | | **461** | **92** | **19** |
 
 ## Validated live
 

--- a/docs/getting-started/understanding-a-scan.fr.md
+++ b/docs/getting-started/understanding-a-scan.fr.md
@@ -526,7 +526,7 @@ mot.
 {
   "control": "compute_instance_public_ip_with_open_securitygroup",
   "evidence": {
-    "observed": "attribut « public_ip » non collecté sur les ressources de type « compute_instance » (garde de capacité)",
+    "observed": "attribut « nic_public_ips / public_ip » non collecté sur les ressources de type « compute_instance » (garde de capacité)",
     "source": "terraform-plan"
   },
   "references": [

--- a/docs/getting-started/understanding-a-scan.md
+++ b/docs/getting-started/understanding-a-scan.md
@@ -523,7 +523,7 @@ documented in
 {
   "control": "compute_instance_public_ip_with_open_securitygroup",
   "evidence": {
-    "observed": "attribute \"public_ip\" not collected on the resources of type \"compute_instance\" (capability guard)",
+    "observed": "attribute \"nic_public_ips / public_ip\" not collected on the resources of type \"compute_instance\" (capability guard)",
     "source": "terraform-plan"
   },
   "references": [

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -58,7 +58,7 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v6",
+  "inventory_schema": "pepin-inventory/v7",
   "disclaimer": "Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -56,7 +56,7 @@ raises a version number and gets a CHANGELOG line.
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v6",
+  "inventory_schema": "pepin-inventory/v7",
   "disclaimer": "This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -85,7 +85,7 @@ pas.
 | `blockstorage_volume_snapshots_exist` | outscale | live | cette source ne produit aucune ressource de type « blockstorage_volume » |
 | `compute_instance_deletion_protection` | outscale | live | attribut décisif « deletion_protection » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `compute_instance_no_secrets_in_user_data` | scaleway | terraform | attribut décisif « user_data » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
-| `compute_instance_public_ip_with_open_securitygroup` | scaleway | live | attribut décisif « public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| `compute_instance_public_ip_with_open_securitygroup` | scaleway | live | attribut décisif « nic_public_ips / public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `database_backup_enabled` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `database_encryption_at_rest_enabled` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `database_service_not_open_to_internet` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |
@@ -206,9 +206,9 @@ Ce qui n'est pas encore prouvé est **compté**, pas masqué :
 | Chiffre | Nombre |
 |---|---:|
 | Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 179 |
-| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 26 |
+| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 27 |
 | Verdicts à prouver au total | 461 |
-| Verdicts restant à prouver | 372 |
+| Verdicts restant à prouver | 369 |
 <!-- /pepin:gen veracity-debt -->
 
 Le reste est listé chemin par chemin dans `internal/veracity/testdata/debt.txt`. Ce registre est
@@ -253,6 +253,20 @@ stderr au moment du scellement.
 créées hors du code, rien des attributs encore inconnus au stade plan. C'est pour cela que le
 verdict dit « périmètre déclaré (plan Terraform, état planifié) » et non « conforme ». Pour la
 configuration effective, utilisez `--live`.
+
+### Un scan porte sur UNE région, et une qualification aussi
+
+`--region` désigne une région (chez Exoscale, une zone : `region_key: zone`). Tout ce qu'un
+rapport dit vaut pour CETTE région, et un compte réparti sur plusieurs régions demande autant de
+scans qu'il a de régions. **Les bundles de preuve ne se fusionnent pas** : chacun scelle son
+périmètre, et les additionner reviendrait à fabriquer un scan qui n'a pas eu lieu.
+
+La conséquence la plus facile à manquer porte sur SecNumCloud. Une qualification couvre un
+périmètre de régions, pas un fournisseur entier : celle d'Outscale couvre `cloudgouv-eu-west-1`
+et elle seule. Un tenant en `eu-west-2` n'est donc pas dans le périmètre qualifié, et le
+descripteur le déclare (`secnumcloud_regions`) pour que le scan cesse de transcrire
+« qualifié » à son sujet — il rend `hors_perimetre`. Sans `--region`, il rend
+`perimetre_inconnu` : un scan qui ne sait pas où il porte ne tranche pas.
 
 ### `--live` voit exactement ce que voient vos identifiants
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -86,7 +86,7 @@ actually decide them. The reason given is the one that applies to the source tha
 | `blockstorage_volume_snapshots_exist` | outscale | live | this source produces no resource of type "blockstorage_volume" |
 | `compute_instance_deletion_protection` | outscale | live | deciding attribute "deletion_protection" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `compute_instance_no_secrets_in_user_data` | scaleway | terraform | deciding attribute "user_data" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
-| `compute_instance_public_ip_with_open_securitygroup` | scaleway | live | deciding attribute "public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| `compute_instance_public_ip_with_open_securitygroup` | scaleway | live | deciding attribute "nic_public_ips / public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `database_backup_enabled` | scaleway | terraform | this source produces no resource of type "managed_database" |
 | `database_encryption_at_rest_enabled` | scaleway | terraform | this source produces no resource of type "managed_database" |
 | `database_service_not_open_to_internet` | scaleway | terraform | this source produces no resource of type "managed_database" |
@@ -206,9 +206,9 @@ What is not yet proven is **counted**, not hidden:
 | Figure | Count |
 |---|---:|
 | Control x provider x source paths on which Pépin concludes | 179 |
-| Paths whose every reachable verdict is proven end to end | 26 |
+| Paths whose every reachable verdict is proven end to end | 27 |
 | Verdicts to prove in total | 461 |
-| Verdicts left to prove | 372 |
+| Verdicts left to prove | 369 |
 <!-- /pepin:gen veracity-debt -->
 
 The remainder is listed path by path in `internal/veracity/testdata/debt.txt`. That ledger is a
@@ -251,6 +251,20 @@ it on stderr at seal time.
 resources created outside the code, and nothing about attributes still unknown at plan time.
 The verdict says *"declared scope (Terraform plan, planned state)"* rather than "compliant" for
 that reason. Use `--live` for the effective configuration.
+
+### A scan covers ONE region, and so does a qualification
+
+`--region` names one region (on Exoscale, one zone: `region_key: zone`). Everything a report
+says holds for THAT region, and an account spread over several regions needs as many scans as it
+has regions. **Evidence bundles do not merge**: each seals its own scope, and adding them up
+would fabricate a scan that never happened.
+
+The consequence easiest to miss is about SecNumCloud. A qualification covers a scope of regions,
+not a whole provider: Outscale's covers `cloudgouv-eu-west-1` and that one only. A tenant in
+`eu-west-2` is therefore not inside the qualified scope, and the descriptor declares it
+(`secnumcloud_regions`) so the scan stops transcribing "qualified" about it — it reports
+`hors_perimetre`. Without `--region` it reports `perimetre_inconnu`: a scan that does not know
+where it applies does not decide.
 
 ### `--live` sees exactly what your credentials see
 

--- a/docs/providers/outscale.fr.md
+++ b/docs/providers/outscale.fr.md
@@ -16,7 +16,7 @@ d'ouvrir ce fichier pour comprendre la couverture.
 | Juridiction du siège | FR |
 | Établi dans l'UE | oui |
 | Contrôle capitalistique | FR |
-| SecNumCloud | `qualifie` |
+| SecNumCloud | `qualifie` — périmètre : `cloudgouv-eu-west-1` |
 | Exposition extraterritoriale | non |
 | Sources de l'ancrage | 3ds.com/newsroom (Outscale 1er cloud SecNumCloud 3.2) ; en.outscale.com/our-certifications |
 <!-- /pepin:gen provider-outscale-identity -->
@@ -25,6 +25,13 @@ Outscale est le seul des trois dont le descripteur consigne `secnumcloud: qualif
 qualification porte sur le **prestataire**, jamais sur votre tenant : un rapport Pépin n'en dit
 rien, ni dans un sens ni dans l'autre
 ([Périmètre et non-objectifs](../concepts/scope.fr.md)).
+
+Elle porte aussi sur un **périmètre** : la région `cloudgouv-eu-west-1`, et elle seule. Un
+tenant hébergé ailleurs — `eu-west-2`, par exemple — n'est pas dans le périmètre qualifié, et
+le scan le dit : l'attribut `secnumcloud` de la ressource de gouvernance vaut alors
+`hors_perimetre` plutôt que `qualifie`. Sans `--region`, il vaut `perimetre_inconnu` : un scan
+qui ne sait pas où il porte ne tranche pas. La qualification ne vaut donc pas immunité
+extraterritoriale hors de son périmètre.
 
 ## Authentification
 
@@ -72,6 +79,7 @@ Chaque endpoint, y compris la liste parente d'une jointure. Tous les appels OAPI
 | `iam_policy` | `POST /ReadPolicyVersion` | — |
 | `load_balancer` | `POST /ReadLoadBalancers` | — |
 | `network` | `POST /ReadNets` | — |
+| `network_interface` | `POST /ReadVms` | — |
 | `network_peering` | `POST /ReadNetPeerings` | — |
 | `security_group_rule` | `POST /ReadSecurityGroups` | — |
 | `subnet` | `POST /ReadSubnets` | — |
@@ -112,6 +120,7 @@ API de fournisseur.
 | Unité de collecte | Droit minimal | Confirmé | Source |
 |---|---|:-:|---|
 | `security_group_rule` | `api:Read* (EIM) — ReadSecurityGroups` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `network_interface` | `api:Read* (EIM) — ReadVms` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
 | `compute_instance` | `api:Read* (EIM) — ReadVms` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
 | `access_key` | `api:Read* (EIM) — ReadAccounts, ReadAccessKeys` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
 | `api_access_rule` | `api:Read* (EIM) — ReadApiAccessRules` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
@@ -132,6 +141,7 @@ API de fournisseur.
 **Réserves, dites plutôt que masquées.**
 
 - **`security_group_rule`, `compute_instance`, `access_key`, `api_access_rule`, `api_access_summary`, `api_access_policy`, `blockstorage_volume`, `blockstorage_snapshot`, `iam_policy`, `iam_policy_inline`, `network`, `network_peering`, `subnet`, `load_balancer`, `compute_image`** — La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue.
+- **`network_interface`** — Les cartes réseau sont lues DANS la réponse de ReadVms (Vm.Nics[]) : aucun appel ni droit supplémentaire. La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue.
 - **`object_storage_bucket`** — Aucun code de service de stockage objet n'apparaît dans les éléments de politique EIM. Avec les clés du propriétaire du compte, l'accès OOS vient avec le compte ; comment l'accorder à un utilisateur EIM n'est PAS vérifié. Par politique de bucket, les actions de lecture documentées sont s3:ListBucket, s3:HeadBucket, s3:GetBucketAcl, s3:GetBucketPolicy, s3:GetBucketTagging, s3:GetBucketVersioning, s3:GetEncryptionConfiguration, s3:GetBucketObjectLockConfiguration — sans action pour LISTER les buckets d'un compte, qui est pourtant le premier appel.
 - **`kubernetes_cluster`** — Le modèle de permission de GET /api/v2/clusters/all n'est PAS vérifié. Un appel refusé dégrade proprement : les contrôles Kubernetes reviennent « non évalués ».
 <!-- /pepin:gen provider-outscale-permissions -->

--- a/docs/providers/outscale.md
+++ b/docs/providers/outscale.md
@@ -16,7 +16,7 @@ file to understand the coverage.
 | Jurisdiction of the head office | FR |
 | Established in the EU | yes |
 | Capital control | FR |
-| SecNumCloud | `qualifie` |
+| SecNumCloud | `qualifie` — scope: `cloudgouv-eu-west-1` |
 | Extraterritorial exposure | no |
 | Anchoring sources | 3ds.com/newsroom (Outscale 1er cloud SecNumCloud 3.2) ; en.outscale.com/our-certifications |
 <!-- /pepin:gen provider-outscale-identity -->
@@ -24,6 +24,13 @@ file to understand the coverage.
 Outscale is the only one of the three whose descriptor records `secnumcloud: qualifie`. That
 qualification applies to the **provider**, never to your tenant: a Pépin report says nothing
 about it either way ([Scope and non-goals](../concepts/scope.md)).
+
+It also applies to a **scope**: the `cloudgouv-eu-west-1` Region, and that one only. A tenant
+hosted elsewhere — `eu-west-2`, say — is not inside the qualified scope, and the scan says so:
+the governance resource's `secnumcloud` attribute then reads `hors_perimetre` rather than
+`qualifie`. Without `--region` it reads `perimetre_inconnu`: a scan that does not know where it
+applies does not decide. The qualification therefore grants no extraterritorial immunity
+outside its scope.
 
 ## Authentication
 
@@ -69,6 +76,7 @@ Every endpoint, including the parent listing of a join. All OAPI calls are `POST
 | `iam_policy` | `POST /ReadPolicyVersion` | — |
 | `load_balancer` | `POST /ReadLoadBalancers` | — |
 | `network` | `POST /ReadNets` | — |
+| `network_interface` | `POST /ReadVms` | — |
 | `network_peering` | `POST /ReadNetPeerings` | — |
 | `security_group_rule` | `POST /ReadSecurityGroups` | — |
 | `subnet` | `POST /ReadSubnets` | — |
@@ -108,6 +116,7 @@ credentials and no automated check reaches a provider API.
 | Collection unit | Minimum grant | Confirmed | Source |
 |---|---|:-:|---|
 | `security_group_rule` | `api:Read* (EIM) — ReadSecurityGroups` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `network_interface` | `api:Read* (EIM) — ReadVms` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
 | `compute_instance` | `api:Read* (EIM) — ReadVms` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
 | `access_key` | `api:Read* (EIM) — ReadAccounts, ReadAccessKeys` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
 | `api_access_rule` | `api:Read* (EIM) — ReadApiAccessRules` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
@@ -128,6 +137,7 @@ credentials and no automated check reaches a provider API.
 **Reservations, stated rather than papered over.**
 
 - **`security_group_rule`, `compute_instance`, `access_key`, `api_access_rule`, `api_access_summary`, `api_access_policy`, `blockstorage_volume`, `blockstorage_snapshot`, `iam_policy`, `iam_policy_inline`, `network`, `network_peering`, `subnet`, `load_balancer`, `compute_image`** — The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue.
+- **`network_interface`** — Network interfaces are read INSIDE the ReadVms response (Vm.Nics[]): no extra call, no extra grant. The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue.
 - **`object_storage_bucket`** — No object-storage service code appears in the EIM policy elements. With the account owner keys, OOS access comes with the account; how to grant it to an EIM user is NOT verified. Through a bucket policy the documented read actions are s3:ListBucket, s3:HeadBucket, s3:GetBucketAcl, s3:GetBucketPolicy, s3:GetBucketTagging, s3:GetBucketVersioning, s3:GetEncryptionConfiguration, s3:GetBucketObjectLockConfiguration - with no action for LISTING an account buckets, which is the first call made.
 - **`kubernetes_cluster`** — The permission model of GET /api/v2/clusters/all is NOT verified. A refused call degrades cleanly: the Kubernetes controls come back "not evaluated".
 <!-- /pepin:gen provider-outscale-permissions -->

--- a/docs/providers/scaleway.fr.md
+++ b/docs/providers/scaleway.fr.md
@@ -182,7 +182,7 @@ fournisseur.
 | Contrôle | Observable uniquement via | Motif du côté aveugle |
 |---|---|---|
 | `compute_instance_no_secrets_in_user_data` | terraform | attribut décisif « user_data » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
-| `compute_instance_public_ip_with_open_securitygroup` | live | attribut décisif « public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| `compute_instance_public_ip_with_open_securitygroup` | live | attribut décisif « nic_public_ips / public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `database_backup_enabled` | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `database_encryption_at_rest_enabled` | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `database_service_not_open_to_internet` | terraform | cette source ne produit aucune ressource de type « managed_database » |

--- a/docs/providers/scaleway.md
+++ b/docs/providers/scaleway.md
@@ -178,7 +178,7 @@ A `not-applicable` is a claim, so it carries its justification, taken from the p
 | Control | Observable only through | Reason on the blind side |
 |---|---|---|
 | `compute_instance_no_secrets_in_user_data` | terraform | deciding attribute "user_data" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
-| `compute_instance_public_ip_with_open_securitygroup` | live | deciding attribute "public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| `compute_instance_public_ip_with_open_securitygroup` | live | deciding attribute "nic_public_ips / public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `database_backup_enabled` | terraform | this source produces no resource of type "managed_database" |
 | `database_encryption_at_rest_enabled` | terraform | this source produces no resource of type "managed_database" |
 | `database_service_not_open_to_internet` | terraform | this source produces no resource of type "managed_database" |

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -43,7 +43,7 @@ séparément :
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v6** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v7** |
 <!-- /pepin:gen surface-versions -->
 
 Un numéro monte à **tout** changement de forme, ajout compris : il signifie « la surface a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,7 +43,7 @@ independently:
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v6** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v7** |
 <!-- /pepin:gen surface-versions -->
 
 A version rises on **any** shape change, additions included: the number means "the surface has

--- a/docs/reference/inventory.fr.md
+++ b/docs/reference/inventory.fr.md
@@ -12,7 +12,7 @@ gelée, avec les mêmes égards que la surface CLI.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v6
+pepin-inventory/v7
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -157,7 +157,7 @@ code.
 | `blockstorage_volume` | `encrypted` `state` `tags` `volume_id` |
 | `compute_image` | `image_id` `public` `state` `tags` |
 | `compute_instance` | `deletion_protection` `nic_public_ips` `public_ip` `security_group_ids` `state` `tags` `user_data` `vm_id` |
-| `governance_provider` | `capital_control` `eu_established` `extraterritorial_exposure` `jurisdiction` `secnumcloud` |
+| `governance_provider` | `capital_control` `eu_established` `extraterritorial_exposure` `jurisdiction` `secnumcloud` `secnumcloud_regions` |
 | `iam_policy` | `manages_iam` `owner_group` `owner_user` `policy_id` `policy_name` `scope` `statements` |
 | `iam_role` | `admin_privileges` `editable` `manages_iam` `max_session_ttl` `name` `policy_has_expiration` `role_id` `source_ip_restricted` |
 | `iam_user` | `mfa_enabled` `user_id` `username` |
@@ -169,6 +169,7 @@ code.
 | `load_balancer` | `access_log` `listeners` `load_balancer_name` `load_balancer_type` `tags` |
 | `managed_database` | `database_id` `disable_backup` `encryption_at_rest` `ip_filter` |
 | `network` | `cidr` `description` `name` `network_id` `state` `tags` |
+| `network_interface` | `nic_id` `public_ip` `security_group_ids` `vm_id` |
 | `network_peering` | `accepter_account` `peering_id` `source_account` `state` |
 | `object_storage_bucket` | `acl` `acl_grants` `default_encryption_enabled` `kms_key_id` `name` `object_lock_enabled` `policy_public` `public_via_acl` `sse_kms_enabled` `tags` `versioning` |
 | `security_group` | `inbound_default_policy` `security_group_id` |

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -12,7 +12,7 @@ with the same regard as the CLI surface.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v6
+pepin-inventory/v7
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -149,7 +149,7 @@ descriptors and from the Go collectors — never a hand-kept list beside the cod
 | `blockstorage_volume` | `encrypted` `state` `tags` `volume_id` |
 | `compute_image` | `image_id` `public` `state` `tags` |
 | `compute_instance` | `deletion_protection` `nic_public_ips` `public_ip` `security_group_ids` `state` `tags` `user_data` `vm_id` |
-| `governance_provider` | `capital_control` `eu_established` `extraterritorial_exposure` `jurisdiction` `secnumcloud` |
+| `governance_provider` | `capital_control` `eu_established` `extraterritorial_exposure` `jurisdiction` `secnumcloud` `secnumcloud_regions` |
 | `iam_policy` | `manages_iam` `owner_group` `owner_user` `policy_id` `policy_name` `scope` `statements` |
 | `iam_role` | `admin_privileges` `editable` `manages_iam` `max_session_ttl` `name` `policy_has_expiration` `role_id` `source_ip_restricted` |
 | `iam_user` | `mfa_enabled` `user_id` `username` |
@@ -161,6 +161,7 @@ descriptors and from the Go collectors — never a hand-kept list beside the cod
 | `load_balancer` | `access_log` `listeners` `load_balancer_name` `load_balancer_type` `tags` |
 | `managed_database` | `database_id` `disable_backup` `encryption_at_rest` `ip_filter` |
 | `network` | `cidr` `description` `name` `network_id` `state` `tags` |
+| `network_interface` | `nic_id` `public_ip` `security_group_ids` `vm_id` |
 | `network_peering` | `accepter_account` `peering_id` `source_account` `state` |
 | `object_storage_bucket` | `acl` `acl_grants` `default_encryption_enabled` `kms_key_id` `name` `object_lock_enabled` `policy_public` `public_via_acl` `sse_kms_enabled` `tags` `versioning` |
 | `security_group` | `inbound_default_policy` `security_group_id` |

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -30,7 +30,7 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v6** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v7** |
 <!-- /pepin:gen surface-versions -->
 
 « Gelé » signifie qu'un test échoue quand la forme bouge sans que sa version ait suivi : les

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -30,7 +30,7 @@ See [Exit codes](exit-codes.md).
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v6** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v7** |
 <!-- /pepin:gen surface-versions -->
 
 "Frozen" means a test fails when the shape moves and its version has not: field paths and JSON

--- a/internal/assess/assess.go
+++ b/internal/assess/assess.go
@@ -64,10 +64,15 @@ var frameworkSlug = map[string]string{
 // TestDecidingAttributesDeclareKnownTypes — la chaîne va du Rego aux types, puis des
 // types aux attributs, et aucun maillon ne flotte.
 var requiredAttr = map[string]map[string][]string{
-	"compute_instance_deletion_protection":               {"": {"deletion_protection"}},
-	"compute_instance_no_secrets_in_user_data":           {"": {"user_data"}},
-	"compute_instance_has_security_group":                {"": {"security_group_ids"}},
-	"compute_instance_public_ip_with_open_securitygroup": {"": {"public_ip"}},
+	"compute_instance_deletion_protection":     {"": {"deletion_protection"}},
+	"compute_instance_no_secrets_in_user_data": {"": {"user_data"}},
+	"compute_instance_has_security_group":      {"": {"security_group_ids"}},
+	// La donnée qui décide de l'exposition n'est plus le seul `public_ip` de la
+	// machine : une VM peut être joignable par une carte SECONDAIRE, et c'est
+	// `nic_public_ips` qui l'atteste. « Au moins un » suffit — les deux disent la
+	// même chose, chacun pour une carte. Exiger le seul `public_ip` rendait
+	// `not-evaluated` une machine dont on avait parfaitement lu les cartes.
+	"compute_instance_public_ip_with_open_securitygroup": {"": {"public_ip", "nic_public_ips"}},
 	"compute_image_not_public":                           {"": {"public"}},
 	"iam_no_root_access_key":                             {"": {"root_owned", "scope"}},
 	// Sans date de création, l'ÂGE d'une clé ne se déduit pas : une absence n'est pas

--- a/internal/commonrules/rules/compute_instance_public_ip_with_open_securitygroup.rego
+++ b/internal/commonrules/rules/compute_instance_public_ip_with_open_securitygroup.rego
@@ -12,11 +12,23 @@
 #   effectivement vulnérable, ni qu'un port anodin ne l'est pas. Il mesure la
 #   surface, pas l'exploitabilité.
 #
+#   L'EXPOSITION EST UNE PROPRIÉTÉ DE LA CARTE, PAS DE LA MACHINE. Mesuré sur un
+#   tenant réel : une VM dont la carte primaire est privée avec un groupe fermé et
+#   dont la carte secondaire porte l'IP publique ET un groupe ouvert sur 22 ne
+#   produisait AUCUN finding — la règle confrontait l'union des IP aux groupes de la
+#   seule carte primaire. Un port d'administration joignable depuis Internet, et un
+#   rapport muet.
+#
+#   L'aplatissement est fautif dans les DEUX sens, et c'est ce qui interdit de le
+#   corriger en réunissant tout : une carte publique au groupe fermé plus une carte
+#   privée au groupe ouvert donneraient « publique et ouverte », un écart que la
+#   machine ne porte pas. Ce qui compte est l'APPARIEMENT (ip, groupes) par carte.
+#
 # Origine : osc-policy OSC-VM-014. SCSL : CLD-NET-3.
-# Contrat : type normalisé agnostique `compute_instance` (attributs natifs
-#   osc-sdk-go Vm). Champs : vm_id, public_ip (string), security_group_ids
-#   ([]string, DÉRIVÉ depuis Vm.SecurityGroups[].SecurityGroupId). Corrélé aux
-#   `security_group_rule` entrants ouverts sur Internet.
+# Contrat : types normalisés agnostiques `compute_instance` et `network_interface`.
+#   `compute_instance` : vm_id, public_ip, security_group_ids (carte primaire).
+#   `network_interface` : nic_id, vm_id, public_ip, security_group_ids (CETTE carte).
+#   Corrélés aux `security_group_rule` entrants ouverts sur Internet.
 package pepin.rules
 
 import rego.v1
@@ -56,9 +68,9 @@ _sg_sensitive[sg_id] contains port if {
 
 # ── critical : tous les ports ouverts sur Internet ────────────────────────────────
 deny contains f if {
-	some vm in resources_of_type("compute_instance")
-	_vm_has_public_ip(vm)
-	some sg_id in object.get(vm.attributes, "security_group_ids", [])
+	some couple in _exposed
+	vm := couple.vm
+	sg_id := couple.sg
 	sg_id in _sg_ids_any_port
 	id := object.get(vm.attributes, "vm_id", vm.id)
 	f := {
@@ -79,9 +91,9 @@ deny contains f if {
 
 # ── high : un port sensible ouvert sur Internet ───────────────────────────────────
 deny contains f if {
-	some vm in resources_of_type("compute_instance")
-	_vm_has_public_ip(vm)
-	some sg_id in object.get(vm.attributes, "security_group_ids", [])
+	some couple in _exposed
+	vm := couple.vm
+	sg_id := couple.sg
 	not sg_id in _sg_ids_any_port
 	ports := sort([p | some p in _sg_sensitive[sg_id]])
 	count(ports) > 0
@@ -102,9 +114,42 @@ deny contains f if {
 	}
 }
 
+# _exposed — les couples (machine, groupe) réellement exposés, appariés PAR CARTE.
+#
+# Quand les cartes sont collectées, elles font foi : chaque carte joignable apporte SES
+# groupes, et une carte privée n'en apporte aucun. C'est le seul appariement fidèle.
+_exposed contains {"vm": vm, "sg": sg_id} if {
+	some nic in resources_of_type("network_interface")
+	_has_public_ip(nic)
+	some vm in resources_of_type("compute_instance")
+	object.get(vm.attributes, "vm_id", vm.id) == object.get(nic.attributes, "vm_id", "")
+	some sg_id in object.get(nic.attributes, "security_group_ids", [])
+}
+
+# REPLI, pour toute source qui ne collecte pas les cartes — un plan Terraform, un
+# provider dont l'API ne les expose pas. La machine y est jugée sur ses propres
+# attributs, exactement comme avant. Un repli qui se tairait ferait DISPARAÎTRE des
+# écarts que le dépôt détecte aujourd'hui, ce qui serait pire que le défaut corrigé.
+_exposed contains {"vm": vm, "sg": sg_id} if {
+	some vm in resources_of_type("compute_instance")
+	not _has_nics(vm)
+	_vm_has_public_ip(vm)
+	some sg_id in object.get(vm.attributes, "security_group_ids", [])
+}
+
+# _has_nics — cette machine a-t-elle des cartes collectées ? La jointure porte sur
+# `vm_id` des deux côtés, tous deux issus de la MÊME réponse d'API : une carte sans
+# `vm_id` ne rattache rien et ne fait donc pas taire le repli.
+_has_nics(vm) if {
+	some nic in resources_of_type("network_interface")
+	object.get(vm.attributes, "vm_id", vm.id) == object.get(nic.attributes, "vm_id", "")
+}
+
+_has_public_ip(r) if object.get(r.attributes, "public_ip", "") != ""
+
 # Une VM est joignable si son IP primaire OU l'IP publique d'une NIC secondaire existe :
 # ne regarder que `public_ip` laissait passer les VMs multi-cartes (contrat NicLight.LinkPublicIp).
-_vm_has_public_ip(vm) if object.get(vm.attributes, "public_ip", "") != ""
+_vm_has_public_ip(vm) if _has_public_ip(vm)
 
 _vm_has_public_ip(vm) if {
 	some ip in object.get(vm.attributes, "nic_public_ips", [])

--- a/internal/commonrules/rules/compute_instance_public_ip_with_open_securitygroup_test.rego
+++ b/internal/commonrules/rules/compute_instance_public_ip_with_open_securitygroup_test.rego
@@ -91,3 +91,83 @@ test_public_vm_all_ports_sentinel_is_critical if {
 	f.code == _vm_code
 	f.severity == "critical"
 }
+
+# ── L'EXPOSITION EST UNE PROPRIÉTÉ DE LA CARTE ────────────────────────────────
+
+# Le cas MESURÉ sur le tenant : carte primaire privée avec un groupe fermé, carte
+# secondaire portant l'IP publique ET un groupe ouvert sur 22. Aucun finding n'était
+# produit, alors que SSH répondait sur l'IP publique.
+_deux_cartes(attrs_vm, cartes, regles) := {"resources": array.concat(
+	array.concat(
+		[{"provider": "outscale", "type": "compute_instance", "id": "i-1", "attributes": attrs_vm}],
+		[{"provider": "outscale", "type": "network_interface", "id": c.nic_id, "attributes": c} | some c in cartes],
+	),
+	[{"provider": "outscale", "type": "security_group_rule", "id": r.security_group_id, "attributes": r} | some r in regles],
+)}
+
+_ssh_ouvert(sg) := {"security_group_id": sg, "direction": "inbound", "action": "accept", "protocol": "tcp", "port_from": 22, "port_to": 22, "cidrs": ["0.0.0.0/0"]}
+
+_cld_net_3 := "compute_instance_public_ip_with_open_securitygroup"
+
+_findings_net3(input_doc) := {f | some f in deny with input as input_doc; f.code == _cld_net_3}
+
+# ✗ La carte SECONDAIRE porte l'IP publique et le groupe ouvert : c'est un écart.
+test_a_public_secondary_nic_with_an_open_group_is_denied if {
+	fs := _findings_net3(_deux_cartes(
+		{"vm_id": "i-1", "security_group_ids": ["sg-web"]},
+		[
+			{"nic_id": "eni-1", "vm_id": "i-1", "security_group_ids": ["sg-web"]},
+			{"nic_id": "eni-2", "vm_id": "i-1", "public_ip": "198.51.100.7", "security_group_ids": ["sg-ssh"]},
+		],
+		[_ssh_ouvert("sg-ssh")],
+	))
+	count(fs) == 1
+	some f in fs
+	f.severity == "high"
+	f.subject == "i-1"
+}
+
+# LE CONTRE-EXEMPLE que l'appariement existe pour tenir : une carte PUBLIQUE au
+# groupe fermé, plus une carte PRIVÉE au groupe ouvert. Réunir les deux dirait
+# « publique et ouverte » — un écart que cette machine ne porte pas. Rien n'est
+# joignable depuis Internet, et la règle doit se taire.
+test_a_public_nic_and_a_separate_open_nic_stay_silent if {
+	count(_findings_net3(_deux_cartes(
+		{"vm_id": "i-1", "security_group_ids": ["sg-web"]},
+		[
+			{"nic_id": "eni-1", "vm_id": "i-1", "public_ip": "198.51.100.7", "security_group_ids": ["sg-web"]},
+			{"nic_id": "eni-2", "vm_id": "i-1", "security_group_ids": ["sg-ssh"]},
+		],
+		[_ssh_ouvert("sg-ssh")],
+	))) == 0
+}
+
+# UN seul finding quand la carte primaire est déjà celle qui expose : le repli ne doit
+# pas s'ajouter au chemin des cartes, sinon un même fait produirait deux écarts.
+test_one_finding_when_the_primary_nic_is_the_exposed_one if {
+	count(_findings_net3(_deux_cartes(
+		{"vm_id": "i-1", "public_ip": "198.51.100.7", "security_group_ids": ["sg-ssh"]},
+		[{"nic_id": "eni-1", "vm_id": "i-1", "public_ip": "198.51.100.7", "security_group_ids": ["sg-ssh"]}],
+		[_ssh_ouvert("sg-ssh")],
+	))) == 1
+}
+
+# LE REPLI. Une source qui ne collecte pas les cartes — un plan Terraform — juge la
+# machine sur ses propres attributs, exactement comme avant. Un repli muet ferait
+# DISPARAÎTRE des écarts que le dépôt détecte aujourd'hui.
+test_without_nics_the_vm_is_judged_on_its_own_attributes if {
+	count(_findings_net3({"resources": [
+		{"provider": "outscale", "type": "compute_instance", "id": "i-1", "attributes": {"vm_id": "i-1", "public_ip": "198.51.100.7", "security_group_ids": ["sg-ssh"]}},
+		{"provider": "outscale", "type": "security_group_rule", "id": "sg-ssh", "attributes": _ssh_ouvert("sg-ssh")},
+	]})) == 1
+}
+
+# Une carte d'une AUTRE machine n'expose pas celle-ci : la jointure porte sur `vm_id`,
+# et une jointure trop large est le faux positif le plus coûteux du dépôt.
+test_a_nic_of_another_vm_never_exposes_this_one if {
+	count(_findings_net3({"resources": [
+		{"provider": "outscale", "type": "compute_instance", "id": "i-1", "attributes": {"vm_id": "i-1", "security_group_ids": ["sg-web"]}},
+		{"provider": "outscale", "type": "network_interface", "id": "eni-9", "attributes": {"nic_id": "eni-9", "vm_id": "i-2", "public_ip": "198.51.100.9", "security_group_ids": ["sg-ssh"]}},
+		{"provider": "outscale", "type": "security_group_rule", "id": "sg-ssh", "attributes": _ssh_ouvert("sg-ssh")},
+	]})) == 0
+}

--- a/internal/docgen/providers.go
+++ b/internal/docgen/providers.go
@@ -69,7 +69,14 @@ func providerIdentityTable(t providerStrings, d genprovider.Descriptor) string {
 	row(t.fieldJurisdiction, s.Juridiction)
 	row(t.fieldEUEstablished, boolLabel(t, s.EUEtabli))
 	row(t.fieldCapital, s.ControleCapitalistique)
-	row(t.fieldSecNumCloud, "`"+s.SecNumCloud+"`")
+	// Le statut ne se rend JAMAIS seul quand un périmètre est déclaré : une
+	// qualification porte sur des régions, et « qualifie » sans elles est
+	// précisément ce qu'un tenant hors périmètre lisait à son sujet.
+	secnum := "`" + s.SecNumCloud + "`"
+	if len(s.SecNumCloudRegions) > 0 {
+		secnum += " " + t.scopedTo + " `" + strings.Join(s.SecNumCloudRegions, "`, `") + "`"
+	}
+	row(t.fieldSecNumCloud, secnum)
 	row(t.fieldExtraterritorial, boolLabel(t, s.ExpositionExtraterritoriale))
 	row(t.fieldSources, oneLine(s.Sources))
 	return b.String()
@@ -333,6 +340,7 @@ type providerStrings struct {
 	fieldDescription, fieldScope, fieldRegionKey, fieldAuth    string
 	fieldJurisdiction, fieldEUEstablished, fieldCapital        string
 	fieldSecNumCloud, fieldExtraterritorial, fieldSources      string
+	scopedTo                                                   string
 	rowConfigFile, noteParent, noteS3, noteManagedK8s, baseURL string
 	unset, yes, no, none, noDescriptor                         string
 }
@@ -352,6 +360,7 @@ func providerText(lang string) providerStrings {
 			fieldAuth: "Authentification de l'API", fieldJurisdiction: "Juridiction du siège",
 			fieldEUEstablished: "Établi dans l'UE", fieldCapital: "Contrôle capitalistique",
 			fieldSecNumCloud: "SecNumCloud", fieldExtraterritorial: "Exposition extraterritoriale",
+			scopedTo:       "— périmètre :",
 			fieldSources:   "Sources de l'ancrage",
 			rowConfigFile:  "fichier de configuration natif",
 			noteParent:     "liste parente d'une jointure (appelée en premier)",
@@ -375,6 +384,7 @@ func providerText(lang string) providerStrings {
 		fieldAuth: "API authentication", fieldJurisdiction: "Jurisdiction of the head office",
 		fieldEUEstablished: "Established in the EU", fieldCapital: "Capital control",
 		fieldSecNumCloud: "SecNumCloud", fieldExtraterritorial: "Extraterritorial exposure",
+		scopedTo:       "— scope:",
 		fieldSources:   "Anchoring sources",
 		rowConfigFile:  "native configuration file",
 		noteParent:     "parent listing of a join (called first)",

--- a/internal/genprovider/controltypes.go
+++ b/internal/genprovider/controltypes.go
@@ -22,7 +22,7 @@ package genprovider
 // dérivation, non.
 var extraControlTypes = map[string][]string{
 	"blockstorage_volume_snapshots_exist":                {"blockstorage_snapshot"},
-	"compute_instance_public_ip_with_open_securitygroup": {"security_group_rule"},
+	"compute_instance_public_ip_with_open_securitygroup": {"network_interface", "security_group_rule"},
 	"iam_apiaccesspolicy_max_key_expiration":             {"api_access_rule", "api_access_summary"},
 	"iam_apiaccessrule_defined":                          {"api_access_policy", "api_access_rule", "api_access_summary"},
 	"iam_apiaccessrule_no_public_cidr":                   {"api_access_policy", "api_access_summary"},

--- a/internal/genprovider/genprovider.go
+++ b/internal/genprovider/genprovider.go
@@ -109,12 +109,24 @@ type Permission struct {
 // sources officielles (cf. `sources`). Indépendants de la collecte : projetés en
 // ressource synthétique `governance_provider` évaluée par CLD-GVN-4.
 type Souverainete struct {
-	EUEtabli                    *bool  `yaml:"eu_etabli"`                    // siège du fournisseur établi dans l'UE
-	Juridiction                 string `yaml:"juridiction"`                  // pays du siège (ex. FR, CH)
-	ControleCapitalistique      string `yaml:"controle_capitalistique"`      // juridiction du contrôle ultime (FR, UE, extra_ue, a_verifier)
-	SecNumCloud                 string `yaml:"secnumcloud"`                  // qualifie | en_cours | non
-	ExpositionExtraterritoriale *bool  `yaml:"exposition_extraterritoriale"` // soumis à une loi extraterritoriale (ex. Cloud Act)
-	Sources                     string `yaml:"sources"`                      // URLs/justification de l'ancrage
+	EUEtabli               *bool  `yaml:"eu_etabli"`               // siège du fournisseur établi dans l'UE
+	Juridiction            string `yaml:"juridiction"`             // pays du siège (ex. FR, CH)
+	ControleCapitalistique string `yaml:"controle_capitalistique"` // juridiction du contrôle ultime (FR, UE, extra_ue, a_verifier)
+	SecNumCloud            string `yaml:"secnumcloud"`             // qualifie | en_cours | non
+	// SecNumCloudRegions : les régions que la qualification COUVRE.
+	//
+	// Une qualification SecNumCloud porte sur un périmètre, et ce périmètre est une
+	// liste de régions — pas le fournisseur entier. Chez Outscale, la qualification
+	// couvre `cloudgouv-eu-west-1` et elle seule ; un tenant en `eu-west-2` lisait
+	// pourtant « SecNumCloud qualifié » dans un `pass` de souveraineté. C'est la
+	// première affirmation qu'un auditeur conteste, et l'outil n'a rien à affirmer
+	// de plus que ce qu'il a observé.
+	//
+	// Vide = périmètre non renseigné : la qualification est alors transcrite telle
+	// quelle, comme avant. On ne DÉDUIT pas un périmètre d'une absence.
+	SecNumCloudRegions          []string `yaml:"secnumcloud_regions"`
+	ExpositionExtraterritoriale *bool    `yaml:"exposition_extraterritoriale"` // soumis à une loi extraterritoriale (ex. Cloud Act)
+	Sources                     string   `yaml:"sources"`                      // URLs/justification de l'ancrage
 }
 
 // Contrat : ancrage sur l'API native (état de chaque type) et applicabilité des
@@ -248,6 +260,17 @@ func (g GenericProvider) MapTerraform(resources []tfparse.Resource) (model.Inven
 // évaluée par la règle CLD-GVN-4. Le second retour est faux si la souveraineté
 // n'est pas renseignée pour ce provider.
 func (g GenericProvider) GovernanceResource() (model.Resource, bool) {
+	return g.GovernanceResourceIn("")
+}
+
+// GovernanceResourceIn projette la souveraineté pour la région RÉELLEMENT scannée.
+//
+// La région entre dans la projection parce qu'un des faits en dépend : une
+// qualification porte sur un périmètre, et transcrire « qualifié » pour un tenant
+// hébergé hors de ce périmètre serait affirmer plus que ce qui a été observé.
+// `GovernanceResource` reste la forme sans région, pour le catalogue — qui décrit le
+// fournisseur, pas un scan.
+func (g GenericProvider) GovernanceResourceIn(region string) (model.Resource, bool) {
 	s := g.desc.Souverainete
 	if s.EUEtabli == nil && s.Juridiction == "" && s.ControleCapitalistique == "" {
 		return model.Resource{}, false
@@ -263,7 +286,14 @@ func (g GenericProvider) GovernanceResource() (model.Resource, bool) {
 		attrs["capital_control"] = s.ControleCapitalistique
 	}
 	if s.SecNumCloud != "" {
-		attrs["secnumcloud"] = s.SecNumCloud
+		attrs["secnumcloud"] = secNumCloudPour(s, region)
+	}
+	if len(s.SecNumCloudRegions) > 0 {
+		regions := make([]any, len(s.SecNumCloudRegions))
+		for i, r := range s.SecNumCloudRegions {
+			regions[i] = r
+		}
+		attrs["secnumcloud_regions"] = regions
 	}
 	if s.ExpositionExtraterritoriale != nil {
 		attrs["extraterritorial_exposure"] = *s.ExpositionExtraterritoriale
@@ -423,4 +453,35 @@ func subst(s string, vars map[string]string) string {
 		s = strings.ReplaceAll(s, "{"+k+"}", v)
 	}
 	return s
+}
+
+// Les trois valeurs que `secnumcloud` peut prendre une fois confrontée à la région.
+const (
+	// SecNumCloudHorsPerimetre : la région scannée est CONNUE et hors du périmètre
+	// qualifié. Ce n'est pas « non qualifié » — le fournisseur l'est —, c'est « pas
+	// ici », et la nuance est exactement celle qu'un auditeur vérifie.
+	SecNumCloudHorsPerimetre = "hors_perimetre"
+	// SecNumCloudPerimetreInconnu : la qualification a un périmètre, et le scan ne
+	// sait pas dans quelle région il porte (un plan Terraform n'en a pas). On ne
+	// conclut donc ni dans un sens ni dans l'autre.
+	SecNumCloudPerimetreInconnu = "perimetre_inconnu"
+)
+
+// secNumCloudPour rend le statut de qualification POUR la région scannée.
+//
+// Sans périmètre déclaré, ou pour un statut autre que `qualifie`, rien ne change :
+// on ne fabrique pas une restriction que le descripteur n'énonce pas (ADR-0014).
+func secNumCloudPour(s Souverainete, region string) string {
+	if s.SecNumCloud != "qualifie" || len(s.SecNumCloudRegions) == 0 {
+		return s.SecNumCloud
+	}
+	if region == "" {
+		return SecNumCloudPerimetreInconnu
+	}
+	for _, r := range s.SecNumCloudRegions {
+		if r == region {
+			return s.SecNumCloud
+		}
+	}
+	return SecNumCloudHorsPerimetre
 }

--- a/internal/genprovider/secnumcloud_test.go
+++ b/internal/genprovider/secnumcloud_test.go
@@ -1,0 +1,103 @@
+package genprovider
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Une qualification SecNumCloud porte sur un PÉRIMÈTRE de régions, pas sur un
+// fournisseur entier. Celle d'Outscale couvre `cloudgouv-eu-west-1` et elle seule ; un
+// tenant en `eu-west-2` lisait pourtant « SecNumCloud qualifié » dans un `pass` de
+// souveraineté. C'est la première affirmation qu'un auditeur conteste, et tout
+// l'argument de l'outil est qu'il n'affirme jamais plus qu'il n'a observé.
+
+func souv(statut string, regions ...string) Souverainete {
+	return Souverainete{SecNumCloud: statut, SecNumCloudRegions: regions}
+}
+
+func TestTheQualificationIsScopedToItsRegions(t *testing.T) {
+	for _, c := range []struct {
+		nom     string
+		s       Souverainete
+		region  string
+		attendu string
+	}{
+		{"région dans le périmètre", souv("qualifie", "cloudgouv-eu-west-1"), "cloudgouv-eu-west-1", "qualifie"},
+		// LE cas de l'issue : la région est connue, et elle est hors périmètre. Ce
+		// n'est pas « non qualifié » — le fournisseur l'est —, c'est « pas ici ».
+		{"région hors périmètre", souv("qualifie", "cloudgouv-eu-west-1"), "eu-west-2", SecNumCloudHorsPerimetre},
+		// Un plan Terraform n'a pas de région. Ne pas savoir n'est pas savoir que non :
+		// on ne tranche donc ni dans un sens ni dans l'autre (ADR-0014).
+		{"région inconnue", souv("qualifie", "cloudgouv-eu-west-1"), "", SecNumCloudPerimetreInconnu},
+		// LES CONTRE-EXEMPLES : sans périmètre déclaré, rien ne change. On ne fabrique
+		// pas une restriction que le descripteur n'énonce pas — les deux autres
+		// fournisseurs seraient sinon dégradés sans qu'aucune source ne le justifie.
+		{"aucun périmètre déclaré", souv("qualifie"), "eu-west-2", "qualifie"},
+		{"non qualifié, avec région", souv("non"), "eu-west-2", "non"},
+		{"en cours, avec périmètre", souv("en_cours", "cloudgouv-eu-west-1"), "eu-west-2", "en_cours"},
+		{"statut vide", souv(""), "eu-west-2", ""},
+	} {
+		t.Run(c.nom, func(t *testing.T) {
+			if got := secNumCloudPour(c.s, c.region); got != c.attendu {
+				t.Errorf("région %q → %q, attendu %q", c.region, got, c.attendu)
+			}
+		})
+	}
+}
+
+// TestTheQualifiedRegionsAreInTheProviderCatalogue : un périmètre ne peut nommer
+// qu'une région que le fournisseur a. Une faute de frappe y rendrait la qualification
+// inatteignable — donc `hors_perimetre` partout — sans que rien ne rougisse.
+func TestTheQualifiedRegionsAreInTheProviderCatalogue(t *testing.T) {
+	vus := 0
+	for nom, d := range descripteursDuDepotInterne(t) {
+		for _, r := range d.Souverainete.SecNumCloudRegions {
+			vus++
+			if !contient(d.Regions, r) {
+				t.Errorf("providers/%s.yaml : le périmètre SecNumCloud nomme %q, absente du catalogue de régions (%v)",
+					nom, r, d.Regions)
+			}
+		}
+	}
+	if vus == 0 {
+		t.Skip("aucun périmètre SecNumCloud déclaré")
+	}
+}
+
+func contient(l []string, v string) bool {
+	for _, e := range l {
+		if e == v {
+			return true
+		}
+	}
+	return false
+}
+
+// descripteursDuDepotInterne charge les descripteurs COMMITTÉS depuis le paquet
+// interne. Doublon assumé de son homologue du test externe : le registre du processus
+// est vide hors du binaire, et une garde qui parcourt une carte vide passe sans rien
+// mesurer.
+func descripteursDuDepotInterne(t *testing.T) map[string]Descriptor {
+	t.Helper()
+	entrees, err := os.ReadDir(filepath.Join("..", "..", "providers"))
+	if err != nil {
+		t.Fatalf("lecture des descripteurs : %v", err)
+	}
+	out := map[string]Descriptor{}
+	for _, e := range entrees {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		d, lerr := Load(os.DirFS(filepath.Join("..", "..", "providers")), e.Name())
+		if lerr != nil {
+			t.Fatalf("chargement de %s : %v", e.Name(), lerr)
+		}
+		out[strings.TrimSuffix(e.Name(), ".yaml")] = d
+	}
+	if len(out) == 0 {
+		t.Fatal("aucun descripteur chargé : la garde ne mesure rien")
+	}
+	return out
+}

--- a/internal/model/schema.go
+++ b/internal/model/schema.go
@@ -103,7 +103,25 @@ import (
 //	différence pour nommer ce qu'il a trouvé, et la DÉDUIRE d'une absence serait la
 //	fabrication que l'ADR-0014 refuse. Mappé sur l'entrant seul : rien ne lit la
 //	contrepartie sortante.
-const InventoryFormat = "pepin-inventory/v6"
+//
+// v7 : un nouveau type, `network_interface` — une ressource par carte réseau, portant
+//
+//	`nic_id`, `vm_id`, `public_ip` et `security_group_ids` (contrat osc-sdk-go
+//	v2.24.0 Vm.Nics []NicLight). Ajout PUR : aucun type ni attribut existant ne bouge.
+//	Il est nécessaire parce que l'exposition est une propriété de la CARTE, et que
+//	l'aplatir sur la machine perd l'APPARIEMENT — une carte publique au groupe fermé
+//	plus une carte privée au groupe ouvert se lisent, une fois réunies, comme
+//	« publique et ouverte ». Un consommateur qui l'ignore lit ce qu'il lisait déjà.
+//
+//	La même version porte un second ajout PUR : `governance_provider` peut porter
+//	`secnumcloud_regions`, le périmètre de régions que la qualification COUVRE. Il
+//	est là parce qu'une qualification ne porte pas sur un fournisseur entier :
+//	celle d'Outscale couvre `cloudgouv-eu-west-1` et elle seule, et un tenant en
+//	`eu-west-2` lisait « qualifié » à son sujet. L'attribut `secnumcloud` est
+//	désormais rendu POUR la région scannée (`qualifie` | `hors_perimetre` |
+//	`perimetre_inconnu`), et le périmètre voyage à côté pour qu'un consommateur
+//	puisse le vérifier plutôt que de croire le statut sur parole.
+const InventoryFormat = "pepin-inventory/v7"
 
 // InventorySchemaVersion extrait le N du suffixe `/vN`. Comme pour le bundle, la
 // constante et le signal sur le fil sont la même chose : impossible de faire

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -60,6 +60,10 @@ type TerraformMapper interface {
 // CLD-GVN-4. Optionnel : ok=false si la souveraineté n'est pas renseignée.
 type GovernanceProvider interface {
 	GovernanceResource() (model.Resource, bool)
+	// GovernanceResourceIn projette la souveraineté pour la région RÉELLEMENT
+	// scannée : un fait de souveraineté peut dépendre du périmètre (une
+	// qualification porte sur des régions, pas sur un fournisseur entier).
+	GovernanceResourceIn(region string) (model.Resource, bool)
 }
 
 var registry = map[string]Provider{}

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -1,13 +1,13 @@
 {
   "controls": 58,
   "paths": 179,
-  "paths_proven": 26,
+  "paths_proven": 27,
   "obligations": 461,
-  "proven": 89,
+  "proven": 92,
   "verdicts": {
     "fail": {
       "required": 141,
-      "proven": 23
+      "proven": 24
     },
     "not-applicable": {
       "required": 22,
@@ -15,11 +15,11 @@
     },
     "not-evaluated": {
       "required": 157,
-      "proven": 19
+      "proven": 20
     },
     "pass": {
       "required": 141,
-      "proven": 36
+      "proven": 37
     }
   },
   "live_paths": 101,
@@ -476,6 +476,11 @@
             "fail",
             "pass",
             "not-evaluated"
+          ],
+          "proven": [
+            "fail",
+            "pass",
+            "not-evaluated"
           ]
         },
         {
@@ -513,6 +518,7 @@
         }
       ],
       "scenarios": [
+        "internal/veracity/testdata/scenarios/nic-exposure-outscale-live.yaml",
         "internal/veracity/testdata/scenarios/public-vm-open-sg-outscale-terraform.yaml"
       ],
       "tenants": [

--- a/internal/veracity/testdata/debt.txt
+++ b/internal/veracity/testdata/debt.txt
@@ -8,7 +8,7 @@
 # Une ligne qui disparaît est une dette payée. Une ligne qui apparaît sans
 # scénario est un contrôle ajouté sans sa preuve, et la CI la refuse.
 #
-# chemins : 179 · entierement prouves : 26 · obligations : 461 · restantes : 372
+# chemins : 179 · entierement prouves : 27 · obligations : 461 · restantes : 369
 
 blockstorage_snapshot_not_public exoscale live not-applicable
 blockstorage_snapshot_not_public outscale live fail,pass,not-evaluated
@@ -37,7 +37,6 @@ compute_instance_no_secrets_in_user_data scaleway live not-evaluated
 compute_instance_no_secrets_in_user_data scaleway terraform not-evaluated
 compute_instance_public_ip_with_open_securitygroup exoscale live fail,pass,not-evaluated
 compute_instance_public_ip_with_open_securitygroup exoscale terraform fail,pass,not-evaluated
-compute_instance_public_ip_with_open_securitygroup outscale live fail,pass,not-evaluated
 compute_instance_public_ip_with_open_securitygroup scaleway live fail,pass,not-evaluated
 compute_instance_public_ip_with_open_securitygroup scaleway terraform not-evaluated
 database_backup_enabled scaleway terraform not-evaluated

--- a/internal/veracity/testdata/scenarios/nic-exposure-outscale-live.yaml
+++ b/internal/veracity/testdata/scenarios/nic-exposure-outscale-live.yaml
@@ -1,0 +1,88 @@
+# Exposition par une carte réseau SECONDAIRE, sur une collecte live Outscale.
+#
+# Le chemin traverse le collecteur RÉEL : `/ReadVms`, l'éclatement de `Vm.Nics[]` en une
+# ressource `network_interface` par carte, le mapping déclaratif (`LinkPublicIp.PublicIp`
+# → `public_ip`, `SecurityGroups[].SecurityGroupId` → `security_group_ids`), la règle,
+# puis l'assessment. C'est l'entrée exigée par le contrat : le type est produit par la
+# spec `collecte`.
+#
+# # Ce que ce scénario tient, et qu'aucun test Rego ne tient
+#
+# La règle savait déjà apparier une IP et des groupes ; ce qu'elle n'avait pas, c'est la
+# DONNÉE. Le faux négatif fondateur venait du collecteur : `Vm.SecurityGroups` documente
+# les groupes de la carte PRIMAIRE, et une VM publique par sa carte secondaire était
+# confrontée aux groupes de la mauvaise carte. Un mapping qui cesserait de projeter
+# `Nics[]` rendrait la règle muette sans casser un seul test unitaire.
+control: compute_instance_public_ip_with_open_securitygroup
+provider: outscale
+source: live
+
+scenarios:
+  - expect: fail
+    why: "carte primaire privee et fermee, carte secondaire portant l'IP publique ET 22 ouvert : SSH repond"
+    api:
+      /ReadVms: |
+        {"Vms": [{"VmId": "i-cb7729a3",
+                  "State": "running",
+                  "SecurityGroups": [{"SecurityGroupId": "sg-web-ok"}],
+                  "Nics": [{"NicId": "eni-primaire",
+                            "SecurityGroups": [{"SecurityGroupId": "sg-web-ok"}]},
+                           {"NicId": "eni-secondaire",
+                            "LinkPublicIp": {"PublicIp": "198.51.100.170"},
+                            "SecurityGroups": [{"SecurityGroupId": "sg-ssh-world"}]}]}]}
+      /ReadSecurityGroups: |
+        {"SecurityGroups": [{"SecurityGroupId": "sg-ssh-world",
+                             "SecurityGroupName": "pepin-audit-ssh-world",
+                             "InboundRules": [{"IpProtocol": "tcp",
+                                               "FromPortRange": 22,
+                                               "ToPortRange": 22,
+                                               "IpRanges": ["0.0.0.0/0"]}],
+                             "OutboundRules": []},
+                            {"SecurityGroupId": "sg-web-ok",
+                             "SecurityGroupName": "pepin-audit-web-ok",
+                             "InboundRules": [{"IpProtocol": "tcp",
+                                               "FromPortRange": 443,
+                                               "ToPortRange": 443,
+                                               "IpRanges": ["0.0.0.0/0"]}],
+                             "OutboundRules": []}]}
+
+  - expect: pass
+    why: "les MEMES cartes, l'IP publique deplacee sur celle dont le groupe est ferme : rien n'est joignable"
+    api:
+      /ReadVms: |
+        {"Vms": [{"VmId": "i-cb7729a3",
+                  "State": "running",
+                  "SecurityGroups": [{"SecurityGroupId": "sg-web-ok"}],
+                  "Nics": [{"NicId": "eni-primaire",
+                            "LinkPublicIp": {"PublicIp": "198.51.100.170"},
+                            "SecurityGroups": [{"SecurityGroupId": "sg-web-ok"}]},
+                           {"NicId": "eni-secondaire",
+                            "SecurityGroups": [{"SecurityGroupId": "sg-ssh-world"}]}]}]}
+      /ReadSecurityGroups: |
+        {"SecurityGroups": [{"SecurityGroupId": "sg-ssh-world",
+                             "SecurityGroupName": "pepin-audit-ssh-world",
+                             "InboundRules": [{"IpProtocol": "tcp",
+                                               "FromPortRange": 22,
+                                               "ToPortRange": 22,
+                                               "IpRanges": ["0.0.0.0/0"]}],
+                             "OutboundRules": []},
+                            {"SecurityGroupId": "sg-web-ok",
+                             "SecurityGroupName": "pepin-audit-web-ok",
+                             "InboundRules": [{"IpProtocol": "tcp",
+                                               "FromPortRange": 443,
+                                               "ToPortRange": 443,
+                                               "IpRanges": ["0.0.0.0/0"]}],
+                             "OutboundRules": []}]}
+
+  - expect: not-evaluated
+    why: "le droit api:Read* manque sur les regles de groupe : la donnee qui etablit l'exposition n'est jamais arrivee"
+    deny:
+      - /ReadSecurityGroups
+    api:
+      /ReadVms: |
+        {"Vms": [{"VmId": "i-cb7729a3",
+                  "State": "running",
+                  "SecurityGroups": [{"SecurityGroupId": "sg-web-ok"}],
+                  "Nics": [{"NicId": "eni-primaire",
+                            "LinkPublicIp": {"PublicIp": "198.51.100.170"},
+                            "SecurityGroups": [{"SecurityGroupId": "sg-web-ok"}]}]}]}

--- a/providers/outscale.yaml
+++ b/providers/outscale.yaml
@@ -23,6 +23,13 @@ souverainete:
   juridiction: FR
   controle_capitalistique: FR  # marque/filiale de Dassault Systèmes (France)
   secnumcloud: qualifie        # SecNumCloud 3.2 (ANSSI, déc. 2023) — 1er cloud public qualifié
+  # La qualification porte sur la RÉGION cloudgouv-eu-west-1, et sur elle seule.
+  # Source : support Outscale, « Is the cloudgouv-eu-west-1b AZ SecNumCloud qualified » —
+  # « The entire cloudgouv-eu-west-1 Region, meaning both of its AZs, is SecNumCloud
+  # qualified » (support.outscale.com/hc/en-us/articles/4420389575195), et le blog
+  # Outscale sur la seconde AZ de « la région Cloud qualifiée SecNumCloud ».
+  # Un tenant en eu-west-2 lisait « SecNumCloud qualifié » dans un pass de souveraineté.
+  secnumcloud_regions: [cloudgouv-eu-west-1]
   exposition_extraterritoriale: false
   sources: "3ds.com/newsroom (Outscale 1er cloud SecNumCloud 3.2) ; en.outscale.com/our-certifications"
 
@@ -74,6 +81,12 @@ permissions:
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
     note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
     note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+  - unit: network_interface
+    grant: "api:Read* (EIM) — ReadVms"
+    etat: a_verifier
+    source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
+    note: "Les cartes réseau sont lues DANS la réponse de ReadVms (Vm.Nics[]) : aucun appel ni droit supplémentaire. La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
+    note_en: "Network interfaces are read INSIDE the ReadVms response (Vm.Nics[]): no extra call, no extra grant. The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
   - unit: compute_instance
     grant: "api:Read* (EIM) — ReadVms"
     etat: a_verifier
@@ -251,6 +264,36 @@ collecte:
         security_group_ids: pluck:SecurityGroupId
         nic_public_ips: [pluck:LinkPublicIp, pluck:PublicIp]
         tags: kv
+
+    # Cartes réseau, une ressource normalisée par NIC.
+    #
+    # L'exposition est une propriété de la CARTE, pas de la machine, et l'aplatir sur la
+    # VM perd l'APPARIEMENT : mesuré sur un tenant réel, une VM dont la carte primaire est
+    # privée avec un groupe fermé et dont la carte secondaire porte l'IP publique ET un
+    # groupe ouvert sur 22 ne produisait aucun finding. `Vm.SecurityGroups` documente les
+    # groupes de la carte PRIMAIRE ; l'union des IP suffisait à rendre la VM « publique »,
+    # mais la règle la confrontait aux groupes de la mauvaise carte.
+    #
+    # L'inverse est aussi vrai, et c'est ce qui interdit d'aplatir : une carte publique au
+    # groupe fermé plus une carte privée au groupe ouvert donneraient, une fois réunies,
+    # « publique et ouverte » — un écart que la machine ne porte pas.
+    #
+    # Contrat : osc-sdk-go v2.24.0, Vm.Nics []NicLight{NicId, LinkPublicIp
+    # (LinkPublicIpLightForVm.PublicIp), SecurityGroups []SecurityGroupLight}.
+    - type: network_interface
+      path: /ReadVms
+      method: POST
+      body: "{}"
+      items: Vms[*].Nics[*]
+      id: nic_id
+      paging: { style: token-body, token_param: NextPageToken, token_path: NextPageToken, size_param: ResultsPerPage, size: 1000 }
+      map:
+        nic_id: NicId
+        vm_id: _parent.VmId
+        public_ip: LinkPublicIp.PublicIp
+        security_group_ids: SecurityGroups
+      transforms:
+        security_group_ids: pluck:SecurityGroupId
   
     # Clés d'accès de NIVEAU COMPTE (appelant). ReadAccessKeys sans UserName renvoie les
     # clés de l'identité de scan ; si elle est le root (cas d'un scan account-owner/admin),
@@ -609,6 +652,14 @@ contrat:
         peer_security_group_ids: SecurityGroupsMembers (*[]SecurityGroupsMember) → pluck SecurityGroupId ; ENTRANT seulement
         security_group_id: SecurityGroupId
         security_group_name: SecurityGroupName (du SG parent)
+    network_interface:
+      etat: verifie
+      source: Vm.Nics[] (NicLight)
+      mapping:
+        nic_id: NicId
+        vm_id: VmId (de la Vm porteuse)
+        public_ip: LinkPublicIp.PublicIp (LinkPublicIpLightForVm)
+        security_group_ids: SecurityGroups[].SecurityGroupId (SecurityGroupLight) — groupes de CETTE carte
     compute_instance:
       etat: verifie
       source: Vm


### PR DESCRIPTION
Two false greens, one perimeter. **Neither moves a verdict on the reference
corpus** — both were found by auditing real tenants, and both are about data the
tool never had rather than logic it got wrong.

## #170 — a machine publicly reachable, and a silent report

A VM public through its **second** network card, with SSH open on that card,
produced **no finding at all**.

The collector already projected the union of the NICs' public addresses, so the
machine counted as public. But it confronted that with `Vm.SecurityGroups`, which
the OAPI documents as the **primary** card's groups:

```
vm i-cb7729a3  public_ip=None  nic_public_ips=['148.253.114.170']
               security_group_ids=['sg-2cf714d0']    ← web-ok, the PRIMARY card
```

SSH answered on `148.253.114.170`, through the *secondary* card's group. The rule
worked; the data it was given did not describe that machine.

### Exposure is a property of the card

A `network_interface` resource is now collected per NIC (`nic_id`, `vm_id`,
`public_ip`, `security_group_ids`, from `Vm.Nics[]` — contract verified in
osc-sdk-go v2.24.0), and the rule pairs an address with the groups **of the same
card**.

**The fix is deliberately not a wider union**, and that is the part worth reading:
flattening is wrong in *both* directions.

| primary card | secondary card | flattened union would say | truth |
|---|---|---|---|
| private, closed | **public, open on 22** | public + open ✔ | **deviation** |
| **public**, closed | private, **open on 22** | public + open ✗ | nothing reachable |

The second row is a deviation the machine does not carry. Two counterexample tests
hold each direction; a third holds that one fact still produces **one** finding
when the primary card is the exposed one.

Where NICs are not collected — a Terraform plan, a provider whose API does not
expose them — the machine is still judged on its own attributes. A fallback that
went silent would have made deviations **disappear** that this repo detects today,
which is worse than the defect being fixed.

### The capability lock had to widen with it

Requiring only `compute_instance.public_ip` returned `not-evaluated` for a machine
whose cards had been read perfectly well. Either that **or** `nic_public_ips` now
suffices — they say the same thing, each for one card. The generated docs pick that
up: *"attribut décisif « nic_public_ips / public_ip »"*.

Veracity: this path goes from unproven to **3/3**, entering through the **real**
collector, because what needed proving is the mapping — a spec that stopped
projecting `Nics[]` would silence the rule without breaking a single unit test.
Ledger: 26 → 27 paths fully proven, 372 → 369 obligations remaining.

## #167 — a qualification covers regions, not a provider

`secnumcloud: qualifie` was declared for the provider as a whole. Outscale's
qualification covers `cloudgouv-eu-west-1` **and that one only**, so an `eu-west-2`
tenant read "SecNumCloud qualifié" inside a sovereignty `pass`. That is the first
claim an auditor contests, and the whole argument of this tool is that it never
claims more than it observed.

The descriptor declares the scope (sourced from Outscale's own support article and
blog), and the attribute is rendered **for the region actually scanned**:

```
--region cloudgouv-eu-west-1  → secnumcloud = qualifie
--region eu-west-2            → secnumcloud = hors_perimetre
(no --region)                 → secnumcloud = perimetre_inconnu
```

`hors_perimetre` is not "not qualified" — the provider is — it is "not here", and
that nuance is exactly what an auditor checks. `perimetre_inconnu` is there because
not knowing is not knowing that not (ADR-0014). Without a declared scope nothing
changes: we do not fabricate a restriction the descriptor does not state, so the
other two providers are untouched.

The generated identity table can no longer print the status without its scope:

```
| SecNumCloud | `qualifie` — scope: `cloudgouv-eu-west-1` |
```

and a guard requires every qualified region to exist in that provider's region
catalogue — a typo there would make the qualification unreachable, so
`hors_perimetre` everywhere, with nothing going red.

### What I did not do, and why

**No deny for a tenant outside the scope.** It would turn every Outscale
`eu-west-2` scan from `0` to `1` without anyone deciding it, and being outside a
qualified perimeter is not a misconfiguration — plenty of tenants run there
legitimately. What was wrong is the **transcription**, and that is what is fixed.
The substantive half comes along anyway: the qualification no longer grants
extraterritorial immunity outside its scope, because the rule's `!= "qualifie"`
guards now see `hors_perimetre`.

Plus the paragraph the issue asked for, in both languages: a scan covers one
region, a multi-region account needs one scan per region, and **bundles do not
merge** — adding them up would fabricate a scan that never happened.

## The frozen surface caught me twice, the same way

I ran `frozen-update` between two content changes and recorded an entry 7
describing an intermediate state that never existed. The guard refused the version
mismatch rather than letting it through. The correction is written with its
assertions (same version on both entries, contents actually different) rather than
applied blind — the same mistake as last time, caught by the same guard.

Inventory schema **v6 → v7**, carrying both additions under one version since v7
has not shipped.

## Impact ADR

- **ADR-0014** (an absent datum is not fabricated) — the reason `perimetre_inconnu`
  exists rather than defaulting either way, and the reason a provider with no
  declared scope is untouched.
- **ADR-0006** (never an unproven `pass`) — the widened lock still refuses to
  conclude when neither address attribute was collected.
- **ADR-0003** (frozen inventory contract) — one bump, both additions justified in
  the history.

None reopened, none needed.

## Gates

`mise run prepush` green. 358 Rego tests (was 353). Zero verdict movement across
the reference corpus.

Closes #167
Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)
