### PR TITLE
chore(deps): scankit 0.3.5 — one subject with several causes is one deviation

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -63,6 +63,16 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Un sujet fautif par plusieurs voies ne se lit plus comme plusieurs écarts.** Trois
+  blocs `deny` d'`objectstorage_bucket_public_access` — ACL prédéfinie, grant, politique
+  de bucket — concluent sur le même bucket, et chaque cause est réelle. Mais un bucket
+  public est UN problème, et l'imprimer trois fois faisait paraître le rapport plus gros
+  que ce qu'il mesure. Pire, cela occupait les trois places du panneau « action
+  immédiate », qui annonce les trois écarts les **plus graves** et en livrait trois fois
+  le même. Corrigé en amont dans scankit 0.3.5 : une ligne par sujet avec ses causes en
+  dessous, et le panneau déduplique par (code, sujet) avant de classer. L'agrégation ne
+  porte que sur l'**affichage** — le décompte du bloc, les formats analysables et le
+  tableau de sévérité continuent de porter chaque cause séparément.
 - **Un document qui n'a pas la forme d'un inventaire est refusé au lieu d'être scanné
   comme un inventaire vide.** Une sortie `terraform show -json` passée sans
   `--terraform`, ou un objet vide, étaient acceptés et évalués comme un inventaire

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@ belongs in `git log`.
 
 ### Fixed
 
+- **A subject at fault by several routes no longer reads as several deviations.** Three
+  `deny` blocks of `objectstorage_bucket_public_access` — a canned ACL, a grant, a bucket
+  policy — conclude on the same bucket, and each cause is real. But a public bucket is
+  *one* problem, and printing it three times made the report look bigger than what it
+  measures. Worse, it took all three slots of the "immediate action" panel, which
+  announces the three **most severe** deviations and delivered the same one three times.
+  Fixed upstream in scankit 0.3.5: one line per subject with its causes beneath, and the
+  panel deduplicates by (code, subject) before ranking. The aggregation is of the
+  **display only** — the block's count, the parsable formats and the severity tally still
+  carry every cause separately.
 - **A document without an inventory's shape is refused instead of being scanned as an
   empty one.** A `terraform show -json` output handed over without `--terraform`, or an
   empty object, was accepted and evaluated as an empty inventory: exit 3, "nothing

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/sirupsen/logrus v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10
-	github.com/stephrobert/scankit v0.3.4
+	github.com/stephrobert/scankit v0.3.5
 	github.com/tchap/go-patricia/v2 v2.3.3 // indirect
 	github.com/valyala/fastjson v1.6.10 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.36 // indirect

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stephrobert/scankit v0.3.4 h1:KELImeVtDn+28YWeFWZRlJzBFJdZ41SrCL+qlZ1p6o4=
-github.com/stephrobert/scankit v0.3.4/go.mod h1:ujhvahsG9HgtJC75QBgVsKRhepGvdo9Ey6RtJ6va6lM=
+github.com/stephrobert/scankit v0.3.5 h1:cJSHbAf7MbaHp9aNurNMjyTTVIxXHE+etXQbNs6eTCY=
+github.com/stephrobert/scankit v0.3.5/go.mod h1:ujhvahsG9HgtJC75QBgVsKRhepGvdo9Ey6RtJ6va6lM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=

