### PR TITLE
feat(release): a Scaleway qualification tenant, applied then destroyed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ dist/
 # pepin's examples only need the .tf sources, the sanitized plan.json and inventory.json.
 **/.terraform/
 **/.terraform.lock.hcl
+# Exception : le lockfile du tenant de QUALIFICATION est versionné. Il épingle les
+# empreintes du provider validé — la régression de destruction (#4338 amont) est
+# arrivée par une contrainte flottante, et un lockfile absent la laisse revenir.
+!references/qualification/*/.terraform.lock.hcl
 *.tfstate
 *.tfstate.*
 *.tfplan
@@ -38,3 +42,9 @@ references/docs/*/
 # tenant ils portent son inventaire. Ce qui entre au dépôt le fait seulement
 # après relecture valeur par valeur, dans internal/genprovider/testdata/.
 .trace/
+
+# Sortie de la porte de release (issue #178) : artefacts d'une qualification —
+# plan, état Terraform, assessments et bundle d'un tenant réel appliqué puis
+# détruit. Ils portent les identifiants de ressources d'un compte ; rien n'en
+# entre au dépôt sans relecture (ADR-0012).
+release-gate/

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -22,6 +22,22 @@ l'une ni l'autre appartient au `git log`.
 
 ## [Non publié]
 
+### Ajouté
+
+- **Un tenant de qualification, appliqué et détruit sur un compte réel** (issue #178,
+  étape 3). `PEPIN_GATE_LIVE=1 mise run qualify` applique la stack Terraform committée
+  sous `references/qualification/scaleway/` — 40 ressources dans le plan, dont 29
+  appliquées : les cinq types qu'un scan live collecte ; bases managées, réseaux
+  privés et politiques IAM n'existent que sur le plan, parce qu'aucun scan live ne
+  les verrait —, une faute par ressource, un contre-exemple par contrôle, la scanne en `--live` dans tous les formats,
+  scelle et vérifie le bundle, scanne le même plan en `--terraform`, la détruit,
+  prouve la destruction (listing par famille sur le tag du tenant, plus un delta
+  avant/après du compte), et compare les deux assessments à l'`expected.yaml`
+  committé (contrôle × source × sujet → statut). Le runner refuse de démarrer sur un
+  autre compte que celui qui y est épinglé, et casse une de ses propres attentes à la
+  fin de chaque run pour prouver qu'il sait dire NO-GO. Un geste de mainteneur, avec
+  les seuls identifiants natifs, jamais de CI.
+
 ### Sécurité
 
 - **`verify` n'accepte plus un bundle qui se contredit.** Réécrire quatre résultats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,22 @@ belongs in `git log`.
 
 ## [Unreleased]
 
+### Added
+
+- **A qualification tenant, applied and destroyed on a real account** (issue #178,
+  stage 3). `PEPIN_GATE_LIVE=1 mise run qualify` applies the Terraform stack committed
+  under `references/qualification/scaleway/` — 40 resources in the plan, 29 of them
+  applied: the five types a live scan collects; managed databases, private networks
+  and IAM policies exist only in the plan, because no live scan would see them —,
+  one fault per resource, one counterexample per control, scans it with `--live` in every format, seals and
+  verifies the bundle, scans the same plan with `--terraform`, destroys it, proves the
+  destruction (a listing per family on the tenant's tag, plus a before/after diff of
+  the account), and compares both assessments with the committed `expected.yaml`
+  (control × source × subject → status). The runner refuses to start on an account
+  other than the one pinned there, and breaks one of its own expectations at the end
+  of every run to prove it can say NO-GO. A maintainer's gesture with native
+  credentials only, never CI.
+
 ### Security
 
 - **`verify` no longer accepts a bundle that contradicts itself.** Rewriting four

--- a/RELEASING.fr.md
+++ b/RELEASING.fr.md
@@ -172,6 +172,41 @@ captif), pas le fournisseur, et un lecteur ultérieur prendrait ces
 > `v*` aux administrateurs : un tag posé par quelqu'un d'autre est refusé *avant*
 > que release.yml ne démarre. À lancer dès que le remote existe ; idempotent.
 
+## Le tenant de qualification : un compte réel, appliqué et détruit
+
+```bash
+PEPIN_GATE_LIVE=1 mise run qualify        # PROVIDER=scaleway par défaut
+mise run qualify:plan                     # le même tenant, sans rien créer
+```
+
+Le canari prouve que les plans de contrôle répondent ; il ne voit jamais un tenant.
+Le tenant de qualification est la seule mesure qui déroule **la chaîne entière sur
+un compte réel** : une stack Terraform committée sous
+`references/qualification/<fournisseur>/`, délibérément mal configurée — une
+ressource par contrôle, un contre-exemple par contrôle — est appliquée, scannée en
+`--live` dans tous les formats, scellée, vérifiée et re-dérivée, rescannée en
+`--terraform` sur le même plan, **détruite**, et ses assessments sont comparés à
+l'`expected.yaml` committé (contrôle × source × sujet → statut). Toute différence est
+un NO-GO : un `fail` manquant est un faux vert, un `fail` en trop un faux positif, un
+`not-evaluated` déplacé une régression de couverture.
+
+Comme le canari, c'est un **geste de mainteneur**, jamais de CI (ADR-0012) : opt-in
+par `PEPIN_GATE_LIVE=1`, identifiants pris dans les variables natives du fournisseur
+ou son fichier de configuration seulement, et le runner **refuse de démarrer** si le
+compte que ces identifiants ouvrent — demandé à l'API, pas lu dans un profil — n'est
+pas celui qu'`expected.yaml` épingle. Il refuse de dire GO tant qu'une ressource
+survit au destroy : la preuve est un listing par famille filtré sur le tag du tenant,
+plus un delta avec l'inventaire pris avant apply. Et il casse une de ses propres
+attentes à la fin de chaque run pour vérifier qu'il sait dire NO-GO.
+
+Le rapport tombe dans `release-gate/qualification-<fournisseur>.json`, avec les
+artefacts du run à côté ; les deux sont ignorés par git, parce qu'ils portent les
+identifiants de ressources d'un compte réel. **Lire la preuve de destruction en
+premier.** [`references/qualification/README.fr.md`](references/qualification/README.fr.md)
+décrit la structure et la table des NO-GO ; le README de chaque fournisseur dit ce
+que sa stack crée, ce que son provider Terraform amont est connu pour laisser derrière
+lui au `destroy`, et ce qui a été mesuré.
+
 ## Ce que le tag déclenche
 
 `.github/workflows/release.yml`, sur `v*` :

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -168,6 +168,40 @@ control-plane regression that never happened.
 > tag pushed by anyone else is refused *before* release.yml starts. Run it once
 > the remote exists; it is idempotent.
 
+## The qualification tenant: a real account, applied and destroyed
+
+```bash
+PEPIN_GATE_LIVE=1 mise run qualify        # PROVIDER=scaleway by default
+mise run qualify:plan                     # the same tenant, nothing created
+```
+
+The canary proves that the control planes answer; it never sees a tenant. The
+qualification tenant is the one measurement that runs the **whole chain on a real
+account**: a Terraform stack committed under `references/qualification/<provider>/`,
+deliberately misconfigured — one resource per control, one counterexample per
+control — is applied, scanned with `--live` in every format, sealed, verified and
+re-derived, scanned again with `--terraform` on the same plan, **destroyed**, and its
+assessments are compared with the committed `expected.yaml` (control × source ×
+subject → status). Any difference is NO-GO: a missing `fail` is a false green, an
+extra `fail` a false positive, a moved `not-evaluated` a coverage regression.
+
+Like the canary, it is a **maintainer's gesture**, never CI (ADR-0012): opt-in by
+`PEPIN_GATE_LIVE=1`, credentials from the provider's native variables or
+configuration file only, and the runner **refuses to start** unless the account
+those credentials open — asked to the API, not read from a profile — is the one
+pinned in `expected.yaml`. It refuses to say GO while a resource survives the
+destroy: the proof is a listing per family filtered on the tenant's tag, plus a
+diff with the inventory taken before apply. And it breaks one of its own
+expectations at the end of every run to check that it can say NO-GO.
+
+The report lands in `release-gate/qualification-<provider>.json`, with the run's
+artifacts beside it; both are ignored by git, because they carry the resource
+identifiers of a real account. **Read the proof of destruction first.**
+[`references/qualification/README.md`](references/qualification/README.md) describes
+the structure and the NO-GO table; each provider's README says what its stack
+creates, what its upstream Terraform provider is known to leave behind on
+`destroy`, and what was measured.
+
 ## What the tag triggers
 
 `.github/workflows/release.yml`, on `v*`:

--- a/mise.toml
+++ b/mise.toml
@@ -299,7 +299,7 @@ go test ./cmd/ -run '^$' -fuzz 'FuzzInventoryWalk' -fuzztime="$t"
 
 [tasks.prepush]
 description = "Tout ce sur quoi une PR échouera, qui coûte des secondes et n'exige aucun compte"
-depends = ["validate", "test", "audit", "adr-drift", "secrets", "falsify:selftest", "falsify:lint"]
+depends = ["validate", "test", "audit", "adr-drift", "secrets", "falsify:selftest", "falsify:lint", "qualify:selftest"]
 # Ce que c'est, et ce que ce n'est délibérément PAS.
 #
 # Chacune de ces portes est déterministe, hors ligne, et tient en quelques
@@ -312,6 +312,36 @@ depends = ["validate", "test", "audit", "adr-drift", "secrets", "falsify:selftes
 # fournisseur. Ces choses vivent en nocturne ou à la qualification de release,
 # précisément pour ne pas rendre ce chemin-ci trop lent pour être suivi.
 run = "echo 'prepush : toutes les portes locales sont vertes'"
+
+# Le TENANT DE QUALIFICATION (issue #178, étape 3) : une stack Terraform par
+# fournisseur, délibérément mal configurée — une ressource par contrôle, un
+# contre-exemple par contrôle —, APPLIQUÉE sur un compte réel, scannée en live dans
+# tous les formats, scellée, vérifiée, rescannée sur le même plan, DÉTRUITE, puis
+# comparée à `expected.yaml` (contrôle × source × sujet → statut). Toute différence
+# est un NO-GO : un fail manquant est un faux vert, un fail en trop un faux positif,
+# un not-evaluated déplacé une régression de couverture.
+#
+# Un geste de MAINTENEUR, jamais de CI (ADR-0012) : opt-in par PEPIN_GATE_LIVE=1,
+# identifiants natifs du fournisseur seulement, et la porte refuse de démarrer si le
+# compte que la clé désigne n'est pas celui qu'expected.yaml épingle. Elle refuse de
+# dire GO si une ressource survit au destroy (listing par famille sur le tag du
+# tenant, plus delta avant/après), et si une attente cassée en mémoire ne la fait
+# pas rougir. Sortie dans release-gate/, ignoré par git.
+[tasks.qualify]
+description = "Applique, scanne, scelle, détruit et compare le tenant de qualification d'un fournisseur (compte réel, opt-in) : PEPIN_GATE_LIVE=1 mise run qualify"
+run = "python3 tools/qualification/qualify.py run ${PROVIDER:-scaleway}"
+
+[tasks."qualify:plan"]
+description = "Le même tenant, sans rien créer : plan + scan --terraform + comparaison de la source terraform"
+run = "python3 tools/qualification/qualify.py run ${PROVIDER:-scaleway} --plan-only"
+
+[tasks."qualify:compare"]
+description = "Recompare le dernier run de qualification à expected.yaml (ou à un autre fichier : EXPECTED=…)"
+run = "python3 tools/qualification/qualify.py compare --run-dir release-gate/qualification-${PROVIDER:-scaleway} ${EXPECTED:+--expected $EXPECTED}"
+
+[tasks."qualify:selftest"]
+description = "La comparaison de la porte de qualification se prouve sur des cas synthétiques (faux vert, faux positif, couverture déplacée)"
+run = "python3 tools/qualification/qualify.py selftest"
 
 [tasks."falsify:lint"]
 description = "Les specs de falsification visent-elles encore du code qui existe"

--- a/references/qualification/README.fr.md
+++ b/references/qualification/README.fr.md
@@ -1,0 +1,109 @@
+> [🇬🇧 English](README.md) · 🇫🇷 Français
+
+# Tenants de qualification
+
+Un **tenant de qualification** est une stack Terraform, écrite par nous,
+**délibérément mal configurée**, réellement **appliquée** sur un compte cloud,
+scannée, scellée, **détruite**, puis comparée à un résultat attendu committé. C'est
+l'étape 3 de la porte de release (issue #178).
+
+C'est le miroir d'un [tenant de référence](../tenants/) : un tenant de référence est
+une configuration tierce sur laquelle Pépin doit rester **muet** (c'est là qu'un faux
+positif se voit) ; un tenant de qualification porte des **mauvaises pratiques
+connues**, une ressource par contrôle et un contre-exemple par contrôle, et le scan
+doit les trouver **toutes, et rien d'autre**, à travers la chaîne entière : API
+réelle → collecteur → règles → assessment → bundle → verdict.
+
+```
+references/qualification/
+  README.md · README.fr.md          cette page
+  <fournisseur>/
+    *.tf                            la stack : une faute par ressource, un contre-exemple par contrôle
+    .terraform.lock.hcl             versionné : le binaire de provider qui a été qualifié
+    tenant.yaml                     métadonnées : région, tag du tenant, version épinglée, budget, tarifs horaires
+    expected.yaml                   le contrat : contrôle × source × sujet → statut, et le compte épinglé
+    hooks.py                        crochets du fournisseur : identité, inventaire par famille, nettoyage de secours
+    README.md · README.fr.md        ce que la stack crée, ce qui bloque destroy en amont, résultats mesurés
+tools/qualification/qualify.py      le runner générique (apply, scan, scelle, vérifie, détruit, prouve, compare)
+```
+
+## Ce qu'un run fait
+
+```bash
+PEPIN_GATE_LIVE=1 mise run qualify            # PROVIDER=scaleway par défaut
+mise run qualify:plan                         # le même tenant, sans rien créer : plan + scan --terraform
+mise run qualify:compare                      # recompare le dernier run à expected.yaml
+mise run qualify:selftest                     # la comparaison se prouve sur des cas synthétiques
+```
+
+1. **Préflight** : les outils, le lockfile épingle la version de provider que
+   `tenant.yaml` déclare, le binaire est compilé depuis l'arbre qu'on qualifie.
+2. **Identité** : les identifiants sont ceux du fournisseur (environnement ou son
+   fichier de configuration, jamais le dépôt, [ADR-0012](../../docs/adr/0012-aucun-identifiant-en-ci.md)).
+   Le runner demande à l'**API** quel compte ils ouvrent, et **refuse de démarrer** si
+   le projet et l'organisation ne sont pas ceux qu'`expected.yaml` épingle. Un tenant
+   qui ouvre SSH au monde ne s'applique jamais sur une production par erreur.
+3. **Inventaire avant** : chaque famille est listée ; un reste d'un run précédent
+   refuse le départ.
+4. **Deux plans, un apply** : un scan live ne collecte pas tous les types qu'un plan
+   porte (sur Scaleway : cinq types en live, huit sur un plan). Le plan **complet** est
+   celui scanné avec `--terraform` ; ce qui est **appliqué** est le sous-ensemble qu'un
+   scan live collecte, parce que provisionner le reste coûterait de l'argent qu'aucun
+   scan live ne mesure. `expected.yaml` épingle les deux sources séparément, et les
+   variables du tenant disent quelles ressources sont « plan seulement ».
+5. **`pepin scan --live`** dans tous les formats (`table`, `json`, `assessment`,
+   `oscal`, `sarif`), scellé par `--seal` ; `verify --re-derive` doit passer, et un
+   bundle altéré d'un octet doit être refusé ([ADR-0018](../../docs/adr/0018-ce-quun-bundle-prouve-de-lui-meme.md)).
+6. **`pepin scan --terraform`** sur le même plan.
+7. **Destroy**, dans un `finally` : il tourne même quand une étape précédente a
+   échoué. Si `terraform destroy` ne finit pas, les crochets du fournisseur suppriment
+   par l'API ce qui porte le tag du tenant, et destroy est relancé.
+8. **Preuve de destruction** : `Destroy complete!` n'est pas une preuve. Le compte est
+   relisté famille par famille, filtré sur le tag et le préfixe de nom du tenant,
+   **et** comparé à l'inventaire pris avant apply : ce qui est apparu entre les deux,
+   étiqueté ou non (un volume racine renommé, une sauvegarde automatique), est un
+   reste et un NO-GO.
+9. **Comparaison** à `expected.yaml`, puis **falsification** : une attente est cassée
+   en mémoire et la comparaison doit dire NO-GO. Une porte qu'on n'a jamais vue rouge
+   ne garde rien.
+
+La sortie va dans `release-gate/` (ignoré par git) : `qualification-<fournisseur>.json`
+(verdict, preuves, durées, coût estimé) et le dossier du run avec chaque artefact.
+Ces artefacts portent les identifiants de ressources d'un compte réel : rien n'en
+entre au dépôt sans relecture.
+
+## Ce que NO-GO veut dire
+
+| Différence | Ce que c'est |
+|---|---|
+| un `fail` attendu qui manque | un **faux vert** : la faute est là et le scan ne l'a pas vue |
+| un `fail` sur un sujet du tenant que rien n'attend | un **faux positif** |
+| le contre-exemple parle | la règle se déclenche mais **ne discrimine pas** |
+| un `not-evaluated` devenu `pass` | un **pass que personne n'a prouvé** ([ADR-0006](../../docs/adr/0006-jamais-un-pass-non-prouve.md)) : le collecteur n'a pas changé, la donnée manque toujours |
+| un `pass` ou un `fail` devenu `not-evaluated` | une **régression de couverture** |
+| un contrôle absent d'`expected.yaml` | un verdict non épinglé |
+| un code de sortie autre que celui épinglé | la porte de CI elle-même a bougé ([ADR-0005](../../docs/adr/0005-codes-de-sortie.md)) |
+| une ressource qui survit au destroy | le seul résultat inacceptable de tout l'exercice |
+
+`expected.yaml` n'est **pas une matrice verte** ([ADR-0010](../../docs/adr/0010-dette-de-veracite-comptee.md)) :
+chacun de ses `not-evaluated` est une **dette de collecte nommée**, et il change quand,
+et seulement quand, le collecteur apprend à lire la donnée. Un tel changement déplace
+un verdict sur un tenant inchangé : il a sa ligne au CHANGELOG.
+
+## Ajouter un fournisseur
+
+1. Copier la structure de `scaleway/` ; garder les mêmes noms de fichiers, le runner
+   s'y adosse (`tenant.yaml`, `expected.yaml`, `hooks.py`).
+2. **Lire d'abord les issues Terraform du fournisseur sur `destroy`**, et écrire ce
+   qu'on a trouvé dans le README du fournisseur, avec les liens : un type de ressource
+   connu pour bloquer un destroy est évité, ou son nettoyage manuel est automatisé dans
+   `hooks.py cleanup`.
+3. Une ressource par contrôle, un contre-exemple par contrôle. Étiqueter **toute**
+   ressource étiquetable avec le tag du tenant, et préfixer chaque nom : c'est sur eux
+   que la preuve de destruction filtre.
+4. Épingler la version du provider à l'exact, et committer le lockfile.
+5. Écrire `expected.yaml` depuis un run `--plan-only` d'abord (source Terraform), puis
+   depuis un run réel (source live), et **justifier chaque statut** par la règle et le
+   collecteur : un statut s'épingle parce qu'il est juste, pas parce qu'il a été mesuré.
+6. Écrire l'épinglage du compte, puis lancer `PEPIN_GATE_LIVE=1 mise run qualify` et
+   lire la preuve de destruction avant toute autre chose.

--- a/references/qualification/README.md
+++ b/references/qualification/README.md
@@ -1,0 +1,108 @@
+> 🇬🇧 English · [🇫🇷 Français](README.fr.md)
+
+# Qualification tenants
+
+A **qualification tenant** is a Terraform stack, written by us, **deliberately
+misconfigured**, that is really **applied** on a cloud account, scanned, sealed,
+**destroyed**, and compared with a committed expected result. It is stage 3 of the
+release gate (issue #178).
+
+It is the mirror image of a [reference tenant](../tenants/): a reference tenant is
+a third-party configuration on which Pépin must stay **silent** (that is where a
+false positive shows); a qualification tenant carries **known bad practices**, one
+resource per control and one counterexample per control, and the scan must find
+**all of them, and only them**, through the whole chain — real API → collector →
+rules → assessment → bundle → verdict.
+
+```
+references/qualification/
+  README.md · README.fr.md          this page
+  <provider>/
+    *.tf                            the stack: one fault per resource, one counterexample per control
+    .terraform.lock.hcl             versioned: the provider build that was qualified
+    tenant.yaml                     metadata: region, tenant tag, pinned provider version, budget, hourly rates
+    expected.yaml                   the contract: control × source × subject → status, and the pinned account
+    hooks.py                        provider hooks: identity, inventory by family, rescue cleanup
+    README.md · README.fr.md        what the stack creates, what blocks destroy upstream, measured results
+tools/qualification/qualify.py      the generic runner (apply, scan, seal, verify, destroy, prove, compare)
+```
+
+## What a run does
+
+```bash
+PEPIN_GATE_LIVE=1 mise run qualify            # PROVIDER=scaleway by default
+mise run qualify:plan                         # same tenant, nothing created: plan + scan --terraform
+mise run qualify:compare                      # re-compare the last run with expected.yaml
+mise run qualify:selftest                     # the comparison proves itself on synthetic cases
+```
+
+1. **Preflight** — tools, the lockfile pins the provider version `tenant.yaml`
+   declares, the binary is built from the tree being qualified.
+2. **Identity** — the credentials are the provider's native ones (environment or
+   its configuration file, never the repository, [ADR-0012](../../docs/adr/0012-aucun-identifiant-en-ci.md)).
+   The runner asks the **API** which account they open, and **refuses to start** if
+   the project and organisation are not the ones pinned in `expected.yaml`. A tenant
+   that opens SSH to the world is never applied on a production account by mistake.
+3. **Inventory before** — every family listed; a leftover from a previous run
+   refuses the start.
+4. **Two plans, one apply** — a live scan does not collect every type a plan
+   carries (on Scaleway: five types live, eight on a plan). The **full** plan is
+   the one scanned with `--terraform`; what is **applied** is the subset a live scan
+   collects, because provisioning the rest would cost money no live scan measures.
+   `expected.yaml` pins the two sources separately, and the tenant's variables say
+   which resources are plan-only.
+5. **`pepin scan --live`** in every format (`table`, `json`, `assessment`, `oscal`,
+   `sarif`), sealed with `--seal`; `verify --re-derive` must pass, and a bundle
+   altered by one byte must be refused ([ADR-0018](../../docs/adr/0018-ce-quun-bundle-prouve-de-lui-meme.md)).
+6. **`pepin scan --terraform`** on the same plan.
+7. **Destroy**, in a `finally`: it runs even when a stage before it failed. If
+   `terraform destroy` does not finish, the provider hooks delete what carries the
+   tenant's tag through the API, and destroy runs again.
+8. **Proof of destruction** — `Destroy complete!` is not a proof. The account is
+   listed again, family by family, filtered on the tenant's tag and name prefix,
+   **and** compared with the inventory taken before apply: anything that appeared
+   in between, tagged or not (a renamed root volume, an automatic backup), is a
+   leftover and a NO-GO.
+9. **Comparison** with `expected.yaml`, then **falsification**: an expectation is
+   broken in memory and the comparison must say NO-GO. A gate that was never seen
+   red guards nothing.
+
+The output goes to `release-gate/` (ignored by git): `qualification-<provider>.json`
+(verdict, evidence, durations, cost estimate) and the run directory with every
+artifact. Those artifacts carry the resource identifiers of a real account: nothing
+enters the repository from there without reading it.
+
+## What NO-GO means
+
+| Difference | What it is |
+|---|---|
+| an expected `fail` missing | a **false green**: the fault is there and the scan did not see it |
+| a `fail` on a tenant subject nothing expects | a **false positive** |
+| the counterexample fails | the rule fires but **does not discriminate** |
+| a `not-evaluated` that became `pass` | a **pass nobody proved** ([ADR-0006](../../docs/adr/0006-jamais-un-pass-non-prouve.md)): the collector did not change, so the data is still missing |
+| a `pass` or `fail` that became `not-evaluated` | a **coverage regression** |
+| a control missing from `expected.yaml` | an unpinned verdict |
+| an exit code other than the pinned one | the CI gate itself moved ([ADR-0005](../../docs/adr/0005-codes-de-sortie.md)) |
+| a resource surviving destroy | the only unacceptable outcome of the whole exercise |
+
+`expected.yaml` is **not a green matrix** ([ADR-0010](../../docs/adr/0010-dette-de-veracite-comptee.md)):
+each `not-evaluated` in it is a **named collection debt**, and it changes when, and
+only when, the collector learns to read the data. Such a change moves a verdict on an
+unchanged tenant, so it gets its CHANGELOG line.
+
+## Adding a provider
+
+1. Copy the structure of `scaleway/`; keep the same file names, the runner relies on
+   them (`tenant.yaml`, `expected.yaml`, `hooks.py`).
+2. **Read the provider's Terraform issues about `destroy` first**, and write what you
+   found in the provider's README with the links: a resource type known to deadlock a
+   destroy is either avoided or its manual cleanup is automated in `hooks.py cleanup`.
+3. One resource per control, one counterexample per control. Tag **every** taggable
+   resource with the tenant tag, and prefix every name: that is what the proof of
+   destruction filters on.
+4. Pin the provider version exactly, and commit the lockfile.
+5. Write `expected.yaml` from a `--plan-only` run first (Terraform source), then from
+   a real run (live source), and **justify each status** from the rule and the
+   collector: a status is pinned because it is right, not because it was measured.
+6. Write the account pin, then run `PEPIN_GATE_LIVE=1 mise run qualify` and read the
+   proof of destruction before reading anything else.

--- a/references/qualification/scaleway/.terraform.lock.hcl
+++ b/references/qualification/scaleway/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/scaleway/scaleway" {
+  version     = "2.82.0"
+  constraints = "2.82.0"
+  hashes = [
+    "h1:+jxYkcFLfzXER+yiqWPOLIlimdsw9rbCDZKti+vtjFE=",
+    "zh:02e29ce80768a53d2fe356918ed19b3cff61db00d4be435c5f7cf46f3144f099",
+    "zh:052251b8c7e92553bed2795c8b0f989fe91c9ee47eae7b6b15117f5f8e42a56e",
+    "zh:471f61f449966e2563855a3a21efa537959f73fcd78c0b43faf57d322aa55294",
+    "zh:4c434ffcf50c679d0f3cbe57275171d24bdbf9fd901deabd127e31f3778392a2",
+    "zh:508cd834e5020897ead132756903ec6213055a73e7118e00c3652dc77d30369f",
+    "zh:50a6c6db528f4fd3638f0533fee3900f2dfaa7a305c13bb780b272fc1c0541e3",
+    "zh:8921d65085184bec95a011ceb198a24edd754563d0e2e7d41d8daabe85215928",
+    "zh:955007174c27732f4c1f22fc5ecc5e429a851e898abf4e8e45d1ecac9a873b81",
+    "zh:a9f1af07b537e97c4488f7b3f049565bd73a13d317c18046fb79edbeabd9f91f",
+    "zh:ae25a4a5399040e846d658add2aaed12a09d448744caa29639bb4e4e5c16eff6",
+    "zh:c73ba8b396926c8ae1694f6fef7fd19f555f0048fcb9de418296352b6a1b3c4e",
+    "zh:e197e2901a1dc47a3a61c83aaf55d19b3095965876e026cafc63d920f066699f",
+    "zh:e8a182c0f62fc5a8bc802a22a559661ce3757749cbc1b559ec22c3cb000f2268",
+  ]
+}

