### PR TITLE
chore(deps): scankit 0.3.4 — a block no longer speaks for another control

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -63,6 +63,17 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Le rapport terminal imprimait le titre et la remédiation d'un contrôle au-dessus
+  des findings d'un AUTRE.** Un bloc imprime un code, un titre et une remédiation puis
+  liste des findings dessous : il affirme donc ces trois choses de chacun d'eux — or le
+  regroupement se faisait sur le seul code SCSL, et une exigence couvre souvent
+  plusieurs contrôles. Le titre et la remédiation étaient alors ceux du premier finding.
+  Mesuré sur un tenant réel, la ligne sur laquelle un lecteur agit lui disait de
+  révoquer une clé root pour corriger une autorisation `Resource="*"`. Corrigé en amont
+  dans scankit 0.3.4 : la clé de regroupement est désormais exactement ce que le bloc
+  affirme, donc `CLD-IAM-1` rend un bloc par contrôle et le tableau des contrôles cesse
+  d'additionner sévérité et décomptes sur une ligne qui recouvrait deux contrôles. Un
+  contrôle unique sous un code rend à l'identique.
 - **Une VM publique par sa carte secondaire, SSH ouvert sur cette carte, ne produisait
   aucun finding.** Le collecteur projetait l'union des IP publiques des cartes, donc la
   machine comptait pour publique — mais il la confrontait à `Vm.SecurityGroups`, que

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@ belongs in `git log`.
 
 ### Fixed
 
+- **The terminal report printed one control's title and remediation over another
+  control's findings.** A block prints a code, a title and a remediation and then lists
+  findings underneath, so it *asserts* those three of every finding it gathers —  but
+  findings were grouped by SCSL code alone, and a requirement often covers several
+  controls. The title and remediation were then those of the first finding. Measured on
+  a real tenant, the line a reader acts on told them to revoke a root key in order to
+  fix a `Resource="*"` grant. Fixed upstream in scankit 0.3.4: the grouping key is now
+  exactly what the block asserts, so `CLD-IAM-1` renders one block per control and the
+  controls table stops summing severity and counts across different controls on one row.
+  A single control under a code renders identically.
 - **A VM public through a secondary NIC, with SSH open on that NIC, produced no
   finding.** The collector projected the union of the NICs' public IPs, so the machine
   counted as public — but it confronted that with `Vm.SecurityGroups`, which the OAPI

--- a/cmd/testdata/lang/scan-fr.stdout
+++ b/cmd/testdata/lang/scan-fr.stdout
@@ -75,14 +75,27 @@
  HIGH  ·  CLD-NET-1  ·  scaleway
  Base de données managée joignable depuis Internet
 ──────────────────────────────────────────────────────────────────────────────
-  Écarts au total : 2
+  Écarts au total : 1
 
   Détail :
       HIGH  fr-par/11111111-1111-1111-1111-111111111111 — ACL autorisant un CIDR public (0.0.0.0/0) — service exposé à Internet.
-      HIGH  scaleway_instance_security_group.web — SSH (port 22) accepté depuis Internet.
 
   Remédiation
     Restreindre l'ACL de la base aux seuls CIDR applicatifs (réseau privé quand disponible) ; retirer 0.0.0.0/0.