--- a/references/qualification/scaleway/compute.tf
+++ b/references/qualification/scaleway/compute.tf
@@ -1,0 +1,126 @@
+# Calcul — cinq serveurs DEV1-S (0,009 €/h chacun) et deux IP flexibles.
+#
+# Chaque serveur ne porte qu'UNE faute, ou aucune :
+#   exposed   IP publique + SG SSH ouvert      → compute_instance_public_ip_with_open_securitygroup
+#   private   pas d'IP   + SG SSH ouvert      → silencieux (contre-exemple : pas d'exposition)
+#   hardened  IP publique + SG restrictif      → silencieux (contre-exemple : SG discriminant)
+#   untagged  pas d'IP   + SG restrictif, sans étiquettes → governance_resource_required_tags
+#   secrets   pas d'IP   + SG restrictif, cloud-init avec mot de passe → compute_instance_no_secrets_in_user_data
+#
+# TOUS portent un cloud-init : l'attribut `user_data` doit être présent sur chaque
+# serveur pour que le verrou de capacité (ADR-0006, intersection par type) laisse
+# le contrôle des secrets conclure « pass » sur ceux qui n'en ont pas. Seul
+# `secrets` porte un secret ; les autres portent un cloud-config anodin, qui est le
+# contre-exemple du détecteur.
+#
+# Volume racine : stockage LOCAL de la gamme (l_ssd), détruit avec le serveur
+# (`delete_on_termination = true`, écrit plutôt que présumé). Pas de volume Block
+# additionnel : l'API Instance ne crée plus de b_ssd, et un volume Block orphelin
+# est exactement le reste qu'on ne retrouve pas (issue #2853, corrigée en 2.48).
+#
+# Volontairement ABSENT : toute interface privée (`scaleway_instance_private_nic`),
+# dont la destruction est cassée depuis le provider 2.81.0 (#4338). Le cas d'une
+# machine à deux cartes (audit #E) ne peut donc pas être exercé sur Scaleway
+# aujourd'hui, et le README le consigne.
+
+locals {
+  cloud_init_plain = <<-EOT
+    #cloud-config
+    package_update: false
+    timezone: Europe/Paris
+  EOT
+
+  # Un mot de passe en clair dans le cloud-init : détecté par le motif
+  # « mot de passe en clair » (confiance heuristique) de la règle commune. La
+  # valeur est évidemment factice — elle n'ouvre rien, nulle part.
+  cloud_init_with_secret = <<-EOT
+    #cloud-config
+    users:
+      - name: pepin
+        plain_text_passwd: pepin-qualification-fake-password
+        lock_passwd: false
+  EOT
+}
+
+resource "scaleway_instance_ip" "exposed" {
+  tags = local.untagged
+}
+
+resource "scaleway_instance_ip" "hardened" {
+  tags = local.untagged
+}
+
+# ÉCART compute_instance_public_ip_with_open_securitygroup (CLD-NET-3) : IP publique
+# ET SG qui ouvre SSH à Internet → sévérité high (port sensible), sujet = id serveur.
+resource "scaleway_instance_server" "exposed" {
+  name              = "pepin-qual-vm-exposed"
+  type              = var.instance_type
+  image             = "ubuntu_jammy"
+  ip_id             = scaleway_instance_ip.exposed.id
+  security_group_id = scaleway_instance_security_group.ssh_open.id
+  tags              = local.tagged
+  user_data         = { cloud-init = local.cloud_init_plain }
+
+  root_volume {
+    delete_on_termination = true
+  }
+}
+
+# CONTRE-EXEMPLE : même SG ouvert, mais AUCUNE IP publique → pas d'exposition.
+resource "scaleway_instance_server" "private" {
+  name              = "pepin-qual-vm-private"
+  type              = var.instance_type
+  image             = "ubuntu_jammy"
+  security_group_id = scaleway_instance_security_group.ssh_open.id
+  tags              = local.tagged
+  user_data         = { cloud-init = local.cloud_init_plain }
+
+  root_volume {
+    delete_on_termination = true
+  }
+}
+
+# CONTRE-EXEMPLE : IP publique, mais SG restrictif → pas d'exposition.
+resource "scaleway_instance_server" "hardened" {
+  name              = "pepin-qual-vm-hardened"
+  type              = var.instance_type
+  image             = "ubuntu_jammy"
+  ip_id             = scaleway_instance_ip.hardened.id
+  security_group_id = scaleway_instance_security_group.hardened.id
+  tags              = local.tagged
+  user_data         = { cloud-init = local.cloud_init_plain }
+
+  root_volume {
+    delete_on_termination = true
+  }
+}
+
+# ÉCART governance_resource_required_tags (CLD-GVN-1) : aucune étiquette de
+# gouvernance (seul le tag du tenant, qui sert à la preuve de destruction).
+resource "scaleway_instance_server" "untagged" {
+  name              = "pepin-qual-vm-untagged"
+  type              = var.instance_type
+  image             = "ubuntu_jammy"
+  security_group_id = scaleway_instance_security_group.hardened.id
+  tags              = local.untagged
+  user_data         = { cloud-init = local.cloud_init_plain }
+
+  root_volume {
+    delete_on_termination = true
+  }
+}
+
+# ÉCART compute_instance_no_secrets_in_user_data (CLD-CMP-9) : observable sur le
+# PLAN (la collecte live ne lit pas GetServerUserData, contrat `a_verifier`).
+resource "scaleway_instance_server" "secrets" {
+  name              = "pepin-qual-vm-secrets"
+  type              = var.instance_type
+  image             = "ubuntu_jammy"
+  security_group_id = scaleway_instance_security_group.hardened.id
+  tags              = local.tagged
+  user_data         = { cloud-init = local.cloud_init_with_secret }
+
+  root_volume {
+    delete_on_termination = true
+  }
+}

