### PR TITLE
fix(cmd,docgen): refuse what is not an inventory, and measure what a plan carries

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -63,6 +63,26 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Un document qui n'a pas la forme d'un inventaire est refusé au lieu d'être scanné
+  comme un inventaire vide.** Une sortie `terraform show -json` passée sans
+  `--terraform`, ou un objet vide, étaient acceptés et évalués comme un inventaire
+  vide : code 3, « rien de mesuré ». Honnête sur ce qui a été mesuré, faux sur la
+  cause — l'appelant n'a pas un périmètre vide, il a donné le mauvais fichier, ce qui
+  est le code 2. Un plan est nommé comme tel (« ce fichier est un plan Terraform : le
+  scanner avec `--terraform` »), et l'échange inverse était déjà refusé : les deux sens
+  marchent désormais du même pas. Les tests du dépôt s'appuyaient sur le défaut : deux
+  d'entre eux passaient un plan en position d'inventaire.
+- **La matrice de couverture mesure ce qu'un plan porte au lieu de déclarer ce que le
+  mapping nomme.** `compute_instance_public_ip_with_open_securitygroup` affichait ✅ pour
+  outscale/terraform alors que `public_ip` est calculé — Terraform ne le connaît
+  qu'après `apply`, donc aucun plan réel ne le porte — et les scénarios de véracité
+  confirmaient la cellule sur un plan écrit à la main où l'attribut est un littéral. La
+  couverture est désormais corrigée par ce que les plans des tenants de référence,
+  générés depuis du HCL tiers, produisent réellement. Trois cellules passent de ✅ à ◐,
+  et le motif distingue « le mapping ne le nomme pas » (qui se corrige dans la spec) de
+  « le mapping le nomme mais aucun plan ne le porte » (qui ne s'y corrige pas du tout).
+  Six obligations qui ne pouvaient jamais être tenues quittent le registre de véracité
+  avec elles.
 - **Le rapport terminal imprimait le titre et la remédiation d'un contrôle au-dessus
   des findings d'un AUTRE.** Un bloc imprime un code, un titre et une remédiation puis
   liste des findings dessous : il affirme donc ces trois choses de chacun d'eux — or le

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,23 @@ belongs in `git log`.
 
 ### Fixed
 
+- **A document without an inventory's shape is refused instead of being scanned as an
+  empty one.** A `terraform show -json` output handed over without `--terraform`, or an
+  empty object, was accepted and evaluated as an empty inventory: exit 3, "nothing
+  measured". Honest about what was measured, wrong about the cause — the caller does not
+  have an empty scope, they gave the wrong file, which is exit 2. A plan is named as such
+  ("this file is a Terraform plan: scan it with `--terraform`"), and the opposite swap
+  was already refused, so both directions now move in step. The repository's own tests
+  were relying on the defect: two of them passed a plan in the inventory position.
+- **The coverage matrix measures what a plan carries instead of declaring what the
+  mapping names.** `compute_instance_public_ip_with_open_securitygroup` read ✅ for
+  outscale/terraform while `public_ip` is computed — Terraform only knows it after
+  `apply`, so no real plan carries it — and the veracity scenarios confirmed the cell on
+  a hand-written plan where the attribute is a literal. Coverage is now corrected by what
+  the reference tenant plans, generated from third-party HCL, actually yield. Three cells
+  drop from ✅ to ◐, and the reason distinguishes "the mapping does not name it" (fixed in
+  the spec) from "the mapping names it but no plan carries it" (not fixable there at all).
+  Six obligations that could never be met leave the veracity ledger with them.
 - **The terminal report printed one control's title and remediation over another
   control's findings.** A block prints a code, a title and a remediation and then lists
   findings underneath, so it *asserts* those three of every finding it gathers —  but

--- a/cmd/messages_test.go
+++ b/cmd/messages_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -146,5 +148,76 @@ func TestAnUnknownRegionIsFlaggedBeforeTheCollectFails(t *testing.T) {
 		"scan", "outscale", "--terraform", "examples/outscale/terraform/plan.json", "--region", "eu-nowhere-9")
 	if strings.Contains(horsLive, "n'est pas au catalogue") {
 		t.Errorf("avertissement émis hors --live :\n%s", horsLive)
+	}
+}
+
+// TestEachInputShapeIsRefusedInTheWrongPosition : les trois formes qu'un appelant
+// peut confondre, dans les deux positions.
+//
+// N'importe quel objet JSON était accepté comme un inventaire VIDE : un plan
+// Terraform passé sans `--terraform`, ou un `{}`, rendaient « périmètre vide » et le
+// code 3. C'est honnête sur ce qui a été mesuré, et faux sur la CAUSE — l'appelant
+// n'a pas un périmètre vide, il a donné le mauvais fichier. L'échange inverse était
+// déjà refusé ; les deux sens marchent maintenant du même pas, et la table les tient
+// ensemble pour qu'ils ne puissent plus diverger.
+func TestEachInputShapeIsRefusedInTheWrongPosition(t *testing.T) {
+	bin := buildPepin(t)
+	vide := filepath.Join(t.TempDir(), "vide.json")
+	if err := os.WriteFile(vide, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("écriture de la fixture : %v", err)
+	}
+	for _, c := range []struct {
+		nom      string
+		args     []string
+		refuse   bool
+		attendus []string
+	}{
+		{
+			nom:      "un plan en position d'inventaire",
+			args:     []string{"scan", "outscale", "examples/outscale/terraform/plan.json"},
+			refuse:   true,
+			attendus: []string{"plan Terraform", "--terraform"},
+		},
+		{
+			nom:      "un objet vide en position d'inventaire",
+			args:     []string{"scan", "outscale", vide},
+			refuse:   true,
+			attendus: []string{"resources"},
+		},
+		{
+			// L'autre sens, qui refusait déjà : la table le garde en phase.
+			nom:      "un inventaire en position de plan",
+			args:     []string{"scan", "outscale", "--terraform", "examples/outscale/inventory.json"},
+			refuse:   true,
+			attendus: []string{"planned_values"},
+		},
+		{
+			// LE CONTRE-EXEMPLE : un vrai inventaire passe. Un refus qui refuserait
+			// tout serait vert pour la pire des raisons.
+			nom:    "un inventaire en position d'inventaire",
+			args:   []string{"scan", "outscale", "examples/outscale/inventory.json"},
+			refuse: false,
+		},
+	} {
+		t.Run(c.nom, func(t *testing.T) {
+			stdout, stderr := runPepin(t, bin, []string{"LANG=fr_FR.UTF-8"}, c.args...)
+			if !c.refuse {
+				if strings.Contains(stderr, "erreur :") {
+					t.Fatalf("un inventaire valide a été refusé :\n%s", stderr)
+				}
+				if !strings.Contains(stdout, "Synthèse") {
+					t.Errorf("le scan n'a pas produit de rapport :\n%s", stdout)
+				}
+				return
+			}
+			if !strings.Contains(stderr, "erreur :") {
+				t.Fatalf("aucun refus :\nstdout=%s\nstderr=%s", stdout, stderr)
+			}
+			for _, mot := range c.attendus {
+				if !strings.Contains(stderr, mot) {
+					t.Errorf("le refus ne mentionne pas %q :\n%s", mot, stderr)
+				}
+			}
+		})
 	}
 }