+
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/exposition-filtrage-reseau/#socle-cld-net-1
+
+──────────────────────────────────────────────────────────────────────────────
+ HIGH  ·  CLD-NET-1  ·  scaleway
+ SSH (port 22) ouvert à Internet
+──────────────────────────────────────────────────────────────────────────────
+  Écarts au total : 1
+
+  Détail :
+      HIGH  scaleway_instance_security_group.web — SSH (port 22) accepté depuis Internet.
+
+  Remédiation
+    Restreindre la règle à des sources/destinations et ports légitimes (CIDR d'administration, bastion, VPN) ; ne jamais exposer un service sensible à 0.0.0.0/0.
 
   ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/exposition-filtrage-reseau/#socle-cld-net-1
 
@@ -150,7 +163,8 @@
   │ CLD-CHF-2  │ Base de données managée sans chiffrement au rep… │ HIGH     │ scaleway │ 1 │
   │ CLD-CMP-9  │ Secret en clair dans les données utilisateur (u… │ HIGH     │ scaleway │ 1 │
   │ CLD-IAM-12 │ Politique IAM permettant une élévation de privi… │ HIGH     │ scaleway │ 1 │
-  │ CLD-NET-1  │ Base de données managée joignable depuis Intern… │ HIGH     │ scaleway │ 2 │
+  │ CLD-NET-1  │ Base de données managée joignable depuis Intern… │ HIGH     │ scaleway │ 1 │
+  │ CLD-NET-1  │ SSH (port 22) ouvert à Internet                  │ HIGH     │ scaleway │ 1 │
   │ CLD-NET-2  │ Politique entrante par défaut d'un groupe de sé… │ HIGH     │ scaleway │ 1 │
   │ CLD-STO-3  │ Sauvegardes automatiques d'une base managée dés… │ HIGH     │ scaleway │ 1 │
   │ CLD-GVN-1  │ Inventaire et étiquetage incomplets              │ MEDIUM   │ scaleway │ 1 │

--- a/docs/getting-started/quickstart.fr.md
+++ b/docs/getting-started/quickstart.fr.md
@@ -96,7 +96,6 @@ Il se referme sur le tableau par contrôle et le verdict :
 <!-- pepin:gen scan-vulnerable-tail -->
 ```text
 […]
-
   Contrôles
   ╭────────────┬──────────────────────────────────────────────────┬──────────┬──────────┬───╮
   │ Code       │ Contrôle                                         │ Sév      │ Palier   │ # │
@@ -105,7 +104,8 @@ Il se referme sur le tableau par contrôle et le verdict :
   │ CLD-CHF-2  │ Base de données managée sans chiffrement au rep… │ HIGH     │ scaleway │ 1 │
   │ CLD-CMP-9  │ Secret en clair dans les données utilisateur (u… │ HIGH     │ scaleway │ 1 │
   │ CLD-IAM-12 │ Politique IAM permettant une élévation de privi… │ HIGH     │ scaleway │ 1 │
-  │ CLD-NET-1  │ Base de données managée joignable depuis Intern… │ HIGH     │ scaleway │ 2 │
+  │ CLD-NET-1  │ Base de données managée joignable depuis Intern… │ HIGH     │ scaleway │ 1 │
+  │ CLD-NET-1  │ SSH (port 22) ouvert à Internet                  │ HIGH     │ scaleway │ 1 │
   │ CLD-NET-2  │ Politique entrante par défaut d'un groupe de sé… │ HIGH     │ scaleway │ 1 │
   │ CLD-STO-3  │ Sauvegardes automatiques d'une base managée dés… │ HIGH     │ scaleway │ 1 │
   │ CLD-GVN-1  │ Inventaire et étiquetage incomplets              │ MEDIUM   │ scaleway │ 1 │

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -92,7 +92,6 @@ and closes with the per-control table and the verdict:
 <!-- pepin:gen scan-vulnerable-tail -->
 ```text
 […]
-
   Controls
   ╭────────────┬──────────────────────────────────────────────────┬──────────┬──────────┬───╮
   │ Code       │ Control                                          │ Sev      │ Tier     │ # │
@@ -101,7 +100,8 @@ and closes with the per-control table and the verdict:
   │ CLD-CHF-2  │ Managed database without encryption at rest      │ HIGH     │ scaleway │ 1 │
   │ CLD-CMP-9  │ Cleartext secret in the user data (user-data)    │ HIGH     │ scaleway │ 1 │
   │ CLD-IAM-12 │ IAM policy allowing privilege escalation         │ HIGH     │ scaleway │ 1 │
-  │ CLD-NET-1  │ Managed database reachable from the internet     │ HIGH     │ scaleway │ 2 │
+  │ CLD-NET-1  │ Managed database reachable from the internet     │ HIGH     │ scaleway │ 1 │
+  │ CLD-NET-1  │ SSH (port 22) open to the internet               │ HIGH     │ scaleway │ 1 │
   │ CLD-NET-2  │ Security group inbound default policy set to "a… │ HIGH     │ scaleway │ 1 │
   │ CLD-STO-3  │ Automatic backups disabled on a managed database │ HIGH     │ scaleway │ 1 │
   │ CLD-GVN-1  │ Incomplete inventory and tagging                 │ MEDIUM   │ scaleway │ 1 │

--- a/docs/getting-started/understanding-a-scan.fr.md
+++ b/docs/getting-started/understanding-a-scan.fr.md
@@ -125,14 +125,27 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
  HIGH  ·  CLD-NET-1  ·  scaleway
  Base de données managée joignable depuis Internet
 ──────────────────────────────────────────────────────────────────────────────
-  Écarts au total : 2
+  Écarts au total : 1
 
   Détail :
       HIGH  fr-par/11111111-1111-1111-1111-111111111111 — ACL autorisant un CIDR public (0.0.0.0/0) — service exposé à Internet.
-      HIGH  scaleway_instance_security_group.web — SSH (port 22) accepté depuis Internet.
 
   Remédiation
     Restreindre l'ACL de la base aux seuls CIDR applicatifs (réseau privé quand disponible) ; retirer 0.0.0.0/0.
+
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/exposition-filtrage-reseau/#socle-cld-net-1
+
+──────────────────────────────────────────────────────────────────────────────
+ HIGH  ·  CLD-NET-1  ·  scaleway
+ SSH (port 22) ouvert à Internet
+──────────────────────────────────────────────────────────────────────────────
+  Écarts au total : 1
+
+  Détail :
+      HIGH  scaleway_instance_security_group.web — SSH (port 22) accepté depuis Internet.
+
+  Remédiation
+    Restreindre la règle à des sources/destinations et ports légitimes (CIDR d'administration, bastion, VPN) ; ne jamais exposer un service sensible à 0.0.0.0/0.
 
   ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/exposition-filtrage-reseau/#socle-cld-net-1
 
@@ -200,7 +213,8 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
   │ CLD-CHF-2  │ Base de données managée sans chiffrement au rep… │ HIGH     │ scaleway │ 1 │
   │ CLD-CMP-9  │ Secret en clair dans les données utilisateur (u… │ HIGH     │ scaleway │ 1 │
   │ CLD-IAM-12 │ Politique IAM permettant une élévation de privi… │ HIGH     │ scaleway │ 1 │
-  │ CLD-NET-1  │ Base de données managée joignable depuis Intern… │ HIGH     │ scaleway │ 2 │
+  │ CLD-NET-1  │ Base de données managée joignable depuis Intern… │ HIGH     │ scaleway │ 1 │
+  │ CLD-NET-1  │ SSH (port 22) ouvert à Internet                  │ HIGH     │ scaleway │ 1 │
   │ CLD-NET-2  │ Politique entrante par défaut d'un groupe de sé… │ HIGH     │ scaleway │ 1 │
   │ CLD-STO-3  │ Sauvegardes automatiques d'une base managée dés… │ HIGH     │ scaleway │ 1 │
   │ CLD-GVN-1  │ Inventaire et étiquetage incomplets              │ MEDIUM   │ scaleway │ 1 │

--- a/docs/getting-started/understanding-a-scan.md
+++ b/docs/getting-started/understanding-a-scan.md
@@ -126,14 +126,27 @@ large tenant, you want to know the tool started. The closing line is
  HIGH  ·  CLD-NET-1  ·  scaleway
  Managed database reachable from the internet
 ──────────────────────────────────────────────────────────────────────────────
-  Total deviations: 2
+  Total deviations: 1
 
   Details:
       HIGH  fr-par/11111111-1111-1111-1111-111111111111 — Managed database "fr-par/11111111-1111-1111-1111-111111111111": ACL allowing a public CIDR (0.0.0.0/0) — the service is exposed to the internet.
-      HIGH  scaleway_instance_security_group.web — Security group "scaleway_instance_security_group.web": SSH (port 22) accepted from the internet.
 
   Remediation
     Restrict the database ACL to the application CIDRs only (a private network where one is available); remove 0.0.0.0/0.
+
+  ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/exposition-filtrage-reseau/#socle-cld-net-1
+
+──────────────────────────────────────────────────────────────────────────────
+ HIGH  ·  CLD-NET-1  ·  scaleway
+ SSH (port 22) open to the internet
+──────────────────────────────────────────────────────────────────────────────
+  Total deviations: 1
+
+  Details:
+      HIGH  scaleway_instance_security_group.web — Security group "scaleway_instance_security_group.web": SSH (port 22) accepted from the internet.
+
+  Remediation
+    Restrict the rule to legitimate sources/destinations and ports (administration CIDR, bastion, VPN); never expose a sensitive service to 0.0.0.0/0.
 
   ↳ docs: https://blog.stephane-robert.info/docs/securiser/socle/referentiel/cloud/exposition-filtrage-reseau/#socle-cld-net-1
 
@@ -201,7 +214,8 @@ large tenant, you want to know the tool started. The closing line is
   │ CLD-CHF-2  │ Managed database without encryption at rest      │ HIGH     │ scaleway │ 1 │
   │ CLD-CMP-9  │ Cleartext secret in the user data (user-data)    │ HIGH     │ scaleway │ 1 │
   │ CLD-IAM-12 │ IAM policy allowing privilege escalation         │ HIGH     │ scaleway │ 1 │
-  │ CLD-NET-1  │ Managed database reachable from the internet     │ HIGH     │ scaleway │ 2 │
+  │ CLD-NET-1  │ Managed database reachable from the internet     │ HIGH     │ scaleway │ 1 │
+  │ CLD-NET-1  │ SSH (port 22) open to the internet               │ HIGH     │ scaleway │ 1 │
   │ CLD-NET-2  │ Security group inbound default policy set to "a… │ HIGH     │ scaleway │ 1 │
   │ CLD-STO-3  │ Automatic backups disabled on a managed database │ HIGH     │ scaleway │ 1 │
   │ CLD-GVN-1  │ Incomplete inventory and tagging                 │ MEDIUM   │ scaleway │ 1 │

--- a/docs/providers/exoscale.fr.md
+++ b/docs/providers/exoscale.fr.md
@@ -219,11 +219,11 @@ pepin scan exoscale --terraform examples/exoscale/terraform/plan.json
 <!-- pepin:gen provider-exoscale-scan -->
 ```text
 […]
-  │ CLD-IAM-1  │ Rôle IAM aux privilèges excessifs                │ HIGH     │ exoscale │ 1 │
   │ CLD-IAM-12 │ Politique IAM permettant une élévation de privi… │ HIGH     │ exoscale │ 1 │
   │ CLD-IAM-4  │ Rôle IAM sans restriction d'IP source            │ HIGH     │ exoscale │ 2 │
   │ CLD-K8S-2  │ Plan de contrôle Kubernetes non hautement dispo… │ HIGH     │ exoscale │ 1 │
-  │ CLD-NET-1  │ SSH (port 22) ouvert à Internet                  │ HIGH     │ exoscale │ 2 │
+  │ CLD-NET-1  │ RDP (port 3389) ouvert à Internet                │ HIGH     │ exoscale │ 1 │
+  │ CLD-NET-1  │ SSH (port 22) ouvert à Internet                  │ HIGH     │ exoscale │ 1 │
   │ CLD-GVN-1  │ Inventaire et étiquetage incomplets              │ MEDIUM   │ exoscale │ 1 │
   │ CLD-K8S-3  │ Mises à jour automatiques du cluster Kubernetes… │ MEDIUM   │ exoscale │ 1 │
   │ CLD-GVN-3  │ Ressource hébergée hors Union européenne         │ LOW      │ exoscale │ 3 │

--- a/docs/providers/exoscale.md
+++ b/docs/providers/exoscale.md
@@ -216,11 +216,11 @@ pepin scan exoscale --terraform examples/exoscale/terraform/plan.json
 <!-- pepin:gen provider-exoscale-scan -->
 ```text
 […]
-  │ CLD-IAM-1  │ IAM role with excessive privileges             │ HIGH     │ exoscale │ 1 │
   │ CLD-IAM-12 │ IAM policy allowing privilege escalation       │ HIGH     │ exoscale │ 1 │
   │ CLD-IAM-4  │ IAM role without a source IP restriction       │ HIGH     │ exoscale │ 2 │
   │ CLD-K8S-2  │ Kubernetes control plane not highly available  │ HIGH     │ exoscale │ 1 │
-  │ CLD-NET-1  │ SSH (port 22) open to the internet             │ HIGH     │ exoscale │ 2 │
+  │ CLD-NET-1  │ RDP (port 3389) open to the internet           │ HIGH     │ exoscale │ 1 │
+  │ CLD-NET-1  │ SSH (port 22) open to the internet             │ HIGH     │ exoscale │ 1 │
   │ CLD-GVN-1  │ Incomplete inventory and tagging               │ MEDIUM   │ exoscale │ 1 │
   │ CLD-K8S-3  │ Automatic Kubernetes cluster upgrades disabled │ MEDIUM   │ exoscale │ 1 │
   │ CLD-GVN-3  │ Resource hosted outside the European Union     │ LOW      │ exoscale │ 3 │

--- a/docs/providers/outscale.fr.md
+++ b/docs/providers/outscale.fr.md
@@ -288,8 +288,8 @@ pepin scan outscale --terraform examples/outscale/terraform/plan.json
 <!-- pepin:gen provider-outscale-scan -->
 ```text
 […]
-  ├────────────┼──────────────────────────────────────────────────┼──────────┼──────────┼───┤
-  │ CLD-IAM-1  │ Politique IAM à privilèges administratifs (acti… │ CRITICAL │ outscale │ 2 │
+  │ CLD-IAM-1  │ Politique IAM à privilèges administratifs (acti… │ CRITICAL │ outscale │ 1 │
+  │ CLD-IAM-1  │ Politique IAM avec ressource joker               │ HIGH     │ outscale │ 1 │
   │ CLD-IAM-12 │ Politique IAM permettant une élévation de privi… │ HIGH     │ outscale │ 1 │
   │ CLD-NET-1  │ SSH (port 22) ouvert à Internet                  │ HIGH     │ outscale │ 1 │
   │ CLD-STO-2  │ Image machine partagée publiquement              │ HIGH     │ outscale │ 1 │

--- a/docs/providers/outscale.md
+++ b/docs/providers/outscale.md
@@ -282,8 +282,8 @@ pepin scan outscale --terraform examples/outscale/terraform/plan.json
 <!-- pepin:gen provider-outscale-scan -->
 ```text
 […]
-  ├────────────┼──────────────────────────────────────────────────┼──────────┼──────────┼───┤
-  │ CLD-IAM-1  │ IAM policy with administrative privileges (wild… │ CRITICAL │ outscale │ 2 │
+  │ CLD-IAM-1  │ IAM policy with administrative privileges (wild… │ CRITICAL │ outscale │ 1 │
+  │ CLD-IAM-1  │ IAM policy with a wildcard resource              │ HIGH     │ outscale │ 1 │
   │ CLD-IAM-12 │ IAM policy allowing privilege escalation         │ HIGH     │ outscale │ 1 │
   │ CLD-NET-1  │ SSH (port 22) open to the internet               │ HIGH     │ outscale │ 1 │
   │ CLD-STO-2  │ Machine image shared publicly                    │ HIGH     │ outscale │ 1 │

--- a/docs/providers/scaleway.fr.md
+++ b/docs/providers/scaleway.fr.md
@@ -209,10 +209,10 @@ pepin scan scaleway --terraform examples/scaleway/terraform/plan.json
 <!-- pepin:gen provider-scaleway-scan -->
 ```text
 […]
-  │ CLD-CHF-2  │ Base de données managée sans chiffrement au rep… │ HIGH     │ scaleway │ 1 │
   │ CLD-CMP-9  │ Secret en clair dans les données utilisateur (u… │ HIGH     │ scaleway │ 1 │
   │ CLD-IAM-12 │ Politique IAM permettant une élévation de privi… │ HIGH     │ scaleway │ 1 │
-  │ CLD-NET-1  │ Base de données managée joignable depuis Intern… │ HIGH     │ scaleway │ 2 │
+  │ CLD-NET-1  │ Base de données managée joignable depuis Intern… │ HIGH     │ scaleway │ 1 │
+  │ CLD-NET-1  │ SSH (port 22) ouvert à Internet                  │ HIGH     │ scaleway │ 1 │
   │ CLD-NET-2  │ Politique entrante par défaut d'un groupe de sé… │ HIGH     │ scaleway │ 1 │
   │ CLD-STO-3  │ Sauvegardes automatiques d'une base managée dés… │ HIGH     │ scaleway │ 1 │
   │ CLD-GVN-1  │ Inventaire et étiquetage incomplets              │ MEDIUM   │ scaleway │ 1 │

--- a/docs/providers/scaleway.md
+++ b/docs/providers/scaleway.md
@@ -205,10 +205,10 @@ pepin scan scaleway --terraform examples/scaleway/terraform/plan.json
 <!-- pepin:gen provider-scaleway-scan -->
 ```text
 […]
-  │ CLD-CHF-2  │ Managed database without encryption at rest      │ HIGH     │ scaleway │ 1 │
   │ CLD-CMP-9  │ Cleartext secret in the user data (user-data)    │ HIGH     │ scaleway │ 1 │
   │ CLD-IAM-12 │ IAM policy allowing privilege escalation         │ HIGH     │ scaleway │ 1 │
-  │ CLD-NET-1  │ Managed database reachable from the internet     │ HIGH     │ scaleway │ 2 │
+  │ CLD-NET-1  │ Managed database reachable from the internet     │ HIGH     │ scaleway │ 1 │
+  │ CLD-NET-1  │ SSH (port 22) open to the internet               │ HIGH     │ scaleway │ 1 │
   │ CLD-NET-2  │ Security group inbound default policy set to "a… │ HIGH     │ scaleway │ 1 │
   │ CLD-STO-3  │ Automatic backups disabled on a managed database │ HIGH     │ scaleway │ 1 │
   │ CLD-GVN-1  │ Incomplete inventory and tagging                 │ MEDIUM   │ scaleway │ 1 │

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -43,7 +43,6 @@ est précisément la raison de ne rien en parser.
 <!-- pepin:gen scan-vulnerable-tail -->
 ```text
 […]
-
   Contrôles
   ╭────────────┬──────────────────────────────────────────────────┬──────────┬──────────┬───╮
   │ Code       │ Contrôle                                         │ Sév      │ Palier   │ # │
@@ -52,7 +51,8 @@ est précisément la raison de ne rien en parser.
   │ CLD-CHF-2  │ Base de données managée sans chiffrement au rep… │ HIGH     │ scaleway │ 1 │
   │ CLD-CMP-9  │ Secret en clair dans les données utilisateur (u… │ HIGH     │ scaleway │ 1 │
   │ CLD-IAM-12 │ Politique IAM permettant une élévation de privi… │ HIGH     │ scaleway │ 1 │
-  │ CLD-NET-1  │ Base de données managée joignable depuis Intern… │ HIGH     │ scaleway │ 2 │
+  │ CLD-NET-1  │ Base de données managée joignable depuis Intern… │ HIGH     │ scaleway │ 1 │
+  │ CLD-NET-1  │ SSH (port 22) ouvert à Internet                  │ HIGH     │ scaleway │ 1 │
   │ CLD-NET-2  │ Politique entrante par défaut d'un groupe de sé… │ HIGH     │ scaleway │ 1 │
   │ CLD-STO-3  │ Sauvegardes automatiques d'une base managée dés… │ HIGH     │ scaleway │ 1 │
   │ CLD-GVN-1  │ Inventaire et étiquetage incomplets              │ MEDIUM   │ scaleway │ 1 │

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -43,7 +43,6 @@ parse it.
 <!-- pepin:gen scan-vulnerable-tail -->
 ```text
 […]
-
   Controls
   ╭────────────┬──────────────────────────────────────────────────┬──────────┬──────────┬───╮
   │ Code       │ Control                                          │ Sev      │ Tier     │ # │
@@ -52,7 +51,8 @@ parse it.
   │ CLD-CHF-2  │ Managed database without encryption at rest      │ HIGH     │ scaleway │ 1 │
   │ CLD-CMP-9  │ Cleartext secret in the user data (user-data)    │ HIGH     │ scaleway │ 1 │
   │ CLD-IAM-12 │ IAM policy allowing privilege escalation         │ HIGH     │ scaleway │ 1 │
-  │ CLD-NET-1  │ Managed database reachable from the internet     │ HIGH     │ scaleway │ 2 │
+  │ CLD-NET-1  │ Managed database reachable from the internet     │ HIGH     │ scaleway │ 1 │
+  │ CLD-NET-1  │ SSH (port 22) open to the internet               │ HIGH     │ scaleway │ 1 │
   │ CLD-NET-2  │ Security group inbound default policy set to "a… │ HIGH     │ scaleway │ 1 │
   │ CLD-STO-3  │ Automatic backups disabled on a managed database │ HIGH     │ scaleway │ 1 │
   │ CLD-GVN-1  │ Incomplete inventory and tagging                 │ MEDIUM   │ scaleway │ 1 │

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/sirupsen/logrus v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10
-	github.com/stephrobert/scankit v0.3.3
+	github.com/stephrobert/scankit v0.3.4
 	github.com/tchap/go-patricia/v2 v2.3.3 // indirect
 	github.com/valyala/fastjson v1.6.10 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.36 // indirect

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stephrobert/scankit v0.3.3 h1:kXEUIgXb+0/DwC0pMANyb3tlPcEDhOx6MI5d1C/nr2M=
-github.com/stephrobert/scankit v0.3.3/go.mod h1:ujhvahsG9HgtJC75QBgVsKRhepGvdo9Ey6RtJ6va6lM=
+github.com/stephrobert/scankit v0.3.4 h1:KELImeVtDn+28YWeFWZRlJzBFJdZ41SrCL+qlZ1p6o4=
+github.com/stephrobert/scankit v0.3.4/go.mod h1:ujhvahsG9HgtJC75QBgVsKRhepGvdo9Ey6RtJ6va6lM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=


### PR DESCRIPTION
Closes #166. The correction itself is upstream — [scankit#30](https://github.com/stephrobert/scankit/pull/30),
released as `v0.3.4` — because rendering lives there (CLAUDE.md §9). This PR is the
version bump and the outputs it moves.

## What was wrong

A block prints a code, a title and a remediation, then lists findings underneath. It
therefore **asserts those three of every finding it gathers**. Grouping on the SCSL
code alone made that false as soon as a requirement covered several controls — which
is common, and which the #172 work confirmed (`CLD-NET-4` covers two).

On this repository's own fixture, before:

```text
 CRITICAL  ·  CLD-IAM-1  ·  outscale
 Politique IAM à privilèges administratifs (action joker)
  Écarts au total : 2
  Détail :
      CRIT  ci-admin     — autorisation Allow portant Action="*"
      HIGH  ci-deployer  — autorisation Allow portant Resource="*"   ← another control
  Remédiation
    Remplacer Action="*" par la liste exhaustive des actions réellement nécessaires.
```

**The remediation is the line a reader acts on**, and it pointed at the wrong fix.

After:

```text
 CRITICAL  ·  CLD-IAM-1  ·  outscale
 Politique IAM à privilèges administratifs (action joker)
  Écarts au total : 1
      CRIT  ci-admin — autorisation Allow portant Action="*"
  Remédiation
    Remplacer Action="*" par la liste exhaustive des actions réellement nécessaires.

 HIGH  ·  CLD-IAM-1  ·  outscale
 Politique IAM avec ressource joker
      HIGH  ci-deployer — autorisation Allow portant Resource="*"
  Remédiation
    Restreindre Resource aux ressources réellement visées.
```

## What moves in this repo

- `CLD-IAM-1` renders two blocks on the Outscale fixture, `CLD-NET-1` two on the
  Scaleway one — each with its own title, severity and remediation.
- The controls table follows, because its rows now match the blocks: it stops summing
  `Sév` and `#` across different controls on one row.
- **A single control under a code renders identically.** The French reference output
  moved only where a block split, and nowhere else.
- Two blocks of one requirement stay adjacent: at equal severity the code sorts first,
  so the readability that grouping-by-code provided survives.

## The release needed a repair, and it is worth recording

The `v0.3.4` tag was pushed before its commit reached `main` — a direct push to `main`
is refused by the repository rules, as it should be. The Release workflow had already
run on the tag, so deleting a published tag would have been the worse move: a published
Go module version is not something to churn.

The commit went to `main` through a PR instead. GitHub's rebase merge re-created it
under a new SHA, so the tag points at an equivalent-but-distinct commit. **The tag's
tree is byte-identical to `main`'s** (`2a0cd42…` on both), so `v0.3.4` publishes exactly
what `main` carries and no consumer sees a difference. I left it there rather than
re-tagging a published version to fix a cosmetic ancestry.

## Impact ADR

- **ADR-0002** (shared engine) — respected: the fix is upstream, no local renderer.
- **ADR-0021** (scankit pinning is a security boundary) — this is an upgrade,
  `0.3.3 → 0.3.4`; the guard that goes red on a downgrade is untouched.

## Gates

`mise run prepush` green.

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)