--- a/references/qualification/scaleway/database.tf
+++ b/references/qualification/scaleway/database.tf
@@ -1,0 +1,61 @@
+# Bases managées — deux instances db-dev-s (la plus petite gamme disponible).
+#
+# Les trois contrôles de base de données ne sont observables que sur le PLAN
+# (`scaleway_rdb_instance`, `scaleway_rdb_acl` ; la collecte live RDB est à
+# câbler). Les instances sont tout de même APPLIQUÉES : le plan scanné doit être
+# celui qui a été appliqué, sans quoi la qualification comparerait deux tenants.
+#
+# `exposed` porte les trois écarts sur une seule instance — c'est l'exception
+# assumée à « une faute par ressource » : trois bases coûteraient trois fois le
+# temps de création/destruction (2 à 5 minutes chacune) pour trois sujets
+# distincts d'un même type. `hardened` est le contre-exemple des trois.
+#
+# Le mot de passe vient du runner (variable sensible, engendrée à chaque run).
+
+# ÉCARTS database_service_not_open_to_internet (ACL 0.0.0.0/0),
+# database_encryption_at_rest_enabled (chiffrement absent),
+# database_backup_enabled (sauvegardes désactivées).
+resource "scaleway_rdb_instance" "exposed" {
+  name               = "pepin-qual-rdb-exposed"
+  node_type          = var.rdb_node_type
+  engine             = "PostgreSQL-16"
+  is_ha_cluster      = false
+  disable_backup     = true
+  encryption_at_rest = false
+  user_name          = "pepin"
+  password           = var.rdb_password
+  tags               = local.tagged
+}
+
+resource "scaleway_rdb_acl" "exposed" {
+  instance_id = scaleway_rdb_instance.exposed.id
+
+  acl_rules {
+    ip          = "0.0.0.0/0"
+    description = "ouvert a Internet"
+  }
+}
+
+# CONTRE-EXEMPLE : chiffrée au repos, sauvegardée, ACL restreinte à un /8 privé.
+resource "scaleway_rdb_instance" "hardened" {
+  name                      = "pepin-qual-rdb-hardened"
+  node_type                 = var.rdb_node_type
+  engine                    = "PostgreSQL-16"
+  is_ha_cluster             = false
+  disable_backup            = false
+  backup_schedule_frequency = 24
+  backup_schedule_retention = 7
+  encryption_at_rest        = true
+  user_name                 = "pepin"
+  password                  = var.rdb_password
+  tags                      = local.tagged
+}
+
+resource "scaleway_rdb_acl" "hardened" {
+  instance_id = scaleway_rdb_instance.hardened.id
+
+  acl_rules {
+    ip          = "10.0.0.0/8"
+    description = "reseau applicatif prive"
+  }
+}