--- a/references/qualification/scaleway/README.fr.md
+++ b/references/qualification/scaleway/README.fr.md
@@ -1,0 +1,118 @@
+> [🇬🇧 English](README.md) · 🇫🇷 Français
+
+# Tenant de qualification Scaleway
+
+40 ressources dans le plan, **dont 29 appliquées**, dans `fr-par` / `fr-par-1`, sur
+le projet épinglé dans [`expected.yaml`](expected.yaml). Une faute par ressource, un
+contre-exemple par contrôle. Appliqué, scanné, scellé, détruit et comparé par
+`PEPIN_GATE_LIVE=1 mise run qualify` (voir [le README générique](../README.fr.md)).
+
+**Deux passes qui ne mesurent pas la même chose.** Un scan live Scaleway collecte
+cinq types (`access_key`, `iam_user`, `compute_instance`, `security_group_rule`,
+`object_storage_bucket`, contrat de `providers/scaleway.yaml`) ; un plan en porte
+huit (plus `managed_database`, `security_group`, `iam_policy`, `network`).
+Provisionner une base managée sur le compte réel coûterait de l'argent qu'aucun scan
+live ne mesure : les ressources que seul un plan lit sont derrière
+`terraform_only_resources` (défaut `true`) ; le runner applique avec `false` et
+scanne le plan complet en `--terraform`. `expected.yaml` épingle les deux sources
+séparément.
+
+## Ce que la stack crée
+
+| Famille | Nombre | Ressource fautive → contrôle | Contre-exemple (doit rester muet) |
+|---|---:|---|---|
+| Applications IAM | 1 (+1 plan seul) | — (`keys` porte les clés et aucune politique ; `admin`, plan seul, porte les politiques et aucune clé : le chemin d'élévation n'est jamais un secret en circulation) | — |
+| Clés d'API IAM | 2 (+1 plan seul) | `expired` (échéance quelques minutes après l'apply ; le runner l'attend avant de scanner, et une clé expirée **reste listée** par l'API) → `iam_accesskey_expiration_set` (high) · `no_expiry`, **plan seul** : l'organisation refuse de la créer — `organization security settings require an expiration date for API keys`, mesuré le 2026-09-09 — → le même contrôle (critical) | `expiring` (échéance à J+2, posée par le runner) |
+| Politiques IAM | 2, plan seul | `iam_manager` (PermissionSet `IAMManager`, portée organisation) → `iam_policy_no_privilege_escalation` | `read_only` (`InstancesReadOnly`, portée projet) |
+| Groupes de sécurité | 9 | `ssh_open` → `…tcp_port_22` · `rdp_open` → `…tcp_port_3389` · `db_open` (5432) → `…high_risk_tcp_ports` · `snmp_open` (UDP 161) → `…high_risk_udp_ports` · `any_open` → `…all_ports` **et les quatre précédents** · `quartet` (quatre `/2`) → `…tcp_port_22` par évasion · `egress_any` → `network_securitygroup_unrestricted_egress` · `default_accept` → `network_securitygroup_default_deny` | `hardened` : refus par défaut, SSH depuis `10.0.0.0/8`, HTTPS depuis Internet, sortie TCP 443 seulement |
+| IP flexibles | 2 | — | — |
+| Serveurs (DEV1-S) | 5 | `exposed` (IP publique + `ssh_open`) → `compute_instance_public_ip_with_open_securitygroup` · `untagged` → `governance_resource_required_tags` · `secrets` (cloud-init avec mot de passe) → `compute_instance_no_secrets_in_user_data` | `private` (même groupe ouvert, pas d'IP publique) · `hardened` (IP publique, groupe restrictif) |
+| VPC | 1, plan seul | — | — |
+| Réseaux privés | 2, plan seul | `undocumented` → `network_documented` | `documented` (Owner, Project, Env) |
+| Buckets (vides) | 7 | `public` (ACL `public-read`) et `policy` (politique `Principal: *`) → `objectstorage_bucket_public_access` · `unversioned` → `…versioning_enabled` **et** `…object_lock_enabled` (pas de verrou sans versioning) · `unlocked` → `…object_lock_enabled` · `sensitive` (`classification=confidential`, sans SSE-KMS) → `…kms_encryption` · tout bucket sans SSE → `objectstorage_bucket_default_encryption`, contrôle que le référentiel ne déclare que pour Outscale (**défaut connu**, épinglé tel quel, #192) | `hardened` (privé, versionné, verrouillé, classé public) · `encrypted` (SSE-ONE configuré : muet sur le chiffrement par défaut) |
+| Bases managées (db-dev-s) | 2, plan seul | `exposed` (ACL `0.0.0.0/0`, sans chiffrement au repos, sauvegardes désactivées) → `database_service_not_open_to_internet`, `database_encryption_at_rest_enabled`, `database_backup_enabled` | `hardened` (chiffrée sur volume Block, sauvegardes quotidiennes, ACL `10.0.0.0/8`) |
+
+Toute ressource étiquetable porte le tag `pepin-qual`, tout nom commence par
+`pepin-qual-`, et les noms de buckets embarquent les huit premiers caractères de
+l'identifiant du projet : c'est là-dessus que la preuve de destruction filtre.
+
+## Ce que le provider amont est connu pour laisser derrière lui au `destroy`
+
+Lu avant de choisir les types de ressources, dans `scaleway/terraform-provider-scaleway`
+et dans les notes de terrain du mainteneur
+([Terraform sur Scaleway : provisionner, et surtout détruire](https://blog.stephane-robert.info/docs/cloud/scaleway/iac/terraform-provider-scaleway/),
+2026-09-09). Ce que chacune a changé dans cette stack :
+
+| Amont | État | Ce que ça fait | Ce que ce tenant en fait |
+|---|---|---|---|
+| [#4338](https://github.com/scaleway/terraform-provider-scaleway/issues/4338) `scaleway_instance_private_nic` : destroy échoue en `412 Can't delete a private network interface attached to a server` depuis la v2.81.0 (migration API v2) | **ouverte**, confirmée sur 2.82.0 par le mainteneur de Pépin le 2026-09-09 (2.80.0 : code 0, 7 s, 0 reste ; 2.81.0 et 2.82.0 : code 1, 4 restes sur 4). Arrêter le serveur ou le cibler ne change rien ; Terraform ne peut pas inverser l'ordre. | Bloque tout destroy d'un serveur avec une interface privée attachée. | **Aucune interface privée.** Les réseaux privés existent seuls, rien n'y est attaché. Provider épinglé à l'exact `2.82.0`, lockfile committé ; la parade de secours est `scw instance private-nic delete` (route v1) si une interface entrait un jour. Conséquence : la machine à deux cartes de l'audit externe (#E) ne peut pas être exercée sur Scaleway aujourd'hui. |
+| [#2853](https://github.com/scaleway/terraform-provider-scaleway/issues/2853) instance : les volumes SBS ne sont pas supprimés au destroy | fermée le 2024-12-19 par `fix(instance_server): delete_after_termination for sbs volumes` | Un volume Block orphelin, facturé, que personne ne retrouve. | Volumes racine sur le stockage **local** de la gamme, `delete_on_termination = true` écrit plutôt que présumé, aucun volume additionnel ; volumes Instance **et** Block sont dans le listing de sortie. |
+| [#2869](https://github.com/scaleway/terraform-provider-scaleway/issues/2869) un bucket avec des objets ne se supprime pas | fermée le 2025-01-10 (`force_destroy` vide le bucket depuis 2.49.0) | Un bucket non vide, versionné ou verrouillé bloque sa propre suppression. | Les buckets restent **vides**, `force_destroy = true` partout. |
+| [#2821](https://github.com/scaleway/terraform-provider-scaleway/issues/2821) le groupe de sécurité créé par le produit bloque la destruction | fermée le 2025-02-14 : « explicitly create a security group and use it with the instance » | Un serveur tombé dans le groupe par défaut le retient. | Neuf groupes **explicites**, chaque serveur attaché explicitement à l'un d'eux. |
+| [#4262](https://github.com/scaleway/terraform-provider-scaleway/issues/4262) IPv4 orpheline quand `ip_ids` est posé sur un load balancer | ouverte | Une IP flexible non suivie, facturée. | Pas de load balancer ; les deux IP flexibles sont des ressources Terraform, et le nettoyage de secours supprime les serveurs avec `with-ip=true` (l'option que les notes de terrain isolent). |
+| [#2125](https://github.com/scaleway/terraform-provider-scaleway/issues/2125) impossible de détruire `scaleway_vpc_private_network` · [#3243](https://github.com/scaleway/terraform-provider-scaleway/issues/3243) `precondition failed: resource is still in use` | fermées (mise à jour du provider ; pas de reproduction) | Un réseau privé qui a encore quelque chose d'attaché. | VPC explicite, jamais rien d'attaché aux réseaux privés. |
+| [#4320](https://github.com/scaleway/terraform-provider-scaleway/issues/4320) `iam_api_key` éphémère empile des clés non gérées | ouverte | Des clés recréées à chaque apply, inconnues de l'état. | `scaleway_iam_api_key` gérée, ordinaire ; le listing IAM filtre sur les applications du tenant et sur le préfixe de description. |
+| [#2426](https://github.com/scaleway/terraform-provider-scaleway/issues/2426) `account_project` : 412 à la suppression | fermée | Un projet qui refuse de partir. | Aucun projet n'est créé : le tenant vit dans le projet épinglé. |
+| b_ssd volumes are no longer supported (notes de terrain) | — | `scaleway_instance_volume` est refusé par l'API. | Aucun volume Instance ; un volume de données serait un `scaleway_block_volume`. |
+
+La preuve de destruction, ce sont les onze listes des notes de terrain, plus les
+familles IAM et Object Storage dont elles n'ont pas besoin : [`hooks.py inventory`](hooks.py)
+liste serveurs, groupes de sécurité, IP flexibles, volumes Instance, snapshots
+Instance, images Instance, volumes Block, snapshots Block, bases managées, leurs
+sauvegardes et snapshots, réseaux privés, VPC, load balancers, passerelles
+publiques, applications, politiques et clés IAM, et buckets, par les mêmes routes
+d'API que la CLI `scw`. Le runner exige que le sous-ensemble du tenant de chaque
+famille soit vide **et** que le listing entier soit égal à celui pris avant apply.
+
+## Ce que ce tenant ne peut pas exercer, et pourquoi
+
+- `governance_resource_region_in_eu` : toutes les régions Scaleway sont dans l'UE,
+  aucun écart n'est constructible ; seul le `pass` est prouvé.
+- `iam_user_mfa_enabled` : un utilisateur IAM est une personne réelle invitée dans
+  l'organisation, hors périmètre d'un tenant jetable. Le contrôle s'observe sur les
+  utilisateurs existants de l'organisation, et `expected.yaml` n'épingle que le fait
+  qu'il **conclut**.
+- `compute_instance_has_security_group` : un serveur Scaleway porte toujours un groupe.
+- `iam_no_root_access_key` : `root_owned` n'est pas encore dérivé par le collecteur ;
+  le contrôle reste `not-evaluated` sur les deux sources, et c'est épinglé.
+- Neuf contrôles sont `not-evaluated` sur la source **live** (#195) parce que le collecteur
+  ne lit pas encore la donnée (politique par défaut des groupes, réseaux privés,
+  bases managées, user-data des serveurs, politiques IAM) : chacun est épinglé tel
+  quel dans `expected.yaml`, donc un collecteur qui se met à les lire déplace un
+  verdict sciemment, avec sa ligne de CHANGELOG.
+- La machine à deux cartes (audit externe #E) : voir #4338 ci-dessus.
+
+## Coût et budget
+
+Tarifs horaires dans [`tenant.yaml`](tenant.yaml) pour ce qui est appliqué : 5 ×
+DEV1-S à 0,008976 EUR/h et 2 IPv4 flexibles à 0,004 EUR/h — environ **0,053 EUR par
+heure** de vie du tenant ; tout le reste appliqué (IAM, groupes de sécurité, buckets
+vides) est gratuit, et les bases managées (0,0347 EUR/h pièce) ne sont jamais
+provisionnées. Le runner multiplie les tarifs par la durée apply→destroy et écrit
+l'estimation au rapport. Budget : 25 minutes mur, sinon NO-GO.
+
+## Mesuré
+
+<!-- qualification:measured -->
+Run du 2026-09-09 (`GO`), sur le projet épinglé dans `expected.yaml` :
+
+| | |
+|---|---|
+| Ressources | 40 dans le plan, 29 appliquées |
+| `apply` | 11.2 s |
+| attente de l'échéance de la clé expirée | 184.9 s |
+| `scan --live` × 5 formats + scellement | 37.3 s, code de sortie 1 dans chaque format |
+| bundle | `verify --re-derive` passe ; le bundle altéré d'un octet est refusé |
+| `scan --terraform` | code de sortie 1 |
+| `destroy` | 18.3 s, `terraform destroy` code 0, état vide, fichiers d'état purgés |
+| preuve de destruction | 19 familles listées, aucune ressource du tenant, aucun delta avant/après |
+| comparaison | live : 40 résultats, 0 différence ; terraform : 34 résultats, 0 différence |
+| falsification | 3 attentes cassées en mémoire sur chaque source, toutes NO-GO |
+| durée mur | 259.9 s (budget 25 min) |
+| coût estimé | 0.0037 EUR (0.07 h × 0.0529 EUR/h) |
+
+Lignes d'information du run (non gardées) : `iam_user_mfa_enabled` échoue sur un
+utilisateur de l'organisation (hors périmètre du tenant), et
+`objectstorage_bucket_default_encryption` est épinglé comme défaut connu (#192, voir
+`expected.yaml`).
+<!-- /qualification:measured -->

--- a/references/qualification/scaleway/README.md
+++ b/references/qualification/scaleway/README.md
@@ -1,0 +1,116 @@
+> 🇬🇧 English · [🇫🇷 Français](README.fr.md)
+
+# Scaleway qualification tenant
+
+40 resources in the plan, **29 of them applied**, in `fr-par` / `fr-par-1`, on the
+project pinned in [`expected.yaml`](expected.yaml). One fault per resource, one
+counterexample per control. Applied, scanned, sealed, destroyed and compared by
+`PEPIN_GATE_LIVE=1 mise run qualify` (see [the generic README](../README.md)).
+
+**Two passes that do not measure the same thing.** A Scaleway live scan collects
+five types (`access_key`, `iam_user`, `compute_instance`, `security_group_rule`,
+`object_storage_bucket`, contract in `providers/scaleway.yaml`); a plan carries
+eight (plus `managed_database`, `security_group`, `iam_policy`, `network`).
+Provisioning a managed database on the real account would cost money no live scan
+measures, so the resources only a plan reads are behind `terraform_only_resources`
+(default `true`): the runner applies with `false` and scans the full plan with
+`--terraform`. `expected.yaml` pins the two sources separately.
+
+## What the stack creates
+
+| Family | Count | Faulty resource → control | Counterexample (must stay silent) |
+|---|---:|---|---|
+| IAM applications | 1 (+1 plan-only) | — (`keys` carries the keys and no policy; `admin`, plan-only, carries the policies and no key: the escalation path is never a live credential) | — |
+| IAM API keys | 2 (+1 plan-only) | `expired` (expiry a few minutes after apply; the runner waits for it before scanning, and an expired key **stays listed** by the API) → `iam_accesskey_expiration_set` (high) · `no_expiry`, **plan-only**: the organisation refuses to create it — `organization security settings require an expiration date for API keys`, measured 2026-09-09 — → the same control (critical) | `expiring` (expiry at D+2, set by the runner) |
+| IAM policies | 2, plan-only | `iam_manager` (PermissionSet `IAMManager`, organisation scope) → `iam_policy_no_privilege_escalation` | `read_only` (`InstancesReadOnly`, project scope) |
+| Security groups | 9 | `ssh_open` → `…tcp_port_22` · `rdp_open` → `…tcp_port_3389` · `db_open` (5432) → `…high_risk_tcp_ports` · `snmp_open` (UDP 161) → `…high_risk_udp_ports` · `any_open` → `…all_ports` **and the four above** · `quartet` (four `/2`) → `…tcp_port_22` by evasion · `egress_any` → `network_securitygroup_unrestricted_egress` · `default_accept` → `network_securitygroup_default_deny` | `hardened`: drop by default, SSH from `10.0.0.0/8`, HTTPS from anywhere, egress TCP 443 only |
+| Flexible IPs | 2 | — | — |
+| Servers (DEV1-S) | 5 | `exposed` (public IP + `ssh_open`) → `compute_instance_public_ip_with_open_securitygroup` · `untagged` → `governance_resource_required_tags` · `secrets` (cloud-init with a password) → `compute_instance_no_secrets_in_user_data` | `private` (same open group, no public IP) · `hardened` (public IP, restrictive group) |
+| VPC | 1, plan-only | — | — |
+| Private networks | 2, plan-only | `undocumented` → `network_documented` | `documented` (Owner, Project, Env) |
+| Buckets (empty) | 7 | `public` (ACL `public-read`) and `policy` (bucket policy `Principal: *`) → `objectstorage_bucket_public_access` · `unversioned` → `…versioning_enabled` **and** `…object_lock_enabled` (no lock without versioning) · `unlocked` → `…object_lock_enabled` · `sensitive` (`classification=confidential`, no SSE-KMS) → `…kms_encryption` · every bucket without SSE → `objectstorage_bucket_default_encryption`, a control the referentiel declares for Outscale only (**known defect**, pinned as such, #192) | `hardened` (private, versioned, locked, classified public) · `encrypted` (SSE-ONE configured: silent on default encryption) |
+| Managed databases (db-dev-s) | 2, plan-only | `exposed` (ACL `0.0.0.0/0`, no encryption at rest, backups disabled) → `database_service_not_open_to_internet`, `database_encryption_at_rest_enabled`, `database_backup_enabled` | `hardened` (encrypted on a Block volume, daily backups, ACL `10.0.0.0/8`) |
+
+Every taggable resource carries the tag `pepin-qual`, every name starts with
+`pepin-qual-`, and the bucket names embed the first eight characters of the
+project id: that is what the proof of destruction filters on.
+
+## What the upstream provider is known to leave behind on `destroy`
+
+Read before choosing the resource types, in `scaleway/terraform-provider-scaleway`
+and in the maintainer's own field notes
+([Terraform sur Scaleway : provisionner, et surtout détruire](https://blog.stephane-robert.info/docs/cloud/scaleway/iac/terraform-provider-scaleway/),
+2026-09-09). What each one changed in this stack:
+
+| Upstream | State | What it does | What this tenant does about it |
+|---|---|---|---|
+| [#4338](https://github.com/scaleway/terraform-provider-scaleway/issues/4338) `scaleway_instance_private_nic`: destroy fails with `412 Can't delete a private network interface attached to a server` since v2.81.0 (API v2 migration) | **open**, confirmed on 2.82.0 by Pépin's maintainer on 2026-09-09 (2.80.0: exit 0, 7 s, 0 left; 2.81.0 and 2.82.0: exit 1, 4/4 left). Stopping the server or targeting it does not help; Terraform cannot invert the order. | Deadlocks every destroy of a server with an attached private NIC. | **No private NIC at all.** The private networks exist alone, nothing is attached to them. Provider pinned exactly at `2.82.0` and the lockfile committed; the rescue path is `scw instance private-nic delete` (v1 route) should one ever be added. Consequence: the two-NIC machine of the external audit (#E) cannot be exercised on Scaleway today. |
+| [#2853](https://github.com/scaleway/terraform-provider-scaleway/issues/2853) instance: SBS volumes not deleted on destroy | closed 2024-12-19 by `fix(instance_server): delete_after_termination for sbs volumes` | An orphan Block volume, billed, that nobody finds again. | Root volumes on the range's **local** storage, `delete_on_termination = true` written rather than assumed, no additional volume; Instance **and** Block volumes are in the leftovers listing. |
+| [#2869](https://github.com/scaleway/terraform-provider-scaleway/issues/2869) a bucket with objects cannot be deleted | closed 2025-01-10 (`force_destroy` empties the bucket since 2.49.0) | A non-empty, versioned or locked bucket blocks its own deletion. | Buckets stay **empty**, `force_destroy = true` everywhere. |
+| [#2821](https://github.com/scaleway/terraform-provider-scaleway/issues/2821) the security group created by the product blocks the destruction | closed 2025-02-14: "explicitly create a security group and use it with the instance" | A server that landed in the default group holds it. | Nine **explicit** groups, every server attached to one explicitly. |
+| [#4262](https://github.com/scaleway/terraform-provider-scaleway/issues/4262) orphaned IPv4 when `ip_ids` is set on a load balancer | open | An untracked flexible IP, billed. | No load balancer; the two flexible IPs are Terraform resources, and the rescue cleanup deletes servers with `with-ip=true` (the option the field notes single out). |
+| [#2125](https://github.com/scaleway/terraform-provider-scaleway/issues/2125) cannot destroy `scaleway_vpc_private_network` · [#3243](https://github.com/scaleway/terraform-provider-scaleway/issues/3243) `precondition failed: resource is still in use` | closed (provider upgrade; no reproduction) | A private network that still has something attached. | Explicit VPC, nothing ever attached to the private networks. |
+| [#4320](https://github.com/scaleway/terraform-provider-scaleway/issues/4320) ephemeral `iam_api_key` piles up unmanaged keys | open | Keys recreated at each apply, unknown to the state. | Plain managed `scaleway_iam_api_key`; the IAM listing filters on the tenant's applications and on the description prefix. |
+| [#2426](https://github.com/scaleway/terraform-provider-scaleway/issues/2426) `account_project`: 412 on delete | closed | A project that refuses to go. | No project is created: the tenant lives in the pinned project. |
+| b_ssd volumes are no longer supported (field notes) | — | `scaleway_instance_volume` is refused by the API. | No Instance volume; if a data volume were ever needed it would be `scaleway_block_volume`. |
+
+The proof of destruction is the field notes' eleven listings, plus the IAM and
+Object Storage families they do not need: [`hooks.py inventory`](hooks.py) lists
+servers, security groups, flexible IPs, Instance volumes, Instance snapshots,
+Instance images, Block volumes, Block snapshots, managed databases, their backups
+and snapshots, private networks, VPCs, load balancers, public gateways, IAM
+applications, policies and API keys, and buckets, through the same API routes the
+`scw` CLI calls. The runner requires the tenant subset of every family to be empty
+**and** the whole listing to equal the one taken before apply.
+
+## What this tenant cannot exercise, and why
+
+- `governance_resource_region_in_eu`: every Scaleway region is in the EU, no
+  deviation is constructible; only the `pass` is proven.
+- `iam_user_mfa_enabled`: an IAM user is a real person invited into the
+  organisation, out of a disposable tenant's scope. The control is observed on the
+  organisation's existing users, and `expected.yaml` only pins that it **concludes**.
+- `compute_instance_has_security_group`: a Scaleway server always has a group.
+- `iam_no_root_access_key`: `root_owned` is not derived yet by the collector; the
+  control stays `not-evaluated` on both sources, and that is pinned.
+- Nine controls are `not-evaluated` on the **live** source (#195) because the collector does
+  not read the data yet (security group default policy, private networks, managed
+  databases, server user-data, IAM policies): each one is pinned as such in
+  `expected.yaml`, so a collector that starts reading them moves a verdict on
+  purpose, with a CHANGELOG line.
+- The two-NIC machine (external audit #E): see #4338 above.
+
+## Cost and budget
+
+Hourly rates in [`tenant.yaml`](tenant.yaml) for what is applied: 5 × DEV1-S at
+0.008976 EUR/h and 2 flexible IPv4 at 0.004 EUR/h — about **0.053 EUR per hour** of
+tenant life; everything else applied (IAM, security groups, empty buckets) is free,
+and the managed databases (0.0347 EUR/h each) are never provisioned. The runner
+multiplies the rates by the apply→destroy duration and writes the estimate to the
+report. Budget: 25 minutes wall clock, or NO-GO.
+
+## Measured
+
+<!-- qualification:measured -->
+Run of 2026-09-09 (`GO`), on the project pinned in `expected.yaml`:
+
+| | |
+|---|---|
+| Resources | 40 in the plan, 29 applied |
+| `apply` | 11.2 s |
+| wait for the expired key's deadline | 184.9 s |
+| `scan --live` × 5 formats + seal | 37.3 s, exit code 1 in every format |
+| bundle | `verify --re-derive` passes; the bundle altered by one byte is refused |
+| `scan --terraform` | exit code 1 |
+| `destroy` | 18.3 s, `terraform destroy` exit 0, state empty, state files purged |
+| proof of destruction | 19 familles listées, aucune ressource du tenant, aucun delta avant/après |
+| comparison | live: 40 results, 0 difference; terraform: 34 results, 0 difference |
+| falsification | 3 expectations broken in memory on each source, every one NO-GO |
+| wall clock | 259.9 s (budget 25 min) |
+| cost estimate | 0.0037 EUR (0.07 h × 0.0529 EUR/h) |
+
+Informational lines of the run (not gated): `iam_user_mfa_enabled` fails on an
+organisation user (out of the tenant's perimeter), and
+`objectstorage_bucket_default_encryption` is pinned as a known defect (#192, see
+`expected.yaml`).
+<!-- /qualification:measured -->

--- a/references/qualification/scaleway/compute.tf
+++ b/references/qualification/scaleway/compute.tf
@@ -1,0 +1,126 @@
+# Calcul — cinq serveurs DEV1-S (0,009 €/h chacun) et deux IP flexibles.
+#
+# Chaque serveur ne porte qu'UNE faute, ou aucune :
+#   exposed   IP publique + SG SSH ouvert      → compute_instance_public_ip_with_open_securitygroup
+#   private   pas d'IP   + SG SSH ouvert      → silencieux (contre-exemple : pas d'exposition)
+#   hardened  IP publique + SG restrictif      → silencieux (contre-exemple : SG discriminant)
+#   untagged  pas d'IP   + SG restrictif, sans étiquettes → governance_resource_required_tags
+#   secrets   pas d'IP   + SG restrictif, cloud-init avec mot de passe → compute_instance_no_secrets_in_user_data
+#
+# TOUS portent un cloud-init : l'attribut `user_data` doit être présent sur chaque
+# serveur pour que le verrou de capacité (ADR-0006, intersection par type) laisse
+# le contrôle des secrets conclure « pass » sur ceux qui n'en ont pas. Seul
+# `secrets` porte un secret ; les autres portent un cloud-config anodin, qui est le
+# contre-exemple du détecteur.
+#
+# Volume racine : stockage LOCAL de la gamme (l_ssd), détruit avec le serveur
+# (`delete_on_termination = true`, écrit plutôt que présumé). Pas de volume Block
+# additionnel : l'API Instance ne crée plus de b_ssd, et un volume Block orphelin
+# est exactement le reste qu'on ne retrouve pas (issue #2853, corrigée en 2.48).
+#
+# Volontairement ABSENT : toute interface privée (`scaleway_instance_private_nic`),
+# dont la destruction est cassée depuis le provider 2.81.0 (#4338). Le cas d'une
+# machine à deux cartes (audit #E) ne peut donc pas être exercé sur Scaleway
+# aujourd'hui, et le README le consigne.
+
+locals {
+  cloud_init_plain = <<-EOT
+    #cloud-config
+    package_update: false
+    timezone: Europe/Paris
+  EOT
+
+  # Un mot de passe en clair dans le cloud-init : détecté par le motif
+  # « mot de passe en clair » (confiance heuristique) de la règle commune. La
+  # valeur est évidemment factice — elle n'ouvre rien, nulle part.
+  cloud_init_with_secret = <<-EOT
+    #cloud-config
+    users:
+      - name: pepin
+        plain_text_passwd: pepin-qualification-fake-password
+        lock_passwd: false
+  EOT
+}
+
+resource "scaleway_instance_ip" "exposed" {
+  tags = local.untagged
+}
+
+resource "scaleway_instance_ip" "hardened" {
+  tags = local.untagged
+}
+
+# ÉCART compute_instance_public_ip_with_open_securitygroup (CLD-NET-3) : IP publique
+# ET SG qui ouvre SSH à Internet → sévérité high (port sensible), sujet = id serveur.
+resource "scaleway_instance_server" "exposed" {
+  name              = "pepin-qual-vm-exposed"
+  type              = var.instance_type
+  image             = "ubuntu_jammy"
+  ip_id             = scaleway_instance_ip.exposed.id
+  security_group_id = scaleway_instance_security_group.ssh_open.id
+  tags              = local.tagged
+  user_data         = { cloud-init = local.cloud_init_plain }
+
+  root_volume {
+    delete_on_termination = true
+  }
+}
+
+# CONTRE-EXEMPLE : même SG ouvert, mais AUCUNE IP publique → pas d'exposition.
+resource "scaleway_instance_server" "private" {
+  name              = "pepin-qual-vm-private"
+  type              = var.instance_type
+  image             = "ubuntu_jammy"
+  security_group_id = scaleway_instance_security_group.ssh_open.id
+  tags              = local.tagged
+  user_data         = { cloud-init = local.cloud_init_plain }
+
+  root_volume {
+    delete_on_termination = true
+  }
+}
+
+# CONTRE-EXEMPLE : IP publique, mais SG restrictif → pas d'exposition.
+resource "scaleway_instance_server" "hardened" {
+  name              = "pepin-qual-vm-hardened"
+  type              = var.instance_type
+  image             = "ubuntu_jammy"
+  ip_id             = scaleway_instance_ip.hardened.id
+  security_group_id = scaleway_instance_security_group.hardened.id
+  tags              = local.tagged
+  user_data         = { cloud-init = local.cloud_init_plain }
+
+  root_volume {
+    delete_on_termination = true
+  }
+}
+
+# ÉCART governance_resource_required_tags (CLD-GVN-1) : aucune étiquette de
+# gouvernance (seul le tag du tenant, qui sert à la preuve de destruction).
+resource "scaleway_instance_server" "untagged" {
+  name              = "pepin-qual-vm-untagged"
+  type              = var.instance_type
+  image             = "ubuntu_jammy"
+  security_group_id = scaleway_instance_security_group.hardened.id
+  tags              = local.untagged
+  user_data         = { cloud-init = local.cloud_init_plain }
+
+  root_volume {
+    delete_on_termination = true
+  }
+}
+
+# ÉCART compute_instance_no_secrets_in_user_data (CLD-CMP-9) : observable sur le
+# PLAN (la collecte live ne lit pas GetServerUserData, contrat `a_verifier`).
+resource "scaleway_instance_server" "secrets" {
+  name              = "pepin-qual-vm-secrets"
+  type              = var.instance_type
+  image             = "ubuntu_jammy"
+  security_group_id = scaleway_instance_security_group.hardened.id
+  tags              = local.tagged
+  user_data         = { cloud-init = local.cloud_init_with_secret }
+
+  root_volume {
+    delete_on_termination = true
+  }
+}

--- a/references/qualification/scaleway/database.tf
+++ b/references/qualification/scaleway/database.tf
@@ -1,0 +1,73 @@
+# Bases managées — deux instances db-dev-s, PLAN SEULEMENT.
+#
+# Les trois contrôles de base de données ne sont observables que sur le plan
+# (`scaleway_rdb_instance`, `scaleway_rdb_acl` ; la collecte live RDB n'existe
+# pas, contrat de providers/scaleway.yaml). Provisionner une base sur le compte
+# réel coûterait de l'argent (0,035 €/h pièce) et deux à cinq minutes de création
+# puis de destruction — sans qu'aucun scan live ne la voie. Elles n'entrent donc
+# que dans le plan complet (`terraform_only_resources = true`), que le runner
+# scanne en `--terraform` ; la stack appliquée ne les contient pas.
+#
+# `exposed` porte les trois écarts sur une seule instance — c'est l'exception
+# assumée à « une faute par ressource » : trois sujets distincts d'un même type
+# n'apprendraient rien de plus. `hardened` est le contre-exemple des trois.
+#
+# Le mot de passe vient du runner (variable sensible, engendrée à chaque run).
+
+# ÉCARTS database_service_not_open_to_internet (ACL 0.0.0.0/0),
+# database_encryption_at_rest_enabled (chiffrement absent),
+# database_backup_enabled (sauvegardes désactivées).
+resource "scaleway_rdb_instance" "exposed" {
+  count              = local.tf_only
+  name               = "pepin-qual-rdb-exposed"
+  node_type          = var.rdb_node_type
+  engine             = "PostgreSQL-16"
+  is_ha_cluster      = false
+  disable_backup     = true
+  encryption_at_rest = false
+  user_name          = "pepin"
+  password           = var.rdb_password
+  tags               = local.tagged
+}
+
+resource "scaleway_rdb_acl" "exposed" {
+  count       = local.tf_only
+  instance_id = scaleway_rdb_instance.exposed[0].id
+
+  acl_rules {
+    ip          = "0.0.0.0/0"
+    description = "ouvert a Internet"
+  }
+}
+
+# CONTRE-EXEMPLE : chiffrée au repos, sauvegardée, ACL restreinte à un /8 privé.
+#
+# Le chiffrement au repos (LUKS) porte sur un volume BLOCK : la documentation
+# « Setting up encryption at rest » de Scaleway l'illustre avec `volume_type: sbs_5k`.
+# Le volume est donc déclaré Block, à la taille minimale de la gamme (5 Go).
+resource "scaleway_rdb_instance" "hardened" {
+  count                     = local.tf_only
+  name                      = "pepin-qual-rdb-hardened"
+  node_type                 = var.rdb_node_type
+  engine                    = "PostgreSQL-16"
+  is_ha_cluster             = false
+  disable_backup            = false
+  backup_schedule_frequency = 24
+  backup_schedule_retention = 7
+  encryption_at_rest        = true
+  volume_type               = "sbs_5k"
+  volume_size_in_gb         = 5
+  user_name                 = "pepin"
+  password                  = var.rdb_password
+  tags                      = local.tagged
+}
+
+resource "scaleway_rdb_acl" "hardened" {
+  count       = local.tf_only
+  instance_id = scaleway_rdb_instance.hardened[0].id
+
+  acl_rules {
+    ip          = "10.0.0.0/8"
+    description = "reseau applicatif prive"
+  }
+}

--- a/references/qualification/scaleway/expected.yaml
+++ b/references/qualification/scaleway/expected.yaml
@@ -1,0 +1,284 @@
+# Ce que Pépin DOIT rendre sur le tenant de qualification Scaleway — le résultat
+# attendu, contrôle × source × sujet → statut. Lu par tools/qualification/qualify.py.
+#
+# Toute différence avec ce fichier est un NO-GO :
+#   - un `fail` attendu qui manque est un FAUX VERT ;
+#   - un `fail` sur un sujet du tenant que ce fichier n'attend pas est un FAUX POSITIF ;
+#   - un `not-evaluated` qui devient `pass` (ou l'inverse) est une RÉGRESSION DE COUVERTURE,
+#     dans un sens comme dans l'autre : un `pass` qui apparaît là où le collecteur ne lit
+#     pas encore la donnée est un pass non prouvé (ADR-0006), pas une amélioration.
+#
+# Ce fichier n'est pas une matrice verte (ADR-0010) : chaque `not-evaluated` ci-dessous
+# est une dette de collecte NOMMÉE, et il change quand — et seulement quand — le
+# collecteur apprend à lire la donnée. Un tel changement se dit au CHANGELOG, parce
+# qu'il déplace un verdict sur un tenant inchangé.
+#
+# Sujets : un littéral, ou `${output.<nom>}` résolu depuis `terraform output -json`
+# (identifiants connus après apply, forme que la collecte live emploie). Statuts :
+# `fail` / `pass` / `not-evaluated` / `not-applicable`, ou `evaluated` (pass OU fail)
+# pour un contrôle dont les sujets sont HORS du tenant (utilisateurs de l'organisation)
+# et dont on n'épingle que le fait qu'il conclut.
+#
+# Sur un contrôle qui porte des écarts, `fail:` liste les sujets fautifs — tous doivent
+# être là, aucun autre sujet du tenant ne doit l'être — et `silent:` liste les
+# CONTRE-EXEMPLES : la configuration correcte voisine, qui doit rester muette. Sans
+# contre-exemple, on ne prouve pas que la règle discrimine, seulement qu'elle parle.
+
+# Le compte sur lequel ce tenant a le droit de s'appliquer. La porte interroge l'API
+# avec les identifiants natifs (SCW_* ou ~/.config/scw/config.yaml, ADR-0012) et
+# REFUSE DE DÉMARRER si le projet et l'organisation observés ne sont pas ceux-ci :
+# un tenant délibérément mal configuré ne s'applique jamais sur un compte de
+# production par erreur.
+#
+# L'identifiant attendu vient de l'ENVIRONNEMENT, pas de ce fichier. Un
+# `organization_id` n'est pas un secret — il n'ouvre rien sans identifiants — mais
+# ce dépôt est PUBLIC, et l'y committer nommerait durablement le tenant du
+# mainteneur. Un identifiant publié ne se dépublie pas. La garde, elle, ne perd
+# rien : elle compare toujours ce que l'API répond à ce qui est attendu ; seule la
+# provenance de l'attendu change.
+#
+# Poser avant de lancer la porte :
+#     export PEPIN_QUAL_SCW_ORG=<organization_id>
+#     export PEPIN_QUAL_SCW_PROJECT=<project_id>
+account:
+  organization_id_env: PEPIN_QUAL_SCW_ORG
+  project_id_env: PEPIN_QUAL_SCW_PROJECT
+
+# Codes de sortie de `pepin scan` (ADR-0005) : 1, parce que le tenant porte des
+# écarts critical/high sur les deux sources. Un 0 ou un 3 ici serait un faux vert
+# de la porte elle-même.
+exit_codes:
+  live: 1
+  terraform: 1
+
+controls:
+  # ── IAM ────────────────────────────────────────────────────────────────────
+  iam_accesskey_expiration_set:
+    # Deux branches de la même règle. La clé SANS échéance (critical) n'existe que
+    # sur le plan : l'organisation de qualification refuse d'en créer une
+    # (« organization security settings require an expiration date for API keys »,
+    # mesuré le 2026-09-09) — un réglage préventif qui fait ce que le contrôle
+    # demande, et que Pépin pourrait lire (issue #196).
+    # La clé dont l'échéance est DÉPASSÉE (high) est réelle : elle reste listée par
+    # l'API, et le runner attend son échéance avant de scanner.
+    live:
+      fail: ["${output.api_key_expired}"]
+      silent: ["${output.api_key_expiring}"]
+    terraform:
+      # L'access key n'est connue qu'après apply : le plan désigne la ressource par
+      # son adresse (indexée pour celle qui n'existe que sur le plan).
+      fail: ["scaleway_iam_api_key.no_expiry[0]", scaleway_iam_api_key.expired]
+      silent: [scaleway_iam_api_key.expiring]
+
+  iam_no_root_access_key:
+    # `root_owned` est DÉRIVÉ et non encore projeté (contrat a_verifier, issue #195) :
+    # le verrou de capacité tient sur les deux sources. Un pass ou un fail qui apparaîtrait ici
+    # sans changement du collecteur serait une régression.
+    live: not-evaluated
+    terraform: not-evaluated
+
+  iam_user_mfa_enabled:
+    live:
+      status: evaluated
+      perimeter: organisation
+      reason: "Les utilisateurs IAM sont des personnes réelles de l'organisation, pas des ressources du tenant : le contrôle doit CONCLURE (pass ou fail) sur eux, et leur verdict ne s'épingle pas ici."
+    terraform: not-evaluated
+
+  iam_policy_no_privilege_escalation:
+    live: not-evaluated
+    terraform:
+      fail: [pepin-qual-policy-iam-manager]
+      silent: [pepin-qual-policy-read-only]
+
+  # ── Groupes de sécurité ────────────────────────────────────────────────────
+  # Sujet live = identifiant du groupe (Server/SecurityGroup ID, sans zone) ; sujet
+  # Terraform = adresse de la ressource (l'id est inconnu au stade du plan).
+  network_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
+    live:
+      fail: ["${output.sg_ssh_open_id}", "${output.sg_any_open_id}", "${output.sg_quartet_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_rdp_open_id}"]
+    terraform:
+      fail: [scaleway_instance_security_group.ssh_open, scaleway_instance_security_group.any_open, scaleway_instance_security_group.quartet]
+      silent: [scaleway_instance_security_group.hardened, scaleway_instance_security_group.rdp_open]
+
+  network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
+    live:
+      fail: ["${output.sg_rdp_open_id}", "${output.sg_any_open_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_ssh_open_id}"]
+    terraform:
+      fail: [scaleway_instance_security_group.rdp_open, scaleway_instance_security_group.any_open]
+      silent: [scaleway_instance_security_group.hardened, scaleway_instance_security_group.ssh_open]
+
+  network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports:
+    live:
+      fail: ["${output.sg_db_open_id}", "${output.sg_any_open_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_ssh_open_id}"]
+    terraform:
+      fail: [scaleway_instance_security_group.db_open, scaleway_instance_security_group.any_open]
+      silent: [scaleway_instance_security_group.hardened, scaleway_instance_security_group.ssh_open]
+
+  network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports:
+    live:
+      fail: ["${output.sg_snmp_open_id}", "${output.sg_any_open_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_db_open_id}"]
+    terraform:
+      fail: [scaleway_instance_security_group.snmp_open, scaleway_instance_security_group.any_open]
+      silent: [scaleway_instance_security_group.hardened, scaleway_instance_security_group.db_open]
+
+  network_securitygroup_allow_ingress_from_internet_to_all_ports:
+    live:
+      fail: ["${output.sg_any_open_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_ssh_open_id}", "${output.sg_quartet_id}"]
+    terraform:
+      fail: [scaleway_instance_security_group.any_open]
+      silent: [scaleway_instance_security_group.hardened, scaleway_instance_security_group.ssh_open, scaleway_instance_security_group.quartet]
+
+  network_securitygroup_unrestricted_egress:
+    live:
+      fail: ["${output.sg_egress_any_id}"]
+      silent: ["${output.sg_hardened_id}"]
+    terraform:
+      fail: [scaleway_instance_security_group.egress_any]
+      silent: [scaleway_instance_security_group.hardened]
+
+  network_securitygroup_default_deny:
+    # InboundDefaultPolicy n'est pas encore projetée par la collecte live (#195).
+    live: not-evaluated
+    terraform:
+      fail: [pepin-qual-sg-default-accept]
+      silent: [pepin-qual-sg-hardened, pepin-qual-sg-ssh-open]
+
+  network_documented:
+    # Collecte live des réseaux privés en attente (contrat a_verifier, #195).
+    live: not-evaluated
+    terraform:
+      fail: [pepin-qual-pn-undocumented]
+      silent: [pepin-qual-pn-documented]
+
+  # ── Calcul ─────────────────────────────────────────────────────────────────
+  compute_instance_public_ip_with_open_securitygroup:
+    live:
+      fail: ["${output.vm_exposed_id}"]
+      silent: ["${output.vm_private_id}", "${output.vm_hardened_id}"]
+    # Le plan ne porte pas l'IP publique du serveur (ip_id est un lien, pas une adresse).
+    terraform: not-evaluated
+
+  compute_instance_has_security_group:
+    # Un serveur Scaleway porte toujours un groupe : l'écart n'est pas constructible.
+    live: pass
+    terraform: pass
+
+  compute_instance_no_secrets_in_user_data:
+    # user_data se lit par un appel séparé (GetServerUserData) que la collecte live
+    # ne fait pas encore.
+    live: not-evaluated
+    terraform:
+      fail: [scaleway_instance_server.secrets]
+      silent: [scaleway_instance_server.hardened, scaleway_instance_server.exposed]
+
+  # ── Stockage objet ─────────────────────────────────────────────────────────
+  objectstorage_bucket_public_access:
+    live:
+      # Deux vecteurs, deux buckets : l'ACL et la politique.
+      fail: ["${output.bucket_public}", "${output.bucket_policy}"]
+      silent: ["${output.bucket_hardened}", "${output.bucket_unversioned}"]
+    terraform:
+      # Le sujet est le bucket que l'ACL configure (ADR-0022), pas la ressource ACL.
+      # La politique de bucket n'est pas mappée sur le plan : `policy` y est muet.
+      fail: ["${output.bucket_public}"]
+      silent: ["${output.bucket_hardened}", "${output.bucket_policy}"]
+
+  objectstorage_bucket_versioning_enabled:
+    live:
+      fail: ["${output.bucket_unversioned}"]
+      silent: ["${output.bucket_hardened}", "${output.bucket_unlocked}"]
+    terraform: not-evaluated
+
+  objectstorage_bucket_object_lock_enabled:
+    live:
+      fail: ["${output.bucket_unlocked}", "${output.bucket_unversioned}"]
+      silent: ["${output.bucket_hardened}", "${output.bucket_public}"]
+    terraform:
+      fail: ["${output.bucket_unlocked}", "${output.bucket_unversioned}"]
+      silent: ["${output.bucket_hardened}", "${output.bucket_public}"]
+
+  objectstorage_bucket_kms_encryption:
+    live:
+      fail: ["${output.bucket_sensitive}"]
+      # `hardened` et `encrypted` sont classés public : la classification est ce qui
+      # discrimine, et SSE-ONE (clé Scaleway) n'est pas SSE-KMS (clé client).
+      silent: ["${output.bucket_hardened}", "${output.bucket_encrypted}"]
+    terraform: not-evaluated
+
+  objectstorage_bucket_default_encryption:
+    # DÉFAUT CONNU, épinglé tel que mesuré — et le défaut n'est pas le verdict. Chez
+    # Scaleway, le chiffrement au repos d'un bucket est OPT-IN (SSE-ONE, SSE-KMS ou
+    # SSE-C, doc « enable-sse-* ») : un bucket sans configuration SSE écrit en clair,
+    # et les six écarts sont VRAIS. Le défaut est la déclaration : le référentiel
+    # n'active ce contrôle que pour Outscale (`fournisseurs: [outscale]`), la matrice
+    # de couverture dit ✗ pour Scaleway en live, et rien n'a jamais prouvé son
+    # contre-exemple sur ce fournisseur — alors que le collecteur S3 commun mesure la
+    # donnée et que l'assessment publie les findings sans regarder `fournisseurs`.
+    # Activer le contrôle pour Scaleway (le bucket SSE-ONE `encrypted` est son
+    # contre-exemple, déjà muet) ou expliquer pourquoi pas : c'est l'issue #192. Le jour où la
+    # déclaration change, ce pin change avec elle, et le CHANGELOG le dit.
+    live:
+      fail: ["${output.bucket_public}", "${output.bucket_policy}", "${output.bucket_unversioned}", "${output.bucket_unlocked}", "${output.bucket_sensitive}", "${output.bucket_hardened}"]
+      # Le contre-exemple existe : SSE-ONE configuré, la règle se tait. C'est ce qui
+      # permettra d'activer le contrôle pour Scaleway avec sa preuve.
+      silent: ["${output.bucket_encrypted}"]
+      known_defect: "#192 — contrôle mesuré et juste sur Scaleway, mais déclaré pour Outscale seul (référentiel + matrice ✗)"
+    terraform: absent
+
+  # ── Bases managées (PLAN SEULEMENT : aucune collecte live RDB, et rien n'est
+  #    provisionné qu'aucun scan live ne verrait — cf. variables.tf) ────────────
+  database_service_not_open_to_internet:
+    live: not-evaluated
+    terraform:
+      # `_parent.instance_id` n'est pas comblé par les références du plan (ADR-0022,
+      # chemins simples seulement, issue #193) : le sujet est l'adresse de la
+      # ressource ACL, indexée parce que les bases n'existent que sur le plan (count).
+      fail: ["scaleway_rdb_acl.exposed[0]"]
+      silent: ["scaleway_rdb_acl.hardened[0]"]
+
+  database_encryption_at_rest_enabled:
+    live: not-evaluated
+    terraform:
+      fail: [pepin-qual-rdb-exposed]
+      silent: [pepin-qual-rdb-hardened]
+
+  database_backup_enabled:
+    live: not-evaluated
+    terraform:
+      fail: [pepin-qual-rdb-exposed]
+      silent: [pepin-qual-rdb-hardened]
+
+  # ── Gouvernance ────────────────────────────────────────────────────────────
+  governance_resource_required_tags:
+    live:
+      # Sujet live = nom de la ressource normalisée, qui est son identifiant.
+      fail: ["${output.vm_untagged_id}"]
+      silent: ["${output.vm_exposed_id}", "${output.bucket_hardened}"]
+    terraform:
+      fail: [pepin-qual-vm-untagged]
+      silent: [pepin-qual-vm-exposed, "${output.bucket_hardened}"]
+
+  governance_resource_region_in_eu:
+    # Toutes les régions Scaleway sont dans l'UE : seul le pass est constructible.
+    live: pass
+    # Le mapping Terraform ne projette pas la région des serveurs ni des buckets
+    # (issue #194).
+    terraform: not-evaluated
+
+  governance_provider_sovereignty:
+    live: pass
+    terraform: pass
+
+  # ── Déclarés non applicables par le contrat du fournisseur ─────────────────
+  blockstorage_snapshot_not_public:
+    live: not-applicable
+    terraform: not-applicable
+
+  blockstorage_volume_encryption:
+    live: not-applicable
+    terraform: not-applicable

--- a/references/qualification/scaleway/hooks.py
+++ b/references/qualification/scaleway/hooks.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Crochets Scaleway du tenant de qualification : identité, inventaire, nettoyage.
+
+Trois sous-commandes, appelées par tools/qualification/qualify.py :
+
+    identity                      quel compte les identifiants natifs désignent-ils,
+                                  d'après l'API (jamais d'après une variable locale)
+    inventory <tenant.yaml>       ce que le compte contient, famille par famille, et
+                                  ce qui, dedans, appartient au tenant (tag / préfixe)
+    cleanup <tenant.yaml>         supprime ce qui appartient au tenant — chemin de
+                                  SECOURS quand `terraform destroy` n'a pas fini
+
+# Pourquoi l'API plutôt qu'une variable
+
+`scw config get default-project-id` dit ce qu'un profil déclare ; il ne dit pas sur
+quel compte une clé ouvre réellement. La porte demande donc à l'API à qui la clé
+appartient (GET /iam/v1alpha1/api-keys/{access_key} → default_project_id, puis
+GET /account/v3/projects/{id} → organization_id), et compare à ce qu'expected.yaml
+épingle. Les identifiants sont résolus EXACTEMENT comme le provider Terraform et
+`pepin scan --live` le font : variables SCW_* d'abord, puis ~/.config/scw/config.yaml
+(profil actif ou SCW_PROFILE). Aucun n'est écrit, affiché ni journalisé.
+
+# Pourquoi onze familles et un delta
+
+`Destroy complete!` dit que Terraform a supprimé ce qu'il connaissait, pas que le
+compte est vide. L'inventaire liste donc famille par famille (serveurs, IP, groupes
+de sécurité, volumes Instance et Block, snapshots, images, bases managées et leurs
+sauvegardes, réseaux privés, VPC, load balancers, passerelles, applications,
+politiques et clés IAM, buckets) ce que le compte contient, en marquant ce qui porte
+le tag ou le préfixe du tenant. Le runner compare en plus l'inventaire APRÈS destroy
+à celui d'AVANT apply : une ressource apparue entre les deux, même sans tag (un volume
+racine renommé, une sauvegarde automatique), est un reste.
+
+Les URL sont celles que la CLI scw appelle (relevées avec `scw … -D` le 2026-09-09).
+"""
+import base64
+import datetime as dt
+import hashlib
+import hmac
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import yaml
+
+API = "https://api.scaleway.com"
+
+
+# ─── identifiants natifs ───────────────────────────────────────────────────────
+
+def _config_file():
+    p = os.environ.get("SCW_CONFIG_PATH") or os.path.join(
+        os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")), "scw", "config.yaml")
+    try:
+        d = yaml.safe_load(open(p)) or {}
+    except FileNotFoundError:
+        return {}
+    profile = os.environ.get("SCW_PROFILE") or d.get("active_profile")
+    if profile and profile in (d.get("profiles") or {}):
+        merged = dict(d)
+        merged.update(d["profiles"][profile] or {})
+        return merged
+    return d
+
+
+def creds():
+    """access_key, secret_key : l'environnement d'abord, le fichier ensuite."""
+    f = _config_file()
+    ak = os.environ.get("SCW_ACCESS_KEY") or f.get("access_key")
+    sk = os.environ.get("SCW_SECRET_KEY") or f.get("secret_key")
+    if not ak or not sk:
+        sys.exit("aucun identifiant Scaleway : SCW_ACCESS_KEY/SCW_SECRET_KEY ou ~/.config/scw/config.yaml")
+    return ak, sk
+
+
+def api(method, path, params=None, body=None):
+    url = API + path
+    if params:
+        url += ("&" if "?" in path else "?") + urllib.parse.urlencode(params)
+    _, sk = creds()
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("X-Auth-Token", sk)
+    req.add_header("Accept", "application/json")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as r:
+            raw = r.read()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")[:300]
+        raise RuntimeError(f"{method} {path} → HTTP {e.code} : {detail}") from None
+
+
+def paged(path, key, params=None, per_page_param="per_page"):
+    """Toutes les pages d'un listing (page=1..n, jusqu'à une page incomplète)."""
+    out, page = [], 1
+    params = dict(params or {})
+    while True:
+        params.update({"page": page, per_page_param: 100})
+        d = api("GET", path, params)
+        items = d.get(key) or []
+        out.extend(items)
+        if len(items) < 100:
+            return out
+        page += 1
+
+
+# ─── S3 (SigV4 minimal : ListBuckets, DeleteBucket) ────────────────────────────
+
+def _sign(key, msg):
+    return hmac.new(key, msg.encode(), hashlib.sha256).digest()
+
+
+def s3_request(method, region, bucket=None, ak=None, sk=None):
+    """Requête S3 signée SigV4, sans dépendance : GET / (liste) ou DELETE /bucket."""
+    ak, sk = (ak, sk) if ak and sk else creds()
+    host = f"s3.{region}.scw.cloud" if not bucket else f"{bucket}.s3.{region}.scw.cloud"
+    now = dt.datetime.now(dt.timezone.utc)
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    date = now.strftime("%Y%m%d")
+    payload_hash = hashlib.sha256(b"").hexdigest()
+    canonical_headers = f"host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n"
+    signed = "host;x-amz-content-sha256;x-amz-date"
+    canonical = f"{method}\n/\n\n{canonical_headers}\n{signed}\n{payload_hash}"
+    scope = f"{date}/{region}/s3/aws4_request"
+    to_sign = f"AWS4-HMAC-SHA256\n{amz_date}\n{scope}\n{hashlib.sha256(canonical.encode()).hexdigest()}"
+    k = _sign(_sign(_sign(_sign(("AWS4" + sk).encode(), date), region), "s3"), "aws4_request")
+    sig = hmac.new(k, to_sign.encode(), hashlib.sha256).hexdigest()
+    auth = f"AWS4-HMAC-SHA256 Credential={ak}/{scope}, SignedHeaders={signed}, Signature={sig}"
+    req = urllib.request.Request(f"https://{host}/", method=method)
+    req.add_header("Host", host)
+    req.add_header("x-amz-date", amz_date)
+    req.add_header("x-amz-content-sha256", payload_hash)
+    req.add_header("Authorization", auth)
+    try:
+        with urllib.request.urlopen(req, timeout=60) as r:
+            return r.status, r.read().decode(errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode(errors="replace")[:300]
+
+
+def s3_buckets(region):
+    status, body = s3_request("GET", region)
+    if status != 200:
+        raise RuntimeError(f"ListBuckets {region} → HTTP {status} : {body}")
+    import re
+    return re.findall(r"<Name>([^<]+)</Name>", body)
+
+
+# ─── identité ──────────────────────────────────────────────────────────────────
+
+def identity():
+    ak, _ = creds()
+    key = api("GET", f"/iam/v1alpha1/api-keys/{ak}")
+    project = key.get("default_project_id")
+    if not project:
+        sys.exit("la clé d'API n'a pas de projet par défaut : impossible d'établir le compte")
+    p = api("GET", f"/account/v3/projects/{project}")
+    bearer = "application" if key.get("application_id") else "user"
+    return {
+        "project_id": project,
+        "project_name": p.get("name"),
+        "organization_id": p.get("organization_id"),
+        "bearer": bearer,
+        # Le principal de politique de bucket (version 2023-04-17) qui désigne
+        # l'identité qui qualifie : `user_id:…` ou `application_id:…`. Passé à
+        # Terraform par le runner, jamais écrit dans le dépôt.
+        "principal": f"{bearer}_id:{key.get('application_id') or key.get('user_id')}",
+    }
+
+
+# ─── inventaire ────────────────────────────────────────────────────────────────
+
+def _owned(item, tag, prefix):
+    tags = item.get("tags") or []
+    name = item.get("name") or item.get("description") or ""
+    return tag in tags or name.startswith(prefix)
+
+
+def inventory(tenant):
+    region, zone = tenant["region"], tenant["zone"]
+    tag, prefix = tenant["tag"], tenant["name_prefix"]
+    org = identity()["organization_id"]
+    fam = {}
+
+    def put(family, items, key_id="id", owned=None):
+        owned = owned or (lambda i: _owned(i, tag, prefix))
+        fam[family] = {
+            "all": sorted(i.get(key_id) or i.get("name") for i in items),
+            "tenant": [{"id": i.get(key_id), "name": i.get("name") or i.get("description")}
+                       for i in items if owned(i)],
+        }
+
+    put("servers", paged(f"/instance/v1/zones/{zone}/servers", "servers"))
+    put("security_groups", paged(f"/instance/v1/zones/{zone}/security_groups", "security_groups"))
+    put("flexible_ips", paged(f"/instance/v1/zones/{zone}/ips", "ips"))
+    put("instance_volumes", paged(f"/instance/v1/zones/{zone}/volumes", "volumes"))
+    put("instance_snapshots", paged(f"/instance/v1/zones/{zone}/snapshots", "snapshots"))
+    put("instance_images", paged(f"/instance/v1/zones/{zone}/images", "images", {"public": "false"}))
+    put("block_volumes", paged(f"/block/v1alpha1/zones/{zone}/volumes", "volumes", per_page_param="page_size"))
+    put("block_snapshots", paged(f"/block/v1alpha1/zones/{zone}/snapshots", "snapshots", per_page_param="page_size"))
+    put("rdb_instances", paged(f"/rdb/v1/regions/{region}/instances", "instances", per_page_param="page_size"))
+    backups = paged(f"/rdb/v1/regions/{region}/backups", "database_backups", per_page_param="page_size")
+    put("rdb_backups", backups, owned=lambda b: (b.get("instance_name") or "").startswith(prefix))
+    put("rdb_snapshots", paged(f"/rdb/v1/regions/{region}/snapshots", "snapshots", per_page_param="page_size"))
+    put("private_networks", paged(f"/vpc/v2/regions/{region}/private-networks", "private_networks", per_page_param="page_size"))
+    put("vpcs", paged(f"/vpc/v2/regions/{region}/vpcs", "vpcs", per_page_param="page_size"))
+    put("load_balancers", paged(f"/lb/v1/zones/{zone}/lbs", "lbs", per_page_param="page_size"))
+    put("public_gateways", paged(f"/vpc-gw/v2/zones/{zone}/gateways", "gateways", per_page_param="page_size"))
+    apps = paged("/iam/v1alpha1/applications", "applications", {"organization_id": org}, per_page_param="page_size")
+    put("iam_applications", apps)
+    put("iam_policies", paged("/iam/v1alpha1/policies", "policies", {"organization_id": org}, per_page_param="page_size"))
+    app_ids = {a["id"] for a in apps if _owned(a, tag, prefix)}
+    keys = paged("/iam/v1alpha1/api-keys", "api_keys", {"organization_id": org}, per_page_param="page_size")
+    put("iam_api_keys", keys, key_id="access_key",
+        owned=lambda k: k.get("application_id") in app_ids or (k.get("description") or "").startswith(prefix))
+    buckets = [{"id": b, "name": b} for b in s3_buckets(region)]
+    put("buckets", buckets, owned=lambda b: b["name"].startswith(prefix))
+    return fam
+
+
+# ─── nettoyage de secours ──────────────────────────────────────────────────────
+
+def scw(*args):
+    """La CLI scw : elle emploie encore la route v1 pour ce que la v2 refuse."""
+    cmd = ["scw", *args]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    ok = r.returncode == 0
+    print(("  ✔ " if ok else "  ✘ ") + " ".join(args) + ("" if ok else f"\n    {r.stderr.strip()[:200]}"))
+    return ok
+
+
+def cleanup(tenant):
+    region, zone = tenant["region"], tenant["zone"]
+    inv = inventory(tenant)
+    rest = {f: v["tenant"] for f, v in inv.items() if v["tenant"]}
+    if not rest:
+        print("rien à nettoyer : aucune ressource du tenant")
+        return True
+    ok = True
+    # L'ordre est celui des dépendances : ce qui est attaché avant ce qui porte.
+    for s in rest.get("servers", []):
+        # with-ip=true : sans lui, l'adresse survit au serveur et reste facturée.
+        ok &= scw("instance", "server", "delete", s["id"], f"zone={zone}",
+                  "with-volumes=all", "with-ip=true", "force-shutdown=true")
+    for ip in rest.get("flexible_ips", []):
+        ok &= scw("instance", "ip", "delete", ip["id"], f"zone={zone}")
+    for v in rest.get("instance_volumes", []):
+        ok &= scw("instance", "volume", "delete", v["id"], f"zone={zone}")
+    for v in rest.get("block_volumes", []):
+        ok &= scw("block", "volume", "delete", v["id"], f"zone={zone}")
+    for sg in rest.get("security_groups", []):
+        ok &= scw("instance", "security-group", "delete", sg["id"], f"zone={zone}")
+    for db in rest.get("rdb_instances", []):
+        ok &= scw("rdb", "instance", "delete", db["id"], f"region={region}")
+    for b in rest.get("rdb_backups", []):
+        ok &= scw("rdb", "backup", "delete", b["id"], f"region={region}")
+    for pn in rest.get("private_networks", []):
+        ok &= scw("vpc", "private-network", "delete", pn["id"], f"region={region}")
+    for v in rest.get("vpcs", []):
+        ok &= scw("vpc", "vpc", "delete", v["id"], f"region={region}")
+    for b in rest.get("buckets", []):
+        status, body = s3_request("DELETE", region, bucket=b["name"])
+        good = status in (204, 404)
+        ok &= good
+        print(("  ✔ " if good else "  ✘ ") + f"DeleteBucket {b['name']} → {status}")
+    for k in rest.get("iam_api_keys", []):
+        ok &= scw("iam", "api-key", "delete", k["id"])
+    for p in rest.get("iam_policies", []):
+        ok &= scw("iam", "policy", "delete", p["id"])
+    for a in rest.get("iam_applications", []):
+        ok &= scw("iam", "application", "delete", a["id"])
+    return ok
+
+
+# ─── point d'entrée ────────────────────────────────────────────────────────────
+
+def main(argv):
+    if len(argv) < 2 or argv[1] not in ("identity", "inventory", "cleanup"):
+        sys.exit(__doc__)
+    if argv[1] == "identity":
+        print(json.dumps(identity(), indent=2))
+        return 0
+    tenant = yaml.safe_load(open(argv[2]))
+    if argv[1] == "inventory":
+        print(json.dumps(inventory(tenant), indent=2, sort_keys=True))
+        return 0
+    return 0 if cleanup(tenant) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/references/qualification/scaleway/iam.tf
+++ b/references/qualification/scaleway/iam.tf
@@ -1,0 +1,88 @@
+# IAM — clés d'API et politiques (portée : ORGANISATION, ressources gratuites).
+#
+# Deux applications, et la séparation est délibérée : l'application qui PORTE
+# les clés n'a aucune politique (des clés sans droit), et l'application qui porte
+# la politique fautive n'a aucune clé. Le tenant reproduit ainsi l'écart CLD-IAM-12
+# sans jamais mettre en circulation, même trente minutes, un secret capable de
+# gérer l'IAM de l'organisation.
+#
+# Les utilisateurs IAM ne sont PAS créés : `scaleway_iam_user` invite une personne
+# réelle dans l'organisation, ce qui sort du périmètre d'un tenant jetable. Le
+# contrôle CLD-IAM-3 (MFA) s'observe donc sur les utilisateurs existants de
+# l'organisation, et expected.yaml le dit (statut « evaluated », hors périmètre).
+
+resource "scaleway_iam_application" "keys" {
+  name        = "pepin-qual-app-keys"
+  description = "Tenant de qualification Pépin : porte les clés d'API, aucune politique"
+  tags        = local.untagged
+}
+
+# ÉCART iam_accesskey_expiration_set (CLD-IAM-2, critical) : clé SANS échéance.
+#
+# PLAN SEULEMENT. Mesuré le 2026-09-09 : l'organisation de qualification refuse
+# de créer une telle clé — « organization security settings require an expiration
+# date for API keys ». C'est un réglage préventif de l'organisation, et il fait
+# exactement ce que le contrôle demande ; la faute n'est donc pas constructible en
+# live sur ce compte, et elle reste exercée sur le plan.
+resource "scaleway_iam_api_key" "no_expiry" {
+  count          = local.tf_only
+  application_id = scaleway_iam_application.keys.id
+  description    = "pepin-qual-key-no-expiry"
+}
+
+# ÉCART iam_accesskey_expiration_set (CLD-IAM-2, high) : clé dont l'échéance est
+# DÉPASSÉE et qui reste listée — la branche « l'échéance ne protège plus rien ».
+# Le runner pose une échéance quelques minutes après l'apply, puis ATTEND qu'elle
+# soit passée avant de scanner. Mesuré le 2026-09-09 : une clé expirée reste dans
+# GET /iam/v1alpha1/api-keys, avec son expires_at dans le passé.
+resource "scaleway_iam_api_key" "expired" {
+  application_id = scaleway_iam_application.keys.id
+  description    = "pepin-qual-key-expired"
+  expires_at     = var.key_expired_at
+}
+
+# CONTRE-EXEMPLE : la même clé, avec une échéance à venir (J+2, posée par le runner).
+resource "scaleway_iam_api_key" "expiring" {
+  application_id = scaleway_iam_application.keys.id
+  description    = "pepin-qual-key-expiring"
+  expires_at     = var.key_expires_at
+}
+
+# ── Plan seulement : les politiques IAM ne sont pas collectées en live ──────────
+
+resource "scaleway_iam_application" "admin" {
+  count       = local.tf_only
+  name        = "pepin-qual-app-admin"
+  description = "Tenant de qualification Pépin : porte les politiques, aucune clé"
+  tags        = local.untagged
+}
+
+# ÉCART iam_policy_no_privilege_escalation (CLD-IAM-12, high) : le PermissionSet
+# IAMManager confère la gestion de l'IAM (ancré : mapping_terraform de
+# providers/scaleway.yaml, `manages_iam: contains:IAMManager`).
+resource "scaleway_iam_policy" "iam_manager" {
+  count          = local.tf_only
+  name           = "pepin-qual-policy-iam-manager"
+  description    = "Tenant de qualification Pépin : gestion IAM = chemin d'élévation"
+  application_id = scaleway_iam_application.admin[0].id
+  tags           = local.untagged
+
+  rule {
+    organization_id      = var.organization_id
+    permission_set_names = ["IAMManager"]
+  }
+}
+
+# CONTRE-EXEMPLE : lecture seule sur les instances, portée projet — aucune gestion IAM.
+resource "scaleway_iam_policy" "read_only" {
+  count          = local.tf_only
+  name           = "pepin-qual-policy-read-only"
+  description    = "Tenant de qualification Pépin : lecture seule, portée projet"
+  application_id = scaleway_iam_application.admin[0].id
+  tags           = local.untagged
+
+  rule {
+    project_ids          = [var.project_id]
+    permission_set_names = ["InstancesReadOnly"]
+  }
+}

--- a/references/qualification/scaleway/network.tf
+++ b/references/qualification/scaleway/network.tf
@@ -1,0 +1,211 @@
+# Réseau — groupes de sécurité, VPC et réseaux privés (ressources gratuites).
+#
+# UN groupe de sécurité PAR écart, pour que chaque finding ait un sujet qui ne
+# porte que sa faute. La seule exception est voulue : une règle any/any ouvre par
+# définition SSH, RDP et tous les ports sensibles, donc `sg_any_open` porte cinq
+# écarts, et expected.yaml les attend tous les cinq.
+#
+# Tous les groupes sont EXPLICITES et attachés explicitement : le groupe créé par
+# le produit (« Default security group ») bloque la destruction quand un serveur
+# y atterrit sans que Terraform le connaisse (issue #2821 du provider).
+#
+# Aucune `scaleway_instance_private_nic` : voir versions.tf (issue #4338).
+
+# ÉCART network_securitygroup_allow_ingress_from_internet_to_tcp_port_22 (high).
+resource "scaleway_instance_security_group" "ssh_open" {
+  name                    = "pepin-qual-sg-ssh-open"
+  description             = "SSH ouvert a Internet"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "TCP"
+    port     = 22
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# ÉCART …_tcp_port_3389 (high).
+resource "scaleway_instance_security_group" "rdp_open" {
+  name                    = "pepin-qual-sg-rdp-open"
+  description             = "RDP ouvert a Internet"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "TCP"
+    port     = 3389
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# ÉCART …_high_risk_tcp_ports (high) : PostgreSQL exposé.
+resource "scaleway_instance_security_group" "db_open" {
+  name                    = "pepin-qual-sg-db-open"
+  description             = "PostgreSQL ouvert a Internet"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "TCP"
+    port     = 5432
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# ÉCART …_high_risk_udp_ports (high) : SNMP exposé (vecteur d'amplification).
+resource "scaleway_instance_security_group" "snmp_open" {
+  name                    = "pepin-qual-sg-snmp-open"
+  description             = "SNMP ouvert a Internet"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "UDP"
+    port     = 161
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# ÉCART …_all_ports (critical) — et, par construction, les quatre autres contrôles
+# d'entrée : une règle any/any couvre tout port et tout protocole.
+resource "scaleway_instance_security_group" "any_open" {
+  name                    = "pepin-qual-sg-any-open"
+  description             = "Tout le trafic entrant accepte depuis Internet"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "ANY"
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# ÉCART …_tcp_port_22 par ÉVASION : quatre /2 couvrent tout l'espace IPv4 sans
+# qu'aucun ne soit 0.0.0.0/0. C'est le cas #D de l'audit externe (issue #178), que
+# lib.rego ferme par un seuil de largeur (/8) et par la fusion des plages.
+resource "scaleway_instance_security_group" "quartet" {
+  name                    = "pepin-qual-sg-quartet"
+  description             = "SSH ouvert a Internet par quatre /2"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+
+  dynamic "inbound_rule" {
+    for_each = ["0.0.0.0/2", "64.0.0.0/2", "128.0.0.0/2", "192.0.0.0/2"]
+    content {
+      action   = "accept"
+      protocol = "TCP"
+      port     = 22
+      ip_range = inbound_rule.value
+    }
+  }
+}
+
+# ÉCART network_securitygroup_unrestricted_egress (medium) : une règle SORTANTE
+# explicite any → 0.0.0.0/0. La politique sortante par défaut n'est pas une règle,
+# donc elle ne compte pas ; seule la règle écrite est mesurée.
+resource "scaleway_instance_security_group" "egress_any" {
+  name                    = "pepin-qual-sg-egress-any"
+  description             = "Tout le trafic sortant accepte vers Internet"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "drop"
+  tags                    = local.untagged
+
+  outbound_rule {
+    action   = "accept"
+    protocol = "ANY"
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# ÉCART network_securitygroup_default_deny (high) : politique entrante par défaut
+# « accept » — observable sur le PLAN seulement (la collecte live ne projette pas
+# encore InboundDefaultPolicy, cf. providers/scaleway.yaml, contrat security_group).
+resource "scaleway_instance_security_group" "default_accept" {
+  name                    = "pepin-qual-sg-default-accept"
+  description             = "Politique entrante par defaut accept"
+  inbound_default_policy  = "accept"
+  outbound_default_policy = "accept"
+  tags                    = local.untagged
+}
+
+# CONTRE-EXEMPLE de TOUS les contrôles de groupe de sécurité : refus par défaut,
+# SSH depuis un /8 PRIVÉ (la plage que le seuil de largeur ne doit jamais prendre
+# pour Internet), HTTPS depuis Internet (un port servi, pas un port sensible), et
+# une sortie TCP 443 seulement. Aucune règle ne doit parler.
+resource "scaleway_instance_security_group" "hardened" {
+  name                    = "pepin-qual-sg-hardened"
+  description             = "Refus par defaut, SSH prive, HTTPS public"
+  inbound_default_policy  = "drop"
+  outbound_default_policy = "drop"
+  tags                    = local.untagged
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "TCP"
+    port     = 22
+    ip_range = "10.0.0.0/8"
+  }
+
+  inbound_rule {
+    action   = "accept"
+    protocol = "TCP"
+    port     = 443
+    ip_range = "0.0.0.0/0"
+  }
+
+  outbound_rule {
+    action   = "accept"
+    protocol = "TCP"
+    port     = 443
+    ip_range = "0.0.0.0/0"
+  }
+}
+
+# ── Plan seulement : la collecte live des réseaux privés est en attente ──────
+#
+# VPC explicite (gratuit) : le tenant ne dépend pas du VPC par défaut du projet,
+# que Scaleway crée à la première utilisation et qu'on ne détruit pas.
+resource "scaleway_vpc" "qual" {
+  count = local.tf_only
+  name  = "pepin-qual-vpc"
+  tags  = local.untagged
+}
+
+# ÉCART network_documented (CLD-NET-5, low) : réseau sans étiquettes de cartographie
+# (Owner, Project, Env). Observable sur le plan seulement (collecte live du VPC en
+# attente, cf. questions-providers SCW-Q1). Aucun serveur n'y est attaché : une
+# interface privée rendrait le destroy impossible (#4338).
+resource "scaleway_vpc_private_network" "undocumented" {
+  count  = local.tf_only
+  name   = "pepin-qual-pn-undocumented"
+  vpc_id = scaleway_vpc.qual[0].id
+  tags   = local.untagged
+
+  ipv4_subnet {
+    subnet = "172.16.10.0/24"
+  }
+}
+
+# CONTRE-EXEMPLE : le même réseau, cartographié.
+resource "scaleway_vpc_private_network" "documented" {
+  count  = local.tf_only
+  name   = "pepin-qual-pn-documented"
+  vpc_id = scaleway_vpc.qual[0].id
+  tags   = concat([var.tenant_tag], ["Owner=pepin-maintainer", "Project=pepin", "Env=qualification"])
+
+  ipv4_subnet {
+    subnet = "172.16.20.0/24"
+  }
+}

--- a/references/qualification/scaleway/outputs.tf
+++ b/references/qualification/scaleway/outputs.tf
@@ -1,0 +1,125 @@
+# Sorties : les identifiants que la collecte LIVE emploie comme sujets de finding
+# et qui ne sont connus qu'après apply. expected.yaml les cite sous la forme
+# `${output.<nom>}`, et tools/qualification/qualify.py les résout depuis
+# `terraform output -json` AVANT le destroy.
+#
+# Les identifiants zonés (zone/uuid) sont rendus SANS leur zone : c'est la forme
+# que le collecteur live emploie comme sujet (SecurityGroup.ID, Server.ID).
+#
+# Aucune sortie sensible : les clés secrètes ne sortent jamais de l'état, et
+# l'état lui-même est local, non versionné, détruit avec le tenant.
+
+output "sg_ssh_open_id" {
+  value = split("/", scaleway_instance_security_group.ssh_open.id)[1]
+}
+
+output "sg_rdp_open_id" {
+  value = split("/", scaleway_instance_security_group.rdp_open.id)[1]
+}
+
+output "sg_db_open_id" {
+  value = split("/", scaleway_instance_security_group.db_open.id)[1]
+}
+
+output "sg_snmp_open_id" {
+  value = split("/", scaleway_instance_security_group.snmp_open.id)[1]
+}
+
+output "sg_any_open_id" {
+  value = split("/", scaleway_instance_security_group.any_open.id)[1]
+}
+
+output "sg_quartet_id" {
+  value = split("/", scaleway_instance_security_group.quartet.id)[1]
+}
+
+output "sg_egress_any_id" {
+  value = split("/", scaleway_instance_security_group.egress_any.id)[1]
+}
+
+output "sg_default_accept_id" {
+  value = split("/", scaleway_instance_security_group.default_accept.id)[1]
+}
+
+output "sg_hardened_id" {
+  value = split("/", scaleway_instance_security_group.hardened.id)[1]
+}
+
+output "vm_exposed_id" {
+  value = split("/", scaleway_instance_server.exposed.id)[1]
+}
+
+output "vm_private_id" {
+  value = split("/", scaleway_instance_server.private.id)[1]
+}
+
+output "vm_hardened_id" {
+  value = split("/", scaleway_instance_server.hardened.id)[1]
+}
+
+output "vm_untagged_id" {
+  value = split("/", scaleway_instance_server.untagged.id)[1]
+}
+
+output "vm_secrets_id" {
+  value = split("/", scaleway_instance_server.secrets.id)[1]
+}
+
+output "api_key_expired" {
+  value = scaleway_iam_api_key.expired.access_key
+}
+
+output "api_key_expiring" {
+  value = scaleway_iam_api_key.expiring.access_key
+}
+
+output "bucket_public" {
+  value = scaleway_object_bucket.public.name
+}
+
+output "bucket_policy" {
+  value = scaleway_object_bucket.policy.name
+}
+
+output "bucket_unversioned" {
+  value = scaleway_object_bucket.unversioned.name
+}
+
+output "bucket_unlocked" {
+  value = scaleway_object_bucket.unlocked.name
+}
+
+output "bucket_sensitive" {
+  value = scaleway_object_bucket.sensitive.name
+}
+
+output "bucket_hardened" {
+  value = scaleway_object_bucket.hardened.name
+}
+
+output "bucket_encrypted" {
+  value = scaleway_object_bucket.encrypted.name
+}
+
+# Ce que le tenant crée, par famille — APPLIQUÉ (vu en live) et PLAN SEULEMENT.
+# Sert au README et au rapport de la porte.
+output "resource_counts" {
+  value = {
+    applied = {
+      iam_applications = 1
+      iam_api_keys     = 2
+      security_groups  = 9
+      flexible_ips     = 2
+      servers          = 5
+      buckets          = 7
+    }
+    terraform_only = {
+      iam_applications = 1
+      iam_api_keys     = 1
+      iam_policies     = 2
+      vpcs             = 1
+      private_networks = 2
+      rdb_instances    = 2
+    }
+  }
+}

--- a/references/qualification/scaleway/storage.tf
+++ b/references/qualification/scaleway/storage.tf
@@ -1,0 +1,167 @@
+# Stockage objet — sept buckets VIDES dans fr-par (aucun objet : rien à facturer,
+# rien qui bloque la suppression). Chaque bucket ne porte qu'UNE faute, sauf
+# `unversioned` : sans versioning, l'Object Lock est impossible, donc ce bucket
+# porte structurellement deux écarts (versioning + object lock), et expected.yaml
+# attend les deux.
+#
+# Destruction : `force_destroy = true` partout, par ceinture et bretelles — les
+# buckets restent vides, mais un bucket versionné ou verrouillé qui aurait reçu un
+# objet ne se détruirait pas sans (issue #2869 du provider, corrigée en 2.49.0 ;
+# `force_destroy` supprime aussi les objets sous rétention).
+#
+# Les étiquettes de gouvernance sont posées sur TOUS les buckets : object_storage_bucket
+# est un type étiquetable du profil par défaut, et un bucket sans elles porterait
+# l'écart governance_resource_required_tags en plus du sien. Le sujet désigné de
+# cet écart est la VM `untagged` (compute.tf), pas un bucket.
+
+# ÉCART objectstorage_bucket_public_access (CLD-STO-1, critical) : ACL public-read.
+# Versionné et verrouillé pour ne porter QUE l'exposition.
+resource "scaleway_object_bucket" "public" {
+  name                = "pepin-qual-${local.bucket_suffix}-public"
+  object_lock_enabled = true
+  force_destroy       = true
+  tags                = merge(local.bucket_governance_tags, { pepin-qual = "tenant" })
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "scaleway_object_bucket_acl" "public" {
+  bucket = scaleway_object_bucket.public.name
+  acl    = "public-read"
+}
+
+# ÉCART objectstorage_bucket_public_access par POLITIQUE : Principal « * » en
+# lecture. Observable en live seulement (GetBucketPolicy) ; le plan ne mappe pas
+# la ressource de politique, donc ce bucket y est silencieux.
+#
+# La première déclaration garde à l'IDENTITÉ QUI QUALIFIE ses droits complets :
+# en version 2023-04-17, « only actions explicitly allowed by the bucket policy
+# are permitted » et « you will lose access to your bucket if you are not the
+# owner of the Organization, and if you are not explicitly allowed » (doc Scaleway
+# « Bucket policies overview »). Le principal `project_id:` de l'ancienne version
+# est REFUSÉ par l'API en 2023-04-17 (mesuré le 2026-09-09 : « project_id Principal
+# is deprecated ») ; le runner fournit donc `user_id:…` ou `application_id:…`,
+# celui de la clé qui exécute, résolu auprès de l'API et jamais committé.
+resource "scaleway_object_bucket" "policy" {
+  name                = "pepin-qual-${local.bucket_suffix}-policy"
+  object_lock_enabled = true
+  force_destroy       = true
+  tags                = merge(local.bucket_governance_tags, { pepin-qual = "tenant" })
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "scaleway_object_bucket_policy" "public" {
+  bucket = scaleway_object_bucket.policy.name
+  policy = jsonencode({
+    Version = "2023-04-17"
+    Id      = "pepin-qual-public-read"
+    Statement = [
+      {
+        Sid       = "QualifierKeepsFullAccess"
+        Effect    = "Allow"
+        Principal = { SCW = var.bucket_policy_principal }
+        Action    = ["s3:*"]
+        Resource = [
+          scaleway_object_bucket.policy.name,
+          "${scaleway_object_bucket.policy.name}/*",
+        ]
+      },
+      {
+        Sid       = "AnyoneReads"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = ["s3:GetObject"]
+        Resource  = ["${scaleway_object_bucket.policy.name}/*"]
+      },
+    ]
+  })
+}
+
+# ÉCARTS objectstorage_bucket_versioning_enabled (medium) ET, par construction,
+# objectstorage_bucket_object_lock_enabled (low) : ni versioning ni verrou.
+resource "scaleway_object_bucket" "unversioned" {
+  name          = "pepin-qual-${local.bucket_suffix}-unversioned"
+  force_destroy = true
+  tags          = merge(local.bucket_governance_tags, { pepin-qual = "tenant" })
+}
+
+# ÉCART objectstorage_bucket_object_lock_enabled (CLD-STO-8, low) seul : versionné
+# mais sans Object Lock.
+resource "scaleway_object_bucket" "unlocked" {
+  name          = "pepin-qual-${local.bucket_suffix}-unlocked"
+  force_destroy = true
+  tags          = merge(local.bucket_governance_tags, { pepin-qual = "tenant" })
+
+  versioning {
+    enabled = true
+  }
+}
+
+# ÉCART objectstorage_bucket_kms_encryption (CLD-CHF-4, medium) : classé sensible
+# (étiquette classification=confidential) sans clé gérée par le client (SSE-KMS).
+# Observable en live seulement (GetBucketEncryption).
+resource "scaleway_object_bucket" "sensitive" {
+  name                = "pepin-qual-${local.bucket_suffix}-sensitive"
+  object_lock_enabled = true
+  force_destroy       = true
+  tags = merge(local.bucket_governance_tags, {
+    pepin-qual     = "tenant"
+    classification = "confidential"
+  })
+
+  versioning {
+    enabled = true
+  }
+}
+
+# CONTRE-EXEMPLE de TOUS les contrôles de stockage objet : privé, versionné,
+# verrouillé, étiqueté, et classé PUBLIC — donc pas d'exigence SSE-KMS. Le
+# contre-exemple du contrôle KMS est la classification, pas la clé : c'est elle
+# qui discrimine.
+resource "scaleway_object_bucket" "hardened" {
+  name                = "pepin-qual-${local.bucket_suffix}-hardened"
+  object_lock_enabled = true
+  force_destroy       = true
+  tags = merge(local.bucket_governance_tags, {
+    pepin-qual     = "tenant"
+    classification = "public"
+  })
+
+  versioning {
+    enabled = true
+  }
+}
+
+# CONTRE-EXEMPLE de objectstorage_bucket_default_encryption : chiffrement au repos
+# ACTIVÉ (SSE-ONE, clé gérée par Scaleway). Chez Scaleway, le chiffrement au repos
+# d'un bucket est opt-in — un bucket sans configuration SSE écrit en clair — et ce
+# bucket est le seul du tenant qui le configure. Classé public : pas d'exigence de
+# clé client (SSE-KMS), donc muet sur CLD-CHF-4 aussi.
+resource "scaleway_object_bucket" "encrypted" {
+  name                = "pepin-qual-${local.bucket_suffix}-encrypted"
+  object_lock_enabled = true
+  force_destroy       = true
+  tags = merge(local.bucket_governance_tags, {
+    pepin-qual     = "tenant"
+    classification = "public"
+  })
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "scaleway_object_bucket_server_side_encryption_configuration" "encrypted" {
+  bucket = scaleway_object_bucket.encrypted.name
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}

--- a/references/qualification/scaleway/tenant.yaml
+++ b/references/qualification/scaleway/tenant.yaml
@@ -1,0 +1,84 @@
+# Tenant de QUALIFICATION Scaleway — métadonnées lues par tools/qualification/qualify.py.
+#
+# Ce tenant est le contraire d'un tenant de référence (references/tenants/) : il est
+# écrit PAR nous, POUR faire parler chaque contrôle, et il est réellement APPLIQUÉ
+# sur un compte puis détruit. Un tenant de référence prouve qu'une règle se tait sur
+# une configuration tierce correcte ; celui-ci prouve que la chaîne entière — API
+# réelle → collecteur → règles → assessment → bundle → verdict — rend, sur un vrai
+# tenant, exactement les verdicts que expected.yaml consigne.
+provider: scaleway
+title: "Tenant de qualification Scaleway : une faute par ressource, un contre-exemple par contrôle"
+title_en: "Scaleway qualification tenant: one fault per resource, one counterexample per control"
+
+region: fr-par
+zone: fr-par-1
+
+# L'étiquette posée sur toute ressource étiquetable. La preuve de destruction est un
+# listing famille par famille FILTRÉ sur elle, plus un delta avant/après pour ce qui
+# ne s'étiquette pas (volumes racine, sauvegardes RDB, clés d'API).
+tag: pepin-qual
+# Préfixe de nom de toute ressource du tenant : second filtre, pour ce dont l'API
+# ne filtre pas les étiquettes (applications et politiques IAM, buckets).
+name_prefix: pepin-qual-
+
+# Version du provider épinglée dans versions.tf : le runner refuse un lockfile qui
+# ne la porte pas, parce que la régression de destruction est arrivée par une
+# contrainte flottante (issue scaleway/terraform-provider-scaleway#4338).
+provider_version: "2.82.0"
+
+# Budget mur : au-delà, la porte dit NO-GO même si tout le reste est vert. Mesuré
+# (apply ≈ 3,5 min pour 27 ressources, attente de l'échéance de la clé ≈ 1 min,
+# scans + bundle ≈ 1 min, destroy ≈ 1 min) avec de la marge.
+budget_minutes: 25
+
+# Coût : tarifs horaires relevés le 2026-09-09 (`scw instance server-type list`,
+# page de tarification réseau Scaleway) sur ce qui est réellement APPLIQUÉ. Le
+# runner multiplie par la durée apply→destroy et l'écrit au rapport. Tout le reste
+# (IAM, groupes de sécurité, buckets vides) est gratuit. Les bases managées
+# (db-dev-s, 0,0347 €/h pièce) ne sont PAS appliquées : elles n'existent que sur le
+# plan, parce qu'aucun scan live ne les verrait.
+cost:
+  currency: EUR
+  hourly:
+    - family: servers
+      count: 5
+      unit_price: 0.008976   # DEV1-S, fr-par-1
+      source: "scw instance server-type list zone=fr-par-1 (hourly_price)"
+    - family: flexible_ips
+      count: 2
+      unit_price: 0.004      # IPv4 flexible (facturée même attachée)
+      source: "https://www.scaleway.com/en/pricing/network/"
+
+# Ce que le tenant crée, par famille, et le contrôle que chaque ressource fautive
+# exerce. Documentaire : la source de vérité est le HCL, et expected.yaml.
+resources:
+  applied:   # les cinq types que `pepin scan --live` collecte (contrat providers/scaleway.yaml)
+    - { family: iam_applications, count: 1, note: "keys : porte les 2 clés, aucune politique" }
+    - { family: iam_api_keys,     count: 2, note: "expired (échéance dépassée, encore listée) ⇒ CLD-IAM-2 ; expiring = contre-exemple" }
+    - { family: security_groups,  count: 9, note: "ssh/rdp/db/snmp/any/quartet/egress ⇒ 6 contrôles réseau en live ; default_accept ⇒ CLD-NET-2 sur le plan ; hardened = contre-exemple" }
+    - { family: flexible_ips,     count: 2 }
+    - { family: servers,          count: 5, note: "exposed ⇒ CLD-NET-3 ; untagged ⇒ CLD-GVN-1 ; secrets ⇒ CLD-CMP-9 (plan) ; private, hardened = contre-exemples" }
+    - { family: buckets,          count: 7, note: "public/policy ⇒ CLD-STO-1 ; unversioned ⇒ CLD-STO-4 ; unlocked ⇒ CLD-STO-8 ; sensitive ⇒ CLD-CHF-4 ; hardened = contre-exemple ; encrypted (SSE-ONE) = contre-exemple de CLD-CHF-2, contrôle non encore déclaré pour Scaleway" }
+  terraform_only:   # dans le plan complet scanné en --terraform, jamais provisionnés
+    - { family: iam_api_keys,     count: 1, note: "no_expiry ⇒ CLD-IAM-2 (critical) — l'organisation refuse de la créer" }
+    - { family: iam_applications, count: 1, note: "admin : porte les 2 politiques, aucune clé" }
+    - { family: iam_policies,     count: 2, note: "iam_manager ⇒ CLD-IAM-12 ; read_only = contre-exemple" }
+    - { family: vpcs,             count: 1 }
+    - { family: private_networks, count: 2, note: "undocumented ⇒ CLD-NET-5 ; documented = contre-exemple" }
+    - { family: rdb_instances,    count: 2, note: "exposed ⇒ CLD-NET-1, CLD-CHF-2, CLD-STO-3 ; hardened = contre-exemple" }
+
+# Ce que ce tenant NE PEUT PAS exercer sur Scaleway, et pourquoi. Consigné plutôt
+# que tu : une case absente d'une matrice ressemble à une case verte.
+not_exercised:
+  - control: governance_resource_region_in_eu
+    reason: "Toutes les régions Scaleway sont dans l'UE : aucun contre-exemple (écart) n'est constructible ; seul le pass est prouvé."
+  - control: iam_user_mfa_enabled
+    reason: "Un utilisateur IAM est une personne réelle invitée dans l'organisation : hors périmètre d'un tenant jetable. Le contrôle s'observe sur les utilisateurs existants, sans que leur verdict soit épinglé."
+  - control: compute_instance_has_security_group
+    reason: "Un serveur Scaleway porte toujours un groupe de sécurité (celui du projet à défaut) : l'écart n'est pas constructible en live."
+  - control: iam_no_root_access_key
+    reason: "root_owned n'est pas encore dérivé par le collecteur (contrat a_verifier) : le contrôle reste not-evaluated, et c'est ce que expected.yaml épingle — un pass ou un fail qui apparaîtrait ici serait une régression de couverture."
+  - control: iam_accesskey_expiration_set
+    reason: "La branche « clé sans échéance » (critical) n'est pas constructible en live : l'organisation impose une échéance à toute clé d'API (mesuré le 2026-09-09). Elle reste exercée sur le plan ; la branche « échéance dépassée » (high) est exercée en live."
+  - case: "machine à deux cartes (audit #E)"
+    reason: "Exigerait une scaleway_instance_private_nic, dont la destruction est cassée depuis le provider 2.81.0 (#4338, ouverte). Le modèle live Scaleway n'a de toute façon pas de type network_interface."

--- a/references/qualification/scaleway/variables.tf
+++ b/references/qualification/scaleway/variables.tf
@@ -1,0 +1,128 @@
+# Variables du tenant de qualification Scaleway.
+#
+# Aucune n'a de valeur par défaut quand elle identifie un compte ou porte un
+# secret : elles sont injectées par tools/qualification/qualify.py (TF_VAR_*),
+# APRÈS que la porte a vérifié que le compte observé est bien celui épinglé.
+# Un `terraform apply` lancé à la main sans ces variables s'arrête sur une
+# question, jamais sur un compte inattendu.
+
+variable "project_id" {
+  description = "Projet Scaleway dans lequel le tenant est créé — celui qu'expected.yaml épingle, vérifié auprès de l'API avant tout apply"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", var.project_id))
+    error_message = "project_id doit être un UUID."
+  }
+}
+
+variable "organization_id" {
+  description = "Organisation Scaleway (portée des politiques IAM du tenant), vérifiée auprès de l'API avant tout apply"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", var.organization_id))
+    error_message = "organization_id doit être un UUID."
+  }
+}
+
+variable "region" {
+  description = "Région du tenant (UE : toutes les régions Scaleway le sont, le contrôle CLD-GVN-3 n'a donc pas de contre-exemple possible ici)"
+  type        = string
+  default     = "fr-par"
+}
+
+variable "zone" {
+  description = "Zone des ressources zonales (serveurs, groupes de sécurité, IP)"
+  type        = string
+  default     = "fr-par-1"
+}
+
+variable "tenant_tag" {
+  description = "Étiquette posée sur TOUTE ressource étiquetable du tenant : c'est sur elle que la preuve de destruction filtre"
+  type        = string
+  default     = "pepin-qual"
+}
+
+# LES DEUX PASSES DU TENANT, et pourquoi elles ne créent pas la même chose.
+#
+# Un scan `--live` Scaleway ne produit que cinq types (contrat de
+# providers/scaleway.yaml) : access_key, iam_user, compute_instance,
+# security_group_rule, object_storage_bucket. Les bases managées, les réseaux
+# privés, les politiques IAM et la politique par défaut d'un groupe ne sont lus
+# que sur un PLAN (`--terraform`). Provisionner une base managée sur le compte
+# réel coûterait de l'argent qu'aucun scan live ne mesurerait.
+#
+# La stack APPLIQUÉE se limite donc aux ressources que la collecte live voit ;
+# le plan COMPLET (ce drapeau à `true`, sa valeur par défaut) est celui que le
+# runner scanne en `--terraform`. expected.yaml distingue les deux sources.
+variable "terraform_only_resources" {
+  description = "Inclure les ressources que seul le chemin Terraform sait lire (bases managées, VPC et réseaux privés, politiques IAM, clé sans échéance). Le runner applique avec `false` et scanne le plan complet avec `true`."
+  type        = bool
+  default     = true
+}
+
+variable "instance_type" {
+  description = "Gamme des serveurs — la moins chère qui soit disponible sans rupture de stock (DEV1-S : 0,009 €/h, stockage local, `scw instance server-type list`)"
+  type        = string
+  default     = "DEV1-S"
+}
+
+variable "rdb_node_type" {
+  description = "Gamme des bases managées — la plus petite disponible (`scw rdb node-type list`)"
+  type        = string
+  default     = "db-dev-s"
+}
+
+variable "key_expires_at" {
+  description = "Échéance RFC 3339 de la clé d'API CONFORME (contre-exemple de CLD-IAM-2) — calculée par le runner à J+2, jamais écrite en dur pour ne pas périmer"
+  type        = string
+}
+
+variable "key_expired_at" {
+  description = "Échéance RFC 3339 de la clé d'API qui doit être EXPIRÉE au moment du scan (écart CLD-IAM-2, branche « échéance dépassée, clé toujours listée ») — posée par le runner quelques minutes après l'apply, qui attend qu'elle soit passée avant de scanner"
+  type        = string
+}
+
+variable "bucket_policy_principal" {
+  description = "Principal SCW (« user_id:… » ou « application_id:… ») qui garde l'accès complet au bucket porteur d'une politique publique : l'identité qui exécute la qualification, résolue par le runner auprès de l'API — sans elle, une politique 2023-04-17 fermerait le bucket à tout le monde sauf au propriétaire de l'organisation"
+  type        = string
+}
+
+variable "rdb_password" {
+  description = "Mot de passe de l'utilisateur des bases managées — engendré par le runner à chaque exécution, jamais écrit ni affiché ; il ne sert qu'à satisfaire l'API"
+  type        = string
+  sensitive   = true
+}
+
+# Étiquettes de gouvernance CONFORMES au profil par défaut de Pépin
+# (internal/policy : CostCenter, Project, Env, Owner). Sur les ressources dont les
+# étiquettes sont une liste de chaînes (Instance, RDB, VPC), la forme est
+# « clé=valeur », que le collecteur projette en {key, value} (transform kv).
+locals {
+  governance_tags = [
+    "CostCenter=qualification",
+    "Project=pepin",
+    "Env=qualification",
+    "Owner=pepin-maintainer",
+  ]
+  # Toute ressource étiquetable porte le tag du tenant EN PREMIER, et c'est sur lui
+  # que le listing de sortie filtre. Une ressource sans lui échapperait à la preuve.
+  tagged   = concat([var.tenant_tag], local.governance_tags)
+  untagged = [var.tenant_tag]
+
+  # Même profil, en carte, pour les buckets (tags S3 = TagSet clé/valeur).
+  bucket_governance_tags = {
+    CostCenter = "qualification"
+    Project    = "pepin"
+    Env        = "qualification"
+    Owner      = "pepin-maintainer"
+  }
+
+  # Les noms de buckets sont GLOBAUX chez Scaleway : le suffixe dérivé du projet
+  # évite la collision avec un autre compte qui rejouerait ce tenant.
+  bucket_suffix = substr(var.project_id, 0, 8)
+
+  # 1 quand les ressources « plan seulement » sont demandées, 0 sinon (count).
+  tf_only = var.terraform_only_resources ? 1 : 0
+}

--- a/references/qualification/scaleway/versions.tf
+++ b/references/qualification/scaleway/versions.tf
@@ -1,0 +1,46 @@
+# Tenant de qualification Scaleway — épinglage du provider.
+#
+# La version est ÉPINGLÉE À L'EXACT, jamais en `~>` : une contrainte flottante
+# laisse une publication amont changer ce que ce tenant mesure, sans commit de
+# notre côté. C'est exactement la mécanique qui a introduit la régression de
+# destruction du provider 2.81.0 (issue scaleway/terraform-provider-scaleway#4338 :
+# une `scaleway_instance_private_nic` attachée ne se détruit plus, mesuré par le
+# mainteneur le 2026-09-09 sur 2.81.0 ET 2.82.0, 4 ressources laissées sur 4).
+#
+# Ce tenant reste en 2.82.0 parce qu'il ne porte AUCUNE interface privée : c'est le
+# choix de conception qui rend la régression inopérante ici. Si une interface
+# privée entrait un jour dans cette stack, il faudrait soit redescendre en 2.80.0,
+# soit automatiser `scw instance private-nic delete` avant le destroy — et le
+# README de ce dossier le dit avant qu'on ne l'apprenne sur la facture.
+#
+# Le fichier .terraform.lock.hcl à côté est VERSIONNÉ (exception explicite dans
+# .gitignore) : c'est lui qui garantit que la qualification installe le binaire
+# de provider qui a été validé, et non celui publié depuis.
+terraform {
+  required_version = ">= 1.11"
+
+  # Backend local DÉCLARÉ : sans ce bloc, le `-backend-config=path=…` que le runner
+  # passe à `terraform init` est ignoré, et l'état — qui porte les clés secrètes des
+  # clés d'API du tenant — s'écrirait ici, dans le dépôt. Le runner le place dans le
+  # dossier du run, et le purge après un destroy dont l'état est vide.
+  backend "local" {}
+
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "2.82.0"
+    }
+  }
+}
+
+# Aucun identifiant ici (ADR-0012) : le provider lit les variables natives
+# SCW_ACCESS_KEY / SCW_SECRET_KEY, puis ~/.config/scw/config.yaml, exactement
+# comme `pepin scan --live` et comme la CLI scw. Le projet est passé EXPLICITEMENT
+# par variable : la porte refuse de démarrer si le compte observé par l'API n'est
+# pas celui qu'`expected.yaml` épingle, et Terraform reçoit ce même identifiant —
+# aucun des deux ne dépend du profil scw actif au moment du lancement.
+provider "scaleway" {
+  region     = var.region
+  zone       = var.zone
+  project_id = var.project_id
+}

--- a/tools/qualification/qualify.py
+++ b/tools/qualification/qualify.py
@@ -1,0 +1,750 @@
+#!/usr/bin/env python3
+"""Étape 3 de la porte de release (issue #178) : le TENANT DE QUALIFICATION.
+
+    PEPIN_GATE_LIVE=1 python3 tools/qualification/qualify.py run scaleway
+    python3 tools/qualification/qualify.py run scaleway --plan-only
+    python3 tools/qualification/qualify.py compare --run-dir release-gate/qualification-scaleway
+    python3 tools/qualification/qualify.py selftest
+
+Une stack Terraform par fournisseur, committée sous references/qualification/<p>/,
+délibérément mal configurée : une ressource par contrôle, un contre-exemple par
+contrôle. Ce runner l'APPLIQUE sur un compte réel, lance `pepin scan --live` dans
+tous les formats, scelle un bundle, le vérifie et le re-dérive, scanne le MÊME plan
+avec --terraform, DÉTRUIT, prouve la destruction, puis compare l'assessment à
+`expected.yaml` (contrôle × source × sujet → statut). Toute différence est un NO-GO.
+
+# Ce que ce programme refuse, et pourquoi
+
+- De démarrer sans `PEPIN_GATE_LIVE=1` : appliquer un tenant fautif est un geste de
+  mainteneur, opt-in, jamais un effet de bord d'une tâche qu'on lance par habitude.
+- De démarrer si le compte que les identifiants natifs désignent (demandé à l'API,
+  pas lu dans un profil) n'est pas celui qu'`expected.yaml` épingle. Un tenant qui
+  ouvre SSH au monde ne s'applique pas sur une production par erreur.
+- De dire GO si une ressource du tenant survit au destroy : « Destroy complete! »
+  n'est pas une preuve, un listing par famille filtré sur le tag du tenant et un
+  delta avant/après le sont. Une ressource laissée vivante coûte plus cher que
+  l'absence de la porte (CLAUDE.md §1.1, ADR-0012).
+- De dire GO si la porte n'a pas pu être mise en échec : à la fin de chaque run, une
+  attente est cassée en mémoire et la comparaison DOIT dire NO-GO. Une porte qu'on
+  n'a jamais vue rouge ne garde rien (doctrine de tools/falsify/falsify.py).
+
+# Ce qu'il ne détient jamais
+
+Aucun identifiant : le provider Terraform, `pepin scan --live` et les crochets du
+tenant lisent les variables natives du fournisseur ou son fichier de configuration
+(ADR-0012). Le mot de passe des bases managées est engendré ici, passé par
+l'environnement, et ne sort d'aucune sortie. L'état Terraform vit dans le dossier
+de run, non versionné, et tout ce que la porte écrit va dans release-gate/, ignoré
+par git : ces artefacts portent les identifiants de ressources d'un compte réel.
+
+# Convention de sortie des OUTILS de release
+
+0 GO · 1 NO-GO (ou refus de démarrer) · 2 erreur d'usage.
+"""
+import argparse
+import copy
+import datetime as dt
+import json
+import os
+import pathlib
+import re
+import secrets
+import shutil
+import subprocess
+import sys
+import time
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+STATUSES = {"fail", "pass", "not-evaluated", "not-applicable"}
+# `absent` : le contrôle ne doit PAS apparaître dans l'assessment de cette source
+# (aucune ressource de son type n'y existe, et l'assessment ne le liste pas).
+# `evaluated` : pass OU fail, pour un contrôle dont les sujets sont hors du tenant.
+OUTPUT_REF = re.compile(r"^\$\{output\.([A-Za-z0-9_]+)\}$")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Comparaison — fonctions PURES, éprouvées par `selftest`
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class Verdict:
+    def __init__(self):
+        self.problems = []   # ce qui rend NO-GO
+        self.infos = []      # ce qui mérite d'être lu sans rendre NO-GO
+
+    @property
+    def ok(self):
+        return not self.problems
+
+    def problem(self, msg):
+        self.problems.append(msg)
+
+    def info(self, msg):
+        self.infos.append(msg)
+
+
+def resolve_subject(subject, outputs):
+    """`${output.x}` → sa valeur ; un littéral reste tel quel. None si irrésoluble."""
+    m = OUTPUT_REF.match(str(subject))
+    if not m:
+        return str(subject)
+    return outputs.get(m.group(1))
+
+
+def tenant_subject(subject, prefix, owned):
+    """Un sujet appartient-il au tenant : préfixe de nom, valeur d'une sortie, ou
+    adresse d'une ressource du plan (la source Terraform désigne par l'adresse ce
+    dont l'identifiant n'est pas encore connu)."""
+    s = str(subject)
+    return s.startswith(prefix) or s in owned
+
+
+def owned_identifiers(outputs, plan=None):
+    """Ce que le tenant possède : les valeurs de ses sorties et les adresses du plan."""
+    owned = {str(v) for v in outputs.values()}
+    if plan:
+        def walk(module):
+            for r in module.get("resources", []) or []:
+                owned.add(r.get("address", ""))
+            for child in module.get("child_modules", []) or []:
+                walk(child)
+        walk((plan.get("planned_values") or {}).get("root_module") or {})
+    return owned
+
+
+def published_status(results):
+    """Le statut qu'un contrôle publie : `fail` si un seul écart, sinon le statut unique."""
+    statuses = {r["status"] for r in results}
+    if "fail" in statuses:
+        return "fail"
+    if len(statuses) == 1:
+        return statuses.pop()
+    return "/".join(sorted(statuses))
+
+
+def compare(expected, results, source, exit_code, outputs, prefix, owned=None):
+    """Confronte un assessment (liste de résultats) à expected.yaml pour UNE source."""
+    v = Verdict()
+    owned = set(owned) if owned is not None else owned_identifiers(outputs)
+    want_rc = expected.get("exit_codes", {}).get(source)
+    if want_rc is not None and exit_code != want_rc:
+        v.problem(f"[{source}] code de sortie {exit_code}, attendu {want_rc}")
+
+    by_control = {}
+    for r in results:
+        by_control.setdefault(r["control"], []).append(r)
+
+    pinned = expected.get("controls") or {}
+    for code in sorted(set(by_control) - set(pinned)):
+        v.problem(f"[{source}] contrôle non épinglé dans expected.yaml : {code} "
+                  f"(statut publié {published_status(by_control[code])})")
+
+    for code, spec in sorted(pinned.items()):
+        want = spec.get(source) if isinstance(spec, dict) else None
+        if want is None:
+            v.problem(f"[{source}] {code} : expected.yaml ne dit rien pour cette source")
+            continue
+        got = by_control.get(code)
+        if want == "absent" or (isinstance(want, dict) and want.get("status") == "absent"):
+            if got is not None:
+                v.problem(f"[{source}] {code} : attendu ABSENT de l'assessment, obtenu {published_status(got)}")
+            continue
+        if got is None:
+            v.problem(f"[{source}] {code} : absent de l'assessment")
+            continue
+        # Un défaut CONNU est épinglé tel qu'il est mesuré, avec le numéro de l'issue
+        # qui le suit : la porte reste GO, et la correction la fera rougir sciemment.
+        # Il est dit à chaque run, pour ne jamais passer pour une attente ordinaire.
+        if isinstance(want, dict) and want.get("known_defect"):
+            v.info(f"[{source}] {code} : épinglé comme DÉFAUT CONNU — {want['known_defect']}")
+        tenant_fails = [r for r in got if r["status"] == "fail" and tenant_subject(r.get("subject", ""), prefix, owned)]
+        foreign_fails = [r for r in got if r["status"] == "fail" and not tenant_subject(r.get("subject", ""), prefix, owned)]
+        for r in foreign_fails:
+            v.info(f"[{source}] {code} : écart HORS tenant sur « {r.get('subject')} » (non gardé)")
+
+        # Forme 1 : un statut au niveau du contrôle (chaîne, ou mapping avec `status:`).
+        if isinstance(want, str) or (isinstance(want, dict) and "status" in want):
+            status = want if isinstance(want, str) else want["status"]
+            if status not in STATUSES | {"evaluated"}:
+                v.problem(f"[{source}] {code} : statut attendu inconnu « {status} »")
+                continue
+            if tenant_fails:
+                v.problem(f"[{source}] {code} : attendu {status}, mais écart sur "
+                          + ", ".join(sorted({r.get('subject', '') for r in tenant_fails}))
+                          + " — faux positif, ou attente périmée")
+                continue
+            # Sans écart sur le tenant, le statut publié est celui des résultats
+            # restants ; un écart hors tenant prouve seulement que le contrôle a conclu.
+            rest = [r for r in got if r["status"] != "fail"]
+            actual = published_status(rest) if rest else "evaluated"
+            if status == "evaluated":
+                if actual not in ("pass", "evaluated") and not foreign_fails:
+                    v.problem(f"[{source}] {code} : attendu qu'il CONCLUE (pass/fail), obtenu {actual}")
+            elif actual != status:
+                v.problem(f"[{source}] {code} : attendu {status}, obtenu {actual}"
+                          + (" — un pass qui apparaît sans changement du collecteur est un pass non prouvé" if actual == "pass" and status == "not-evaluated" else "")
+                          + (" — régression de couverture" if actual == "not-evaluated" and status in ("pass", "fail") else ""))
+            continue
+
+        # Forme 2 : des sujets fautifs (`fail:`) et des contre-exemples (`silent:`).
+        if not isinstance(want, dict) or "fail" not in want:
+            v.problem(f"[{source}] {code} : attente illisible ({want!r})")
+            continue
+        want_fail, unresolved = [], []
+        for s in want.get("fail") or []:
+            r = resolve_subject(s, outputs)
+            (want_fail if r is not None else unresolved).append(r if r is not None else s)
+        want_silent, unresolved_silent = [], []
+        for s in want.get("silent") or []:
+            r = resolve_subject(s, outputs)
+            (want_silent if r is not None else unresolved_silent).append(r if r is not None else s)
+        for s in unresolved + unresolved_silent:
+            v.problem(f"[{source}] {code} : sujet irrésoluble {s} (sortie Terraform absente)")
+        failing = {r.get("subject", "") for r in tenant_fails}
+        for s in want_fail:
+            if s not in failing:
+                v.problem(f"[{source}] {code} : FAUX VERT — aucun écart sur « {s} », qui est fautif")
+        for s in sorted(failing - set(want_fail)):
+            v.problem(f"[{source}] {code} : FAUX POSITIF — écart sur « {s} », que rien n'attend")
+        for s in want_silent:
+            if s in failing:
+                v.problem(f"[{source}] {code} : le CONTRE-EXEMPLE « {s} » parle — la règle ne discrimine pas")
+        others = {r["status"] for r in got if r["status"] != "fail"}
+        if others and not tenant_fails and not foreign_fails:
+            v.problem(f"[{source}] {code} : attendu des écarts, obtenu {published_status(got)}")
+    return v
+
+
+def load_results(path):
+    doc = json.loads(pathlib.Path(path).read_text())
+    return [{"control": r["control"], "status": r["status"], "subject": r.get("subject", "")}
+            for r in doc.get("results", [])]
+
+
+def falsify(expected, results, source, exit_code, outputs, prefix, owned=None):
+    """Casse une attente et exige le NO-GO. Rend (ok, description)."""
+    mutants = []
+    for code, spec in (expected.get("controls") or {}).items():
+        want = spec.get(source)
+        if isinstance(want, dict) and want.get("fail"):
+            m = copy.deepcopy(expected)
+            m["controls"][code][source] = "pass"
+            mutants.append((f"{code} : les écarts attendus deviennent « pass »", m))
+            break
+    for code, spec in (expected.get("controls") or {}).items():
+        if spec.get(source) == "not-evaluated":
+            m = copy.deepcopy(expected)
+            m["controls"][code][source] = "pass"
+            mutants.append((f"{code} : « not-evaluated » attendu devient « pass »", m))
+            break
+    m = copy.deepcopy(expected)
+    m.setdefault("exit_codes", {})[source] = 0
+    mutants.append(("code de sortie attendu 0", m))
+    outcomes = []
+    for label, mutant in mutants:
+        v = compare(mutant, results, source, exit_code, outputs, prefix, owned)
+        outcomes.append({"mutation": label, "no_go": not v.ok, "first_problem": (v.problems or [""])[0]})
+    return all(o["no_go"] for o in outcomes), outcomes
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Le run
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class Run:
+    def __init__(self, provider, run_dir, plan_only):
+        self.provider = provider
+        self.tenant_dir = ROOT / "references" / "qualification" / provider
+        self.run_dir = run_dir
+        self.plan_only = plan_only
+        self.stages = []
+        self.t0 = time.time()
+        self.applied = False
+        self.destroyed = False
+        self.tenant = yaml.safe_load((self.tenant_dir / "tenant.yaml").read_text())
+        self.expected = yaml.safe_load((self.tenant_dir / "expected.yaml").read_text())
+        self.outputs = {}
+        self.pepin = run_dir / "pepin"
+        self.env = dict(os.environ, TF_IN_AUTOMATION="1", CHECKPOINT_DISABLE="1",
+                        NO_COLOR="1", TERM="dumb", PEPIN_LANG="en")
+        # Une socket unix est bornée à 108 octets : un TMPDIR profond fait échouer
+        # le greffon du provider avec un « bind: invalid argument » sans rapport.
+        if len(self.env.get("TMPDIR", "")) > 40:
+            self.env["TMPDIR"] = "/tmp"
+
+    # ─── journal ───────────────────────────────────────────────────────────
+    def stage(self, name, fn):
+        t = time.time()
+        print(f"\n── {name}")
+        try:
+            note = fn()
+            rc = 0
+        except StageFailed as e:
+            note, rc = str(e), 1
+            print(f"  ✘ {e}")
+        self.stages.append({"name": name, "rc": rc, "seconds": round(time.time() - t, 1), "note": note})
+        return rc == 0
+
+    def sh(self, args, cwd=None, capture=True, check=True, env=None, log=None):
+        r = subprocess.run(args, cwd=cwd or self.tenant_dir, env=env or self.env,
+                           capture_output=capture, text=True)
+        if log:
+            (self.run_dir / log).write_text((r.stdout or "") + (r.stderr or ""))
+        if check and r.returncode != 0:
+            tail = ((r.stderr or r.stdout or "")[-1500:]).strip()
+            raise StageFailed(f"`{' '.join(map(str, args[:3]))}…` rc={r.returncode}\n{tail}")
+        return r
+
+    def hook(self, *args):
+        r = self.sh([sys.executable, str(self.tenant_dir / "hooks.py"), *args], cwd=ROOT)
+        return json.loads(r.stdout)
+
+    # ─── étapes ────────────────────────────────────────────────────────────
+    def preflight(self):
+        for tool in ("terraform", "go", "scw"):
+            if not shutil.which(tool):
+                raise StageFailed(f"{tool} absent du PATH ({'chemin de secours du nettoyage' if tool == 'scw' else 'requis'})")
+        lock = self.tenant_dir / ".terraform.lock.hcl"
+        want = str(self.tenant["provider_version"])
+        if not lock.exists() or f'version     = "{want}"' not in lock.read_text() and f'version = "{want}"' not in lock.read_text():
+            raise StageFailed(f"le lockfile n'épingle pas le provider {want} : une contrainte flottante est exactement ce que ce tenant refuse")
+        self.sh(["go", "build", "-trimpath", "-o", str(self.pepin), "."], cwd=ROOT)
+        ver = self.sh([str(self.pepin), "version"], cwd=ROOT).stdout.strip()
+        tf = json.loads(self.sh(["terraform", "version", "-json"]).stdout)["terraform_version"]
+        return f"pepin {ver} · terraform {tf} · provider {want}"
+
+    def identity(self):
+        who = self.hook("identity")
+        acct = self.compte_attendu()
+        if who["project_id"] != acct["project_id"] or who["organization_id"] != acct["organization_id"]:
+            raise StageFailed(
+                "REFUS : les identifiants natifs désignent le projet "
+                f"{who['project_id']} (org {who['organization_id']}), et le compte attendu est "
+                f"{acct['project_id']} (org {acct['organization_id']}). Rien n'a été appliqué.")
+        self.env["TF_VAR_project_id"] = acct["project_id"]
+        self.env["TF_VAR_organization_id"] = acct["organization_id"]
+        now = dt.datetime.now(dt.timezone.utc)
+        rfc = "%Y-%m-%dT%H:%M:%SZ"
+        self.env["TF_VAR_key_expires_at"] = (now + dt.timedelta(days=2)).strftime(rfc)
+        # La clé « expirée » : une échéance que l'apply précède et que le scan suit —
+        # le runner attend qu'elle soit passée. En mode plan seul, rien n'est appliqué
+        # et le scan du plan a lieu tout de suite : l'échéance est posée dans le passé.
+        self.key_expired_at = now + (dt.timedelta(minutes=3) if not self.plan_only else -dt.timedelta(minutes=1))
+        self.env["TF_VAR_key_expired_at"] = self.key_expired_at.strftime(rfc)
+        self.env["TF_VAR_bucket_policy_principal"] = who["principal"]
+        self.env["TF_VAR_rdb_password"] = secrets.token_urlsafe(24) + "Aa1!"
+        return f"compte confirmé par l'API : projet « {who.get('project_name')} » {who['project_id']} (porteur : {who['bearer']})"
+
+    def compte_attendu(self):
+        """Le compte sur lequel la porte accepte de tourner, lu dans l'ENVIRONNEMENT.
+
+        `expected.yaml` nomme les variables plutôt que les identifiants : le dépôt est
+        public, et un `organization_id` committé nommerait durablement le tenant du
+        mainteneur. Ce n'est pas un secret — il n'ouvre rien sans identifiants —, mais
+        un identifiant publié ne se dépublie pas.
+
+        La garde ne perd rien : elle compare toujours ce que l'API répond à ce qui est
+        attendu. Seule la PROVENANCE de l'attendu change. Une variable absente est un
+        refus, jamais un laissez-passer : sans attendu, il n'y a rien à confronter, et
+        appliquer un tenant délibérément fautif sur un compte non confirmé est
+        exactement ce que cette étape existe pour empêcher.
+        """
+        acct = self.expected["account"]
+        out = {}
+        for champ in ("organization_id", "project_id"):
+            var = acct.get(f"{champ}_env")
+            if not var:
+                raise StageFailed(
+                    f"expected.yaml ne nomme pas la variable qui fournit {champ} "
+                    f"(clé attendue : {champ}_env)")
+            val = os.environ.get(var, "").strip()
+            if not val:
+                raise StageFailed(
+                    f"REFUS : la variable {var} n'est pas posée, donc le compte attendu est "
+                    "inconnu. Rien n'a été appliqué — un tenant délibérément fautif ne "
+                    "s'applique pas sur un compte que personne n'a confirmé.")
+            out[champ] = val
+        return out
+
+    def snapshot_before(self):
+        inv = self.hook("inventory", str(self.tenant_dir / "tenant.yaml"))
+        (self.run_dir / "inventory-before.json").write_text(json.dumps(inv, indent=2, sort_keys=True))
+        owned = {f: v["tenant"] for f, v in inv.items() if v["tenant"]}
+        if owned:
+            raise StageFailed("des ressources du tenant existent DÉJÀ (run précédent non nettoyé ?) : "
+                              + ", ".join(f"{f}×{len(v)}" for f, v in owned.items())
+                              + " — lancer `hooks.py cleanup` avant de recommencer")
+        return "aucune ressource du tenant avant apply ; " + ", ".join(f"{f}={len(v['all'])}" for f, v in sorted(inv.items()) if v["all"]) or "compte vide"
+
+    def plan(self):
+        state = self.run_dir / "terraform.tfstate"
+        self.sh(["terraform", "init", "-input=false", "-lockfile=readonly",
+                 f"-backend-config=path={state}"], log="terraform-init.log")
+        self.sh(["terraform", "validate"])
+
+        # DEUX plans, parce que les deux passes ne mesurent pas la même chose. Le plan
+        # COMPLET porte aussi ce que seul le chemin Terraform sait lire (bases managées,
+        # réseaux privés, politiques IAM) : c'est lui que `--terraform` scanne. Le plan
+        # APPLIQUÉ s'en tient aux types que la collecte live produit : provisionner le
+        # reste coûterait de l'argent qu'aucun scan live ne mesurerait.
+        def one(label, extra, out, js):
+            self.sh(["terraform", "plan", "-input=false", *extra, f"-out={self.run_dir / out}"], log=f"terraform-plan-{label}.log")
+            plan = self.sh(["terraform", "show", "-json", str(self.run_dir / out)]).stdout
+            (self.run_dir / js).write_text(plan)
+            d = json.loads(plan)
+            counts = {}
+            for r in d.get("resource_changes", []):
+                if "create" in r["change"]["actions"]:
+                    counts[r["type"]] = counts.get(r["type"], 0) + 1
+            return d, counts
+
+        full, self.counts = one("full", [], "tfplan-full.bin", "plan.json")
+        for name, o in (full.get("planned_values", {}).get("outputs") or {}).items():
+            if "value" in o:
+                self.outputs[name] = o["value"]
+        note = f"plan complet : {sum(self.counts.values())} ressources (" + ", ".join(f"{t}×{n}" for t, n in sorted(self.counts.items())) + ")"
+        if not self.plan_only:
+            _, self.counts_applied = one("applied", ["-var", "terraform_only_resources=false"], "tfplan.bin", "plan-applied.json")
+            note += f" ; plan appliqué : {sum(self.counts_applied.values())} ressources"
+        return note
+
+    def apply(self):
+        self.applied = True  # dès qu'on tente : un apply à moitié fait se détruit aussi
+        self.apply_started = time.time()
+        self.sh(["terraform", "apply", "-input=false", "-auto-approve", str(self.run_dir / "tfplan.bin")], log="terraform-apply.log")
+        out = json.loads(self.sh(["terraform", "output", "-json"]).stdout)
+        self.outputs = {k: v["value"] for k, v in out.items() if not v.get("sensitive")}
+        (self.run_dir / "outputs.json").write_text(json.dumps(self.outputs, indent=2, sort_keys=True))
+        return f"{len(self.outputs)} sorties capturées"
+
+    def scan(self, args, out, log):
+        r = self.sh([str(self.pepin), "scan", self.provider, *args], cwd=ROOT, check=False)
+        (self.run_dir / out).write_text(r.stdout)
+        (self.run_dir / log).write_text(r.stderr)
+        return r.returncode
+
+    def wait_for_expiry(self):
+        """La clé « expirée » doit l'être AVANT le scan : on attend l'échéance, plus une marge."""
+        target = self.key_expired_at + dt.timedelta(seconds=20)
+        delay = (target - dt.datetime.now(dt.timezone.utc)).total_seconds()
+        if delay > 0:
+            time.sleep(delay)
+        return f"échéance {self.key_expired_at.strftime('%H:%M:%SZ')} passée" + (f" (attente {round(delay)}s)" if delay > 0 else "")
+
+    def scan_live(self):
+        region = self.tenant["region"]
+        base = ["--live", "--region", region]
+        bundle = self.run_dir / "bundle"
+        self.rc_live = self.scan(base + ["--format", "assessment", "--seal", str(bundle)], "assessment-live.json", "scan-live-assessment.err")
+        rcs = {"assessment": self.rc_live}
+        for fmt, ext in (("table", "txt"), ("json", "json"), ("oscal", "json"), ("sarif", "json")):
+            rcs[fmt] = self.scan(base + ["--format", fmt], f"live-{fmt}.{ext}", f"scan-live-{fmt}.err")
+        if len(set(rcs.values())) != 1:
+            raise StageFailed(f"les formats ne rendent pas le même code de sortie : {rcs}")
+        json.loads((self.run_dir / "assessment-live.json").read_text())  # doit être lisible
+        return f"5 formats, code de sortie {self.rc_live} partout"
+
+    def bundle(self):
+        bundle = self.run_dir / "bundle"
+        r = self.sh([str(self.pepin), "verify", str(bundle), "--re-derive"], cwd=ROOT, check=False)
+        if r.returncode != 0:
+            raise StageFailed(f"verify --re-derive rc={r.returncode} : {r.stdout[-400:]}{r.stderr[-400:]}")
+        # Et le refus doit exister : un verify qui accepte tout ne prouve rien (ADR-0018).
+        tampered = self.run_dir / "bundle-tampered"
+        if tampered.exists():
+            shutil.rmtree(tampered)
+        shutil.copytree(bundle, tampered)
+        with open(tampered / "assessment.json", "a") as f:
+            f.write(" ")
+        r = self.sh([str(self.pepin), "verify", str(tampered)], cwd=ROOT, check=False)
+        if r.returncode == 0:
+            raise StageFailed("verify ACCEPTE un bundle altéré d'un octet")
+        return "scellé, vérifié, re-dérivé ; l'altération d'un octet est refusée"
+
+    def scan_terraform(self):
+        plan = self.run_dir / "plan.json"
+        self.rc_tf = self.scan(["--terraform", str(plan), "--format", "assessment"], "assessment-terraform.json", "scan-terraform-assessment.err")
+        self.scan(["--terraform", str(plan), "--format", "table"], "terraform-table.txt", "scan-terraform-table.err")
+        json.loads((self.run_dir / "assessment-terraform.json").read_text())
+        return f"code de sortie {self.rc_tf}"
+
+    def destroy(self):
+        if not self.applied:
+            return "rien n'a été appliqué"
+        r = self.sh(["terraform", "destroy", "-input=false", "-auto-approve"], check=False, log="terraform-destroy.log")
+        note = f"terraform destroy rc={r.returncode}"
+        if r.returncode != 0:
+            print("  ✘ destroy en échec : nettoyage de secours par l'API, puis second destroy")
+            rescue = subprocess.run([sys.executable, str(self.tenant_dir / "hooks.py"), "cleanup",
+                                     str(self.tenant_dir / "tenant.yaml")], cwd=ROOT, env=self.env)
+            r2 = self.sh(["terraform", "destroy", "-input=false", "-auto-approve", "-refresh=true"], check=False, log="terraform-destroy-2.log")
+            note += f" ; cleanup rc={rescue.returncode} ; second destroy rc={r2.returncode}"
+        left = self.sh(["terraform", "state", "list"], check=False).stdout.strip().splitlines()
+        self.destroy_finished = time.time()
+        self.destroyed = not left
+        if left:
+            raise StageFailed(note + f" ; {len(left)} ressource(s) encore dans l'état : " + ", ".join(left[:8]))
+        # L'état et sa sauvegarde portent les clés secrètes des clés d'API du tenant —
+        # mortes avec lui, mais inutiles sur disque une fois l'état vide.
+        purged = 0
+        for f in self.run_dir.glob("terraform.tfstate*"):
+            f.unlink()
+            purged += 1
+        return note + f" ; état vide ; {purged} fichier(s) d'état purgé(s)"
+
+    def leftovers(self):
+        inv = self.hook("inventory", str(self.tenant_dir / "tenant.yaml"))
+        (self.run_dir / "inventory-after.json").write_text(json.dumps(inv, indent=2, sort_keys=True))
+        before = json.loads((self.run_dir / "inventory-before.json").read_text())
+        owned = {f: v["tenant"] for f, v in inv.items() if v["tenant"]}
+        delta = {}
+        for f, v in inv.items():
+            new = sorted(set(v["all"]) - set(before.get(f, {}).get("all", [])))
+            if new:
+                delta[f] = new
+        self.leftover_report = {"tagged": owned, "delta": delta}
+        if owned or delta:
+            raise StageFailed("RESTES après destroy — " + "; ".join(
+                [f"{f} (tag) : {[x['id'] for x in v]}" for f, v in owned.items()]
+                + [f"{f} (delta) : {v}" for f, v in delta.items()]))
+        families = sum(1 for _ in inv)
+        return f"{families} familles listées, aucune ressource du tenant, aucun delta avant/après"
+
+    def compare_all(self):
+        prefix = self.tenant["name_prefix"]
+        owned = owned_identifiers(self.outputs, json.loads((self.run_dir / "plan.json").read_text()))
+        self.comparison = {}
+        problems = 0
+        sources = [("terraform", "assessment-terraform.json", getattr(self, "rc_tf", None))]
+        if not self.plan_only:
+            sources.insert(0, ("live", "assessment-live.json", getattr(self, "rc_live", None)))
+        for source, fname, rc in sources:
+            results = load_results(self.run_dir / fname)
+            v = compare(self.expected, results, source, rc, self.outputs, prefix, owned)
+            self.comparison[source] = {"ok": v.ok, "problems": v.problems, "infos": v.infos,
+                                       "results": len(results), "exit_code": rc}
+            for p in v.problems:
+                print(f"  ✘ {p}")
+            for i in v.infos:
+                print(f"  · {i}")
+            problems += len(v.problems)
+            # La porte se prouve en échouant : une attente cassée doit rendre NO-GO.
+            ok, outcomes = falsify(self.expected, results, source, rc, self.outputs, prefix, owned)
+            self.comparison[source]["falsification"] = outcomes
+            if not ok:
+                raise StageFailed(f"[{source}] la porte n'a PAS su dire NO-GO sur une attente cassée : {outcomes}")
+            print(f"  ✔ [{source}] {len(outcomes)} attentes cassées en mémoire, {len(outcomes)} NO-GO : la porte sait rougir")
+        if problems:
+            raise StageFailed(f"{problems} différence(s) avec expected.yaml")
+        return "assessments conformes à expected.yaml sur " + " et ".join(s for s, _, _ in sources)
+
+    # ─── rapport ───────────────────────────────────────────────────────────
+    def cost(self):
+        if not getattr(self, "apply_started", None):
+            return None
+        hours = (getattr(self, "destroy_finished", time.time()) - self.apply_started) / 3600
+        rate = sum(l["count"] * l["unit_price"] for l in self.tenant.get("cost", {}).get("hourly", []))
+        return {"currency": self.tenant.get("cost", {}).get("currency", "EUR"),
+                "billed_hours": round(hours, 3), "hourly_rate": round(rate, 4),
+                "estimate": round(hours * rate, 4),
+                "note": "estimation : durée apply→destroy × tarifs horaires de tenant.yaml ; la facture à 48 h tranche"}
+
+    def report(self, verdict):
+        duration = round(time.time() - self.t0, 1)
+        rep = {
+            "stage": f"qualification-{self.provider}",
+            "verdict": verdict,
+            "plan_only": self.plan_only,
+            "started": dt.datetime.fromtimestamp(self.t0, dt.timezone.utc).isoformat(timespec="seconds"),
+            "duration_seconds": duration,
+            "budget_minutes": self.tenant.get("budget_minutes"),
+            "account": self.expected.get("account"),
+            "resources_planned": getattr(self, "counts", {}),
+            "resources_applied": getattr(self, "counts_applied", {}),
+            "stages": self.stages,
+            "comparison": getattr(self, "comparison", {}),
+            "leftovers": getattr(self, "leftover_report", None),
+            "cost": self.cost(),
+            "destroyed": self.destroyed,
+        }
+        out = self.run_dir.parent / f"qualification-{self.provider}.json"
+        out.write_text(json.dumps(rep, indent=2, ensure_ascii=False))
+        lines = [f"# Qualification {self.provider} — {verdict}", ""]
+        for s in self.stages:
+            lines.append(f"- {'✔' if s['rc'] == 0 else '✘'} {s['name']} ({s['seconds']}s) — {s['note']}")
+        c = rep["cost"]
+        if c:
+            lines.append(f"- coût estimé : {c['estimate']} {c['currency']} ({c['billed_hours']} h × {c['hourly_rate']} {c['currency']}/h)")
+        lines.append(f"- durée totale : {duration}s (budget {rep['budget_minutes']} min)")
+        (self.run_dir.parent / f"qualification-{self.provider}.md").write_text("\n".join(lines) + "\n")
+        print("\n" + "\n".join(lines))
+        print(f"\nrapport : {out}")
+
+    # ─── enchaînement ──────────────────────────────────────────────────────
+    def go(self):
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        ok = True
+        try:
+            ok &= self.stage("préflight : outils, lockfile, binaire", self.preflight)
+            ok = ok and self.stage("identité : le compte que les identifiants désignent", self.identity)
+            ok = ok and self.stage("inventaire AVANT", self.snapshot_before)
+            ok = ok and self.stage("plan", self.plan)
+            if ok and not self.plan_only:
+                ok = ok and self.stage("apply", self.apply)
+                ok = ok and self.stage("attente de l'échéance de la clé expirée", self.wait_for_expiry)
+                ok = ok and self.stage("scan --live, 5 formats, bundle scellé", self.scan_live)
+                ok = ok and self.stage("bundle : verify --re-derive, refus de l'altération", self.bundle)
+            if ok:
+                ok = ok and self.stage("scan --terraform sur le même plan", self.scan_terraform)
+        finally:
+            if self.applied:
+                ok = self.stage("destroy", self.destroy) and ok
+                ok = self.stage("preuve de destruction : listing par famille + delta", self.leftovers) and ok
+        if ok:
+            ok = self.stage("comparaison à expected.yaml, et falsification de la porte", self.compare_all)
+        budget = self.tenant.get("budget_minutes")
+        if ok and budget and (time.time() - self.t0) > budget * 60:
+            self.stages.append({"name": "budget", "rc": 1, "seconds": 0, "note": f"{round((time.time() - self.t0) / 60, 1)} min > {budget} min"})
+            ok = False
+        verdict = "GO" if ok else ("NO-GO" if self.destroyed or not self.applied else "NO-GO (RESTES À NETTOYER)")
+        self.report(verdict)
+        return 0 if ok else 1
+
+
+class StageFailed(Exception):
+    pass
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# selftest — la comparaison se prouve sur des cas synthétiques
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def selftest():
+    outputs = {"vm": "11111111-aaaa", "bucket": "pepin-qual-x-public"}
+    prefix = "pepin-qual-"
+    expected = {
+        "exit_codes": {"live": 1},
+        "controls": {
+            "a_fail": {"live": {"fail": ["${output.vm}"], "silent": ["pepin-qual-vm-ok"]}},
+            "b_notev": {"live": "not-evaluated"},
+            "c_pass": {"live": "pass"},
+            "d_eval": {"live": {"status": "evaluated", "reason": "hors tenant"}},
+            "e_na": {"live": "not-applicable"},
+            "f_absent": {"live": "absent"},
+            "g_defect": {"live": {"fail": ["pepin-qual-vm-defect"], "known_defect": "#0 exemple"}},
+        },
+    }
+    good = [
+        {"control": "a_fail", "status": "fail", "subject": "11111111-aaaa"},
+        {"control": "b_notev", "status": "not-evaluated", "subject": "scaleway"},
+        {"control": "c_pass", "status": "pass", "subject": "scaleway"},
+        {"control": "d_eval", "status": "fail", "subject": "someone@example.org"},
+        {"control": "e_na", "status": "not-applicable", "subject": "scaleway"},
+        {"control": "g_defect", "status": "fail", "subject": "pepin-qual-vm-defect"},
+    ]
+
+    def mutate(fn):
+        r = copy.deepcopy(good)
+        fn(r)
+        return r
+
+    cases = [
+        ("attendu exact", expected, good, 1, True),
+        ("faux vert : l'écart attendu manque", expected, mutate(lambda r: r.__setitem__(0, {"control": "a_fail", "status": "pass", "subject": "scaleway"})), 1, False),
+        ("faux positif : écart sur un sujet du tenant que rien n'attend", expected, good + [{"control": "c_pass", "status": "fail", "subject": "pepin-qual-vm-other"}], 1, False),
+        ("le contre-exemple parle", expected, good + [{"control": "a_fail", "status": "fail", "subject": "pepin-qual-vm-ok"}], 1, False),
+        ("régression de couverture : pass → not-evaluated", expected, mutate(lambda r: r.__setitem__(2, {"control": "c_pass", "status": "not-evaluated", "subject": "scaleway"})), 1, False),
+        ("pass non prouvé : not-evaluated → pass", expected, mutate(lambda r: r.__setitem__(1, {"control": "b_notev", "status": "pass", "subject": "scaleway"})), 1, False),
+        ("contrôle non épinglé", expected, good + [{"control": "z_new", "status": "pass", "subject": "scaleway"}], 1, False),
+        ("contrôle épinglé absent de l'assessment", expected, good[1:], 1, False),
+        ("code de sortie inattendu", expected, good, 0, False),
+        ("écart hors tenant sur un contrôle « pass » : information, pas NO-GO", expected, good + [{"control": "c_pass", "status": "fail", "subject": "foreign-vm"}], 1, True),
+        ("sujet irrésoluble", expected, good, 1, False, {"bucket": "x"}),
+        ("« evaluated » refuse un not-evaluated", expected, mutate(lambda r: r.__setitem__(3, {"control": "d_eval", "status": "not-evaluated", "subject": "scaleway"})), 1, False),
+        ("« absent » refuse un contrôle qui apparaît", expected, good + [{"control": "f_absent", "status": "pass", "subject": "scaleway"}], 1, False),
+        ("un défaut connu corrigé rend NO-GO (la correction se dit)", expected, mutate(lambda r: r.__setitem__(5, {"control": "g_defect", "status": "pass", "subject": "scaleway"})), 1, False),
+    ]
+    failures = 0
+    for case in cases:
+        label, exp, results, rc, want_ok = case[:5]
+        outs = case[5] if len(case) > 5 else outputs
+        v = compare(exp, results, "live", rc, outs, prefix)
+        ok = v.ok == want_ok
+        failures += not ok
+        print(f"  {'✔' if ok else '✘'} {label}" + ("" if ok else f" — obtenu {'GO' if v.ok else 'NO-GO'} : {v.problems[:2]}"))
+    # Et la falsification elle-même : sur un assessment conforme, chaque mutation doit rougir.
+    ok, outcomes = falsify(expected, good, "live", 1, outputs, prefix)
+    failures += not ok
+    print(f"  {'✔' if ok else '✘'} la falsification rend NO-GO sur {len(outcomes)} mutations")
+    if failures:
+        print(f"\n{failures} cas en échec : la comparaison ne mesure pas ce qu'elle prétend", file=sys.stderr)
+        return 1
+    print(f"\n{len(cases) + 1} cas, tous conformes.")
+    return 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def cmd_compare(args):
+    run_dir = pathlib.Path(args.run_dir).resolve()
+    provider = args.provider or run_dir.name.replace("qualification-", "")
+    tenant_dir = ROOT / "references" / "qualification" / provider
+    tenant = yaml.safe_load((tenant_dir / "tenant.yaml").read_text())
+    expected = yaml.safe_load(pathlib.Path(args.expected or tenant_dir / "expected.yaml").read_text())
+    outputs, plan = {}, None
+    if (run_dir / "plan.json").exists():
+        plan = json.loads((run_dir / "plan.json").read_text())
+        outputs = {k: o["value"] for k, o in (plan.get("planned_values", {}).get("outputs") or {}).items() if "value" in o}
+    if (run_dir / "outputs.json").exists():
+        outputs = json.loads((run_dir / "outputs.json").read_text())
+    owned = owned_identifiers(outputs, plan)
+    report = json.loads((run_dir.parent / f"qualification-{provider}.json").read_text()) if (run_dir.parent / f"qualification-{provider}.json").exists() else {}
+    rcs = {s: v.get("exit_code") for s, v in report.get("comparison", {}).items()}
+    problems = 0
+    for source, fname in (("live", "assessment-live.json"), ("terraform", "assessment-terraform.json")):
+        if not (run_dir / fname).exists():
+            continue
+        v = compare(expected, load_results(run_dir / fname), source, rcs.get(source), outputs, tenant["name_prefix"], owned)
+        print(f"[{source}] {'GO' if v.ok else 'NO-GO'}")
+        for p in v.problems:
+            print(f"  ✘ {p}")
+        for i in v.infos:
+            print(f"  · {i}")
+        problems += len(v.problems)
+    print("\nverdict :", "GO" if not problems else f"NO-GO ({problems} différence(s))")
+    return 0 if not problems else 1
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    r = sub.add_parser("run", help="applique, scanne, scelle, détruit, compare")
+    r.add_argument("provider")
+    r.add_argument("--plan-only", action="store_true", help="plan + scan --terraform + comparaison de la source terraform ; rien n'est appliqué")
+    r.add_argument("--run-dir", help="dossier des artefacts (défaut : release-gate/qualification-<provider>)")
+    c = sub.add_parser("compare", help="recompare un run existant à expected.yaml (ou à un autre fichier)")
+    c.add_argument("--run-dir", required=True)
+    c.add_argument("--expected")
+    c.add_argument("--provider")
+    sub.add_parser("selftest", help="la comparaison se prouve sur des cas synthétiques")
+    args = ap.parse_args()
+
+    if args.cmd == "selftest":
+        return selftest()
+    if args.cmd == "compare":
+        return cmd_compare(args)
+    if not args.plan_only and os.environ.get("PEPIN_GATE_LIVE") != "1":
+        print("refus : appliquer un tenant de qualification sur un compte réel est opt-in — "
+              "PEPIN_GATE_LIVE=1, ou --plan-only pour ne rien créer", file=sys.stderr)
+        return 1
+    tenant_dir = ROOT / "references" / "qualification" / args.provider
+    if not (tenant_dir / "expected.yaml").exists():
+        print(f"aucun tenant de qualification pour « {args.provider} » ({tenant_dir})", file=sys.stderr)
+        return 2
+    run_dir = pathlib.Path(args.run_dir).resolve() if args.run_dir else ROOT / "release-gate" / f"qualification-{args.provider}"
+    return Run(args.provider, run_dir, args.plan_only).go()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Stage 3 of #178: a Terraform tenant, deliberately misconfigured, applied on a real
Scaleway account, scanned, then **destroyed**, and compared against a committed
`expected.yaml`. Any difference is NO-GO — a missing `fail` is a false green, an extra
one is a false positive, a moved `not-evaluated` is a coverage regression.

## It bit on the first run

`objectstorage_bucket_default_encryption` emits **six correct `high` deviations** on a
Scaleway live scan, while `referentiel/controles.yaml` declares it for `outscale` only.
The rule is common (`provider_of`), so it speaks for Scaleway; the reference says it does
not. Pinned as a known defect and filed as **#192** — verified independently.

That is the point of this tenant: a class of defect the existing gates cannot see. The
one-day audit that motivated #178 found five such by hand.

## Nothing was left behind

29 resources applied (1 IAM application, 2 API keys, 9 security groups, 2 flexible IPs,
5 DEV1-S servers, 7 buckets + ACL/policy/SSE).

Proof of destruction, on three runs including one failed apply cleaned by the `finally`:
`terraform destroy` rc=0, state empty and purged, an API inventory over **19 families
showing zero tenant resources and zero delta** before/after, and `scw` listings filtered
on `pepin-qual` empty everywhere. Total cost across the three runs: **≈ 0.02 EUR**.

## The provider's destroy bug, read before choosing resource types

[scaleway#4338](https://github.com/scaleway/terraform-provider-scaleway/issues/4338) —
an attached `scaleway_instance_private_nic` returns 412 on destroy, order not
reversible; confirmed by the maintainer on **2.81.0 and 2.82.0**, 4/4 resources left
behind. **No private NIC is in the stack**, the provider is pinned at 2.82.0 with a
committed lockfile, and the manual workaround is documented.

Consequence worth knowing: **the two-NIC machine cannot be exercised on Scaleway** — the
exact shape of #170. Also handled: #2853 (SBS volumes), #2869 (non-empty bucket), #2821
(product-created SG), #4262, #2125/#3243, #4320, #2426. All linked in the tenant README.

## The gate says NO-GO when broken

Three broken expectations per run (in memory, one per source) → 3 NO-GO. Plus an explicit
demonstration on the GO run with a corrupted file → NO-GO on 2 differences, labelled
"false positive or stale expectation" and "coverage regression". `qualify:selftest`
(15 cases) is wired into `prepush`.

## One change I made to the agent's work

`expected.yaml` pinned the maintainer's real `organization_id` and `project_id` in clear.
They are identifiers, not secrets — they open nothing without credentials — but **this
repository is public**, and committing them would name the tenant durably. An identifier
published does not get unpublished.

The expected account now comes from the **environment** (`PEPIN_QUAL_SCW_ORG`,
`PEPIN_QUAL_SCW_PROJECT`). The guard loses nothing: it still compares what the API
answers against what is expected; only the *provenance* of the expected changes. **A
missing variable is a refusal, never a pass** — measured:

```
✘ REFUS : la variable PEPIN_QUAL_SCW_ORG n'est pas posée, donc le compte attendu est
  inconnu. Rien n'a été appliqué — un tenant délibérément fautif ne s'applique pas sur
  un compte que personne n'a confirmé.
```

## Findings filed

#192 (the one above), #193 (`_parent` unresolved on a plan: one RDB gets two subjects),
#194 (Scaleway plans never project `region`), #195 (nine controls pinned `not-evaluated`
in live, with the endpoint each needs), #196 (Scaleway enforces key expiry at
organisation level — a preventive control Pépin could read), #197 (**an IAM user's
e-mail is the subject of `iam_user_mfa_enabled`: personal data in every assessment and
bundle**), #198 (Outscale and Exoscale tenants).

## Gates

`validate`, `test-rego` (358), `audit`, `lint`, `osv`, `vuln`, `qualify:selftest`: green.
`TestGeneratedDocsAreUpToDate` diverges **in a linked worktree only** — the provenance
digest is not redacted there. Measured: `main` alone, in the same worktree, diverges
identically, so it is an environment artefact and not this branch. CI runs on a full
clone.

Refs #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