--- a/cmd/policy_network_test.go
+++ b/cmd/policy_network_test.go
@@ -68,7 +68,7 @@ deny contains f if {
 	bin := buildPepin(t)
 	// Le scan peut échouer ou non : ce qui se mesure ici n'est pas son verdict, c'est
 	// si le témoin a été touché.
-	_, _ = runPepin(t, bin, nil, "scan", "scaleway", scanFixture, "--policy-dir", dir, "--format", "json")
+	_, _ = runPepin(t, bin, nil, "scan", "scaleway", "--terraform", scanFixture, "--policy-dir", dir, "--format", "json")
 
 	if n := atteint.Load(); n != 0 {
 		t.Errorf("une règle tierce a atteint le réseau (%d requête(s) reçues).\n"+
@@ -91,7 +91,7 @@ deny contains f if {
 // d'épinglage remettrait les blancs sans que rien d'autre ne rougisse.
 func TestNoResultCarriesAnEmptyProof(t *testing.T) {
 	bin := buildPepin(t)
-	stdout, _ := runPepin(t, bin, nil, "scan", "scaleway", scanFixture, "--format", "assessment")
+	stdout, _ := runPepin(t, bin, nil, "scan", "scaleway", "--terraform", scanFixture, "--format", "assessment")
 
 	var doc struct {
 		Results []struct {

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -1194,10 +1194,51 @@ func loadInput(ctx context.Context, p provider.Provider, path string) (any, erro
 	if err := json.Unmarshal(raw, &input); err != nil {
 		return nil, fmt.Errorf(tr("export JSON invalide : %w", "invalid JSON export: %w"), err)
 	}
+	if err := checkIsInventory(input); err != nil {
+		return nil, err
+	}
 	if err := checkProviderMatches(p.Name(), input); err != nil {
 		return nil, err
 	}
 	return input, nil
+}
+
+// checkIsInventory refuse un document qui n'a pas la FORME d'un inventaire.
+//
+// N'importe quel objet JSON était accepté et évalué comme un inventaire VIDE : un
+// `terraform show -json` passé sans `--terraform`, ou un `{}`, rendaient « périmètre
+// vide » et le code 3. C'est honnête sur ce qui a été mesuré, et faux sur la cause :
+// l'appelant n'a pas un périmètre vide, il a donné le mauvais fichier. Le code 2 —
+// erreur technique — est celui d'un export illisible, et c'est exactement ce cas.
+//
+// L'échange inverse était déjà refusé : `--terraform` sur un inventaire rend « plan
+// terraform sans bloc planned_values ni values ». Les deux sens sont maintenant en
+// phase, ce qui est le minimum pour que l'erreur soit reconnaissable dans un pipeline.
+//
+// C'est le même raisonnement qu'aux issues #148/#155, un cran plus tôt : une erreur
+// discrète et réaliste ne doit pas produire un rapport d'allure normale.
+func checkIsInventory(input any) error {
+	m, ok := input.(map[string]any)
+	if !ok {
+		return errors.New(tr(
+			"ce n'est pas un inventaire Pépin : le document racine n'est pas un objet JSON",
+			"this is not a Pépin inventory: the root document is not a JSON object"))
+	}
+	if _, ok := m["resources"]; ok {
+		return nil
+	}
+	// Un plan Terraform porte une forme reconnaissable. Le NOMMER évite à l'appelant
+	// de chercher ce qui manque à un fichier qui, lui, ne manque de rien.
+	for _, cle := range []string{"planned_values", "format_version", "terraform_version"} {
+		if _, ok := m[cle]; ok {
+			return errors.New(tr(
+				"ce fichier est un plan Terraform, pas un inventaire Pépin : le scanner avec --terraform",
+				"this file is a Terraform plan, not a Pépin inventory: scan it with --terraform"))
+		}
+	}
+	return errors.New(tr(
+		"ce n'est pas un inventaire Pépin : aucun tableau « resources » à la racine",
+		"this is not a Pépin inventory: no `resources` array at the root"))
 }
 
 // checkProviderMatches refuse un inventaire dont l'ORIGINE contredit le jeu de règles

--- a/docs/concepts/terraform-vs-live.fr.md
+++ b/docs/concepts/terraform-vs-live.fr.md
@@ -261,9 +261,9 @@ couples, une source produit le type de ressource et son attribut décisif, et l'
 | `blockstorage_volume_snapshots_exist` | outscale | live | cette source ne produit aucune ressource de type « blockstorage_volume » |
 | `compute_instance_deletion_protection` | outscale | live | attribut décisif « deletion_protection » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `compute_instance_no_secrets_in_user_data` | scaleway | terraform | attribut décisif « user_data » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| `compute_instance_public_ip_with_open_securitygroup` | outscale | live | attribut décisif « nic_public_ips / public_ip » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated » |
 | `compute_instance_public_ip_with_open_securitygroup` | scaleway | live | attribut décisif « nic_public_ips / public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `database_backup_enabled` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |
-| `database_encryption_at_rest_enabled` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `database_service_not_open_to_internet` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `governance_resource_region_in_eu` | outscale | live | attribut décisif « region » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_accesskey_expiration_set` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
@@ -276,6 +276,7 @@ couples, une source produit le type de ressource et son attribut décisif, et l'
 | `iam_policy_no_privilege_escalation` | scaleway | terraform | cette source ne produit aucune ressource de type « iam_policy » |
 | `iam_user_mfa_enabled` | exoscale | live | cette source ne produit aucune ressource de type « iam_user » |
 | `iam_user_mfa_enabled` | scaleway | live | cette source ne produit aucune ressource de type « iam_user » |
+| `kubernetes_cluster_audit_logging_enabled` | exoscale | live | attribut décisif « audit_enabled » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated » |
 | `kubernetes_cluster_auto_upgrade_enabled` | outscale | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
 | `kubernetes_cluster_control_plane_highly_available` | outscale | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
 | `kubernetes_cluster_deletion_protection` | outscale | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |

--- a/docs/concepts/terraform-vs-live.md
+++ b/docs/concepts/terraform-vs-live.md
@@ -256,9 +256,9 @@ source produces the resource type and its deciding attribute, and the other does
 | `blockstorage_volume_snapshots_exist` | outscale | live | this source produces no resource of type "blockstorage_volume" |
 | `compute_instance_deletion_protection` | outscale | live | deciding attribute "deletion_protection" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `compute_instance_no_secrets_in_user_data` | scaleway | terraform | deciding attribute "user_data" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| `compute_instance_public_ip_with_open_securitygroup` | outscale | live | deciding attribute "nic_public_ips / public_ip" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns "not-evaluated" |
 | `compute_instance_public_ip_with_open_securitygroup` | scaleway | live | deciding attribute "nic_public_ips / public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `database_backup_enabled` | scaleway | terraform | this source produces no resource of type "managed_database" |
-| `database_encryption_at_rest_enabled` | scaleway | terraform | this source produces no resource of type "managed_database" |
 | `database_service_not_open_to_internet` | scaleway | terraform | this source produces no resource of type "managed_database" |
 | `governance_resource_region_in_eu` | outscale | live | deciding attribute "region" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_accesskey_expiration_set` | outscale | live | this source produces no resource of type "access_key" |
@@ -271,6 +271,7 @@ source produces the resource type and its deciding attribute, and the other does
 | `iam_policy_no_privilege_escalation` | scaleway | terraform | this source produces no resource of type "iam_policy" |
 | `iam_user_mfa_enabled` | exoscale | live | this source produces no resource of type "iam_user" |
 | `iam_user_mfa_enabled` | scaleway | live | this source produces no resource of type "iam_user" |
+| `kubernetes_cluster_audit_logging_enabled` | exoscale | live | deciding attribute "audit_enabled" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns "not-evaluated" |
 | `kubernetes_cluster_auto_upgrade_enabled` | outscale | live | this source produces no resource of type "kubernetes_cluster" |
 | `kubernetes_cluster_control_plane_highly_available` | outscale | live | this source produces no resource of type "kubernetes_cluster" |
 | `kubernetes_cluster_deletion_protection` | outscale | live | this source produces no resource of type "kubernetes_cluster" |

--- a/docs/controls/compute_instance_public_ip_with_open_securitygroup.fr.md
+++ b/docs/controls/compute_instance_public_ip_with_open_securitygroup.fr.md
@@ -52,7 +52,7 @@ déclaré, ou type absent de cette source ».
 | Fournisseur | Plan Terraform | Collecte live |
 |---|:-:|:-:|
 | exoscale | ✅ | ✅ |
-| outscale | ✅ | ✅ |
+| outscale | ◐ | ✅ |
 | scaleway | ◐ | ✅ |
 | kubernetes | sans objet | ✗ |
 
@@ -61,6 +61,7 @@ porte son motif :
 
 | Fournisseur | Source | Statut | Motif |
 |---|---|---|---|
+| outscale | terraform | ◐ `partial` | attribut décisif « nic_public_ips / public_ip » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated » |
 | scaleway | terraform | ◐ `partial` | attribut décisif « nic_public_ips / public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 
 ## Ce que Pépin peut conclure
@@ -68,9 +69,9 @@ porte son motif :
 | Statut | Ce que le statut affirme | Atteignable depuis |
 |---|---|---|
 | `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
-| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live · outscale / live · scaleway / live |
 | `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
-| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | scaleway / terraform |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | outscale / terraform · scaleway / terraform |
 
 Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
 contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».

--- a/docs/controls/compute_instance_public_ip_with_open_securitygroup.md
+++ b/docs/controls/compute_instance_public_ip_with_open_securitygroup.md
@@ -51,7 +51,7 @@ source".
 | Provider | Terraform plan | Live collection |
 |---|:-:|:-:|
 | exoscale | ✅ | ✅ |
-| outscale | ✅ | ✅ |
+| outscale | ◐ | ✅ |
 | scaleway | ◐ | ✅ |
 | kubernetes | n/a | ✗ |
 
@@ -60,6 +60,7 @@ reason:
 
 | Provider | Source | Status | Reason |
 |---|---|---|---|
+| outscale | terraform | ◐ `partial` | deciding attribute "nic_public_ips / public_ip" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns "not-evaluated" |
 | scaleway | terraform | ◐ `partial` | deciding attribute "nic_public_ips / public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 
 ## What Pépin can conclude
@@ -67,9 +68,9 @@ reason:
 | Status | What the status asserts | Reachable from |
 |---|---|---|
 | `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / terraform · scaleway / live |
-| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / terraform · outscale / live · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live · outscale / live · scaleway / live |
 | `not-applicable` | the provider contract declares the control untestable, with its justification | — |
-| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | scaleway / terraform |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | outscale / terraform · scaleway / terraform |
 
 An observable control still returns `not-evaluated` on an inventory that contains no
 resource of the targeted type: "nothing to look at" is not "compliant".

--- a/docs/controls/database_encryption_at_rest_enabled.fr.md
+++ b/docs/controls/database_encryption_at_rest_enabled.fr.md
@@ -52,7 +52,7 @@ déclaré, ou type absent de cette source ».
 |---|:-:|:-:|
 | exoscale | ✗ | ✗ |
 | outscale | ✗ | ✗ |
-| scaleway | ✅ | ✗ |
+| scaleway | ◐ | ✗ |
 | kubernetes | sans objet | ✗ |
 
 Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
@@ -60,6 +60,7 @@ porte son motif :
 
 | Fournisseur | Source | Statut | Motif |
 |---|---|---|---|
+| scaleway | terraform | ◐ `partial` | attribut décisif « encryption_at_rest » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated » |
 | scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « managed_database » |
 
 ## Ce que Pépin peut conclure
@@ -67,9 +68,9 @@ porte son motif :
 | Statut | Ce que le statut affirme | Atteignable depuis |
 |---|---|---|
 | `fail` | un écart a été détecté sur une ressource réelle | scaleway / terraform |
-| `pass` | la donnée décisive a été collectée, et elle est conforme | scaleway / terraform |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | aucun |
 | `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
-| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | scaleway / terraform |
 
 Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
 contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
@@ -104,6 +105,10 @@ tel quel, ou une note ancrée sur la documentation officielle. Voir
 Dans la sortie `assessment`, chercher `"control": "database_encryption_at_rest_enabled"` : son `status` doit être
 `pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
 correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+**Une des deux sources ne sait pas lever le verrou du « pass »** pour ce contrôle :
+le fournisseur cité y produit bien le type visé, mais le scan y rendra `not-evaluated`.
+Le tableau des motifs dit laquelle, et pourquoi.
 
 ## Voir aussi
 

--- a/docs/controls/database_encryption_at_rest_enabled.md
+++ b/docs/controls/database_encryption_at_rest_enabled.md
@@ -51,7 +51,7 @@ source".
 |---|:-:|:-:|
 | exoscale | ✗ | ✗ |
 | outscale | ✗ | ✗ |
-| scaleway | ✅ | ✗ |
+| scaleway | ◐ | ✗ |
 | kubernetes | n/a | ✗ |
 
 Every cell that is not ✅ **while the control is declared for that provider** carries its
@@ -59,6 +59,7 @@ reason:
 
 | Provider | Source | Status | Reason |
 |---|---|---|---|
+| scaleway | terraform | ◐ `partial` | deciding attribute "encryption_at_rest" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns "not-evaluated" |
 | scaleway | live | ✗ `unsupported` | this source produces no resource of type "managed_database" |
 
 ## What Pépin can conclude
@@ -66,9 +67,9 @@ reason:
 | Status | What the status asserts | Reachable from |
 |---|---|---|
 | `fail` | a deviation was detected on a real resource | scaleway / terraform |
-| `pass` | the deciding data was collected, and it is compliant | scaleway / terraform |
+| `pass` | the deciding data was collected, and it is compliant | — |
 | `not-applicable` | the provider contract declares the control untestable, with its justification | — |
-| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | scaleway / terraform |
 
 An observable control still returns `not-evaluated` on an inventory that contains no
 resource of the targeted type: "nothing to look at" is not "compliant".
@@ -103,6 +104,10 @@ is, or a note anchored on the official documentation. See
 In the `assessment` output, look for `"control": "database_encryption_at_rest_enabled"`: its `status` must be `pass`.
 If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
 demonstrated: the reasons table above says why.
+
+**One of the two sources cannot lift the `pass` lock** for this control: the provider
+quoted does produce the targeted type there, but the scan will return `not-evaluated`.
+The reasons table says which one, and why.
 
 ## See also
 

--- a/docs/controls/kubernetes_cluster_audit_logging_enabled.fr.md
+++ b/docs/controls/kubernetes_cluster_audit_logging_enabled.fr.md
@@ -49,7 +49,7 @@ déclaré, ou type absent de cette source ».
 
 | Fournisseur | Plan Terraform | Collecte live |
 |---|:-:|:-:|
-| exoscale | ✅ | ✅ |
+| exoscale | ◐ | ✅ |
 | outscale | ✗ | ✗ |
 | scaleway | ✗ | ✗ |
 | kubernetes | sans objet | ✗ |
@@ -57,16 +57,18 @@ déclaré, ou type absent de cette source ».
 Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
 porte son motif :
 
-_Aucune : toutes les cases déclarées sont pleinement observables._
+| Fournisseur | Source | Statut | Motif |
+|---|---|---|---|
+| exoscale | terraform | ◐ `partial` | attribut décisif « audit_enabled » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated » |
 
 ## Ce que Pépin peut conclure
 
 | Statut | Ce que le statut affirme | Atteignable depuis |
 |---|---|---|
 | `fail` | un écart a été détecté sur une ressource réelle | exoscale / terraform · exoscale / live |
-| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / terraform · exoscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | exoscale / live |
 | `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
-| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | exoscale / terraform |
 
 Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
 contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
@@ -104,6 +106,10 @@ tel quel, ou une note ancrée sur la documentation officielle. Voir
 Dans la sortie `assessment`, chercher `"control": "kubernetes_cluster_audit_logging_enabled"` : son `status` doit être
 `pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
 correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+**Une des deux sources ne sait pas lever le verrou du « pass »** pour ce contrôle :
+le fournisseur cité y produit bien le type visé, mais le scan y rendra `not-evaluated`.
+Le tableau des motifs dit laquelle, et pourquoi.
 
 ## Voir aussi
 

--- a/docs/controls/kubernetes_cluster_audit_logging_enabled.md
+++ b/docs/controls/kubernetes_cluster_audit_logging_enabled.md
@@ -48,7 +48,7 @@ source".
 
 | Provider | Terraform plan | Live collection |
 |---|:-:|:-:|
-| exoscale | ✅ | ✅ |
+| exoscale | ◐ | ✅ |
 | outscale | ✗ | ✗ |
 | scaleway | ✗ | ✗ |
 | kubernetes | n/a | ✗ |
@@ -56,16 +56,18 @@ source".
 Every cell that is not ✅ **while the control is declared for that provider** carries its
 reason:
 
-_None: every declared cell is fully observable._
+| Provider | Source | Status | Reason |
+|---|---|---|---|
+| exoscale | terraform | ◐ `partial` | deciding attribute "audit_enabled" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns "not-evaluated" |
 
 ## What Pépin can conclude
 
 | Status | What the status asserts | Reachable from |
 |---|---|---|
 | `fail` | a deviation was detected on a real resource | exoscale / terraform · exoscale / live |
-| `pass` | the deciding data was collected, and it is compliant | exoscale / terraform · exoscale / live |
+| `pass` | the deciding data was collected, and it is compliant | exoscale / live |
 | `not-applicable` | the provider contract declares the control untestable, with its justification | — |
-| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | exoscale / terraform |
 
 An observable control still returns `not-evaluated` on an inventory that contains no
 resource of the targeted type: "nothing to look at" is not "compliant".
@@ -103,6 +105,10 @@ is, or a note anchored on the official documentation. See
 In the `assessment` output, look for `"control": "kubernetes_cluster_audit_logging_enabled"`: its `status` must be `pass`.
 If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
 demonstrated: the reasons table above says why.
+
+**One of the two sources cannot lift the `pass` lock** for this control: the provider
+quoted does produce the targeted type there, but the scan will return `not-evaluated`.
+The reasons table says which one, and why.
 
 ## See also
 

--- a/docs/coverage.fr.md
+++ b/docs/coverage.fr.md
@@ -43,7 +43,7 @@ et le rapport le dit à chaque scan, contrôle par contrôle, avec le motif.
 
 | Famille | Contrôles | exoscale | outscale | scaleway |
 |---|---:|---|---|---|
-| `chiffrement` | 7 | ✅ 1 · ◐ 0 · ∅ 3 · ✗ 3 | ✅ 2 · ◐ 0 · ∅ 3 · ✗ 2 | ✅ 2 · ◐ 0 · ∅ 1 · ✗ 4 |
+| `chiffrement` | 7 | ✅ 1 · ◐ 0 · ∅ 3 · ✗ 3 | ✅ 2 · ◐ 0 · ∅ 3 · ✗ 2 | ✅ 1 · ◐ 1 · ∅ 1 · ✗ 4 |
 | `compute` | 9 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 5 | ✅ 7 · ◐ 0 · ∅ 0 · ✗ 2 | ✅ 2 · ◐ 0 · ∅ 0 · ✗ 7 |
 | `gouvernance` | 3 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 |
 | `iam` | 15 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 | ✅ 11 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 3 · ◐ 1 · ∅ 0 · ✗ 11 |
@@ -62,9 +62,9 @@ et le rapport le dit à chaque scan, contrôle par contrôle, avec le motif.
 | `compute_instance_deletion_protection` | medium | CLD-CMP-10 | ✗ | ✗ | ◐ | ✅ | ✗ | ✗ |
 | `compute_instance_has_security_group` | critical | CLD-CMP-1 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `compute_instance_no_secrets_in_user_data` | high | CLD-CMP-9 | ✅ | ✅ | ✅ | ✅ | ✅ | ◐ |
-| `compute_instance_public_ip_with_open_securitygroup` | critical | CLD-NET-3 | ✅ | ✅ | ✅ | ✅ | ◐ | ✅ |
+| `compute_instance_public_ip_with_open_securitygroup` | critical | CLD-NET-3 | ✅ | ✅ | ◐ | ✅ | ◐ | ✅ |
 | `database_backup_enabled` | high | CLD-STO-3 | ✗ | ✗ | ✗ | ✗ | ✅ | ✗ |
-| `database_encryption_at_rest_enabled` | high | CLD-CHF-2 | ✗ | ✗ | ✗ | ✗ | ✅ | ✗ |
+| `database_encryption_at_rest_enabled` | high | CLD-CHF-2 | ✗ | ✗ | ✗ | ✗ | ◐ | ✗ |
 | `database_service_not_open_to_internet` | high | CLD-NET-1 | ✗ | ✗ | ✗ | ✗ | ✅ | ✗ |
 | `governance_provider_sovereignty` | high | CLD-GVN-4 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `governance_resource_region_in_eu` | high | CLD-GVN-3 | ✅ | ✅ | ◐ | ✅ | ✅ | ✅ |
@@ -88,7 +88,7 @@ et le rapport le dit à chaque scan, contrôle par contrôle, avec le motif.
 | `k8s_namespace_pod_security_enforced` | high | CLD-K8S-5 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | `k8s_rbac_no_cluster_admin_binding` | critical | CLD-K8S-4 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | `k8s_secrets_external_manager` | high | CLD-K8S-10 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| `kubernetes_cluster_audit_logging_enabled` | medium | CLD-LOG-1 | ✅ | ✅ | ✗ | ✗ | ✗ | ✗ |
+| `kubernetes_cluster_audit_logging_enabled` | medium | CLD-LOG-1 | ◐ | ✅ | ✗ | ✗ | ✗ | ✗ |
 | `kubernetes_cluster_auto_upgrade_enabled` | medium | CLD-K8S-3 | ✅ | ✅ | ✗ | ✅ | ✗ | ✗ |
 | `kubernetes_cluster_control_plane_highly_available` | high | CLD-K8S-2 | ✅ | ✅ | ✗ | ✅ | ✗ | ✗ |
 | `kubernetes_cluster_deletion_protection` | medium | CLD-K8S-3 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
@@ -134,8 +134,10 @@ ici : la matrice les montre déjà, et elles n'apprennent rien de plus.
 | `blockstorage_volume_snapshots_exist` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « blockstorage_volume » |
 | `compute_instance_deletion_protection` | outscale | terraform | ◐ `partial` | attribut décisif « deletion_protection » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `compute_instance_no_secrets_in_user_data` | scaleway | live | ◐ `partial` | attribut décisif « user_data » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| `compute_instance_public_ip_with_open_securitygroup` | outscale | terraform | ◐ `partial` | attribut décisif « nic_public_ips / public_ip » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated » |
 | `compute_instance_public_ip_with_open_securitygroup` | scaleway | terraform | ◐ `partial` | attribut décisif « nic_public_ips / public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `database_backup_enabled` | scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « managed_database » |
+| `database_encryption_at_rest_enabled` | scaleway | terraform | ◐ `partial` | attribut décisif « encryption_at_rest » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated » |
 | `database_encryption_at_rest_enabled` | scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « managed_database » |
 | `database_service_not_open_to_internet` | scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « managed_database » |
 | `governance_resource_region_in_eu` | outscale | terraform | ◐ `partial` | attribut décisif « region » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
@@ -159,6 +161,7 @@ ici : la matrice les montre déjà, et elles n'apprennent rien de plus.
 | `iam_user_mfa_enabled` | outscale | terraform | ∅ `not-applicable` | type de ressource « iam_user » absent de l'API outscale |
 | `iam_user_mfa_enabled` | outscale | live | ∅ `not-applicable` | type de ressource « iam_user » absent de l'API outscale |
 | `iam_user_mfa_enabled` | scaleway | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « iam_user » |
+| `kubernetes_cluster_audit_logging_enabled` | exoscale | terraform | ◐ `partial` | attribut décisif « audit_enabled » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated » |
 | `kubernetes_cluster_auto_upgrade_enabled` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « kubernetes_cluster » |
 | `kubernetes_cluster_control_plane_highly_available` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « kubernetes_cluster » |
 | `kubernetes_cluster_deletion_protection` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « kubernetes_cluster » |
@@ -209,10 +212,10 @@ deux ne peut couvrir la portée de l'autre. Une seule source : la collecte live 
 
 | Fournisseur | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---|---:|---:|---:|---:|
-| exoscale | terraform | 21 | 1 | 5 | 31 |
+| exoscale | terraform | 20 | 2 | 5 | 31 |
 | exoscale | live | 25 | 1 | 5 | 27 |
-| outscale | terraform | 17 | 4 | 4 | 33 |
+| outscale | terraform | 16 | 5 | 4 | 33 |
 | outscale | live | 40 | 1 | 4 | 13 |
-| scaleway | terraform | 18 | 6 | 2 | 32 |
+| scaleway | terraform | 17 | 7 | 2 | 32 |
 | scaleway | live | 16 | 3 | 2 | 37 |
 | kubernetes | live | 4 | 0 | 0 | 54 |

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -42,7 +42,7 @@ and the report says so on every scan, control by control, with the reason.
 
 | Family | Controls | exoscale | outscale | scaleway |
 |---|---:|---|---|---|
-| `chiffrement` | 7 | ✅ 1 · ◐ 0 · ∅ 3 · ✗ 3 | ✅ 2 · ◐ 0 · ∅ 3 · ✗ 2 | ✅ 2 · ◐ 0 · ∅ 1 · ✗ 4 |
+| `chiffrement` | 7 | ✅ 1 · ◐ 0 · ∅ 3 · ✗ 3 | ✅ 2 · ◐ 0 · ∅ 3 · ✗ 2 | ✅ 1 · ◐ 1 · ∅ 1 · ✗ 4 |
 | `compute` | 9 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 5 | ✅ 7 · ◐ 0 · ∅ 0 · ✗ 2 | ✅ 2 · ◐ 0 · ∅ 0 · ✗ 7 |
 | `gouvernance` | 3 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 |
 | `iam` | 15 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 | ✅ 11 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 3 · ◐ 1 · ∅ 0 · ✗ 11 |
@@ -61,9 +61,9 @@ and the report says so on every scan, control by control, with the reason.
 | `compute_instance_deletion_protection` | medium | CLD-CMP-10 | ✗ | ✗ | ◐ | ✅ | ✗ | ✗ |
 | `compute_instance_has_security_group` | critical | CLD-CMP-1 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `compute_instance_no_secrets_in_user_data` | high | CLD-CMP-9 | ✅ | ✅ | ✅ | ✅ | ✅ | ◐ |
-| `compute_instance_public_ip_with_open_securitygroup` | critical | CLD-NET-3 | ✅ | ✅ | ✅ | ✅ | ◐ | ✅ |
+| `compute_instance_public_ip_with_open_securitygroup` | critical | CLD-NET-3 | ✅ | ✅ | ◐ | ✅ | ◐ | ✅ |
 | `database_backup_enabled` | high | CLD-STO-3 | ✗ | ✗ | ✗ | ✗ | ✅ | ✗ |
-| `database_encryption_at_rest_enabled` | high | CLD-CHF-2 | ✗ | ✗ | ✗ | ✗ | ✅ | ✗ |
+| `database_encryption_at_rest_enabled` | high | CLD-CHF-2 | ✗ | ✗ | ✗ | ✗ | ◐ | ✗ |
 | `database_service_not_open_to_internet` | high | CLD-NET-1 | ✗ | ✗ | ✗ | ✗ | ✅ | ✗ |
 | `governance_provider_sovereignty` | high | CLD-GVN-4 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `governance_resource_region_in_eu` | high | CLD-GVN-3 | ✅ | ✅ | ◐ | ✅ | ✅ | ✅ |
@@ -87,7 +87,7 @@ and the report says so on every scan, control by control, with the reason.
 | `k8s_namespace_pod_security_enforced` | high | CLD-K8S-5 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | `k8s_rbac_no_cluster_admin_binding` | critical | CLD-K8S-4 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | `k8s_secrets_external_manager` | high | CLD-K8S-10 | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| `kubernetes_cluster_audit_logging_enabled` | medium | CLD-LOG-1 | ✅ | ✅ | ✗ | ✗ | ✗ | ✗ |
+| `kubernetes_cluster_audit_logging_enabled` | medium | CLD-LOG-1 | ◐ | ✅ | ✗ | ✗ | ✗ | ✗ |
 | `kubernetes_cluster_auto_upgrade_enabled` | medium | CLD-K8S-3 | ✅ | ✅ | ✗ | ✅ | ✗ | ✗ |
 | `kubernetes_cluster_control_plane_highly_available` | high | CLD-K8S-2 | ✅ | ✅ | ✗ | ✅ | ✗ | ✗ |
 | `kubernetes_cluster_deletion_protection` | medium | CLD-K8S-3 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
@@ -133,8 +133,10 @@ already shows them, and they add nothing.
 | `blockstorage_volume_snapshots_exist` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "blockstorage_volume" |
 | `compute_instance_deletion_protection` | outscale | terraform | ◐ `partial` | deciding attribute "deletion_protection" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `compute_instance_no_secrets_in_user_data` | scaleway | live | ◐ `partial` | deciding attribute "user_data" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| `compute_instance_public_ip_with_open_securitygroup` | outscale | terraform | ◐ `partial` | deciding attribute "nic_public_ips / public_ip" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns "not-evaluated" |
 | `compute_instance_public_ip_with_open_securitygroup` | scaleway | terraform | ◐ `partial` | deciding attribute "nic_public_ips / public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `database_backup_enabled` | scaleway | live | ✗ `unsupported` | this source produces no resource of type "managed_database" |
+| `database_encryption_at_rest_enabled` | scaleway | terraform | ◐ `partial` | deciding attribute "encryption_at_rest" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns "not-evaluated" |
 | `database_encryption_at_rest_enabled` | scaleway | live | ✗ `unsupported` | this source produces no resource of type "managed_database" |
 | `database_service_not_open_to_internet` | scaleway | live | ✗ `unsupported` | this source produces no resource of type "managed_database" |
 | `governance_resource_region_in_eu` | outscale | terraform | ◐ `partial` | deciding attribute "region" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
@@ -158,6 +160,7 @@ already shows them, and they add nothing.
 | `iam_user_mfa_enabled` | outscale | terraform | ∅ `not-applicable` | resource type "iam_user" absent from the outscale API |
 | `iam_user_mfa_enabled` | outscale | live | ∅ `not-applicable` | resource type "iam_user" absent from the outscale API |
 | `iam_user_mfa_enabled` | scaleway | terraform | ✗ `unsupported` | this source produces no resource of type "iam_user" |
+| `kubernetes_cluster_audit_logging_enabled` | exoscale | terraform | ◐ `partial` | deciding attribute "audit_enabled" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns "not-evaluated" |
 | `kubernetes_cluster_auto_upgrade_enabled` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "kubernetes_cluster" |
 | `kubernetes_cluster_control_plane_highly_available` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "kubernetes_cluster" |
 | `kubernetes_cluster_deletion_protection` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "kubernetes_cluster" |
@@ -208,10 +211,10 @@ the other's scope. One source only: live collection through a kubeconfig.
 
 | Provider | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---|---:|---:|---:|---:|
-| exoscale | terraform | 21 | 1 | 5 | 31 |
+| exoscale | terraform | 20 | 2 | 5 | 31 |
 | exoscale | live | 25 | 1 | 5 | 27 |
-| outscale | terraform | 17 | 4 | 4 | 33 |
+| outscale | terraform | 16 | 5 | 4 | 33 |
 | outscale | live | 40 | 1 | 4 | 13 |
-| scaleway | terraform | 18 | 6 | 2 | 32 |
+| scaleway | terraform | 17 | 7 | 2 | 32 |
 | scaleway | live | 16 | 3 | 2 | 37 |
 | kubernetes | live | 4 | 0 | 0 | 54 |

--- a/docs/detection-quality.fr.md
+++ b/docs/detection-quality.fr.md
@@ -16,7 +16,7 @@ pourcentage sans mesure derrière est un faux vert déplacé dans un tableau de
 bord, et il y est pire qu'ailleurs : personne ne relit un tableau de bord.
 
 Les chiffres sont donc laids, et c'est le point. « 58 contrôles » ne dit rien de
-la qualité d'une détection ; « 92 verdicts prouvés sur 461 » dit où en est le
+la qualité d'une détection ; « 90 verdicts prouvés sur 455 » dit où en est le
 produit, et rétrécit dans le bon sens à chaque scénario écrit.
 
 ## Les chiffres
@@ -25,9 +25,9 @@ produit, et rétrécit dans le bon sens à chaque scénario écrit.
 |---|---:|
 | Contrôles au référentiel | 58 |
 | Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 179 |
-| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 27 |
-| Verdicts à prouver au total | 461 |
-| Verdicts prouvés | 92 |
+| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 29 |
+| Verdicts à prouver au total | 455 |
+| Verdicts prouvés | 90 |
 
 ## Couverture de véracité, par verdict
 
@@ -37,11 +37,11 @@ demanderait d'inventer une non-applicabilité.
 
 | Verdict | Ce qu'il met en scène | À prouver | Prouvés | % |
 |---|---|---:|---:|---:|
-| `fail` | une configuration vulnérable est détectée | 141 | 24 | 17 |
-| `pass` | une configuration réellement correcte est confirmée | 141 | 37 | 26 |
+| `fail` | une configuration vulnérable est détectée | 138 | 23 | 16 |
+| `pass` | une configuration réellement correcte est confirmée | 138 | 36 | 26 |
 | `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 157 | 20 | 12 |
 | `not-applicable` | le contrat du fournisseur déclare le mécanisme inexistant | 22 | 11 | 50 |
-| **Total** | | **461** | **92** | **19** |
+| **Total** | | **455** | **90** | **19** |
 
 ## Validé en live
 

--- a/docs/detection-quality.md
+++ b/docs/detection-quality.md
@@ -16,7 +16,7 @@ with no measurement behind it is a false green moved into a dashboard, and it is
 worse there than anywhere else: nobody re-reads a dashboard.
 
 The figures are therefore ugly, and that is the point. "58 controls" says nothing
-about the quality of a detection; "92 verdicts proven out of 461" says where the
+about the quality of a detection; "90 verdicts proven out of 455" says where the
 product stands, and shrinks the right way with every scenario written.
 
 ## The figures
@@ -25,9 +25,9 @@ product stands, and shrinks the right way with every scenario written.
 |---|---:|
 | Controls in the reference | 58 |
 | Control x provider x source paths on which Pépin concludes | 179 |
-| Paths whose EVERY reachable verdict is proven end to end | 27 |
-| Verdicts to prove in total | 461 |
-| Verdicts proven | 92 |
+| Paths whose EVERY reachable verdict is proven end to end | 29 |
+| Verdicts to prove in total | 455 |
+| Verdicts proven | 90 |
 
 ## Veracity coverage, by verdict
 
@@ -37,11 +37,11 @@ inventing a non-applicability.
 
 | Verdict | What it stages | To prove | Proven | % |
 |---|---|---:|---:|---:|
-| `fail` | a vulnerable configuration is detected | 141 | 24 | 17 |
-| `pass` | a genuinely correct configuration is confirmed | 141 | 37 | 26 |
+| `fail` | a vulnerable configuration is detected | 138 | 23 | 16 |
+| `pass` | a genuinely correct configuration is confirmed | 138 | 36 | 26 |
 | `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 157 | 20 | 12 |
 | `not-applicable` | the provider's contract declares the mechanism non-existent | 22 | 11 | 50 |
-| **Total** | | **461** | **92** | **19** |
+| **Total** | | **455** | **90** | **19** |
 
 ## Validated live
 

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -62,6 +62,7 @@ aucune source** ne peut actuellement lever les quatre verrous du `pass`. Ils peu
 <!-- pepin:gen never-pass -->
 | Contrôle | Sévérité | Motif |
 |---|---|---|
+| `database_encryption_at_rest_enabled` | high | attribut décisif « encryption_at_rest » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated » |
 | `governance_resource_required_tags` | medium | aucun type de ressource visé et le contrôle ne lit pas le descripteur du fournisseur : le verrou du « pass » ne peut pas être levé, le scan rend « not-evaluated » tant qu'aucun écart n'est détecté |
 <!-- /pepin:gen never-pass -->
 
@@ -85,9 +86,9 @@ pas.
 | `blockstorage_volume_snapshots_exist` | outscale | live | cette source ne produit aucune ressource de type « blockstorage_volume » |
 | `compute_instance_deletion_protection` | outscale | live | attribut décisif « deletion_protection » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `compute_instance_no_secrets_in_user_data` | scaleway | terraform | attribut décisif « user_data » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| `compute_instance_public_ip_with_open_securitygroup` | outscale | live | attribut décisif « nic_public_ips / public_ip » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated » |
 | `compute_instance_public_ip_with_open_securitygroup` | scaleway | live | attribut décisif « nic_public_ips / public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `database_backup_enabled` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |
-| `database_encryption_at_rest_enabled` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `database_service_not_open_to_internet` | scaleway | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `governance_resource_region_in_eu` | outscale | live | attribut décisif « region » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_accesskey_expiration_set` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
@@ -100,6 +101,7 @@ pas.
 | `iam_policy_no_privilege_escalation` | scaleway | terraform | cette source ne produit aucune ressource de type « iam_policy » |
 | `iam_user_mfa_enabled` | exoscale | live | cette source ne produit aucune ressource de type « iam_user » |
 | `iam_user_mfa_enabled` | scaleway | live | cette source ne produit aucune ressource de type « iam_user » |
+| `kubernetes_cluster_audit_logging_enabled` | exoscale | live | attribut décisif « audit_enabled » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated » |
 | `kubernetes_cluster_auto_upgrade_enabled` | outscale | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
 | `kubernetes_cluster_control_plane_highly_available` | outscale | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
 | `kubernetes_cluster_deletion_protection` | outscale | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
@@ -146,11 +148,11 @@ Par fournisseur et par source, sur l'ensemble des contrôles du référentiel :
 <!-- pepin:gen coverage-totals -->
 | Fournisseur | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---|---:|---:|---:|---:|
-| exoscale | terraform | 21 | 1 | 5 | 31 |
+| exoscale | terraform | 20 | 2 | 5 | 31 |
 | exoscale | live | 25 | 1 | 5 | 27 |
-| outscale | terraform | 17 | 4 | 4 | 33 |
+| outscale | terraform | 16 | 5 | 4 | 33 |
 | outscale | live | 40 | 1 | 4 | 13 |
-| scaleway | terraform | 18 | 6 | 2 | 32 |
+| scaleway | terraform | 17 | 7 | 2 | 32 |
 | scaleway | live | 16 | 3 | 2 | 37 |
 | kubernetes | live | 4 | 0 | 0 | 54 |
 <!-- /pepin:gen coverage-totals -->
@@ -206,9 +208,9 @@ Ce qui n'est pas encore prouvé est **compté**, pas masqué :
 | Chiffre | Nombre |
 |---|---:|
 | Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 179 |
-| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 27 |
-| Verdicts à prouver au total | 461 |
-| Verdicts restant à prouver | 369 |
+| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 29 |
+| Verdicts à prouver au total | 455 |
+| Verdicts restant à prouver | 365 |
 <!-- /pepin:gen veracity-debt -->
 
 Le reste est listé chemin par chemin dans `internal/veracity/testdata/debt.txt`. Ce registre est

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -64,6 +64,7 @@ but they will never confirm compliance.
 <!-- pepin:gen never-pass -->
 | Control | Severity | Reason |
 |---|---|---|
+| `database_encryption_at_rest_enabled` | high | deciding attribute "encryption_at_rest" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns "not-evaluated" |
 | `governance_resource_required_tags` | medium | no targeted resource type, and the control does not read the provider descriptor: the "pass" lock cannot be lifted, so the scan returns "not-evaluated" as long as no deviation is detected |
 <!-- /pepin:gen never-pass -->
 
@@ -86,9 +87,9 @@ actually decide them. The reason given is the one that applies to the source tha
 | `blockstorage_volume_snapshots_exist` | outscale | live | this source produces no resource of type "blockstorage_volume" |
 | `compute_instance_deletion_protection` | outscale | live | deciding attribute "deletion_protection" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `compute_instance_no_secrets_in_user_data` | scaleway | terraform | deciding attribute "user_data" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| `compute_instance_public_ip_with_open_securitygroup` | outscale | live | deciding attribute "nic_public_ips / public_ip" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns "not-evaluated" |
 | `compute_instance_public_ip_with_open_securitygroup` | scaleway | live | deciding attribute "nic_public_ips / public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `database_backup_enabled` | scaleway | terraform | this source produces no resource of type "managed_database" |
-| `database_encryption_at_rest_enabled` | scaleway | terraform | this source produces no resource of type "managed_database" |
 | `database_service_not_open_to_internet` | scaleway | terraform | this source produces no resource of type "managed_database" |
 | `governance_resource_region_in_eu` | outscale | live | deciding attribute "region" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_accesskey_expiration_set` | outscale | live | this source produces no resource of type "access_key" |
@@ -101,6 +102,7 @@ actually decide them. The reason given is the one that applies to the source tha
 | `iam_policy_no_privilege_escalation` | scaleway | terraform | this source produces no resource of type "iam_policy" |
 | `iam_user_mfa_enabled` | exoscale | live | this source produces no resource of type "iam_user" |
 | `iam_user_mfa_enabled` | scaleway | live | this source produces no resource of type "iam_user" |
+| `kubernetes_cluster_audit_logging_enabled` | exoscale | live | deciding attribute "audit_enabled" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns "not-evaluated" |
 | `kubernetes_cluster_auto_upgrade_enabled` | outscale | live | this source produces no resource of type "kubernetes_cluster" |
 | `kubernetes_cluster_control_plane_highly_available` | outscale | live | this source produces no resource of type "kubernetes_cluster" |
 | `kubernetes_cluster_deletion_protection` | outscale | live | this source produces no resource of type "kubernetes_cluster" |
@@ -146,11 +148,11 @@ Per provider and per source, over all controls in the reference:
 <!-- pepin:gen coverage-totals -->
 | Provider | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---|---:|---:|---:|---:|
-| exoscale | terraform | 21 | 1 | 5 | 31 |
+| exoscale | terraform | 20 | 2 | 5 | 31 |
 | exoscale | live | 25 | 1 | 5 | 27 |
-| outscale | terraform | 17 | 4 | 4 | 33 |
+| outscale | terraform | 16 | 5 | 4 | 33 |
 | outscale | live | 40 | 1 | 4 | 13 |
-| scaleway | terraform | 18 | 6 | 2 | 32 |
+| scaleway | terraform | 17 | 7 | 2 | 32 |
 | scaleway | live | 16 | 3 | 2 | 37 |
 | kubernetes | live | 4 | 0 | 0 | 54 |
 <!-- /pepin:gen coverage-totals -->
@@ -206,9 +208,9 @@ What is not yet proven is **counted**, not hidden:
 | Figure | Count |
 |---|---:|
 | Control x provider x source paths on which Pépin concludes | 179 |
-| Paths whose every reachable verdict is proven end to end | 27 |
-| Verdicts to prove in total | 461 |
-| Verdicts left to prove | 369 |
+| Paths whose every reachable verdict is proven end to end | 29 |
+| Verdicts to prove in total | 455 |
+| Verdicts left to prove | 365 |
 <!-- /pepin:gen veracity-debt -->
 
 The remainder is listed path by path in `internal/veracity/testdata/debt.txt`. That ledger is a

--- a/docs/providers/exoscale.fr.md
+++ b/docs/providers/exoscale.fr.md
@@ -177,7 +177,7 @@ pepin scan exoscale --terraform plan.json
 <!-- pepin:gen provider-exoscale-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 21 | 1 | 5 | 31 |
+| terraform | 20 | 2 | 5 | 31 |
 | live | 25 | 1 | 5 | 27 |
 <!-- /pepin:gen provider-exoscale-coverage -->
 
@@ -202,6 +202,7 @@ source de vérité est la [matrice de couverture](../coverage.fr.md).
 | Contrôle | Observable uniquement via | Motif du côté aveugle |
 |---|---|---|
 | `iam_user_mfa_enabled` | live | cette source ne produit aucune ressource de type « iam_user » |
+| `kubernetes_cluster_audit_logging_enabled` | live | attribut décisif « audit_enabled » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated » |
 | `objectstorage_bucket_object_lock_enabled` | live | cette source ne produit aucune ressource de type « object_storage_bucket » |
 | `objectstorage_bucket_public_access` | live | cette source ne produit aucune ressource de type « object_storage_bucket » |
 | `objectstorage_bucket_versioning_enabled` | live | cette source ne produit aucune ressource de type « object_storage_bucket » |

--- a/docs/providers/exoscale.md
+++ b/docs/providers/exoscale.md
@@ -174,7 +174,7 @@ pepin scan exoscale --terraform plan.json
 <!-- pepin:gen provider-exoscale-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 21 | 1 | 5 | 31 |
+| terraform | 20 | 2 | 5 | 31 |
 | live | 25 | 1 | 5 | 27 |
 <!-- /pepin:gen provider-exoscale-coverage -->
 
@@ -199,6 +199,7 @@ truth is the [coverage matrix](../coverage.md).
 | Control | Observable only through | Reason on the blind side |
 |---|---|---|
 | `iam_user_mfa_enabled` | live | this source produces no resource of type "iam_user" |
+| `kubernetes_cluster_audit_logging_enabled` | live | deciding attribute "audit_enabled" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns "not-evaluated" |
 | `objectstorage_bucket_object_lock_enabled` | live | this source produces no resource of type "object_storage_bucket" |
 | `objectstorage_bucket_public_access` | live | this source produces no resource of type "object_storage_bucket" |
 | `objectstorage_bucket_versioning_enabled` | live | this source produces no resource of type "object_storage_bucket" |

--- a/docs/providers/outscale.fr.md
+++ b/docs/providers/outscale.fr.md
@@ -228,7 +228,7 @@ rend un booléen. Les règles normalisent les deux
 <!-- pepin:gen provider-outscale-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 17 | 4 | 4 | 33 |
+| terraform | 16 | 5 | 4 | 33 |
 | live | 40 | 1 | 4 | 13 |
 <!-- /pepin:gen provider-outscale-coverage -->
 
@@ -254,6 +254,7 @@ source de vérité est la [matrice de couverture](../coverage.fr.md).
 | `blockstorage_snapshot_not_public` | live | cette source ne produit aucune ressource de type « blockstorage_snapshot » |
 | `blockstorage_volume_snapshots_exist` | live | cette source ne produit aucune ressource de type « blockstorage_volume » |
 | `compute_instance_deletion_protection` | live | attribut décisif « deletion_protection » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| `compute_instance_public_ip_with_open_securitygroup` | live | attribut décisif « nic_public_ips / public_ip » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated » |
 | `governance_resource_region_in_eu` | live | attribut décisif « region » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_accesskey_expiration_set` | live | cette source ne produit aucune ressource de type « access_key » |
 | `iam_accesskey_rotated` | live | cette source ne produit aucune ressource de type « access_key » |

--- a/docs/providers/outscale.md
+++ b/docs/providers/outscale.md
@@ -222,7 +222,7 @@ API returns a boolean. The rules normalize both
 <!-- pepin:gen provider-outscale-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 17 | 4 | 4 | 33 |
+| terraform | 16 | 5 | 4 | 33 |
 | live | 40 | 1 | 4 | 13 |
 <!-- /pepin:gen provider-outscale-coverage -->
 
@@ -248,6 +248,7 @@ truth is the [coverage matrix](../coverage.md).
 | `blockstorage_snapshot_not_public` | live | this source produces no resource of type "blockstorage_snapshot" |
 | `blockstorage_volume_snapshots_exist` | live | this source produces no resource of type "blockstorage_volume" |
 | `compute_instance_deletion_protection` | live | deciding attribute "deletion_protection" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| `compute_instance_public_ip_with_open_securitygroup` | live | deciding attribute "nic_public_ips / public_ip" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns "not-evaluated" |
 | `governance_resource_region_in_eu` | live | deciding attribute "region" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_accesskey_expiration_set` | live | this source produces no resource of type "access_key" |
 | `iam_accesskey_rotated` | live | this source produces no resource of type "access_key" |

--- a/docs/providers/scaleway.fr.md
+++ b/docs/providers/scaleway.fr.md
@@ -156,7 +156,7 @@ pepin scan scaleway --terraform plan.json
 <!-- pepin:gen provider-scaleway-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 18 | 6 | 2 | 32 |
+| terraform | 17 | 7 | 2 | 32 |
 | live | 16 | 3 | 2 | 37 |
 <!-- /pepin:gen provider-scaleway-coverage -->
 
@@ -184,7 +184,6 @@ fournisseur.
 | `compute_instance_no_secrets_in_user_data` | terraform | attribut décisif « user_data » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `compute_instance_public_ip_with_open_securitygroup` | live | attribut décisif « nic_public_ips / public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `database_backup_enabled` | terraform | cette source ne produit aucune ressource de type « managed_database » |
-| `database_encryption_at_rest_enabled` | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `database_service_not_open_to_internet` | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `iam_policy_no_privilege_escalation` | terraform | cette source ne produit aucune ressource de type « iam_policy » |
 | `iam_user_mfa_enabled` | live | cette source ne produit aucune ressource de type « iam_user » |

--- a/docs/providers/scaleway.md
+++ b/docs/providers/scaleway.md
@@ -153,7 +153,7 @@ pepin scan scaleway --terraform plan.json
 <!-- pepin:gen provider-scaleway-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 18 | 6 | 2 | 32 |
+| terraform | 17 | 7 | 2 | 32 |
 | live | 16 | 3 | 2 | 37 |
 <!-- /pepin:gen provider-scaleway-coverage -->
 
@@ -180,7 +180,6 @@ A `not-applicable` is a claim, so it carries its justification, taken from the p
 | `compute_instance_no_secrets_in_user_data` | terraform | deciding attribute "user_data" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `compute_instance_public_ip_with_open_securitygroup` | live | deciding attribute "nic_public_ips / public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `database_backup_enabled` | terraform | this source produces no resource of type "managed_database" |
-| `database_encryption_at_rest_enabled` | terraform | this source produces no resource of type "managed_database" |
 | `database_service_not_open_to_internet` | terraform | this source produces no resource of type "managed_database" |
 | `iam_policy_no_privilege_escalation` | terraform | this source produces no resource of type "iam_policy" |
 | `iam_user_mfa_enabled` | live | this source produces no resource of type "iam_user" |

--- a/internal/docgen/coverage.go
+++ b/internal/docgen/coverage.go
@@ -10,12 +10,16 @@
 package docgen
 
 import (
+	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/stephrobert/pepin/internal/assess"
 	"github.com/stephrobert/pepin/internal/genprovider"
 	"github.com/stephrobert/pepin/internal/i18n"
+	"github.com/stephrobert/pepin/internal/tenants"
+	"github.com/stephrobert/pepin/internal/tfmap"
+	"github.com/stephrobert/pepin/internal/tfparse"
 	"github.com/stephrobert/pepin/internal/veracity"
 	"github.com/stephrobert/pepin/referentiel"
 )
@@ -101,10 +105,33 @@ type Matrix struct {
 type projection struct {
 	types map[string]bool
 	attrs map[string]map[string]bool
+	// declared : ce que le mapping NOMME, avant toute correction par la mesure.
+	//
+	// Gardé parce que les deux motifs de `partial` ne se corrigent pas au même
+	// endroit : « le mapping ne le nomme pas » s'écrit dans la spec, « le mapping le
+	// nomme mais aucun plan ne le porte » ne s'écrit nulle part — la valeur n'existe
+	// qu'après `apply`. Donner le premier motif pour le second, ou l'inverse, envoie
+	// corriger dans le vide.
+	declared map[string]map[string]bool
+	// measured : les types pour lesquels un PLAN RÉEL a servi de témoin.
+	//
+	// La distinction est celle que l'issue #175 nomme. Ce qu'un mapping DÉCLARE
+	// projeter et ce qu'un plan PORTE ne coïncident pas : un identifiant que le plan
+	// va créer n'est pas résolu, il est absent, et la cellule affichait pourtant ✅
+	// parce que le mapping le nomme. Là où un tenant de référence exerce le type, la
+	// mesure fait foi ; là où aucun ne l'exerce, on n'a pas de témoin, et une absence
+	// de témoin n'est pas une preuve — la déclaration reste alors la meilleure
+	// réponse disponible.
+	measured map[string]bool
 }
 
 func newProjection() projection {
-	return projection{types: map[string]bool{}, attrs: map[string]map[string]bool{}}
+	return projection{
+		types:    map[string]bool{},
+		attrs:    map[string]map[string]bool{},
+		declared: map[string]map[string]bool{},
+		measured: map[string]bool{},
+	}
 }
 
 func (p projection) add(typ string, keys ...map[string]bool) {
@@ -153,7 +180,7 @@ func BuildMatrix(root, lang string) (Matrix, error) {
 	for name, desc := range descs {
 		projections[name] = map[Source]projection{
 			SourceLive:      liveProjection(desc, goAttrs),
-			SourceTerraform: terraformProjection(desc),
+			SourceTerraform: terraformProjection(desc, observedOnReferencePlans(root, name, desc.MappingTerraform)),
 		}
 	}
 
@@ -223,6 +250,15 @@ func cellStatus(l i18n.Lang, provider string, ctl referentiel.Control, src Sourc
 			"provider contract: type \""+typ+"\" is not declared `verifie` ("+etatLabel(l, provider, typ)+")")}
 	}
 	if len(required) > 0 && !anyProjected(proj.attrs[typ], required) {
+		// Deux motifs distincts, et la nuance vaut la peine : « le mapping ne le
+		// nomme pas » se corrige en écrivant le mapping ; « le mapping le nomme mais
+		// aucun plan ne le porte » ne se corrige pas ainsi, parce que la valeur
+		// n'existe qu'après `apply`. Confondre les deux envoie corriger dans le vide.
+		if proj.measured[typ] && anyProjected(proj.declared[typ], required) {
+			return Cell{Status: Partial, Reason: i18n.TIn(l,
+				"attribut décisif « "+strings.Join(required, " / ")+" » déclaré par le mapping mais ABSENT des plans de référence (valeur connue seulement après `apply`) : garde de capacité, le scan rend « not-evaluated »",
+				"deciding attribute \""+strings.Join(required, " / ")+"\" declared by the mapping but ABSENT from the reference plans (value known only after `apply`): a capability guard, so the scan returns \"not-evaluated\"")}
+		}
 		return Cell{Status: Partial, Reason: i18n.TIn(l,
 			"attribut décisif « "+strings.Join(required, " / ")+" » non projeté par cette source : garde de capacité, le scan rend « not-evaluated »",
 			"deciding attribute \""+strings.Join(required, " / ")+"\" not projected by this source: a capability guard, so the scan returns \"not-evaluated\"")}
@@ -281,7 +317,7 @@ func liveProjection(desc genprovider.Descriptor, goAttrs map[string]map[string]b
 // terraformProjection décrit ce que le mapping Terraform du descripteur sait produire. La
 // région n'y est observable que si une spec nomme son champ (`region:`) — sur un plan, rien
 // ne la pose implicitement.
-func terraformProjection(desc genprovider.Descriptor) projection {
+func terraformProjection(desc genprovider.Descriptor, observe map[string]map[string]bool) projection {
 	p := newProjection()
 	for _, r := range desc.MappingTerraform.Resources {
 		p.add(r.Type, keysOfString(r.Map), keysOfAny(r.Const))
@@ -289,7 +325,56 @@ func terraformProjection(desc genprovider.Descriptor) projection {
 			p.add("", map[string]bool{"region": true})
 		}
 	}
+	// Là où un plan RÉEL a exercé le type, il fait foi : un attribut que le mapping
+	// déclare mais qu'aucun plan ne porte n'est pas projeté, quoi qu'en dise la spec.
+	for typ, vus := range observe {
+		if p.attrs[typ] == nil {
+			continue
+		}
+		p.measured[typ] = true
+		p.declared[typ] = map[string]bool{}
+		for attr := range p.attrs[typ] {
+			p.declared[typ][attr] = true
+		}
+		for attr := range p.attrs[typ] {
+			if !vus[attr] {
+				delete(p.attrs[typ], attr)
+			}
+		}
+	}
 	return p
+}
+
+// observedOnReferencePlans rend, par type normalisé, les attributs que les plans des
+// tenants de référence de ce fournisseur portent RÉELLEMENT.
+//
+// Les tenants sont générés depuis du HCL tiers, pas écrit pour Pépin : c'est
+// exactement le témoin qui manquait. Les plans écrits à la main pour les tests, eux,
+// portent des identifiants littéraux et confirmeraient n'importe quoi.
+//
+// Aucun plan lisible ⇒ carte vide ⇒ la matrice retombe sur la déclaration. Une
+// mesure absente ne doit pas dégrader ce qu'on ne peut pas contredire.
+func observedOnReferencePlans(root, provider string, spec tfmap.Spec) map[string]map[string]bool {
+	plans, err := filepath.Glob(filepath.Join(root, tenants.Dir, provider, "*", "plan.json"))
+	if err != nil || len(plans) == 0 {
+		return nil
+	}
+	out := map[string]map[string]bool{}
+	for _, plan := range plans {
+		resources, perr := tfparse.ParsePlan(plan)
+		if perr != nil {
+			continue
+		}
+		for _, r := range tfmap.Apply(spec, resources).Resources {
+			if out[r.Type] == nil {
+				out[r.Type] = map[string]bool{}
+			}
+			for attr := range r.Attributes {
+				out[r.Type][attr] = true
+			}
+		}
+	}
+	return out
 }
 
 func keysOfString(m map[string]string) map[string]bool {

--- a/internal/docgen/coverage_measured_test.go
+++ b/internal/docgen/coverage_measured_test.go
@@ -1,0 +1,68 @@
+package docgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// La matrice DÉCLARAIT ce que le mapping nomme, au lieu de MESURER ce qu'un plan
+// porte. Sur un plan Outscale réaliste, `public_ip` est calculé : Terraform ne le
+// connaît qu'après `apply`, donc il est absent — et la cellule affichait ✅ parce que
+// la spec le nomme. Les scénarios de véracité confirmaient la cellule sur un plan
+// écrit à la main où l'attribut est un littéral : une fixture qui se confirme
+// elle-même n'établit rien.
+//
+// Les tenants de référence sont générés depuis du HCL TIERS, pas écrit pour Pépin :
+// c'est le témoin qui manquait.
+
+// TestTheTerraformCoverageIsMeasuredNotDeclared : là où un plan de référence exerce un
+// type, un attribut que le mapping déclare mais qu'aucun plan ne porte ne compte pas
+// comme projeté.
+func TestTheTerraformCoverageIsMeasuredNotDeclared(t *testing.T) {
+	m, err := BuildMatrix(repoRoot, "fr")
+	if err != nil {
+		t.Fatalf("construction de la matrice : %v", err)
+	}
+	var vue bool
+	for _, row := range m.Rows {
+		if row.Code != "compute_instance_public_ip_with_open_securitygroup" {
+			continue
+		}
+		vue = true
+		c := row.Cells["outscale"][SourceTerraform]
+		if c.Status != Partial {
+			t.Errorf("outscale/terraform = %q, attendu %q : `public_ip` est calculé, aucun plan ne le porte",
+				c.Status, Partial)
+		}
+		// Le MOTIF compte autant que le statut : « le mapping ne le nomme pas » se
+		// corrige dans la spec, « le mapping le nomme mais aucun plan ne le porte »
+		// ne se corrige pas ainsi. Donner l'un pour l'autre envoie corriger dans le vide.
+		if !strings.Contains(c.Reason, "après `apply`") {
+			t.Errorf("le motif ne dit pas que la valeur n'existe qu'après apply :\n  %s", c.Reason)
+		}
+	}
+	if !vue {
+		t.Fatal("contrôle absent de la matrice : la garde ne mesure rien")
+	}
+}
+
+// LE CONTRE-EXEMPLE : la mesure ne doit pas tout dégrader. Un attribut que les plans
+// de référence portent RÉELLEMENT laisse sa cellule intacte — sans quoi la matrice
+// aurait simplement échangé un excès de promesse contre un excès de prudence.
+func TestAnAttributeRealPlansDoCarryStaysSupported(t *testing.T) {
+	m, err := BuildMatrix(repoRoot, "fr")
+	if err != nil {
+		t.Fatalf("construction de la matrice : %v", err)
+	}
+	var supportees int
+	for _, row := range m.Rows {
+		for _, prov := range m.CloudProviders {
+			if row.Cells[prov][SourceTerraform].Status == Supported {
+				supportees++
+			}
+		}
+	}
+	if supportees == 0 {
+		t.Fatal("plus aucune cellule terraform `supported` : la mesure a tout dégradé, ce qui n'est pas une correction")
+	}
+}

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -1,13 +1,13 @@
 {
   "controls": 58,
   "paths": 179,
-  "paths_proven": 27,
-  "obligations": 461,
-  "proven": 92,
+  "paths_proven": 29,
+  "obligations": 455,
+  "proven": 90,
   "verdicts": {
     "fail": {
-      "required": 141,
-      "proven": 24
+      "required": 138,
+      "proven": 23
     },
     "not-applicable": {
       "required": 22,
@@ -18,8 +18,8 @@
       "proven": 20
     },
     "pass": {
-      "required": 141,
-      "proven": 37
+      "required": 138,
+      "proven": 36
     }
   },
   "live_paths": 101,
@@ -486,15 +486,11 @@
         {
           "provider": "outscale",
           "source": "terraform",
-          "status": "supported",
+          "status": "partial",
           "required": [
-            "fail",
-            "pass",
             "not-evaluated"
           ],
           "proven": [
-            "fail",
-            "pass",
             "not-evaluated"
           ]
         },
@@ -561,10 +557,8 @@
         {
           "provider": "scaleway",
           "source": "terraform",
-          "status": "supported",
+          "status": "partial",
           "required": [
-            "fail",
-            "pass",
             "not-evaluated"
           ],
           "proven": [
@@ -1371,10 +1365,8 @@
         {
           "provider": "exoscale",
           "source": "terraform",
-          "status": "supported",
+          "status": "partial",
           "required": [
-            "fail",
-            "pass",
             "not-evaluated"
           ],
           "proven": [

--- a/internal/veracity/testdata/debt.txt
+++ b/internal/veracity/testdata/debt.txt
@@ -8,7 +8,7 @@
 # Une ligne qui disparaît est une dette payée. Une ligne qui apparaît sans
 # scénario est un contrôle ajouté sans sa preuve, et la CI la refuse.
 #
-# chemins : 179 · entierement prouves : 27 · obligations : 461 · restantes : 369
+# chemins : 179 · entierement prouves : 29 · obligations : 455 · restantes : 365
 
 blockstorage_snapshot_not_public exoscale live not-applicable
 blockstorage_snapshot_not_public outscale live fail,pass,not-evaluated
@@ -40,7 +40,6 @@ compute_instance_public_ip_with_open_securitygroup exoscale terraform fail,pass,
 compute_instance_public_ip_with_open_securitygroup scaleway live fail,pass,not-evaluated
 compute_instance_public_ip_with_open_securitygroup scaleway terraform not-evaluated
 database_backup_enabled scaleway terraform not-evaluated
-database_encryption_at_rest_enabled scaleway terraform fail,pass
 database_service_not_open_to_internet scaleway terraform not-evaluated
 governance_provider_sovereignty exoscale live fail,pass,not-evaluated
 governance_provider_sovereignty exoscale terraform pass,not-evaluated
@@ -88,7 +87,6 @@ k8s_namespace_pod_security_enforced kubernetes live fail,pass,not-evaluated
 k8s_rbac_no_cluster_admin_binding kubernetes live fail,pass,not-evaluated
 k8s_secrets_external_manager kubernetes live fail,pass,not-evaluated
 kubernetes_cluster_audit_logging_enabled exoscale live fail,pass,not-evaluated
-kubernetes_cluster_audit_logging_enabled exoscale terraform fail,pass
 kubernetes_cluster_auto_upgrade_enabled exoscale live fail,pass,not-evaluated
 kubernetes_cluster_auto_upgrade_enabled exoscale terraform fail,not-evaluated
 kubernetes_cluster_auto_upgrade_enabled outscale live fail,pass,not-evaluated

--- a/internal/veracity/testdata/scenarios/public-vm-open-sg-outscale-terraform.yaml
+++ b/internal/veracity/testdata/scenarios/public-vm-open-sg-outscale-terraform.yaml
@@ -1,21 +1,31 @@
-# VM exposée : IP publique ET groupe de sécurité ouvert sur Internet, chez Outscale.
+# VM exposée, sur un PLAN Terraform Outscale : ce que ce chemin peut réellement conclure.
 #
-# C'est le premier couple de la table de l'issue #115, et il éprouve la frontière
-# que ce contrôle trace : ce n'est pas l'IP publique qui fait l'écart, ni le port
-# ouvert seul, c'est leur CONJONCTION. Un serveur web public est légitime ; le même
-# serveur avec SSH ouvert à tout Internet ne l'est pas.
+# # Pourquoi ce fichier ne prouve plus ni `fail` ni `pass`
 #
-# Le cas `pass` est délibérément PROCHE du cas `fail` : même VM, même IP publique,
-# même groupe de sécurité ouvert à 0.0.0.0/0 — seul le port change. Un contre-exemple
-# qui retirerait l'IP publique ne prouverait rien de la règle, seulement que le
-# contrôle a besoin d'une VM exposée pour parler.
+# Il les prouvait, sur un plan écrit à la main où `public_ip` était un littéral. Or
+# `outscale_vm.public_ip` est calculé : Terraform ne le connaît qu'après `apply`, et un
+# plan réel ne le porte donc JAMAIS. Le scénario éprouvait un document que l'outil
+# n'a aucune chance de rencontrer — une fixture qui se confirme elle-même, et c'est le
+# constat de l'issue #175.
+#
+# Depuis que la matrice de couverture MESURE ce que les plans des tenants de référence
+# portent, au lieu de déclarer ce que le mapping nomme, cette cellule est ◐ : le seul
+# verdict atteignable est `not-evaluated`. Le scénario dit désormais cela, et rien de
+# plus. C'est une perte de couverture APPARENTE, et un gain de vérité : la logique de
+# la règle reste tenue par ses tests Rego, et la chaîne live la prouve de bout en bout
+# (nic-exposure-outscale-live.yaml).
+#
+# Ce qui rouvrirait `fail` ici : mapper la ressource de LIEN
+# (`outscale_public_ip_link`), qui est la façon dont un exploitant attache réellement
+# une IP publique. C'est une jointure INVERSE, elle demande un autre mécanisme, et elle
+# reste ouverte.
 control: compute_instance_public_ip_with_open_securitygroup
 provider: outscale
 source: terraform
 
 scenarios:
-  - expect: fail
-    why: "VM a IP publique dont le groupe de securite ouvre SSH a 0.0.0.0/0 : la conjonction expose l'administration"
+  - expect: not-evaluated
+    why: "plan realiste : public_ip est calcule, donc absent, et le scan refuse de conclure plutot que de rendre un pass"
     plan:
       format_version: "1.2"
       planned_values:
@@ -25,11 +35,7 @@ scenarios:
               type: outscale_vm
               name: web
               values:
-                vm_id: i-expose
-                public_ip: 203.0.113.10
                 state: running
-                security_group_ids:
-                  - sg-web
             - address: outscale_security_group_rule.ssh
               type: outscale_security_group_rule
               name: ssh
@@ -39,31 +45,4 @@ scenarios:
                 ip_protocol: tcp
                 from_port_range: 22
                 to_port_range: 22
-                ip_range: 0.0.0.0/0
-
-  - expect: pass
-    why: "MEME VM publique, MEME groupe ouvert a 0.0.0.0/0, mais sur 443 : un serveur web public est sa raison d'etre"
-    plan:
-      format_version: "1.2"
-      planned_values:
-        root_module:
-          resources:
-            - address: outscale_vm.web
-              type: outscale_vm
-              name: web
-              values:
-                vm_id: i-expose
-                public_ip: 203.0.113.10
-                state: running
-                security_group_ids:
-                  - sg-web
-            - address: outscale_security_group_rule.https
-              type: outscale_security_group_rule
-              name: https
-              values:
-                security_group_id: sg-web
-                flow: Inbound
-                ip_protocol: tcp
-                from_port_range: 443
-                to_port_range: 443
                 ip_range: 0.0.0.0/0


### PR DESCRIPTION
Two issues, one theme: **the tool must not claim to have read what it did not read.**

## #171 — a plan handed over as an inventory

Any JSON object was accepted as an inventory. A `terraform show -json` passed without
`--terraform`, or an empty object, was evaluated as an **empty** inventory:

```
./pepin scan outscale examples/outscale/terraform/plan.json   → exit 3, "INDÉTERMINÉ"
echo '{}' > e.json ; ./pepin scan outscale e.json              → exit 3, "INDÉTERMINÉ"
```

Honest about what was measured, **wrong about the cause**: the caller does not have an
empty scope, they gave the wrong file — a technical error, which already has a code.

```
erreur : ce fichier est un plan Terraform, pas un inventaire Pépin : le scanner avec --terraform
erreur : ce n'est pas un inventaire Pépin : aucun tableau « resources » à la racine
```

Both exit 2. The opposite swap was refused already (`--terraform` on an inventory), so
the two directions now move in step, and a table-driven test over the three shapes in
both positions keeps them there — including the counterexample that a real inventory
still scans.

**The repository's own tests were leaning on the defect.** Two of them passed a plan in
the inventory position and asserted on the assessment of an empty inventory. They now
pass the plan as a plan, which is what they always meant.

## #175 — the matrix declared instead of measuring

`public_ip` on an Outscale VM is **computed**: Terraform knows it only after `apply`, so
no real plan carries it. The cell read ✅ because the *spec names the field*, and the
veracity scenarios confirmed it on a hand-written plan where the attribute is a literal
— a fixture confirming itself rather than evidence.

Coverage is now corrected by what the **reference tenant plans** actually yield. Those
are generated from third-party HCL, not written for Pépin, which is exactly the witness
that was missing.

**Where no reference plan exercises a type, the declaration stands.** An absent
measurement is not a proof, and degrading on it would trade one overstatement for
another. A counterexample test holds that: if every terraform cell went ◐, the "fix"
would be a different kind of lie.

### The reason matters as much as the status

| motive | how it is fixed |
|---|---|
| the mapping does not name it | write the mapping |
| the mapping names it, no plan carries it | **not fixable there at all** — the value does not exist before `apply` |

Giving one reason for the other sends someone to correct nothing, so the two are
distinguished. My first attempt got this wrong and rewrote `security_group_name`'s
motive as "declared but absent" when it is simply not in the mapping; the fix keeps the
declared set before pruning.

### What moved

**Three** cells drop from ✅ to ◐ — not the one the issue named. The same defect was
hiding on scaleway (`database_encryption_at_rest_enabled`) and exoscale
(`kubernetes_cluster_audit_logging_enabled`).

And **six obligations that could never be met leave the veracity ledger**: they were
debt no scenario could ever pay. Fully-proven paths 27 → 29, obligations 461 → 455.

### The scenario that proved an impossible plan

`public-vm-open-sg-outscale-terraform.yaml` proved `fail` on a plan hand-written with
`public_ip: 203.0.113.10` in `planned_values` — a document Terraform cannot produce. It
is replaced by the honest proof of what that path reaches: `not-evaluated`.

That is a loss of *apparent* coverage and a gain in truth. The rule's logic is still
held by its Rego tests, and the live chain proves it end to end
(`nic-exposure-outscale-live.yaml`). What would reopen `fail` there — mapping the public
IP **link** resource, an inverse join needing a different mechanism — is written down in
the scenario rather than left as a silent gap.

## Impact ADR

- **ADR-0005** (exit codes) — respected: this moves a case from `3` to `2`, which is the
  code the ADR already reserves for a technical error; no new code, no changed meaning.
- **ADR-0014** (an absent datum is not fabricated) — the reason the declaration stands
  where no plan exercises a type.
- **ADR-0006** (never an unproven `pass`) — untouched: the cells that dropped were
  already returning `not-evaluated` at runtime. **No verdict moves**; only what the
  documentation claims about them.

None reopened, none needed.

## Gates

`mise run prepush` green.

Closes #171
Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