--- a/references/qualification/scaleway/iam.tf
+++ b/references/qualification/scaleway/iam.tf
@@ -1,0 +1,66 @@
+# IAM — clés d'API et politiques (portée : ORGANISATION, ressources gratuites).
+#
+# Deux applications, et la séparation est délibérée : l'application qui PORTE
+# les clés n'a aucune politique (des clés sans droit), et l'application qui porte
+# la politique fautive n'a aucune clé. Le tenant reproduit ainsi l'écart CLD-IAM-12
+# sans jamais mettre en circulation, même trente minutes, un secret capable de
+# gérer l'IAM de l'organisation.
+#
+# Les utilisateurs IAM ne sont PAS créés : `scaleway_iam_user` invite une personne
+# réelle dans l'organisation, ce qui sort du périmètre d'un tenant jetable. Le
+# contrôle CLD-IAM-3 (MFA) s'observe donc sur les utilisateurs existants de
+# l'organisation, et expected.yaml le dit (statut « evaluated », hors périmètre).
+
+resource "scaleway_iam_application" "keys" {
+  name        = "pepin-qual-app-keys"
+  description = "Tenant de qualification Pépin : porte les clés d'API, aucune politique"
+  tags        = local.untagged
+}
+
+resource "scaleway_iam_application" "admin" {
+  name        = "pepin-qual-app-admin"
+  description = "Tenant de qualification Pépin : porte les politiques, aucune clé"
+  tags        = local.untagged
+}
+
+# ÉCART iam_accesskey_expiration_set (CLD-IAM-2, critical) : clé sans échéance.
+# Sujet du finding = l'access key, connu seulement après apply → output.
+resource "scaleway_iam_api_key" "no_expiry" {
+  application_id = scaleway_iam_application.keys.id
+  description    = "pepin-qual-key-no-expiry"
+}
+
+# CONTRE-EXEMPLE : la même clé, avec une échéance à venir (J+2, posée par le runner).
+resource "scaleway_iam_api_key" "expiring" {
+  application_id = scaleway_iam_application.keys.id
+  description    = "pepin-qual-key-expiring"
+  expires_at     = var.key_expires_at
+}
+
+# ÉCART iam_policy_no_privilege_escalation (CLD-IAM-12, high) : le PermissionSet
+# IAMManager confère la gestion de l'IAM (ancré : mapping_terraform de
+# providers/scaleway.yaml, `manages_iam: contains:IAMManager`).
+resource "scaleway_iam_policy" "iam_manager" {
+  name           = "pepin-qual-policy-iam-manager"
+  description    = "Tenant de qualification Pépin : gestion IAM = chemin d'élévation"
+  application_id = scaleway_iam_application.admin.id
+  tags           = local.untagged
+
+  rule {
+    organization_id      = var.organization_id
+    permission_set_names = ["IAMManager"]
+  }
+}
+
+# CONTRE-EXEMPLE : lecture seule sur les instances, portée projet — aucune gestion IAM.
+resource "scaleway_iam_policy" "read_only" {
+  name           = "pepin-qual-policy-read-only"
+  description    = "Tenant de qualification Pépin : lecture seule, portée projet"
+  application_id = scaleway_iam_application.admin.id
+  tags           = local.untagged
+
+  rule {
+    project_ids          = [var.project_id]
+    permission_set_names = ["InstancesReadOnly"]
+  }
+}

--- a/references/qualification/scaleway/network.tf
+++ b/references/qualification/scaleway/network.tf
@@ -1,0 +1,206 @@
+# Réseau — groupes de sécurité, VPC et réseaux privés (ressources gratuites).
+#
+# UN groupe de sécurité PAR écart, pour que chaque finding ait un sujet qui ne
+# porte que sa faute. La seule exception est voulue : une règle any/any ouvre par
+# définition SSH, RDP et tous les ports sensibles, donc `sg_any_open` porte cinq
+# écarts, et expected.yaml les attend tous les cinq.
+#
+# Tous les groupes sont EXPLICITES et attachés explicitement : le groupe créé par
+# le produit (« Default security group ») bloque la destruction quand un serveur
+# y atterrit sans que Terraform le connaisse (issue #2821 du provider).
+#
+# Aucune `scaleway_instance_private_nic` : voir versions.tf (issue #4338).
+
+# ÉCART network_securitygroup_allow_ingress_from_internet_to_tcp_port_22 (high).
+resource "scaleway_instance_security_group" "ssh_open" {
+  name                    = "pepin-qual-sg-ssh-open"
+  description             = "SSH ouvert a Internet"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "TCP"
+    port     = 22
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# ÉCART …_tcp_port_3389 (high).
+resource "scaleway_instance_security_group" "rdp_open" {
+  name                    = "pepin-qual-sg-rdp-open"
+  description             = "RDP ouvert a Internet"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "TCP"
+    port     = 3389
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# ÉCART …_high_risk_tcp_ports (high) : PostgreSQL exposé.
+resource "scaleway_instance_security_group" "db_open" {
+  name                    = "pepin-qual-sg-db-open"
+  description             = "PostgreSQL ouvert a Internet"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "TCP"
+    port     = 5432
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# ÉCART …_high_risk_udp_ports (high) : SNMP exposé (vecteur d'amplification).
+resource "scaleway_instance_security_group" "snmp_open" {
+  name                    = "pepin-qual-sg-snmp-open"
+  description             = "SNMP ouvert a Internet"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "UDP"
+    port     = 161
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# ÉCART …_all_ports (critical) — et, par construction, les quatre autres contrôles
+# d'entrée : une règle any/any couvre tout port et tout protocole.
+resource "scaleway_instance_security_group" "any_open" {
+  name                    = "pepin-qual-sg-any-open"
+  description             = "Tout le trafic entrant accepte depuis Internet"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "ANY"
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# ÉCART …_tcp_port_22 par ÉVASION : quatre /2 couvrent tout l'espace IPv4 sans
+# qu'aucun ne soit 0.0.0.0/0. C'est le cas #D de l'audit externe (issue #178), que
+# lib.rego ferme par un seuil de largeur (/8) et par la fusion des plages.
+resource "scaleway_instance_security_group" "quartet" {
+  name                    = "pepin-qual-sg-quartet"
+  description             = "SSH ouvert a Internet par quatre /2"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+
+  dynamic "inbound_rule" {
+    for_each = ["0.0.0.0/2", "64.0.0.0/2", "128.0.0.0/2", "192.0.0.0/2"]
+    content {
+      action   = "accept"
+      protocol = "TCP"
+      port     = 22
+      ip_range = inbound_rule.value
+    }
+  }
+}
+
+# ÉCART network_securitygroup_unrestricted_egress (medium) : une règle SORTANTE
+# explicite any → 0.0.0.0/0. La politique sortante par défaut n'est pas une règle,
+# donc elle ne compte pas ; seule la règle écrite est mesurée.
+resource "scaleway_instance_security_group" "egress_any" {
+  name                    = "pepin-qual-sg-egress-any"
+  description             = "Tout le trafic sortant accepte vers Internet"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "drop"
+  tags                    = local.untagged
+
+  outbound_rule {
+    action   = "accept"
+    protocol = "ANY"
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# ÉCART network_securitygroup_default_deny (high) : politique entrante par défaut
+# « accept » — observable sur le PLAN seulement (la collecte live ne projette pas
+# encore InboundDefaultPolicy, cf. providers/scaleway.yaml, contrat security_group).
+resource "scaleway_instance_security_group" "default_accept" {
+  name                    = "pepin-qual-sg-default-accept"
+  description             = "Politique entrante par defaut accept"
+  inbound_default_policy  = "accept"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+}
+
+# CONTRE-EXEMPLE de TOUS les contrôles de groupe de sécurité : refus par défaut,
+# SSH depuis un /8 PRIVÉ (la plage que le seuil de largeur ne doit jamais prendre
+# pour Internet), HTTPS depuis Internet (un port servi, pas un port sensible), et
+# une sortie TCP 443 seulement. Aucune règle ne doit parler.
+resource "scaleway_instance_security_group" "hardened" {
+  name                    = "pepin-qual-sg-hardened"
+  description             = "Refus par defaut, SSH prive, HTTPS public"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "drop"
+  tags                    = local.untagged
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "TCP"
+    port     = 22
+    ip_range = "10.0.0.0/8"
+  }
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "TCP"
+    port     = 443
+    ip_range = "0.0.0.0/0"
+  }
+
+  outbound_rule {
+    action   = "accept"
+    protocol = "TCP"
+    port     = 443
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# VPC explicite (gratuit) : le tenant ne dépend pas du VPC par défaut du projet,
+# que Scaleway crée à la première utilisation et qu'on ne détruit pas.
+resource "scaleway_vpc" "qual" {
+  name = "pepin-qual-vpc"
+  tags = local.untagged
+}
+
+# ÉCART network_documented (CLD-NET-5, low) : réseau sans étiquettes de cartographie
+# (Owner, Project, Env). Observable sur le plan seulement (collecte live du VPC en
+# attente, cf. questions-providers SCW-Q1). Aucun serveur n'y est attaché : une
+# interface privée rendrait le destroy impossible (#4338).
+resource "scaleway_vpc_private_network" "undocumented" {
+  name   = "pepin-qual-pn-undocumented"
+  vpc_id = scaleway_vpc.qual.id
+  tags   = local.untagged
+
+  ipv4_subnet {
+    subnet = "172.16.10.0/24"
+  }
+}
+
+# CONTRE-EXEMPLE : le même réseau, cartographié.
+resource "scaleway_vpc_private_network" "documented" {
+  name   = "pepin-qual-pn-documented"
+  vpc_id = scaleway_vpc.qual.id
+  tags   = concat([var.tenant_tag], ["Owner=pepin-maintainer", "Project=pepin", "Env=qualification"])
+
+  ipv4_subnet {
+    subnet = "172.16.20.0/24"
+  }
+}

--- a/references/qualification/scaleway/variables.tf
+++ b/references/qualification/scaleway/variables.tf
@@ -1,0 +1,97 @@
+# Variables du tenant de qualification Scaleway.
+#
+# Aucune n'a de valeur par défaut quand elle identifie un compte ou porte un
+# secret : elles sont injectées par tools/qualification/qualify.py (TF_VAR_*),
+# APRÈS que la porte a vérifié que le compte observé est bien celui épinglé.
+# Un `terraform apply` lancé à la main sans ces variables s'arrête sur une
+# question, jamais sur un compte inattendu.
+
+variable "project_id" {
+  description = "Projet Scaleway dans lequel le tenant est créé — celui qu'expected.yaml épingle, vérifié auprès de l'API avant tout apply"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", var.project_id))
+    error_message = "project_id doit être un UUID."
+  }
+}
+
+variable "organization_id" {
+  description = "Organisation Scaleway (portée des politiques IAM du tenant), vérifiée auprès de l'API avant tout apply"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", var.organization_id))
+    error_message = "organization_id doit être un UUID."
+  }
+}
+
+variable "region" {
+  description = "Région du tenant (UE : toutes les régions Scaleway le sont, le contrôle CLD-GVN-3 n'a donc pas de contre-exemple possible ici)"
+  type        = string
+  default     = "fr-par"
+}
+
+variable "zone" {
+  description = "Zone des ressources zonales (serveurs, groupes de sécurité, IP)"
+  type        = string
+  default     = "fr-par-1"
+}
+
+variable "tenant_tag" {
+  description = "Étiquette posée sur TOUTE ressource étiquetable du tenant : c'est sur elle que la preuve de destruction filtre"
+  type        = string
+  default     = "pepin-qual"
+}
+
+variable "instance_type" {
+  description = "Gamme des serveurs — la moins chère qui soit disponible sans rupture de stock (DEV1-S : 0,009 €/h, stockage local, `scw instance server-type list`)"
+  type        = string
+  default     = "DEV1-S"
+}
+
+variable "rdb_node_type" {
+  description = "Gamme des bases managées — la plus petite disponible (`scw rdb node-type list`)"
+  type        = string
+  default     = "db-dev-s"
+}
+
+variable "key_expires_at" {
+  description = "Échéance RFC 3339 de la clé d'API CONFORME (contre-exemple de CLD-IAM-2) — calculée par le runner à J+2, jamais écrite en dur pour ne pas périmer"
+  type        = string
+}
+
+variable "rdb_password" {
+  description = "Mot de passe de l'utilisateur des bases managées — engendré par le runner à chaque exécution, jamais écrit ni affiché ; il ne sert qu'à satisfaire l'API"
+  type        = string
+  sensitive   = true
+}
+
+# Étiquettes de gouvernance CONFORMES au profil par défaut de Pépin
+# (internal/policy : CostCenter, Project, Env, Owner). Sur les ressources dont les
+# étiquettes sont une liste de chaînes (Instance, RDB, VPC), la forme est
+# « clé=valeur », que le collecteur projette en {key, value} (transform kv).
+locals {
+  governance_tags = [
+    "CostCenter=qualification",
+    "Project=pepin",
+    "Env=qualification",
+    "Owner=pepin-maintainer",
+  ]
+  # Toute ressource étiquetable porte le tag du tenant EN PREMIER, et c'est sur lui
+  # que le listing de sortie filtre. Une ressource sans lui échapperait à la preuve.
+  tagged   = concat([var.tenant_tag], local.governance_tags)
+  untagged = [var.tenant_tag]
+
+  # Même profil, en carte, pour les buckets (tags S3 = TagSet clé/valeur).
+  bucket_governance_tags = {
+    CostCenter = "qualification"
+    Project    = "pepin"
+    Env        = "qualification"
+    Owner      = "pepin-maintainer"
+  }
+
+  # Les noms de buckets sont GLOBAUX chez Scaleway : le suffixe dérivé du projet
+  # évite la collision avec un autre compte qui rejouerait ce tenant.
+  bucket_suffix = substr(var.project_id, 0, 8)
+}

--- a/references/qualification/scaleway/versions.tf
+++ b/references/qualification/scaleway/versions.tf
@@ -1,0 +1,40 @@
+# Tenant de qualification Scaleway — épinglage du provider.
+#
+# La version est ÉPINGLÉE À L'EXACT, jamais en `~>` : une contrainte flottante
+# laisse une publication amont changer ce que ce tenant mesure, sans commit de
+# notre côté. C'est exactement la mécanique qui a introduit la régression de
+# destruction du provider 2.81.0 (issue scaleway/terraform-provider-scaleway#4338 :
+# une `scaleway_instance_private_nic` attachée ne se détruit plus, mesuré par le
+# mainteneur le 2026-09-09 sur 2.81.0 ET 2.82.0, 4 ressources laissées sur 4).
+#
+# Ce tenant reste en 2.82.0 parce qu'il ne porte AUCUNE interface privée : c'est le
+# choix de conception qui rend la régression inopérante ici. Si une interface
+# privée entrait un jour dans cette stack, il faudrait soit redescendre en 2.80.0,
+# soit automatiser `scw instance private-nic delete` avant le destroy — et le
+# README de ce dossier le dit avant qu'on ne l'apprenne sur la facture.
+#
+# Le fichier .terraform.lock.hcl à côté est VERSIONNÉ (exception explicite dans
+# .gitignore) : c'est lui qui garantit que la qualification installe le binaire
+# de provider qui a été validé, et non celui publié depuis.
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "2.82.0"
+    }
+  }
+}
+
+# Aucun identifiant ici (ADR-0012) : le provider lit les variables natives
+# SCW_ACCESS_KEY / SCW_SECRET_KEY, puis ~/.config/scw/config.yaml, exactement
+# comme `pepin scan --live` et comme la CLI scw. Le projet est passé EXPLICITEMENT
+# par variable : la porte refuse de démarrer si le compte observé par l'API n'est
+# pas celui qu'`expected.yaml` épingle, et Terraform reçoit ce même identifiant —
+# aucun des deux ne dépend du profil scw actif au moment du lancement.
+provider "scaleway" {
+  region     = var.region
+  zone       = var.zone
+  project_id = var.project_id
+}


### PR DESCRIPTION
Closes #117. The correction is upstream — [scankit#32](https://github.com/stephrobert/scankit/pull/32), released as `v0.3.5` — because rendering lives there (CLAUDE.md §9).

## The defect

Three `deny` blocks of `objectstorage_bucket_public_access` conclude on the same bucket
by different routes. Each cause is **real**, so none is a false positive. But a public
bucket is *one* problem, and it took all three slots of the panel that announces the
three **most severe** deviations:

```
  1. 🔴 CRIT  CLD-STO-1 — Bucket « backups » … (ACL accordant l'accès à AllUsers)
  2. 🔴 CRIT  CLD-STO-1 — Bucket « backups » … (ACL publique)
  3. 🔴 CRIT  CLD-STO-1 — Bucket « backups » … (bucket policy avec Principal:*)
```

After:

```
  1. 🔴 CRIT  CLD-STO-1 — Bucket « backups » … (ACL accordant l'accès à un groupe global)
     subject: backups

 CRITICAL  ·  CLD-STO-1  ·  scaleway
 Stockage objet exposé publiquement
  Écarts au total : 3

  Détail :
      CRIT  backups — Bucket « backups » accessible publiquement (ACL accordant l'accès…).
            · Bucket « backups » accessible publiquement (ACL publique).
            · Bucket « backups » accessible publiquement (bucket policy avec Principal « * »).
```

`Écarts au total : 3` — **the measure did not change**, only its presentation. The
parsable formats and the severity tally still carry every cause, so someone who fixes
the ACL and leaves the policy keeps seeing the second one.

## What does not move

**No captured output in this repository changes**, because no fixture here has a subject
at fault by several routes. The behaviour above is measured on a hand-built inventory and
held by scankit's regression tests, both checked against the previous rendering. Saying so
seems better than letting an empty doc diff look like a change that did nothing.

## Impact ADR

- **ADR-0002** (shared engine) — respected: fixed upstream, no local renderer.
- **ADR-0021** (scankit pinning is a security boundary) — an upgrade, `0.3.4 → 0.3.5`.

## Gates

`mise run prepush` green.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)