### PR TITLE
feat(release): Outscale qualification tenant, applied then destroyed; Exoscale, plan only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ references/docs/*/
 # détruit. Ils portent les identifiants de ressources d'un compte ; rien n'en
 # entre au dépôt sans relecture (ADR-0012).
 release-gate/
+
+# Caches Python des outils et crochets lancés en scripts.
+__pycache__/

--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -24,6 +24,15 @@ l'une ni l'autre appartient au `git log`.
 
 ### Ajouté
 
+- **Tenants de qualification Outscale et Exoscale** (issue #198). Outscale : 79 ressources
+  Terraform, plus 6 buckets OOS et une politique EIM inline créés par le crochet `extra`
+  du tenant, appliqués et détruits sur un compte réel — la machine à deux cartes, la clé
+  root, la famille `iam_policy_*`, les snapshots, une OMI publique, des load balancers ;
+  le runner applique désormais `pre_destroy_vars` avant de détruire (une VM protégée ne
+  se détruit pas, provider #88) et reliste jusqu'à ce que les suppressions soient
+  effectives. Exoscale : plan seul, 37 ressources, sans compte — la source Terraform
+  est épinglée, la moitié live attend un compte.
+
 - **Un tenant de qualification, appliqué et détruit sur un compte réel** (issue #178,
   étape 3). `PEPIN_GATE_LIVE=1 mise run qualify` applique la stack Terraform committée
   sous `references/qualification/scaleway/` — 40 ressources dans le plan, dont 29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ belongs in `git log`.
 
 ### Added
 
+- **Qualification tenants for Outscale and Exoscale** (issue #198). Outscale: 79 Terraform
+  resources plus 6 OOS buckets and an inline EIM policy created by the tenant's `extra`
+  hook, applied and destroyed on a real account — the two-NIC machine, the root access
+  key, the `iam_policy_*` family, snapshots, a public OMI, load balancers; the runner
+  now applies `pre_destroy_vars` before destroying (a protected VM does not destroy,
+  provider #88) and re-lists until deletions settle. Exoscale: plan-only, 37 resources,
+  no account — the Terraform source is pinned, the live half waits for an account.
+
 - **A qualification tenant, applied and destroyed on a real account** (issue #178,
   stage 3). `PEPIN_GATE_LIVE=1 mise run qualify` applies the Terraform stack committed
   under `references/qualification/scaleway/` — 40 resources in the plan, 29 of them

--- a/references/qualification/README.fr.md
+++ b/references/qualification/README.fr.md
@@ -22,7 +22,7 @@ references/qualification/
     .terraform.lock.hcl             versionné : le binaire de provider qui a été qualifié
     tenant.yaml                     métadonnées : région, tag du tenant, version épinglée, budget, tarifs horaires
     expected.yaml                   le contrat : contrôle × source × sujet → statut, et le compte épinglé
-    hooks.py                        crochets du fournisseur : identité, inventaire par famille, nettoyage de secours
+    hooks.py                        crochets du fournisseur : identité, variables, extra (ce que Terraform ne sait pas créer), inventaire par famille, nettoyage de secours
     README.md · README.fr.md        ce que la stack crée, ce qui bloque destroy en amont, résultats mesurés
 tools/qualification/qualify.py      le runner générique (apply, scan, scelle, vérifie, détruit, prouve, compare)
 ```
@@ -56,13 +56,18 @@ mise run qualify:selftest                     # la comparaison se prouve sur des
    bundle altéré d'un octet doit être refusé ([ADR-0018](../../docs/adr/0018-ce-quun-bundle-prouve-de-lui-meme.md)).
 6. **`pepin scan --terraform`** sur le même plan.
 7. **Destroy**, dans un `finally` : il tourne même quand une étape précédente a
-   échoué. Si `terraform destroy` ne finit pas, les crochets du fournisseur suppriment
-   par l'API ce qui porte le tag du tenant, et destroy est relancé.
+   échoué. Ce qu'il faut défaire d'abord (une protection contre la suppression, que le
+   provider Outscale ne sait pas traverser, #88) est appliqué avant lui (`tenant.yaml`
+   `pre_destroy_vars`) ; ce que le crochet `extra` a créé hors Terraform est retiré
+   avant lui aussi. Si `terraform destroy` ne finit pas, les crochets du fournisseur
+   suppriment par l'API ce qui porte le tag du tenant, et destroy est relancé.
 8. **Preuve de destruction** : `Destroy complete!` n'est pas une preuve. Le compte est
    relisté famille par famille, filtré sur le tag et le préfixe de nom du tenant,
    **et** comparé à l'inventaire pris avant apply : ce qui est apparu entre les deux,
    étiqueté ou non (un volume racine renommé, une sauvegarde automatique), est un
-   reste et un NO-GO.
+   reste et un NO-GO. Les suppressions sont asynchrones chez plus d'un fournisseur :
+   le listing est répété jusqu'au vide, bornée (`settle_seconds`, 240 s) — ce qui
+   survit au délai est un reste, et le nettoyage de secours est tenté dessus.
 9. **Comparaison** à `expected.yaml`, puis **falsification** : une attente est cassée
    en mémoire et la comparaison doit dire NO-GO. Une porte qu'on n'a jamais vue rouge
    ne garde rien.
@@ -84,6 +89,14 @@ entre au dépôt sans relecture.
 | un contrôle absent d'`expected.yaml` | un verdict non épinglé |
 | un code de sortie autre que celui épinglé | la porte de CI elle-même a bougé ([ADR-0005](../../docs/adr/0005-codes-de-sortie.md)) |
 | une ressource qui survit au destroy | le seul résultat inacceptable de tout l'exercice |
+
+Trois mots de plus qu'`expected.yaml` peut employer : `inconclusive:` liste les sujets
+du tenant sur lesquels une règle dit ne pas savoir conclure (un `not-evaluated` à sujet,
+ADR-0015) ; `known_defect:` épingle un comportement mesuré et faux, avec l'issue qui le
+suit — la porte reste GO et la correction la fait rougir sciemment ; `evaluated` accepte
+`pass` ou `fail` pour un contrôle dont les sujets sont hors du tenant (les utilisateurs
+du compte, sa politique d'accès API). Un tenant sans compte dit `live: unavailable` dans
+`tenant.yaml` : il ne tourne qu'en `--plan-only`, et un run réel est refusé.
 
 `expected.yaml` n'est **pas une matrice verte** ([ADR-0010](../../docs/adr/0010-dette-de-veracite-comptee.md)) :
 chacun de ses `not-evaluated` est une **dette de collecte nommée**, et il change quand,

--- a/references/qualification/README.md
+++ b/references/qualification/README.md
@@ -22,7 +22,7 @@ references/qualification/
     .terraform.lock.hcl             versioned: the provider build that was qualified
     tenant.yaml                     metadata: region, tenant tag, pinned provider version, budget, hourly rates
     expected.yaml                   the contract: control × source × subject → status, and the pinned account
-    hooks.py                        provider hooks: identity, inventory by family, rescue cleanup
+    hooks.py                        provider hooks: identity, variables, extra (what Terraform cannot create), inventory by family, rescue cleanup
     README.md · README.fr.md        what the stack creates, what blocks destroy upstream, measured results
 tools/qualification/qualify.py      the generic runner (apply, scan, seal, verify, destroy, prove, compare)
 ```
@@ -55,14 +55,19 @@ mise run qualify:selftest                     # the comparison proves itself on 
    `sarif`), sealed with `--seal`; `verify --re-derive` must pass, and a bundle
    altered by one byte must be refused ([ADR-0018](../../docs/adr/0018-ce-quun-bundle-prouve-de-lui-meme.md)).
 6. **`pepin scan --terraform`** on the same plan.
-7. **Destroy**, in a `finally`: it runs even when a stage before it failed. If
-   `terraform destroy` does not finish, the provider hooks delete what carries the
-   tenant's tag through the API, and destroy runs again.
+7. **Destroy**, in a `finally`: it runs even when a stage before it failed. What has
+   to be undone first (a deletion protection Outscale refuses to delete through, provider
+   #88) is applied before it (`tenant.yaml` `pre_destroy_vars`); what the `extra` hook
+   created outside Terraform is removed before it too. If `terraform destroy` does not
+   finish, the provider hooks delete what carries the tenant's tag through the API, and
+   destroy runs again.
 8. **Proof of destruction** — `Destroy complete!` is not a proof. The account is
    listed again, family by family, filtered on the tenant's tag and name prefix,
    **and** compared with the inventory taken before apply: anything that appeared
    in between, tagged or not (a renamed root volume, an automatic backup), is a
-   leftover and a NO-GO.
+   leftover and a NO-GO. Deletions are asynchronous on more than one provider, so
+   the listing is repeated until empty, bounded (`settle_seconds`, 240 s): what
+   survives the delay is a leftover, and the rescue cleanup is attempted on it.
 9. **Comparison** with `expected.yaml`, then **falsification**: an expectation is
    broken in memory and the comparison must say NO-GO. A gate that was never seen
    red guards nothing.
@@ -84,6 +89,14 @@ enters the repository from there without reading it.
 | a control missing from `expected.yaml` | an unpinned verdict |
 | an exit code other than the pinned one | the CI gate itself moved ([ADR-0005](../../docs/adr/0005-codes-de-sortie.md)) |
 | a resource surviving destroy | the only unacceptable outcome of the whole exercise |
+
+Three more words `expected.yaml` may use: `inconclusive:` lists the tenant subjects on
+which a rule says it cannot conclude (a `not-evaluated` with a subject, ADR-0015);
+`known_defect:` pins a measured behaviour that is wrong, with the issue that tracks it —
+the gate stays GO and the fix turns it NO-GO on purpose; `evaluated` accepts `pass` or
+`fail` for a control whose subjects are outside the tenant (the account's users, its API
+access policy). A tenant without an account says `live: unavailable` in `tenant.yaml`:
+it runs in `--plan-only` only, and a real run is refused.
 
 `expected.yaml` is **not a green matrix** ([ADR-0010](../../docs/adr/0010-dette-de-veracite-comptee.md)):
 each `not-evaluated` in it is a **named collection debt**, and it changes when, and

--- a/references/qualification/exoscale/.terraform.lock.hcl
+++ b/references/qualification/exoscale/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/exoscale/exoscale" {
+  version     = "0.71.0"
+  constraints = "0.71.0"
+  hashes = [
+    "h1:/mONn9xlzc4vASFl2/iCD5SmlIv++CWFzVdzviK9K3k=",
+    "zh:0d6a018d46b3e630a11c9a38efa09b8db6563b033899f61803d31a77e82d934b",
+    "zh:0fada1acdafe539733319b138dffbcc4894b3d44c367fdb0503cb6897e62278e",
+    "zh:40e02bd536a2870b0b60c00700d22d3c3805de14ed680d54d65d5ce359b719de",
+    "zh:45352f8d19aafa85e80a9ef5ca4804bdd5b704dafe00e1101075fee23695aac5",
+    "zh:49e7c3d784bf409bc81575f074f23bb1f9d7a67d354c2cd3f63ae153c2195962",
+    "zh:718956473da2415c5ff1fcc75a6623ddeb3606b7ce4449dbfc8ebef21857038c",
+    "zh:871f6e40a27439411d54af4bb356907f2280bf34693702d9b7e4ce67acf11ff0",
+    "zh:91a8298f578ef767a8bd255d131c0be707b29778d278172bf907592a64e7f3e2",
+    "zh:94997c39e211ada40841d5ad5008737f2b314b11168e232aa72ac1fcae6548c2",
+    "zh:98e74dbefa86875d5fc1f5a626807dda2ca787b765fbeb76492a0a8ab3f19064",
+    "zh:de3f3667ebabf09b7048bda58b71c43477a170be073c5120b849e4cbd19ed8bb",
+    "zh:f8c48a477463e6ffb0f6bb1ca41b741996cc1da1af96cdd5d300efee5971d718",
+    "zh:fd25e27a446d2efe33fa23a87b6e8354f212a9757e6ba3e02a2fb2f4f8b68840",
+  ]
+}

--- a/references/qualification/exoscale/README.fr.md
+++ b/references/qualification/exoscale/README.fr.md
@@ -1,0 +1,67 @@
+> [🇬🇧 English](README.md) · 🇫🇷 Français
+
+# Tenant de qualification Exoscale (source Terraform seulement)
+
+**Aucun compte Exoscale n'est disponible.** Ce tenant se qualifie donc en
+`--plan-only` : 37 ressources sont planifiées, rien n'est créé, et
+[`expected.yaml`](expected.yaml) épingle ce que `pepin scan exoscale --terraform`
+rend sur ce plan — le chemin qu'un utilisateur suit sans compte
+([ADR-0012](../../docs/adr/0012-aucun-identifiant-en-ci.md) le préfère). Cela a déjà
+de la valeur : les verdicts Terraform de 26 contrôles sont fixés, avec leurs
+contre-exemples.
+
+Ce qu'il ne fait **pas**, et le dit (`tenant.yaml` : `live: unavailable`) :
+appliquer, scanner en `--live`, sceller un bundle, détruire, prouver la destruction.
+`mise run qualify` sur ce tenant est refusé ; `mise run qualify:plan`
+(`PROVIDER=exoscale`) est le seul mode. [`hooks.py`](hooks.py) fournit les
+identifiants factices qu'un plan exige et refuse tout le reste. La lecture des
+issues de `exoscale/terraform-provider-exoscale` sur `destroy` est due avant le
+premier apply, pas avant le premier plan.
+
+```bash
+PROVIDER=exoscale mise run qualify:plan
+```
+
+## Ce que le plan porte
+
+| Famille | Nombre | Ressource fautive → contrôle | Contre-exemple (doit rester muet) |
+|---|---:|---|---|
+| Groupes de sécurité | 9 (+ 15 règles) | `ssh_open` → `…tcp_port_22` · `rdp_open` → `…tcp_port_3389` · `db_open` (5432) → `…high_risk_tcp_ports` · `snmp_open` (UDP 161) → `…high_risk_udp_ports` · `any_open` (tout TCP et tout UDP) → les quatre précédents · `quartet` (quatre `/2`) → `…tcp_port_22` par évasion · `undocumented_flow` (règle sans description, port 443) → `network_flow_matrix_documented` | `hardened` (SSH depuis `10.0.0.0/8`, HTTPS depuis Internet, sortie TCP 443, chaque flux décrit) |
+| Réseaux privés | 2 | `undocumented` → `network_documented` | `documented` (Owner, Project, Env, description) |
+| Instances | 4 | `untagged` → `governance_resource_required_tags` · `secrets` (cloud-init avec mot de passe) → `compute_instance_no_secrets_in_user_data` · `swiss` (zone `ch-gva-2`) → `governance_resource_region_in_eu` (low : hors UE, espace européen de confiance) | `hardened` (étiquetée, `de-fra-1`, cloud-init anodin) |
+| Volume block storage | 1 | — (chiffré par construction : `blockstorage_volume_encryption` passe) | — |
+| Clusters SKS | 2 | `weak` (`starter`, sans auto-upgrade, audit désactivé) → `kubernetes_cluster_control_plane_highly_available`, `…auto_upgrade_enabled`, `…audit_logging_enabled` | `strong` (`pro`, auto-upgrade, endpoint d'audit) |
+| Rôles IAM | 4 | `admin` (`allow` par défaut) → `iam_role_no_admin_privileges` · `no_source_ip` → `iam_role_source_ip_restricted` · `unbounded` (sans `duration(`) → `iam_role_key_lifetime_bounded` | `restricted` (`deny` par défaut, `source_ip`, `duration(`) |
+| Fournisseur | — | `governance_provider_sovereignty` échoue sur `exoscale` lui-même : siège en Suisse, contrôle capitalistique extra-UE — des faits du descripteur, pas du tenant | — |
+
+## Ce que ce tenant ne peut pas exercer, et pourquoi
+
+- **`network_securitygroup_allow_ingress_from_internet_to_all_ports` et
+  `network_securitygroup_unrestricted_egress` ne peuvent pas se déclencher chez
+  Exoscale**, sur aucune source : une règle de groupe n'a pas de protocole « tout »
+  (`tcp`, `udp`, `icmp`, `icmpv6`, `ah`, `esp`, `gre`, `ipip` seulement, provider
+  0.71.0 et API), et les deux règles communes exigent `protocol == all`. `any_open`
+  ouvre tout TCP et tout UDP, les quatre autres contrôles d'entrée parlent ; ces deux-là
+  sont épinglés `pass` par absence, ce que le référentiel et la matrice de couverture
+  devraient cesser de présenter comme de la couverture (#202).
+- **`network_flow_matrix_documented` rend `pass` sur un plan dont la règle
+  `undocumented_flow` n'a pas de description** : une description non écrite est
+  *calculée* sur un plan, l'attribut n'est pas projeté, la garde de capacité se tait,
+  et l'assessment conclut « conforme » — le faux vert que l'intersection de
+  l'[ADR-0006](../../docs/adr/0006-jamais-un-pass-non-prouve.md) existe pour empêcher.
+  Épinglé comme **défaut connu** (#201) ; la correction fera rougir cette porte
+  sciemment.
+- L'IP publique d'une instance et l'état d'usage d'un volume sont calculés à
+  l'apply : `compute_instance_public_ip_with_open_securitygroup` et
+  `blockstorage_volume_snapshots_exist` attendent la moitié live.
+- Buckets SOS : le provider n'a pas de ressource de bucket (`exoscale_sos_bucket_policy`
+  seulement) ; ils seront créés par un crochet `extra`, comme chez Outscale, quand un
+  compte existera.
+- Les utilisateurs IAM sont des personnes réelles, pas des ressources Terraform.
+
+## Mesuré
+
+Run plan seul (`PROVIDER=exoscale mise run qualify:plan`) : 37 ressources planifiées,
+`scan --terraform` en code 1, 26 contrôles épinglés sur la source Terraform, GO, avec
+une attente cassée en mémoire qui rend NO-GO. Rien de créé, rien à détruire, aucun
+coût.

--- a/references/qualification/exoscale/README.md
+++ b/references/qualification/exoscale/README.md
@@ -1,0 +1,63 @@
+> 🇬🇧 English · [🇫🇷 Français](README.fr.md)
+
+# Exoscale qualification tenant (Terraform source only)
+
+**No Exoscale account is available.** This tenant is therefore qualified in
+`--plan-only` mode: 37 resources are planned, nothing is created, and
+[`expected.yaml`](expected.yaml) pins what `pepin scan exoscale --terraform` returns
+on that plan — the path a user follows without an account
+([ADR-0012](../../docs/adr/0012-aucun-identifiant-en-ci.md) prefers it). That already
+has value: it fixes the Terraform verdicts of 26 controls, with counterexamples.
+
+What it does **not** do, and says so (`tenant.yaml`: `live: unavailable`): apply,
+`scan --live`, seal a bundle, destroy, prove the destruction. `mise run qualify` on this
+tenant is refused; `mise run qualify:plan` (`PROVIDER=exoscale`) is the only mode.
+[`hooks.py`](hooks.py) provides the placeholder credentials a plan needs and refuses
+everything else. Reading the `exoscale/terraform-provider-exoscale` issues on `destroy`
+is due before the first apply, not before the first plan.
+
+```bash
+PROVIDER=exoscale mise run qualify:plan
+```
+
+## What the plan carries
+
+| Family | Count | Faulty resource → control | Counterexample (must stay silent) |
+|---|---:|---|---|
+| Security groups | 9 (+ 15 rules) | `ssh_open` → `…tcp_port_22` · `rdp_open` → `…tcp_port_3389` · `db_open` (5432) → `…high_risk_tcp_ports` · `snmp_open` (UDP 161) → `…high_risk_udp_ports` · `any_open` (all TCP and all UDP ports) → the four above · `quartet` (four `/2`) → `…tcp_port_22` by evasion · `undocumented_flow` (a rule without description, on port 443) → `network_flow_matrix_documented` | `hardened` (SSH from `10.0.0.0/8`, HTTPS from anywhere, egress TCP 443, every flow described) |
+| Private networks | 2 | `undocumented` → `network_documented` | `documented` (Owner, Project, Env, description) |
+| Instances | 4 | `untagged` → `governance_resource_required_tags` · `secrets` (cloud-init with a password) → `compute_instance_no_secrets_in_user_data` · `swiss` (zone `ch-gva-2`) → `governance_resource_region_in_eu` (low: outside the EU, inside the European trusted area) | `hardened` (labelled, `de-fra-1`, plain cloud-init) |
+| Block storage volume | 1 | — (encrypted by construction: `blockstorage_volume_encryption` passes) | — |
+| SKS clusters | 2 | `weak` (`starter`, no auto-upgrade, audit disabled) → `kubernetes_cluster_control_plane_highly_available`, `…auto_upgrade_enabled`, `…audit_logging_enabled` | `strong` (`pro`, auto-upgrade, audit endpoint) |
+| IAM roles | 4 | `admin` (`allow` by default) → `iam_role_no_admin_privileges` · `no_source_ip` → `iam_role_source_ip_restricted` · `unbounded` (no `duration(`) → `iam_role_key_lifetime_bounded` | `restricted` (`deny` by default, `source_ip`, `duration(`) |
+| Provider | — | `governance_provider_sovereignty` fails on `exoscale` itself: head office in Switzerland, decisive non-EU capital control — facts of the descriptor, not of the tenant | — |
+
+## What this tenant cannot exercise, and why
+
+- **`network_securitygroup_allow_ingress_from_internet_to_all_ports` and
+  `network_securitygroup_unrestricted_egress` cannot fire on Exoscale**, on either
+  source: a security group rule has no "all protocols" value (`tcp`, `udp`, `icmp`,
+  `icmpv6`, `ah`, `esp`, `gre`, `ipip` only, provider 0.71.0 and the API), and both
+  common rules require `protocol == all`. `any_open` opens every TCP and UDP port and
+  the four other ingress controls fire; these two are pinned `pass` by absence, which
+  the referentiel and the coverage matrix should stop presenting as coverage (#202).
+- **`network_flow_matrix_documented` returns `pass` on a plan whose `undocumented_flow`
+  rule has no description**: a description that is not written is *computed* on a
+  plan, so the attribute is not projected, the capability guard stays silent, and the
+  assessment concludes "compliant" — the false green [ADR-0006](../../docs/adr/0006-jamais-un-pass-non-prouve.md)'s
+  intersection exists to prevent. Pinned as a **known defect** (#201); the fix will
+  turn this gate NO-GO on purpose.
+- The public IP of an instance and the attachment state of a volume are computed at
+  apply: `compute_instance_public_ip_with_open_securitygroup` and
+  `blockstorage_volume_snapshots_exist` wait for the live half.
+- SOS buckets: the provider has no bucket resource (`exoscale_sos_bucket_policy`
+  only); they will be created by an `extra` hook, as on Outscale, when an account
+  exists.
+- IAM users are real people, not Terraform resources.
+
+## Measured
+
+Plan-only run (`PROVIDER=exoscale mise run qualify:plan`): 37 resources planned,
+`scan --terraform` exit code 1, 26 controls pinned on the Terraform source, GO, with
+one expectation broken in memory turning NO-GO. Nothing created, nothing to destroy,
+no cost.

--- a/references/qualification/exoscale/compute.tf
+++ b/references/qualification/exoscale/compute.tf
@@ -1,0 +1,79 @@
+# Calcul — quatre instances (plan seul : rien n'est créé).
+#
+#   untagged  sans étiquettes de gouvernance              → governance_resource_required_tags
+#   secrets   cloud-init avec un mot de passe               → compute_instance_no_secrets_in_user_data
+#   swiss     en ch-gva-2 (Suisse : hors UE, espace de confiance) → governance_resource_region_in_eu (low)
+#   hardened  étiquetée, en zone UE, cloud-init anodin       → silencieuse
+#
+# L'exposition (CLD-NET-3) ne se juge pas sur un plan : `public_ip_address` est
+# calculée à l'apply. Elle attend la moitié live de ce tenant.
+
+locals {
+  cloud_init_plain = <<-EOT
+    #cloud-config
+    package_update: false
+    timezone: Europe/Paris
+  EOT
+
+  cloud_init_with_secret = <<-EOT
+    #cloud-config
+    users:
+      - name: pepin
+        plain_text_passwd: pepin-qualification-fake-password
+        lock_passwd: false
+  EOT
+}
+
+resource "exoscale_compute_instance" "untagged" {
+  zone               = var.zone
+  name               = "pepin-qual-vm-untagged"
+  template_id        = var.template_id
+  type               = var.instance_type
+  disk_size          = 10
+  security_group_ids = [exoscale_security_group.hardened.id]
+  user_data          = local.cloud_init_plain
+  labels             = local.untagged
+}
+
+resource "exoscale_compute_instance" "secrets" {
+  zone               = var.zone
+  name               = "pepin-qual-vm-secrets"
+  template_id        = var.template_id
+  type               = var.instance_type
+  disk_size          = 10
+  security_group_ids = [exoscale_security_group.hardened.id]
+  user_data          = local.cloud_init_with_secret
+  labels             = local.tagged
+}
+
+resource "exoscale_compute_instance" "swiss" {
+  zone               = var.trusted_zone
+  name               = "pepin-qual-vm-swiss"
+  template_id        = var.template_id
+  type               = var.instance_type
+  disk_size          = 10
+  security_group_ids = [exoscale_security_group.hardened.id]
+  user_data          = local.cloud_init_plain
+  labels             = local.tagged
+}
+
+resource "exoscale_compute_instance" "hardened" {
+  zone               = var.zone
+  name               = "pepin-qual-vm-hardened"
+  template_id        = var.template_id
+  type               = var.instance_type
+  disk_size          = 10
+  security_group_ids = [exoscale_security_group.hardened.id]
+  user_data          = local.cloud_init_plain
+  labels             = local.tagged
+}
+
+# Volume block storage (chiffré par construction chez Exoscale : le mapping le
+# déclare `encrypted: true`, CLD-CHF-2 conforme). Son état d'usage n'est connu qu'à
+# l'apply : CLD-STO-3 attend la moitié live.
+resource "exoscale_block_storage_volume" "data" {
+  zone   = var.zone
+  name   = "pepin-qual-vol-data"
+  size   = 10
+  labels = local.tagged
+}

--- a/references/qualification/exoscale/expected.yaml
+++ b/references/qualification/exoscale/expected.yaml
@@ -1,0 +1,168 @@
+# Ce que Pépin DOIT rendre sur le tenant de qualification Exoscale — source
+# TERRAFORM seulement : aucun compte, donc aucune source live (tenant.yaml
+# `live: unavailable`). Lu par tools/qualification/qualify.py en `--plan-only`.
+#
+# Sujets : adresse de la ressource quand l'identifiant n'est pas connu au stade du
+# plan (ADR-0022), nom sinon. Le compte n'est pas épinglé : il n'y en a pas — le
+# jour où il y en aura un, `account:` nommera sa variable d'environnement, et le
+# runner refusera de tourner sans elle.
+account: {}
+
+exit_codes:
+  terraform: 1
+
+controls:
+  # ── IAM : rôles (politique lue sur le plan) ───────────────────────────────────
+  iam_role_no_admin_privileges:
+    terraform:
+      fail: [pepin-qual-role-admin]
+      silent: [pepin-qual-role-restricted, pepin-qual-role-no-source-ip]
+
+  iam_role_source_ip_restricted:
+    terraform:
+      fail: [pepin-qual-role-no-source-ip]
+      silent: [pepin-qual-role-restricted, pepin-qual-role-admin]
+
+  iam_role_key_lifetime_bounded:
+    terraform:
+      fail: [pepin-qual-role-unbounded]
+      silent: [pepin-qual-role-restricted, pepin-qual-role-admin]
+
+  iam_user_mfa_enabled:
+    # Les utilisateurs ne sont pas des ressources Terraform.
+    terraform: not-evaluated
+
+  # ── Groupes de sécurité ───────────────────────────────────────────────────────
+  # Sujet = adresse du groupe (les règles y désignent leur groupe par référence).
+  network_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
+    terraform:
+      fail: [exoscale_security_group.ssh_open, exoscale_security_group.any_open, exoscale_security_group.quartet]
+      silent: [exoscale_security_group.hardened, exoscale_security_group.rdp_open, exoscale_security_group.undocumented_flow]
+
+  network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
+    terraform:
+      fail: [exoscale_security_group.rdp_open, exoscale_security_group.any_open]
+      silent: [exoscale_security_group.hardened, exoscale_security_group.ssh_open]
+
+  network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports:
+    terraform:
+      fail: [exoscale_security_group.db_open, exoscale_security_group.any_open]
+      silent: [exoscale_security_group.hardened, exoscale_security_group.ssh_open]
+
+  network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports:
+    terraform:
+      fail: [exoscale_security_group.snmp_open, exoscale_security_group.any_open]
+      silent: [exoscale_security_group.hardened, exoscale_security_group.db_open]
+
+  network_securitygroup_allow_ingress_from_internet_to_all_ports:
+    # NON CONSTRUCTIBLE chez Exoscale : une règle n'a pas de protocole « tout »
+    # (tcp, udp, icmp, icmpv6, ah, esp, gre, ipip), et la règle commune exige
+    # `protocol == all`. `any_open` ouvre tout TCP et tout UDP : les quatre autres
+    # contrôles d'entrée parlent, celui-ci ne peut pas. Un pass par absence, donc —
+    # issue #202 (ce contrôle est actif pour Exoscale au référentiel, et la matrice
+    # de couverture le dit ✅).
+    terraform: pass
+
+  network_securitygroup_unrestricted_egress:
+    # Même limite, même raison : `protocol == all` n'existe pas chez Exoscale (#202).
+    terraform: pass
+
+  network_flow_matrix_documented:
+    # DÉFAUT CONNU, épinglé tel que mesuré : la règle `undocumented_flow` n'a pas de
+    # description, et le contrôle rend PASS. Sur un plan, une description absente
+    # est « connue après apply » (computed) : l'attribut n'est pas projeté, la garde
+    # de capacité se tait — et l'assessment conclut « conforme » alors qu'une règle
+    # du type n'a pas l'attribut décisif. C'est le faux vert que l'intersection de
+    # l'ADR-0006 (#102) existe pour empêcher. Issue #201.
+    terraform:
+      status: pass
+      known_defect: "#201 — faux vert sur le plan : la règle sans description est invisible (secours de provenance), le contrôle conclut pass"
+
+  # ── Réseau ────────────────────────────────────────────────────────────────────
+  network_documented:
+    terraform:
+      fail: [pepin-qual-pn-undocumented]
+      silent: [pepin-qual-pn-documented]
+
+  # ── Calcul ────────────────────────────────────────────────────────────────────
+  compute_instance_public_ip_with_open_securitygroup:
+    # L'IP publique est calculée à l'apply : attend la moitié live.
+    terraform: not-evaluated
+
+  compute_instance_has_security_group:
+    terraform: pass
+
+  compute_instance_no_secrets_in_user_data:
+    terraform:
+      fail: [exoscale_compute_instance.secrets]
+      silent: [exoscale_compute_instance.hardened, exoscale_compute_instance.untagged]
+
+  # ── Stockage ──────────────────────────────────────────────────────────────────
+  blockstorage_volume_encryption:
+    # Chiffré par construction (mapping `encrypted: true`).
+    terraform: pass
+
+  blockstorage_volume_snapshots_exist:
+    # L'état d'usage est calculé à l'apply : attend la moitié live.
+    terraform: not-evaluated
+
+  blockstorage_snapshot_not_public:
+    terraform: not-applicable
+
+  objectstorage_bucket_public_access:
+    # Pas de ressource de bucket dans le provider : crochet `extra` à écrire avec le compte.
+    terraform: not-evaluated
+
+  objectstorage_bucket_versioning_enabled:
+    terraform: not-evaluated
+
+  objectstorage_bucket_object_lock_enabled:
+    terraform: not-evaluated
+
+  objectstorage_bucket_kms_encryption:
+    terraform: not-applicable
+
+  # ── SKS ───────────────────────────────────────────────────────────────────────
+  kubernetes_cluster_control_plane_highly_available:
+    terraform:
+      fail: [pepin-qual-sks-weak]
+      silent: [pepin-qual-sks-strong]
+
+  kubernetes_cluster_auto_upgrade_enabled:
+    terraform:
+      fail: [pepin-qual-sks-weak]
+      silent: [pepin-qual-sks-strong]
+
+  kubernetes_cluster_audit_logging_enabled:
+    terraform:
+      fail: [pepin-qual-sks-weak]
+      silent: [pepin-qual-sks-strong]
+
+  # ── Répartiteurs de charge : absents de l'API Exoscale (contrat) ──────────────
+  loadbalancer_ssl_listeners:
+    terraform: not-applicable
+
+  loadbalancer_logging_enabled:
+    terraform: not-applicable
+
+  loadbalancer_http_redirect_to_https:
+    terraform: not-applicable
+
+  # ── Gouvernance ───────────────────────────────────────────────────────────────
+  governance_resource_required_tags:
+    terraform:
+      fail: [pepin-qual-vm-untagged]
+      silent: [pepin-qual-vm-hardened, pepin-qual-vm-secrets]
+
+  governance_resource_region_in_eu:
+    # ch-gva-2 : hors UE, espace européen de confiance — l'écart MINEUR (low), le
+    # seul constructible ici. de-fra-1 est l'UE.
+    terraform:
+      fail: [pepin-qual-vm-swiss]
+      silent: [pepin-qual-vm-hardened]
+
+  governance_provider_sovereignty:
+    # Écart par construction des faits du descripteur (siège en Suisse, contrôle
+    # capitalistique extra-UE) : le sujet est le fournisseur lui-même.
+    terraform:
+      fail: [exoscale]

--- a/references/qualification/exoscale/hooks.py
+++ b/references/qualification/exoscale/hooks.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Crochets Exoscale du tenant de qualification — PLAN SEUL.
+
+Aucun compte Exoscale n'est disponible (tenant.yaml `live: unavailable`). Le runner
+ne demande donc à ces crochets que `variables`, pour donner au provider Terraform
+les identifiants FACTICES qu'un plan sans source de données n'emploie jamais (les
+mêmes que scripts/tenant-plan.py). Les autres commandes REFUSENT, explicitement :
+une identité qu'on ne peut pas confronter et un inventaire qu'on ne peut pas relire
+ne se simulent pas.
+
+Quand un compte existera : `identity` devra demander l'organisation à l'API v2
+(GET /organization, signature EXO2-HMAC-SHA256 — celle que internal/collectkit
+implémente), `inventory` lister les familles (instances, groupes, réseaux privés,
+volumes et snapshots block, clusters SKS, rôles et clés IAM, buckets SOS par zone),
+`cleanup` supprimer par le préfixe du tenant, et `extra` rester vide si le provider
+sait tout créer. Les issues de destruction de exoscale/terraform-provider-exoscale
+sont à lire d'abord.
+"""
+import json
+import sys
+
+
+def variables(mode, identity_path):
+    if mode != "--plan-only":
+        sys.exit("aucun compte Exoscale : ce tenant est plan seul (tenant.yaml `live: unavailable`)")
+    return {
+        "tf_vars": {},
+        # Forme attendue par le provider ; aucune valeur réelle. Un plan n'appelle pas l'API.
+        "env": {"EXOSCALE_API_KEY": "EXOxxxxxxxxxxxxxxxxxxxx",
+                "EXOSCALE_API_SECRET": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+        "wait_until": None,
+        "note": "plan seul : identifiants factices pour le provider, rien à attendre",
+    }
+
+
+def main(argv):
+    if len(argv) < 2:
+        sys.exit(__doc__)
+    if argv[1] == "variables":
+        print(json.dumps(variables(argv[2], argv[3])))
+        return 0
+    if argv[1] == "extra":
+        print(json.dumps({"created": [], "deleted": [], "left": []}))
+        return 0
+    sys.exit(f"{argv[1]} : aucun compte Exoscale — ce tenant est plan seul (tenant.yaml `live: unavailable`)")
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/references/qualification/exoscale/iam.tf
+++ b/references/qualification/exoscale/iam.tf
@@ -1,0 +1,88 @@
+# IAM — quatre rôles (plan seul). Le mapping lit la politique du rôle : stratégie
+# par défaut (allow = administration), présence de `source_ip` (restriction
+# d'origine) et de `duration(` (borne de durée de vie) dans les règles.
+#
+#   admin         allow par défaut, origine et durée bornées   → iam_role_no_admin_privileges
+#   no_source_ip  deny par défaut, durée bornée, sans source_ip → iam_role_source_ip_restricted
+#   unbounded     deny par défaut, source_ip, sans durée        → iam_role_key_lifetime_bounded
+#   restricted    deny par défaut, source_ip et durée           → silencieux
+
+resource "exoscale_iam_role" "admin" {
+  name        = "pepin-qual-role-admin"
+  description = "Tenant de qualification Pepin : administration"
+  editable    = true
+  labels      = local.untagged
+
+  policy = {
+    default_service_strategy = "allow"
+    services = {
+      compute = {
+        type = "rules"
+        rules = [{
+          action     = "allow"
+          expression = "source_ip in ['10.0.0.0/8'] && now - api_key.created_at < duration('720h')"
+        }]
+      }
+    }
+  }
+}
+
+resource "exoscale_iam_role" "no_source_ip" {
+  name        = "pepin-qual-role-no-source-ip"
+  description = "Tenant de qualification Pepin : sans restriction d origine"
+  editable    = true
+  labels      = local.untagged
+
+  policy = {
+    default_service_strategy = "deny"
+    services = {
+      compute = {
+        type = "rules"
+        rules = [{
+          action     = "allow"
+          expression = "now - api_key.created_at < duration('720h')"
+        }]
+      }
+    }
+  }
+}
+
+resource "exoscale_iam_role" "unbounded" {
+  name        = "pepin-qual-role-unbounded"
+  description = "Tenant de qualification Pepin : sans borne de duree"
+  editable    = true
+  labels      = local.untagged
+
+  policy = {
+    default_service_strategy = "deny"
+    services = {
+      compute = {
+        type = "rules"
+        rules = [{
+          action     = "allow"
+          expression = "source_ip in ['10.0.0.0/8']"
+        }]
+      }
+    }
+  }
+}
+
+resource "exoscale_iam_role" "restricted" {
+  name        = "pepin-qual-role-restricted"
+  description = "Tenant de qualification Pepin : origine et duree bornees"
+  editable    = true
+  labels      = local.untagged
+
+  policy = {
+    default_service_strategy = "deny"
+    services = {
+      compute = {
+        type = "rules"
+        rules = [{
+          action     = "allow"
+          expression = "source_ip in ['10.0.0.0/8'] && now - api_key.created_at < duration('720h')"
+        }]
+      }
+    }
+  }
+}

--- a/references/qualification/exoscale/network.tf
+++ b/references/qualification/exoscale/network.tf
@@ -1,0 +1,220 @@
+# Réseau — groupes de sécurité (une ressource par règle chez Exoscale) et réseaux
+# privés. Un groupe par écart, un contre-exemple (`hardened`).
+#
+# Chez Exoscale, chaque règle porte une DESCRIPTION : c'est la matrice des flux
+# (network_flow_matrix_documented, CLD-NET-5). Toutes les règles fautives en ont
+# une, pour ne porter que leur faute ; `undocumented_flow` en est privée, sur un
+# port servi (443), pour ne porter que celle-là.
+
+locals {
+  sgs = {
+    ssh_open          = "SSH ouvert a Internet"
+    rdp_open          = "RDP ouvert a Internet"
+    db_open           = "PostgreSQL ouvert a Internet"
+    snmp_open         = "SNMP ouvert a Internet"
+    any_open          = "Tout le trafic entrant accepte depuis Internet"
+    quartet           = "SSH ouvert a Internet par quatre /2"
+    egress_any        = "Tout le trafic sortant accepte vers Internet"
+    undocumented_flow = "HTTPS sans justification de flux"
+    hardened          = "SSH prive, HTTPS public, sortie 443"
+  }
+}
+
+resource "exoscale_security_group" "ssh_open" {
+  name        = "pepin-qual-sg-ssh-open"
+  description = local.sgs.ssh_open
+}
+
+resource "exoscale_security_group" "rdp_open" {
+  name        = "pepin-qual-sg-rdp-open"
+  description = local.sgs.rdp_open
+}
+
+resource "exoscale_security_group" "db_open" {
+  name        = "pepin-qual-sg-db-open"
+  description = local.sgs.db_open
+}
+
+resource "exoscale_security_group" "snmp_open" {
+  name        = "pepin-qual-sg-snmp-open"
+  description = local.sgs.snmp_open
+}
+
+resource "exoscale_security_group" "any_open" {
+  name        = "pepin-qual-sg-any-open"
+  description = local.sgs.any_open
+}
+
+resource "exoscale_security_group" "quartet" {
+  name        = "pepin-qual-sg-quartet"
+  description = local.sgs.quartet
+}
+
+resource "exoscale_security_group" "egress_any" {
+  name        = "pepin-qual-sg-egress-any"
+  description = local.sgs.egress_any
+}
+
+resource "exoscale_security_group" "undocumented_flow" {
+  name        = "pepin-qual-sg-undocumented-flow"
+  description = local.sgs.undocumented_flow
+}
+
+resource "exoscale_security_group" "hardened" {
+  name        = "pepin-qual-sg-hardened"
+  description = local.sgs.hardened
+}
+
+# ÉCART …_tcp_port_22 (high).
+resource "exoscale_security_group_rule" "ssh_open" {
+  security_group_id = exoscale_security_group.ssh_open.id
+  type              = "INGRESS"
+  protocol          = "TCP"
+  cidr              = "0.0.0.0/0"
+  start_port        = 22
+  end_port          = 22
+  description       = "SSH depuis Internet (faute voulue)"
+}
+
+# ÉCART …_tcp_port_3389 (high).
+resource "exoscale_security_group_rule" "rdp_open" {
+  security_group_id = exoscale_security_group.rdp_open.id
+  type              = "INGRESS"
+  protocol          = "TCP"
+  cidr              = "0.0.0.0/0"
+  start_port        = 3389
+  end_port          = 3389
+  description       = "RDP depuis Internet (faute voulue)"
+}
+
+# ÉCART …_high_risk_tcp_ports (high) : PostgreSQL.
+resource "exoscale_security_group_rule" "db_open" {
+  security_group_id = exoscale_security_group.db_open.id
+  type              = "INGRESS"
+  protocol          = "TCP"
+  cidr              = "0.0.0.0/0"
+  start_port        = 5432
+  end_port          = 5432
+  description       = "PostgreSQL depuis Internet (faute voulue)"
+}
+
+# ÉCART …_high_risk_udp_ports (high) : SNMP.
+resource "exoscale_security_group_rule" "snmp_open" {
+  security_group_id = exoscale_security_group.snmp_open.id
+  type              = "INGRESS"
+  protocol          = "UDP"
+  cidr              = "0.0.0.0/0"
+  start_port        = 161
+  end_port          = 161
+  description       = "SNMP depuis Internet (faute voulue)"
+}
+
+# TOUS les ports TCP et UDP depuis Internet. Chez Exoscale, une règle n'a PAS de
+# protocole « tout » (valeurs : tcp, udp, icmp, icmpv6, ah, esp, gre, ipip) : le
+# contrôle …_all_ports (critical, protocole `all`) n'est donc PAS constructible sur ce
+# fournisseur — sur aucune source —, et tenant.yaml le consigne. Ces deux règles
+# portent les quatre autres contrôles d'entrée.
+resource "exoscale_security_group_rule" "any_open_tcp" {
+  security_group_id = exoscale_security_group.any_open.id
+  type              = "INGRESS"
+  protocol          = "TCP"
+  cidr              = "0.0.0.0/0"
+  start_port        = 1
+  end_port          = 65535
+  description       = "Tout TCP depuis Internet (faute voulue)"
+}
+
+resource "exoscale_security_group_rule" "any_open_udp" {
+  security_group_id = exoscale_security_group.any_open.id
+  type              = "INGRESS"
+  protocol          = "UDP"
+  cidr              = "0.0.0.0/0"
+  start_port        = 1
+  end_port          = 65535
+  description       = "Tout UDP depuis Internet (faute voulue)"
+}
+
+# ÉCART …_tcp_port_22 par ÉVASION : quatre /2.
+resource "exoscale_security_group_rule" "quartet" {
+  for_each          = toset(["0.0.0.0/2", "64.0.0.0/2", "128.0.0.0/2", "192.0.0.0/2"])
+  security_group_id = exoscale_security_group.quartet.id
+  type              = "INGRESS"
+  protocol          = "TCP"
+  cidr              = each.value
+  start_port        = 22
+  end_port          = 22
+  description       = "SSH depuis un quart d'Internet (faute voulue)"
+}
+
+# Tout TCP vers Internet. Même limite : sans protocole « tout », la règle
+# network_securitygroup_unrestricted_egress (protocole `all`) ne peut PAS se
+# déclencher chez Exoscale. Consigné dans tenant.yaml ; cette règle ne porte donc
+# aucun écart attendu.
+resource "exoscale_security_group_rule" "egress_any" {
+  security_group_id = exoscale_security_group.egress_any.id
+  type              = "EGRESS"
+  protocol          = "TCP"
+  cidr              = "0.0.0.0/0"
+  start_port        = 1
+  end_port          = 65535
+  description       = "Tout TCP vers Internet (faute voulue)"
+}
+
+# ÉCART network_flow_matrix_documented (medium) : une règle entrante SANS
+# justification, sur un port servi.
+resource "exoscale_security_group_rule" "undocumented_flow" {
+  security_group_id = exoscale_security_group.undocumented_flow.id
+  type              = "INGRESS"
+  protocol          = "TCP"
+  cidr              = "0.0.0.0/0"
+  start_port        = 443
+  end_port          = 443
+}
+
+# CONTRE-EXEMPLE : SSH depuis un /8 privé, HTTPS depuis Internet, sortie 443 —
+# chaque flux justifié.
+resource "exoscale_security_group_rule" "hardened_ssh_private" {
+  security_group_id = exoscale_security_group.hardened.id
+  type              = "INGRESS"
+  protocol          = "TCP"
+  cidr              = "10.0.0.0/8"
+  start_port        = 22
+  end_port          = 22
+  description       = "Administration depuis le reseau interne"
+}
+
+resource "exoscale_security_group_rule" "hardened_https" {
+  security_group_id = exoscale_security_group.hardened.id
+  type              = "INGRESS"
+  protocol          = "TCP"
+  cidr              = "0.0.0.0/0"
+  start_port        = 443
+  end_port          = 443
+  description       = "Service web public"
+}
+
+resource "exoscale_security_group_rule" "hardened_egress_https" {
+  security_group_id = exoscale_security_group.hardened.id
+  type              = "EGRESS"
+  protocol          = "TCP"
+  cidr              = "0.0.0.0/0"
+  start_port        = 443
+  end_port          = 443
+  description       = "Mises a jour et API sortantes"
+}
+
+# ÉCART network_documented (CLD-NET-5, low) : réseau privé sans étiquettes de
+# cartographie ni description.
+resource "exoscale_private_network" "undocumented" {
+  zone   = var.zone
+  name   = "pepin-qual-pn-undocumented"
+  labels = local.untagged
+}
+
+# CONTRE-EXEMPLE : cartographié.
+resource "exoscale_private_network" "documented" {
+  zone        = var.zone
+  name        = "pepin-qual-pn-documented"
+  description = "Reseau applicatif du tenant de qualification"
+  labels      = merge(local.untagged, { Owner = "pepin-maintainer", Project = "pepin", Env = "qualification" })
+}

--- a/references/qualification/exoscale/outputs.tf
+++ b/references/qualification/exoscale/outputs.tf
@@ -1,0 +1,14 @@
+# Sorties : en plan seul, les identifiants ne sont pas connus ; expected.yaml
+# désigne les ressources par leur adresse ou leur nom. Ces sorties serviront à la
+# moitié live, quand un compte existera.
+
+output "sg_ssh_open_id" { value = exoscale_security_group.ssh_open.id }
+output "sg_hardened_id" { value = exoscale_security_group.hardened.id }
+output "vm_untagged_id" { value = exoscale_compute_instance.untagged.id }
+output "vm_secrets_id" { value = exoscale_compute_instance.secrets.id }
+output "vm_swiss_id" { value = exoscale_compute_instance.swiss.id }
+output "vm_hardened_id" { value = exoscale_compute_instance.hardened.id }
+output "volume_data_id" { value = exoscale_block_storage_volume.data.id }
+output "sks_weak_name" { value = exoscale_sks_cluster.weak.name }
+output "sks_strong_name" { value = exoscale_sks_cluster.strong.name }
+output "role_admin_id" { value = exoscale_iam_role.admin.id }

--- a/references/qualification/exoscale/sks.tf
+++ b/references/qualification/exoscale/sks.tf
@@ -1,0 +1,36 @@
+# SKS — deux clusters (plan seul).
+#
+#   weak    service_level starter (plan de contrôle non redondant), auto_upgrade
+#           false, audit désactivé → trois écarts sur un sujet
+#   strong  service_level pro, auto_upgrade true, audit vers un endpoint → silencieux
+#
+# Les trois contrôles Kubernetes actifs pour Exoscale lisent ces trois champs
+# (mapping_terraform de providers/exoscale.yaml) : un cluster « faible » les porte
+# tous, parce qu'un cluster par écart n'apprendrait rien de plus sur un plan.
+
+resource "exoscale_sks_cluster" "weak" {
+  zone          = var.zone
+  name          = "pepin-qual-sks-weak"
+  service_level = "starter"
+  auto_upgrade  = false
+  labels        = local.tagged
+
+  audit {
+    enabled  = false
+    endpoint = ""
+  }
+}
+
+resource "exoscale_sks_cluster" "strong" {
+  zone          = var.zone
+  name          = "pepin-qual-sks-strong"
+  service_level = "pro"
+  auto_upgrade  = true
+  labels        = local.tagged
+
+  audit {
+    enabled      = true
+    endpoint     = "https://audit.qualification.invalid/sks"
+    bearer_token = "pepin-qualification-fake-token"
+  }
+}

--- a/references/qualification/exoscale/tenant.yaml
+++ b/references/qualification/exoscale/tenant.yaml
@@ -1,0 +1,48 @@
+# Tenant de QUALIFICATION Exoscale — métadonnées lues par tools/qualification/qualify.py.
+#
+# PLAN SEUL : aucun compte Exoscale n'est disponible. Ce tenant épingle la source
+# Terraform — ce que `pepin scan exoscale --terraform` rend sur son plan —, ce qui a
+# déjà de la valeur (c'est le chemin qu'un utilisateur emploie sans compte, ADR-0012).
+# La moitié live (apply, scan --live, bundle, destroy, preuve de destruction)
+# attend un compte ; `mise run qualify` sur ce tenant est REFUSÉ tant que
+# `live: unavailable` est là.
+provider: exoscale
+title: "Tenant de qualification Exoscale : une faute par ressource, source Terraform seulement (pas de compte)"
+title_en: "Exoscale qualification tenant: one fault per resource, Terraform source only (no account)"
+
+live: unavailable
+live_reason: "Aucun compte Exoscale disponible (2026-09-09). La moitié live n'est ni construite ni prouvée : hooks.py refuse identity/inventory/cleanup."
+
+region: de-fra-1
+zone: de-fra-1
+
+tag: pepin-qual
+name_prefix: pepin-qual-
+
+provider_version: "0.71.0"
+
+applied_vars:
+  terraform_only_resources: false
+
+budget_minutes: 5
+
+resources:
+  plan:
+    - { family: security_groups, count: 9, note: "ssh/rdp/db/snmp/any/quartet/egress_any ⇒ 6 contrôles réseau ; undocumented_flow ⇒ CLD-NET-5 (matrice des flux) ; hardened = contre-exemple" }
+    - { family: private_networks, count: 2, note: "undocumented ⇒ CLD-NET-5 ; documented = contre-exemple" }
+    - { family: instances, count: 4, note: "untagged ⇒ CLD-GVN-1 ; secrets ⇒ CLD-CMP-9 ; swiss (ch-gva-2) ⇒ CLD-GVN-3 mineur ; hardened = contre-exemple" }
+    - { family: block_volumes, count: 1, note: "chiffré par construction (CLD-CHF-2 pass) ; CLD-STO-3 attend le live" }
+    - { family: sks_clusters, count: 2, note: "weak (starter, sans auto-upgrade, sans audit) ⇒ CLD-K8S-2, CLD-K8S-3, CLD-LOG-1 ; strong = contre-exemple" }
+    - { family: iam_roles, count: 4, note: "admin ⇒ iam_role_no_admin_privileges ; no_source_ip ⇒ iam_role_source_ip_restricted ; unbounded ⇒ iam_role_key_lifetime_bounded ; restricted = contre-exemple" }
+
+not_exercised:
+  - control: compute_instance_public_ip_with_open_securitygroup
+    reason: "L'IP publique d'une instance est calculée à l'apply : le plan ne peut pas conclure. Attend la moitié live."
+  - control: blockstorage_volume_snapshots_exist
+    reason: "L'état d'usage d'un volume (attached) est calculé à l'apply. Attend la moitié live."
+  - control: objectstorage_bucket_*
+    reason: "Le provider exoscale/exoscale n'a pas de ressource de bucket SOS (seulement exoscale_sos_bucket_policy) : les buckets seront créés par un crochet `extra`, comme chez Outscale, quand un compte existera."
+  - control: iam_user_mfa_enabled
+    reason: "Les utilisateurs IAM ne sont pas des ressources Terraform, et ce sont des personnes réelles de l'organisation."
+  - control: governance_provider_sovereignty
+    reason: "Écart par construction des faits du descripteur (siège en Suisse, contrôle capitalistique extra-UE) : épinglé fail, ce n'est pas le tenant qui le construit."

--- a/references/qualification/exoscale/variables.tf
+++ b/references/qualification/exoscale/variables.tf
@@ -1,0 +1,48 @@
+# Variables du tenant de qualification Exoscale (plan seul).
+
+variable "zone" {
+  description = "Zone UE des ressources : de-fra-1 (Allemagne). Chez Exoscale, la « région » est la zone"
+  type        = string
+  default     = "de-fra-1"
+}
+
+variable "trusted_zone" {
+  description = "Zone hors UE mais en espace européen de confiance (Suisse) : ch-gva-2 — l'écart MINEUR de CLD-GVN-3, constructible ici et nulle part ailleurs"
+  type        = string
+  default     = "ch-gva-2"
+}
+
+variable "template_id" {
+  description = "Modèle (image) des instances. Un plan ne le valide pas ; un apply réel exigera l'identifiant d'un modèle Exoscale de la zone (data source exoscale_template), donc un compte"
+  type        = string
+  default     = "00000000-0000-0000-0000-000000000000"
+}
+
+variable "instance_type" {
+  description = "Gamme des instances (plan seul : aucune facturation)"
+  type        = string
+  default     = "standard.micro"
+}
+
+variable "tenant_tag" {
+  description = "Étiquette (label) posée sur toute ressource étiquetable du tenant"
+  type        = string
+  default     = "pepin-qual"
+}
+
+variable "terraform_only_resources" {
+  description = "Uniformité du runner : rien n'est « plan seulement » ici, puisque tout l'est"
+  type        = bool
+  default     = true
+}
+
+locals {
+  governance = {
+    CostCenter = "qualification"
+    Project    = "pepin"
+    Env        = "qualification"
+    Owner      = "pepin-maintainer"
+  }
+  tagged   = merge({ (var.tenant_tag) = "tenant" }, local.governance)
+  untagged = { (var.tenant_tag) = "tenant" }
+}

--- a/references/qualification/exoscale/versions.tf
+++ b/references/qualification/exoscale/versions.tf
@@ -1,0 +1,29 @@
+# Tenant de qualification Exoscale — épinglage du provider.
+#
+# PLAN SEUL, pour l'instant : aucun compte Exoscale n'est disponible (tenant.yaml
+# `live: unavailable`). Ce tenant épingle donc la SOURCE TERRAFORM — ce que
+# `pepin scan exoscale --terraform` rend sur ce plan — et rien d'autre. La moitié
+# live (apply, scan --live, bundle, destroy, preuve de destruction) attend un
+# compte, et le README le dit plutôt que de laisser croire à une couverture live.
+#
+# Version ÉPINGLÉE À L'EXACT, lockfile versionné : même doctrine que les deux autres
+# tenants. Les issues de destruction du provider exoscale/exoscale sont à lire AVANT
+# le premier apply, pas avant le premier plan : cette lecture reste due.
+terraform {
+  required_version = ">= 1.11"
+
+  backend "local" {}
+
+  required_providers {
+    exoscale = {
+      source  = "exoscale/exoscale"
+      version = "0.71.0"
+    }
+  }
+}
+
+# Aucun identifiant ici (ADR-0012) : le provider lit EXOSCALE_API_KEY et
+# EXOSCALE_API_SECRET. En plan seul, le crochet `variables` fournit des valeurs
+# FACTICES de la bonne forme (celles que scripts/tenant-plan.py emploie déjà) : un
+# plan sans source de données n'appelle pas l'API.
+provider "exoscale" {}

--- a/references/qualification/outscale/.terraform.lock.hcl
+++ b/references/qualification/outscale/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/outscale/outscale" {
+  version     = "1.8.0"
+  constraints = "1.8.0"
+  hashes = [
+    "h1:6rfbJTQN4SwvrDoZ2g+qgCgIKRhyRrzyZy+JVfejp7I=",
+    "zh:0fb8144ff2ebd542870676351981ed407a7f2552c7d42a37fcfb097c353607ec",
+    "zh:2a6189d28ae79e78c51da6509921895924c357708f2ea4c26ca00925ba698584",
+    "zh:3c642503e5dd2bc9ac40c355c25e828c22dcf8c8f0bd85c0fc57fa2cee08a5c6",
+    "zh:4e5496dcd8fadc69025ff6b74e35703605d70ca859b47d32ee31aebdafa25f93",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:98ec05d9ea5f9ff109f7c08ccf0d47ae5b6bf9b9e7a7f876cbe87fc55cd96887",
+    "zh:c564c76d7381f622c467ed3df415eddc04316f0a02666430d13fef5bc23fca42",
+    "zh:cad516e855cf89b1663d95fa2a165700be009b83b79e1afffbe359a58381091d",
+    "zh:d4d4829acc3f3c57e11212b371bbe9954dd8bf148d089a4da11acd7ef55823f0",
+    "zh:d5abfbe561996cec91b5327439ac573df4d30f784977c05b02c6deac549ae8b5",
+    "zh:df29b9c039328eeed78d8478e1b51572fd9b930e57652e739ab673a66dbfc35c",
+    "zh:e38737ab91ee4ac2cec796e78c9cfb5b1bfba42d6c5567a6db4328728b50473c",
+    "zh:e62b2e7513cf36d11b689e0dae55692026974ce9b720d0bb575c0bdf046da848",
+    "zh:f7747fbb05dc19f076b82bc69e1eab55132f37160a7aa5dd05d4f106ec587c75",
+  ]
+}

--- a/references/qualification/outscale/README.fr.md
+++ b/references/qualification/outscale/README.fr.md
@@ -1,0 +1,122 @@
+> [🇬🇧 English](README.md) · 🇫🇷 Français
+
+# Tenant de qualification Outscale
+
+79 ressources Terraform, plus 6 buckets OOS et une politique EIM inline créés par le
+crochet `extra`, en `eu-west-2` / `eu-west-2a`, sur le compte que l'environnement
+nomme (`PEPIN_QUAL_OSC_ACCOUNT`, confirmé par `ReadAccounts` avant tout apply). Une
+faute par ressource, un contre-exemple par contrôle. Appliqué, scanné, scellé,
+détruit et comparé par `PEPIN_GATE_LIVE=1 PROVIDER=outscale mise run qualify` (voir
+[le README générique](../README.fr.md)).
+
+À la différence de Scaleway, un scan live Outscale lit **tout ce que cette stack
+crée** (16 types au contrat de `providers/outscale.yaml`) : les deux passes voient le
+même tenant, et c'est ici que se trouvent les cas que Scaleway ne sait pas exercer en
+live — la machine à deux cartes, la clé root, la famille `iam_policy_*` par les
+documents EIM, les snapshots, l'OMI publique, les load balancers.
+
+## Ce que la stack crée
+
+| Famille | Nombre | Ressource fautive → contrôle | Contre-exemple (doit rester muet) |
+|---|---:|---|---|
+| Groupes de sécurité (tous dans le Net) | 10 (+ 14 règles) | `ssh_open` → `…tcp_port_22` · `rdp_open` → `…tcp_port_3389` · `db_open` (5432) → `…high_risk_tcp_ports` · `snmp_open` (UDP 161) → `…high_risk_udp_ports` · `any_open` → `…all_ports` **et les quatre précédents** · `quartet` (quatre `/2`) → `…tcp_port_22` par évasion · `egress_any` (sortie explicite `-1 → 0.0.0.0/0`) → `network_securitygroup_unrestricted_egress` · `net_ssh_open` → `…tcp_port_22` (le groupe de la carte secondaire) · le groupe **`default` du Net**, créé par le produit et lu par une source de données → `network_securitygroup_default_restrict_traffic` (règle d'usine) et `unrestricted_egress` (sa règle sortante par défaut) | `hardened` (SSH depuis `10.0.0.0/8`, HTTPS depuis Internet, sortie TCP 443) · `net_closed` · tous les groupes ont `remove_default_outbound_rule = true` |
+| VM (`tinav6.c2r4p2`) | 8 | `exposed` (IP publique + `ssh_open`) → `compute_instance_public_ip_with_open_securitygroup` · `two_nics` (carte primaire privée et fermée, carte **secondaire** publique dans `net_ssh_open`) → le même contrôle, par l'appariement des cartes de #187 · `untagged` → `governance_resource_required_tags` · `secrets` (cloud-init avec mot de passe, `UserData` base64) → `compute_instance_no_secrets_in_user_data` · `unprotected` (`Env=prod`, sans protection) → `compute_instance_deletion_protection` | `private` (même groupe ouvert, pas d'IP) · `hardened` (IP publique, groupe restrictif, `Env=prod`, **protégée**) · `two_nics_inverse` (primaire publique et fermée, secondaire privée et ouverte : aplatie elle paraîtrait exposée, appariée elle ne l'est pas) · `untagged` reçoit aussi un *non concluant* sur la protection (pas d'environnement lisible, ADR-0015) |
+| Cartes secondaires, IP publiques | 2 + 4 | — | `outscale_nic` + `outscale_nic_link`, jamais le bloc `nics` (voir plus bas) |
+| Volumes | 2 (+ 8 racines) | `unsnapshotted` et les huit volumes racine → `blockstorage_volume_snapshots_exist` | `snapshotted` (snapshot privée terminée, source des deux OMI) · volumes racine étiquetés par `outscale_tag` |
+| Snapshots | 2 | `public` (`GlobalPermission`) → `blockstorage_snapshot_not_public` | `private` |
+| Images (OMI) | 2 | `public` (permission de lancement globale) → `compute_image_not_public` | `private` |
+| Nets, sous-réseaux | 2 + 2 | `undocumented` → `network_documented` · `autoip` (`MapPublicIpOnLaunch`) → `network_subnet_no_public_ip_by_default` | `documented` · `main` · un **appairage entre les deux Nets** (même compte) est le contre-exemple de `network_peering_cross_organization` |
+| Load balancers (LBU) | 2 | `http` (écouteur HTTP seul, sans journal) → `loadbalancer_ssl_listeners`, `loadbalancer_logging_enabled` · `tcp443` (écouteur TCP 443) → *non concluant* sur `loadbalancer_ssl_listeners` (candidat passthrough TLS), écart `loadbalancer_logging_enabled` | — (un journal activé exige un bucket OOS cible ; non construit) |
+| EIM | 1 utilisateur, 3 clés, 5 politiques | `no_expiry` → `iam_accesskey_expiration_set` · `root` (clé du compte appelant) → `iam_no_root_access_key` · `admin` (`Action: *`) → `iam_policy_no_administrative_privileges` · `wildcard`, `notaction`, `escalation` (`Resource: *`) → `iam_policy_no_wildcard_resource` · `notaction` → `iam_policy_no_notaction_notresource` · `escalation` (`CreateAccessKey`, `LinkPolicy`) → `iam_policy_no_privilege_escalation` | `expiring` (échéance à J+2) · `scoped` (ressource OOS nommée) · toutes les clés sont créées **INACTIVES** : les règles ne lisent pas l'état, et aucun secret utilisable ne circule |
+| Règles d'accès API | 2 | `public` (`0.0.0.0/0`) → `iam_apiaccessrule_no_public_cidr` | `private` (`10.0.0.0/8`) ; les règles s'ajoutent, aucune n'enferme personne dehors |
+| Buckets OOS (crochet `extra`, `aws s3api` sur `oos.eu-west-2.outscale.com`) | 6 | `public` (ACL) et `policy` (`Principal: *`) → `objectstorage_bucket_public_access` · `unversioned` → `…versioning_enabled` et `…object_lock_enabled` · `unlocked` → `…object_lock_enabled` · `unencrypted` (sans SSE) → `objectstorage_bucket_default_encryption` | `hardened` (privé, verrouillé, SSE, étiqueté) |
+| Politique EIM inline (crochet `extra`, `PutUserPolicy`) | 1 | `pepin-qual-inline-admin` (`Action: *` sur l'utilisateur du tenant, l'incident fondateur de l'ADR-0006) → `iam_policy_no_administrative_privileges` | — |
+
+Toute ressource étiquetable porte le tag `pepin-qual`, tout nom commence par
+`pepin-qual-`, et les noms de buckets embarquent les huit premiers chiffres du compte.
+
+## Ce que le provider amont est connu pour laisser derrière lui au `destroy`
+
+Lu avant de choisir les types de ressources, dans `outscale/terraform-provider-outscale`
+(1.8.0 épinglé, lockfile committé). Ce que chacune a changé dans cette stack :
+
+| Amont | État | Ce que ça fait | Ce que ce tenant en fait |
+|---|---|---|---|
+| [#88](https://github.com/outscale/terraform-provider-outscale/issues/88) deletion_protection : une VM protégée fait échouer le destroy (`Error deleting the VM`) | ouverte, confirmée par les mainteneurs en 2024-08 (« you must apply the change first ») | Le contre-exemple protégé bloquerait tout le destroy. | `deletion_protection = var.deletion_protection`, et `tenant.yaml` déclare `pre_destroy_vars: {deletion_protection: false}` : le runner **applique** la déprotection avant de détruire. Le nettoyage de secours fait `UpdateVm DeletionProtection=false` d'abord. |
+| [#28](https://github.com/outscale/terraform-provider-outscale/issues/28) / [#137](https://github.com/outscale/terraform-provider-outscale/issues/137) `outscale_nic_private_ip` : 400/409 au destroy, carte et IP primaire non supprimées | ouvertes | Des IP privées secondaires bloquent la destruction de la carte. | Aucune `outscale_nic_private_ip` : une IP privée primaire par carte. |
+| [#778](https://github.com/outscale/terraform-provider-outscale/issues/778), [#424](https://github.com/outscale/terraform-provider-outscale/issues/424), [#50](https://github.com/outscale/terraform-provider-outscale/issues/50), [#448](https://github.com/outscale/terraform-provider-outscale/issues/448) blocs `nics` / `primary_nic` d'`outscale_vm` : VM remplacée à chaque plan, carte « oubliée » | #778 fermée 2026-07 (ne sera pas corrigée : « use `primary_nic` with a separate `nic_link` ») | Une seconde carte déclarée en ligne ne se détruit pas proprement. | Les cartes secondaires sont des `outscale_nic` + `outscale_nic_link` (+ `outscale_public_ip_link` sur la carte), la parade recommandée par les mainteneurs. |
+| [#622](https://github.com/outscale/terraform-provider-outscale/issues/622) un groupe de sécurité encore attaché ne se détruit pas | fermée 2026-02 | Un groupe référencé par une VM ou un LBU retient. | Chaque groupe n'est attaché qu'à des VM Terraform, détruites d'abord par dépendance. |
+| [#663](https://github.com/outscale/terraform-provider-outscale/issues/663) destruction d'une politique de stickiness LBU en échec | fermée | — | Aucune politique de stickiness. |
+| [#6](https://github.com/outscale/terraform-provider-outscale/issues/6) IP publique relâchée trop tôt | fermée 2022 | — | Ressources `outscale_public_ip` + `outscale_public_ip_link`, ordonnées par dépendance. |
+| Mesuré ici : **`terraform destroy` rend 0 alors qu'un appairage de Nets survit** | à signaler en amont | Un `outscale_net_peering` accepté (+ `_acceptation`) était encore `active` après un destroy réussi. | Le nettoyage de secours le supprime (`DeleteNetPeering`) et la preuve de destruction l'attrape. |
+| Mesuré ici : **les suppressions sont asynchrones** | — | 26 s après un destroy réussi, les deux LBU, dix volumes et deux snapshots étaient encore listés ; deux minutes plus tard, ils « n'existaient plus ». | La preuve de destruction **reliste jusqu'au vide**, bornée par `settle_seconds` (240 s par défaut) : ce qui survit au délai est un reste. |
+| Mesuré ici : un groupe du cloud public ne peut pas retirer sa règle sortante par défaut (`remove_default_outbound_rule` exige `net_id`) | — | Tout groupe du cloud public porte `unrestricted_egress` par construction. | Tous les groupes vivent dans le Net. |
+| Mesuré ici : OOS active le versioning d'un bucket Object Lock et **le fige** (`InvalidBucketState` sur `PutBucketVersioning`) | — | — | Le crochet n'active le versioning explicitement que sur `unlocked`. |
+| Mesuré ici (trois runs) : **`LinkPublicIp` par `VmId` est refusé (400 `InvalidResource`) sur une VM qui a déjà deux cartes** | — | Le contre-exemple `two_nics_inverse` ne se construisait pas quand la seconde carte était attachée d'abord. | L'IP publique est liée pendant que la VM n'a que sa carte primaire ; l'`outscale_nic_link` de la seconde carte dépend de ce lien. |
+| Mesuré ici : **`DeleteImage` ne supprime pas la snapshot qu'une OMI créée depuis une VM implique** | — | Deux snapshots orphelines après un destroy réussi, attrapées par le delta avant/après. | Les deux OMI sont construites depuis la snapshot gérée du tenant (`block_device_mappings`) : rien d'implicite n'est créé. |
+
+La preuve de destruction liste 20 familles par l'OAPI (VM, cartes, IP publiques,
+groupes, volumes, snapshots, images, Nets, sous-réseaux, services Internet, NAT,
+tables de routage, appairages, LBU, keypairs, règles d'accès API, utilisateurs,
+politiques, clés d'accès, buckets), filtrées sur le tag et le préfixe du tenant, et
+compare le listing entier à celui pris avant apply. `octl`, la CLI de référence du
+fournisseur, est ce qu'un mainteneur rejoue à la main :
+
+```bash
+octl iaas vm list --filter 'Tags[].Key:pepin-qual' -o table
+octl iaas securitygroup list -o table --filter 'SecurityGroupName:pepin-qual-'
+octl iaas publicip list -o table
+octl iaas volume list -o table
+octl iaas snapshot list -o table
+octl iaas image list -o table --filter 'ImageName:pepin-qual-'
+octl iaas net list -o table
+octl iaas netpeering list -o table
+octl iaas loadbalancer list -o table
+octl iaas user list -o table
+octl iaas policy list -o table
+octl storage bucket list -o table
+```
+
+Jamais `octl profile current` : il imprime la clé secrète en clair. Et lire les
+états : un moment après un destroy, `octl iaas vm list` montre encore les VM du
+tenant en `terminated` et `octl iaas netpeering list` son appairage en `deleted` (32
+et 4 après quatre runs). Ce sont des entrées terminales, pas des ressources ;
+l'inventaire API de la preuve exclut ces états.
+
+## Ce que ce tenant ne peut pas exercer, et pourquoi
+
+`tenant.yaml`, `not_exercised:` — une ressource hors UE (un compte Outscale vit dans
+une région), une clé de plus de 90 jours, un appairage entre comptes, la politique
+d'accès API du compte (MFA imposée, plafond d'échéance des clés : les forcer
+enfermerait la clé qui qualifie), un tenant sans aucune règle d'accès API, un journal
+LBU activé, un groupe `default` vidé de sa règle d'usine, les clusters OKS.
+
+## Coût et budget
+
+Tarifs horaires dans [`tenant.yaml`](tenant.yaml) : 8 × `tinav6.c2r4p2` à 0,09 EUR/h
+(le type que le mainteneur a donné pour son compte), 2 LBU à 0,03 EUR/h, 4 IP
+publiques, ~100 Go de volumes — environ **0,82 EUR par heure** de vie du tenant.
+Budget : 40 minutes mur, sinon NO-GO.
+
+## Mesuré
+
+<!-- qualification:measured -->
+Run du 2026-09-09 (`GO`), sur le compte que l'environnement nomme :
+
+| | |
+|---|---|
+| Ressources | 79 dans le plan, toutes appliquées, plus 7 ressource(s) hors Terraform : pepin-qual-30044641-public, pepin-qual-30044641-policy, pepin-qual-30044641-unversioned, pepin-qual-30044641-unlocked, pepin-qual-30044641-unencrypted, pepin-qual-30044641-hardened, pepin-qual-user/pepin-qual-inline-admin |
+| `apply` | 210.3 s |
+| `scan --live` × 5 formats + scellement | 50.8 s, code de sortie 1 dans chaque format |
+| bundle | `verify --re-derive` passe ; le bundle altéré d'un octet est refusé |
+| `scan --terraform` | code de sortie 1 |
+| `destroy` | 155.3 s — pré-destroy (deletion_protection=False) rc=0 ; terraform destroy rc=0 ; état vide ; 2 fichier(s) d'état purgé(s) |
+| preuve de destruction | 20 familles listées, aucune ressource du tenant, aucun delta avant/après (après 40s de suppressions asynchrones) |
+| comparaison | live : 145 résultats, 0 différence ; terraform : 54 résultats, 0 différence |
+| falsification | 3 attentes cassées en mémoire sur chaque source, toutes NO-GO |
+| durée mur | 511.5 s (budget 40 min) |
+| coût estimé | 0.0989 EUR (0.121 h × 0.815 EUR/h) |
+
+Écarts hors tenant rapportés par le scan live et non gardés : 74 (clés,
+politiques, règles d'accès API, buckets et groupes par défaut propres au compte).
+<!-- /qualification:measured -->

--- a/references/qualification/outscale/README.md
+++ b/references/qualification/outscale/README.md
@@ -1,0 +1,122 @@
+> 🇬🇧 English · [🇫🇷 Français](README.fr.md)
+
+# Outscale qualification tenant
+
+79 Terraform resources plus 6 OOS buckets and one inline EIM policy created by the
+`extra` hook, in `eu-west-2` / `eu-west-2a`, on the account the environment names
+(`PEPIN_QUAL_OSC_ACCOUNT`, confirmed by `ReadAccounts` before any apply). One fault
+per resource, one counterexample per control. Applied, scanned, sealed, destroyed
+and compared by `PEPIN_GATE_LIVE=1 PROVIDER=outscale mise run qualify` (see
+[the generic README](../README.md)).
+
+Unlike Scaleway, an Outscale live scan reads **everything this stack creates** (16
+types in the `providers/outscale.yaml` contract): the two passes see the same tenant,
+and this is where the cases Scaleway cannot exercise live — the two-NIC machine, the
+root access key, the `iam_policy_*` family through EIM documents, the snapshots, the
+public OMI, the load balancers.
+
+## What the stack creates
+
+| Family | Count | Faulty resource → control | Counterexample (must stay silent) |
+|---|---:|---|---|
+| Security groups (all in the Net) | 10 (+ 14 rules) | `ssh_open` → `…tcp_port_22` · `rdp_open` → `…tcp_port_3389` · `db_open` (5432) → `…high_risk_tcp_ports` · `snmp_open` (UDP 161) → `…high_risk_udp_ports` · `any_open` → `…all_ports` **and the four above** · `quartet` (four `/2`) → `…tcp_port_22` by evasion · `egress_any` (explicit `-1 → 0.0.0.0/0` outbound) → `network_securitygroup_unrestricted_egress` · `net_ssh_open` → `…tcp_port_22` (the secondary card's group) · the Net's **`default` group**, created by the product and read through a data source → `network_securitygroup_default_restrict_traffic` (factory rule) and `unrestricted_egress` (its default outbound rule) | `hardened` (SSH from `10.0.0.0/8`, HTTPS from anywhere, egress TCP 443) · `net_closed` · every group has `remove_default_outbound_rule = true` |
+| VMs (`tinav6.c2r4p2`) | 8 | `exposed` (public IP + `ssh_open`) → `compute_instance_public_ip_with_open_securitygroup` · `two_nics` (primary card private and closed, **secondary** card public in `net_ssh_open`) → the same control, through the NIC pairing of #187 · `untagged` → `governance_resource_required_tags` · `secrets` (cloud-init with a password, base64 `UserData`) → `compute_instance_no_secrets_in_user_data` · `unprotected` (`Env=prod`, no deletion protection) → `compute_instance_deletion_protection` | `private` (same open group, no IP) · `hardened` (public IP, restrictive group, `Env=prod`, **protected**) · `two_nics_inverse` (primary public and closed, secondary private and open: flattened it would look exposed, paired it is not) · `untagged` also gets an *inconclusive* on deletion protection (no readable environment, ADR-0015) |
+| Secondary NICs, public IPs | 2 + 4 | — | `outscale_nic` + `outscale_nic_link`, never the `nics` block (see below) |
+| Volumes | 2 (+ 8 root) | `unsnapshotted` and the eight root volumes → `blockstorage_volume_snapshots_exist` | `snapshotted` (a completed private snapshot, also the source of both OMIs) · root volumes tagged through `outscale_tag` |
+| Snapshots | 2 | `public` (`GlobalPermission`) → `blockstorage_snapshot_not_public` | `private` |
+| Images (OMI) | 2 | `public` (global launch permission) → `compute_image_not_public` | `private` |
+| Nets, subnets | 2 + 2 | `undocumented` → `network_documented` · `autoip` (`MapPublicIpOnLaunch`) → `network_subnet_no_public_ip_by_default` | `documented` · `main` · a **peering between the two Nets** (same account) is the counterexample of `network_peering_cross_organization` |
+| Load balancers (LBU) | 2 | `http` (HTTP listener only, no access log) → `loadbalancer_ssl_listeners`, `loadbalancer_logging_enabled` · `tcp443` (TCP 443 listener) → *inconclusive* on `loadbalancer_ssl_listeners` (TLS passthrough candidate), fails `loadbalancer_logging_enabled` | — (an enabled access log needs an OOS target bucket; not built) |
+| EIM | 1 user, 3 keys, 5 policies | `no_expiry` → `iam_accesskey_expiration_set` · `root` (a key of the calling account) → `iam_no_root_access_key` · `admin` (`Action: *`) → `iam_policy_no_administrative_privileges` · `wildcard`, `notaction`, `escalation` (`Resource: *`) → `iam_policy_no_wildcard_resource` · `notaction` → `iam_policy_no_notaction_notresource` · `escalation` (`CreateAccessKey`, `LinkPolicy`) → `iam_policy_no_privilege_escalation` | `expiring` (expiry at D+2) · `scoped` (a named OOS resource) · every key is created **INACTIVE**: the rules do not read the state, and no usable secret circulates |
+| API access rules | 2 | `public` (`0.0.0.0/0`) → `iam_apiaccessrule_no_public_cidr` | `private` (`10.0.0.0/8`); rules are OR-ed, none locks anyone out |
+| OOS buckets (`extra` hook, `aws s3api` on `oos.eu-west-2.outscale.com`) | 6 | `public` (ACL) and `policy` (`Principal: *`) → `objectstorage_bucket_public_access` · `unversioned` → `…versioning_enabled` and `…object_lock_enabled` · `unlocked` → `…object_lock_enabled` · `unencrypted` (no SSE) → `objectstorage_bucket_default_encryption` | `hardened` (private, locked, SSE, tagged) |
+| Inline EIM policy (`extra` hook, `PutUserPolicy`) | 1 | `pepin-qual-inline-admin` (`Action: *` on the tenant's user, the founding incident of ADR-0006) → `iam_policy_no_administrative_privileges` | — |
+
+Every taggable resource carries the tag `pepin-qual`, every name starts with
+`pepin-qual-`, and the bucket names embed the first eight digits of the account id.
+
+## What the upstream provider is known to leave behind on `destroy`
+
+Read before choosing the resource types, in `outscale/terraform-provider-outscale`
+(1.8.0 pinned, lockfile committed). What each one changed in this stack:
+
+| Upstream | State | What it does | What this tenant does about it |
+|---|---|---|---|
+| [#88](https://github.com/outscale/terraform-provider-outscale/issues/88) deletion_protection: a protected VM makes destroy fail (`Error deleting the VM`) | open, confirmed by the maintainers 2024-08 ("you must apply the change first") | The protected counterexample would block the whole destroy. | `deletion_protection = var.deletion_protection`, and `tenant.yaml` declares `pre_destroy_vars: {deletion_protection: false}`: the runner **applies** the unprotection before destroying. The rescue cleanup does `UpdateVm DeletionProtection=false` first. |
+| [#28](https://github.com/outscale/terraform-provider-outscale/issues/28) / [#137](https://github.com/outscale/terraform-provider-outscale/issues/137) `outscale_nic_private_ip`: 400/409 on destroy, NIC and primary IP not deleted | open | Secondary private IPs deadlock the NIC's destroy. | No `outscale_nic_private_ip`: one primary private IP per NIC. |
+| [#778](https://github.com/outscale/terraform-provider-outscale/issues/778), [#424](https://github.com/outscale/terraform-provider-outscale/issues/424), [#50](https://github.com/outscale/terraform-provider-outscale/issues/50), [#448](https://github.com/outscale/terraform-provider-outscale/issues/448) `nics` / `primary_nic` blocks in `outscale_vm`: VM replaced on every plan, NIC "forgotten" | #778 closed 2026-07 (won't fix: "use `primary_nic` with a separate `nic_link`") | A second card declared inline is not destroyable cleanly. | Secondary cards are `outscale_nic` + `outscale_nic_link` (+ `outscale_public_ip_link` on the NIC), the workaround the maintainers recommend. |
+| [#622](https://github.com/outscale/terraform-provider-outscale/issues/622) a security group still attached cannot be destroyed | closed 2026-02 | A group referenced by a VM or LBU holds. | Every group is attached only to Terraform VMs, destroyed first by dependency. |
+| [#663](https://github.com/outscale/terraform-provider-outscale/issues/663) LBU stickiness policy destroy fails | closed | — | No stickiness policy. |
+| [#6](https://github.com/outscale/terraform-provider-outscale/issues/6) public IP released too early | closed 2022 | — | `outscale_public_ip` + `outscale_public_ip_link` resources, ordered by dependency. |
+| Measured here: **`terraform destroy` returns 0 while a net peering survives** | to report upstream | An accepted `outscale_net_peering` (+ `_acceptation`) was still `active` after a successful destroy. | The rescue cleanup deletes it (`DeleteNetPeering`) and the proof of destruction catches it. |
+| Measured here: **deletions are asynchronous** | — | 26 s after a successful destroy, both LBUs, ten volumes and two snapshots were still listed; two minutes later they "did not exist". | The proof of destruction **re-lists until empty**, bounded by `settle_seconds` (240 s by default): what survives the delay is a leftover. |
+| Measured here: a public-cloud security group cannot drop its default outbound rule (`remove_default_outbound_rule` needs `net_id`) | — | Every public-cloud group carries `unrestricted_egress` by construction. | Every group lives in the Net. |
+| Measured here: OOS sets versioning on an Object-Lock bucket and **freezes it** (`InvalidBucketState` on `PutBucketVersioning`) | — | — | The hook enables versioning explicitly only on `unlocked`. |
+| Measured here (three runs): **`LinkPublicIp` by `VmId` is refused (400 `InvalidResource`) on a VM that already has two cards** | — | The `two_nics_inverse` counterexample could not be built once the second card was attached first. | The public IP is linked while the VM has its primary card only; the second card's `outscale_nic_link` depends on that link. |
+| Measured here: **`DeleteImage` does not delete the snapshot an OMI created from a VM implies** | — | Two orphan snapshots after a successful destroy, caught by the before/after diff. | Both OMIs are built from the tenant's own managed snapshot (`block_device_mappings`), so nothing implicit is created. |
+
+The proof of destruction lists 20 families through the OAPI (VMs, NICs, public IPs,
+security groups, volumes, snapshots, images, Nets, subnets, internet services, NAT
+services, route tables, peerings, LBUs, keypairs, API access rules, users, policies,
+access keys, buckets), filtered on the tenant's tag and prefix, and diffs the whole
+listing with the one taken before apply. `octl`, the provider's reference CLI, is
+what a maintainer replays by hand:
+
+```bash
+octl iaas vm list --filter 'Tags[].Key:pepin-qual' -o table
+octl iaas securitygroup list -o table --filter 'SecurityGroupName:pepin-qual-'
+octl iaas publicip list -o table
+octl iaas volume list -o table
+octl iaas snapshot list -o table
+octl iaas image list -o table --filter 'ImageName:pepin-qual-'
+octl iaas net list -o table
+octl iaas netpeering list -o table
+octl iaas loadbalancer list -o table
+octl iaas user list -o table
+octl iaas policy list -o table
+octl storage bucket list -o table
+```
+
+Never `octl profile current`: it prints the secret key in clear. And read the states:
+for a while after a destroy, `octl iaas vm list` still shows the tenant's VMs as
+`terminated` and `octl iaas netpeering list` its peering as `deleted` (32 and 4 after
+four runs). They are terminal entries, not resources; the API inventory of the proof
+excludes those states.
+
+## What this tenant cannot exercise, and why
+
+`tenant.yaml`, `not_exercised:` — a resource outside the EU (an Outscale account
+lives in one region), a key older than 90 days, a cross-account peering, the account's
+API access policy (MFA enforcement, key expiration ceiling: forcing them would lock
+the qualifying key out), a tenant without any API access rule, an enabled LBU access
+log, a `default` group emptied of its factory rule, OKS clusters.
+
+## Cost and budget
+
+Hourly rates in [`tenant.yaml`](tenant.yaml): 8 × `tinav6.c2r4p2` at 0.09 EUR/h (the type
+the maintainer gave for this account), 2 LBUs at 0.03 EUR/h, 4 public IPs, ~100 GB of
+volumes — about **0.82 EUR per hour** of tenant life. Budget: 40 minutes wall clock,
+or NO-GO.
+
+## Measured
+
+<!-- qualification:measured -->
+Run of 2026-09-09 (`GO`), on the account the environment names:
+
+| | |
+|---|---|
+| Resources | 79 in the plan, all applied, plus 7 ressource(s) hors Terraform : pepin-qual-30044641-public, pepin-qual-30044641-policy, pepin-qual-30044641-unversioned, pepin-qual-30044641-unlocked, pepin-qual-30044641-unencrypted, pepin-qual-30044641-hardened, pepin-qual-user/pepin-qual-inline-admin |
+| `apply` | 210.3 s |
+| `scan --live` × 5 formats + seal | 50.8 s, exit code 1 in every format |
+| bundle | `verify --re-derive` passes; the bundle altered by one byte is refused |
+| `scan --terraform` | exit code 1 |
+| `destroy` | 155.3 s — pré-destroy (deletion_protection=False) rc=0 ; terraform destroy rc=0 ; état vide ; 2 fichier(s) d'état purgé(s) |
+| proof of destruction | 20 familles listées, aucune ressource du tenant, aucun delta avant/après (après 40s de suppressions asynchrones) |
+| comparison | live: 145 results, 0 difference; terraform: 54 results, 0 difference |
+| falsification | 3 expectations broken in memory on each source, every one NO-GO |
+| wall clock | 511.5 s (budget 40 min) |
+| cost estimate | 0.0989 EUR (0.121 h × 0.815 EUR/h) |
+
+Out-of-tenant deviations reported by the live scan and not gated: 74 (the
+account's own keys, policies, API access rules, buckets and default security groups).
+<!-- /qualification:measured -->

--- a/references/qualification/outscale/compute.tf
+++ b/references/qualification/outscale/compute.tf
@@ -1,0 +1,373 @@
+# Calcul — huit VM tinav6.c2r4p2, quatre IP publiques, deux cartes secondaires,
+# deux volumes de données, deux snapshots, deux images.
+#
+# Chaque VM ne porte qu'UNE faute, ou aucune :
+#   exposed           IP publique + SG SSH ouvert         → compute_instance_public_ip_with_open_securitygroup
+#   private           pas d'IP   + SG SSH ouvert         → silencieuse (pas d'exposition)
+#   hardened          IP publique + SG restrictif, Env=prod, PROTÉGÉE → silencieuse (SG discriminant, protection présente)
+#   untagged          pas d'IP   + SG restrictif, sans étiquettes → governance_resource_required_tags
+#   secrets           cloud-init avec mot de passe       → compute_instance_no_secrets_in_user_data
+#   unprotected       Env=prod, sans protection          → compute_instance_deletion_protection
+#   two_nics          carte primaire privée+fermée, carte SECONDAIRE publique+SSH ouvert → CLD-NET-3 (audit #E, #187)
+#   two_nics_inverse  carte primaire publique+fermée, carte secondaire privée+SSH ouvert → silencieuse (l'inverse ne doit pas parler)
+#
+# Volumes racine : chaque VM en a un, en usage, sans snapshot → ils portent TOUS
+# l'écart blockstorage_volume_snapshots_exist. Le volume de données `snapshotted`
+# est le contre-exemple ; `unsnapshotted` la faute isolée.
+#
+# Cartes secondaires : `outscale_nic` + `outscale_nic_link`, jamais les blocs
+# `nics`/`primary_nic` d'`outscale_vm` (issues #778, #424, #50, #448 du provider :
+# remplacement systématique de la VM, carte « oubliée »). Aucune
+# `outscale_nic_private_ip` (#28, #137 : 400/409 au destroy, ouvertes).
+
+locals {
+  sg_ids = {
+    ssh_open = outscale_security_group.ssh_open.security_group_id
+    hardened = outscale_security_group.hardened.security_group_id
+  }
+
+  cloud_init_plain = <<-EOT
+    #cloud-config
+    package_update: false
+    timezone: Europe/Paris
+  EOT
+
+  # Un mot de passe en clair dans le cloud-init : motif « mot de passe en clair »
+  # (confiance heuristique). La valeur est évidemment factice.
+  cloud_init_with_secret = <<-EOT
+    #cloud-config
+    users:
+      - name: pepin
+        plain_text_passwd: pepin-qualification-fake-password
+        lock_passwd: false
+  EOT
+
+  vms = {
+    exposed = { sg = "ssh_open", tags = local.tagged, user_data = local.cloud_init_plain, protect = false }
+    private = { sg = "ssh_open", tags = local.tagged, user_data = local.cloud_init_plain, protect = false }
+    # PROTÉGÉE : levée par le runner avant le destroy (pre_destroy_vars, provider #88).
+    hardened    = { sg = "hardened", tags = local.production_tagged, user_data = local.cloud_init_plain, protect = var.deletion_protection }
+    untagged    = { sg = "hardened", tags = local.untagged, user_data = local.cloud_init_plain, protect = false }
+    secrets     = { sg = "hardened", tags = local.tagged, user_data = local.cloud_init_with_secret, protect = false }
+    unprotected = { sg = "hardened", tags = local.production_tagged, user_data = local.cloud_init_plain, protect = false }
+  }
+}
+
+resource "outscale_vm" "public" {
+  for_each                 = local.vms
+  image_id                 = var.image_id
+  vm_type                  = var.instance_type
+  placement_subregion_name = var.subregion
+  subnet_id                = outscale_subnet.main.subnet_id
+  security_group_ids       = [local.sg_ids[each.value.sg]]
+  deletion_protection      = each.value.protect
+  user_data                = base64encode(each.value.user_data)
+
+  dynamic "tags" {
+    for_each = merge(each.value.tags, { Name = "pepin-qual-vm-${each.key}" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+# IP publiques (dans le Net, liées par identifiant) : `exposed` (la faute) et `hardened` (le contre-exemple).
+resource "outscale_public_ip" "public" {
+  for_each = toset(["exposed", "hardened"])
+
+  dynamic "tags" {
+    for_each = merge(local.untagged, { Name = "pepin-qual-ip-${each.key}" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+# Même course possible sur les VM sans seconde carte : le lien attend le lien de
+# volume de `private`/`hardened`, qui n'est accepté qu'une fois la VM créée.
+resource "outscale_public_ip_link" "public" {
+  for_each     = toset(["exposed", "hardened"])
+  public_ip_id = outscale_public_ip.public[each.key].public_ip_id
+  vm_id        = outscale_vm.public[each.key].vm_id
+  depends_on   = [outscale_internet_service_link.documented, outscale_volume_link.snapshotted, outscale_volume_link.unsnapshotted]
+}
+
+# ── Volumes, snapshots ─────────────────────────────────────────────────────────
+
+# ÉCART blockstorage_volume_snapshots_exist (CLD-STO-3) : en usage, jamais sauvegardé.
+resource "outscale_volume" "unsnapshotted" {
+  subregion_name = var.subregion
+  size           = 10
+  volume_type    = "standard"
+
+  dynamic "tags" {
+    for_each = merge(local.tagged, { Name = "pepin-qual-vol-unsnapshotted" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_volume_link" "unsnapshotted" {
+  device_name = "/dev/xvdb"
+  volume_id   = outscale_volume.unsnapshotted.volume_id
+  vm_id       = outscale_vm.public["private"].vm_id
+}
+
+# CONTRE-EXEMPLE : en usage, avec une snapshot fraîche et terminée.
+resource "outscale_volume" "snapshotted" {
+  subregion_name = var.subregion
+  size           = 10
+  volume_type    = "standard"
+
+  dynamic "tags" {
+    for_each = merge(local.tagged, { Name = "pepin-qual-vol-snapshotted" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_volume_link" "snapshotted" {
+  device_name = "/dev/xvdb"
+  volume_id   = outscale_volume.snapshotted.volume_id
+  vm_id       = outscale_vm.public["hardened"].vm_id
+}
+
+resource "outscale_snapshot" "private" {
+  volume_id   = outscale_volume.snapshotted.volume_id
+  description = "pepin-qual-snap-private"
+
+  dynamic "tags" {
+    for_each = merge(local.tagged, { Name = "pepin-qual-snap-private" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+# ÉCART blockstorage_snapshot_not_public (CLD-STO-2) : partagée avec tout le monde.
+resource "outscale_snapshot" "public" {
+  volume_id   = outscale_volume.snapshotted.volume_id
+  description = "pepin-qual-snap-public"
+
+  dynamic "tags" {
+    for_each = merge(local.tagged, { Name = "pepin-qual-snap-public" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_snapshot_attributes" "public" {
+  snapshot_id = outscale_snapshot.public.snapshot_id
+
+  permissions_to_create_volume_additions {
+    global_permission = true
+  }
+}
+
+# ── Images (OMI) ───────────────────────────────────────────────────────────────
+
+# ÉCART compute_image_not_public (CLD-STO-2) : OMI rendue publique. Construite
+# depuis la snapshot `private` (gérée par Terraform) et non depuis une VM : mesuré,
+# une OMI créée depuis une VM prend une snapshot IMPLICITE que `DeleteImage` ne
+# supprime pas — deux snapshots orphelines après un destroy réussi, attrapées par le
+# delta de la preuve de destruction. Depuis une snapshot gérée, rien d'implicite.
+resource "outscale_image" "public" {
+  image_name       = "pepin-qual-omi-public"
+  root_device_name = "/dev/sda1"
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+    bsu {
+      snapshot_id           = outscale_snapshot.private.snapshot_id
+      delete_on_vm_deletion = true
+    }
+  }
+
+  dynamic "tags" {
+    for_each = merge(local.tagged, { Name = "pepin-qual-omi-public" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_image_launch_permission" "public" {
+  image_id = outscale_image.public.image_id
+
+  permission_additions {
+    global_permission = "true"
+  }
+}
+
+# CONTRE-EXEMPLE : la même image, privée.
+resource "outscale_image" "private" {
+  image_name       = "pepin-qual-omi-private"
+  root_device_name = "/dev/sda1"
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+    bsu {
+      snapshot_id           = outscale_snapshot.private.snapshot_id
+      delete_on_vm_deletion = true
+    }
+  }
+
+  dynamic "tags" {
+    for_each = merge(local.tagged, { Name = "pepin-qual-omi-private" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+# ── Les deux VM à deux cartes, dans le Net ─────────────────────────────────────
+
+# ÉCART CLD-NET-3 par la carte SECONDAIRE : primaire privée dans un groupe fermé,
+# secondaire avec une IP publique dans le groupe SSH ouvert. C'est le cas que
+# l'aplatissement des cartes rendait invisible (#170, #187).
+resource "outscale_vm" "two_nics" {
+  image_id                 = var.image_id
+  vm_type                  = var.instance_type
+  placement_subregion_name = var.subregion
+  subnet_id                = outscale_subnet.main.subnet_id
+  security_group_ids       = [outscale_security_group.net_closed.security_group_id]
+  deletion_protection      = false
+  user_data                = base64encode(local.cloud_init_plain)
+
+  dynamic "tags" {
+    for_each = merge(local.tagged, { Name = "pepin-qual-vm-two-nics" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_nic" "two_nics_secondary" {
+  subnet_id          = outscale_subnet.main.subnet_id
+  security_group_ids = [outscale_security_group.net_ssh_open.security_group_id]
+
+  dynamic "tags" {
+    for_each = merge(local.untagged, { Name = "pepin-qual-nic-two-nics" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_nic_link" "two_nics_secondary" {
+  device_number = 1
+  vm_id         = outscale_vm.two_nics.vm_id
+  nic_id        = outscale_nic.two_nics_secondary.nic_id
+}
+
+resource "outscale_public_ip" "two_nics" {
+  dynamic "tags" {
+    for_each = merge(local.untagged, { Name = "pepin-qual-ip-two-nics" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_public_ip_link" "two_nics" {
+  public_ip_id = outscale_public_ip.two_nics.public_ip_id
+  nic_id       = outscale_nic.two_nics_secondary.nic_id
+  depends_on   = [outscale_nic_link.two_nics_secondary, outscale_internet_service_link.documented]
+}
+
+# CONTRE-EXEMPLE (ligne 2 de la table de #187) : primaire PUBLIQUE dans un groupe
+# fermé, secondaire privée dans le groupe SSH ouvert. Aplaties, ces deux cartes
+# diraient « publique et ouverte » ; appariées, rien n'est joignable.
+resource "outscale_vm" "two_nics_inverse" {
+  image_id                 = var.image_id
+  vm_type                  = var.instance_type
+  placement_subregion_name = var.subregion
+  subnet_id                = outscale_subnet.main.subnet_id
+  security_group_ids       = [outscale_security_group.net_closed.security_group_id]
+  deletion_protection      = false
+  user_data                = base64encode(local.cloud_init_plain)
+
+  dynamic "tags" {
+    for_each = merge(local.tagged, { Name = "pepin-qual-vm-two-nics-inverse" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_public_ip" "two_nics_inverse" {
+  dynamic "tags" {
+    for_each = merge(local.untagged, { Name = "pepin-qual-ip-two-nics-inverse" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+# Lié AVANT la carte secondaire, et c'est l'ordre qui compte : mesuré (trois runs),
+# `LinkPublicIp` par `VmId` sur une VM qui porte déjà DEUX cartes répond « Unable to
+# link Public IP » (400 InvalidResource) — l'API ne sait pas laquelle viser. Tant que
+# la VM n'a que sa carte primaire, le lien par `VmId` la désigne sans ambiguïté ; la
+# seconde carte est attachée ensuite (le lien de carte dépend de celui-ci).
+resource "outscale_public_ip_link" "two_nics_inverse" {
+  public_ip_id = outscale_public_ip.two_nics_inverse.public_ip_id
+  vm_id        = outscale_vm.two_nics_inverse.vm_id
+  depends_on   = [outscale_internet_service_link.documented]
+}
+
+resource "outscale_nic" "two_nics_inverse_secondary" {
+  subnet_id          = outscale_subnet.main.subnet_id
+  security_group_ids = [outscale_security_group.net_ssh_open.security_group_id]
+
+  dynamic "tags" {
+    for_each = merge(local.untagged, { Name = "pepin-qual-nic-two-nics-inverse" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_nic_link" "two_nics_inverse_secondary" {
+  device_number = 1
+  vm_id         = outscale_vm.two_nics_inverse.vm_id
+  nic_id        = outscale_nic.two_nics_inverse_secondary.nic_id
+  depends_on    = [outscale_public_ip_link.two_nics_inverse]
+}
+
+# Les volumes RACINE, créés avec les VM, naissent sans étiquette : `outscale_tag` leur
+# pose la gouvernance et le tag du tenant, pour que la seule ressource sans étiquette
+# soit la VM `untagged`, et que le listing de sortie les voie tous.
+resource "outscale_tag" "root_volumes" {
+  resource_ids = concat(
+    [for vm in outscale_vm.public : tolist(vm.block_device_mappings_created[0].bsu)[0].volume_id],
+    [
+      tolist(outscale_vm.two_nics.block_device_mappings_created[0].bsu)[0].volume_id,
+      tolist(outscale_vm.two_nics_inverse.block_device_mappings_created[0].bsu)[0].volume_id,
+    ],
+  )
+
+  dynamic "tag" {
+    for_each = local.tagged
+    content {
+      key   = tag.key
+      value = tag.value
+    }
+  }
+}

--- a/references/qualification/outscale/expected.yaml
+++ b/references/qualification/outscale/expected.yaml
@@ -1,0 +1,354 @@
+# Ce que Pépin DOIT rendre sur le tenant de qualification Outscale — contrôle × source
+# × sujet → statut. Lu par tools/qualification/qualify.py. Même contrat que le tenant
+# Scaleway (references/qualification/README.fr.md) : un `fail` manquant est un faux
+# vert, un `fail` en trop un faux positif, un `not-evaluated` déplacé une régression
+# de couverture, et toute différence est un NO-GO.
+#
+# Le compte attendu vient de l'ENVIRONNEMENT (le dépôt est public, un identifiant
+# publié ne se dépublie pas) ; une variable absente est un REFUS, jamais un
+# laissez-passer. Le crochet `identity` demande le compte à l'API (ReadAccounts) et
+# le runner compare.
+#
+# Sujets live : identifiants OAPI (`${output.<nom>}`), noms de politiques et de
+# buckets. Sujets Terraform : adresse de la ressource quand l'identifiant n'est pas
+# connu au stade du plan (ADR-0022), nom sinon. `inconclusive:` liste les sujets du
+# tenant sur lesquels la règle DIT ne pas savoir conclure (ADR-0015).
+#
+# Le compte porte aussi des ressources qui ne sont pas du tenant (clés, politiques,
+# règles d'accès API, buckets, un Net et ses groupes) : un écart sur elles est
+# rapporté, jamais gardé — sauf pour les contrôles marqués `evaluated`, qui portent
+# sur des singletons du compte (politique d'accès API) que le tenant ne touche pas.
+account:
+  account_id_env: PEPIN_QUAL_OSC_ACCOUNT
+
+exit_codes:
+  live: 1
+  terraform: 1
+
+controls:
+  # ── EIM : politiques (documents JSON) ─────────────────────────────────────────
+  iam_policy_no_administrative_privileges:
+    live:
+      # La politique managée `admin` ET la politique INLINE posée sur l'utilisateur
+      # par le crochet (l'incident fondateur de l'ADR-0006 : elle échappait à tout).
+      fail: [pepin-qual-policy-admin, pepin-qual-inline-admin]
+      silent: [pepin-qual-policy-wildcard, pepin-qual-policy-scoped]
+    terraform:
+      fail: [pepin-qual-policy-admin]
+      silent: [pepin-qual-policy-wildcard, pepin-qual-policy-scoped]
+
+  iam_policy_no_wildcard_resource:
+    # Trois politiques portent `Resource: *` sans tout autoriser : la ressource joker
+    # est leur point commun, et la règle le dit sur chacune.
+    live:
+      fail: [pepin-qual-policy-wildcard, pepin-qual-policy-notaction, pepin-qual-policy-escalation]
+      silent: [pepin-qual-policy-scoped, pepin-qual-policy-admin]
+    terraform:
+      fail: [pepin-qual-policy-wildcard, pepin-qual-policy-notaction, pepin-qual-policy-escalation]
+      silent: [pepin-qual-policy-scoped, pepin-qual-policy-admin]
+
+  iam_policy_no_notaction_notresource:
+    live:
+      fail: [pepin-qual-policy-notaction]
+      silent: [pepin-qual-policy-scoped]
+    terraform:
+      fail: [pepin-qual-policy-notaction]
+      silent: [pepin-qual-policy-scoped]
+
+  iam_policy_no_privilege_escalation:
+    live:
+      fail: [pepin-qual-policy-escalation]
+      silent: [pepin-qual-policy-scoped, pepin-qual-policy-wildcard]
+    terraform:
+      fail: [pepin-qual-policy-escalation]
+      silent: [pepin-qual-policy-scoped, pepin-qual-policy-wildcard]
+
+  # ── EIM : clés d'accès ────────────────────────────────────────────────────────
+  iam_no_root_access_key:
+    # La clé créée sans `user_name` est celle du compte qui exécute (root) : dérivée
+    # root_owned par différence d'ensembles. Les clés existantes du root, hors tenant,
+    # sont rapportées sans être gardées.
+    live:
+      fail: ["${output.api_key_root}"]
+      silent: ["${output.api_key_no_expiry}", "${output.api_key_expiring}"]
+    # `outscale_access_key` n'est pas mappé sur le plan (#203).
+    terraform: not-evaluated
+
+  iam_accesskey_expiration_set:
+    live:
+      fail: ["${output.api_key_no_expiry}"]
+      silent: ["${output.api_key_expiring}", "${output.api_key_root}"]
+    terraform: not-evaluated
+
+  iam_accesskey_rotated:
+    # Une date de création ne s'antidate pas : aucune clé du tenant n'a 90 jours. Le
+    # contrôle conclut sur les clés existantes du compte, hors tenant.
+    live:
+      status: evaluated
+      perimeter: compte
+      reason: "Les clés du tenant sont neuves ; le verdict porte sur les clés préexistantes du compte, que le tenant ne crée ni ne supprime."
+    terraform: not-evaluated
+
+  # ── Singletons du compte : politique et règles d'accès API ───────────────────
+  iam_account_mfa_enforced:
+    live:
+      status: evaluated
+      perimeter: compte
+      reason: "ApiAccessPolicy.RequireTrustedEnv est un réglage du compte : le forcer fermerait l'API à la clé qui qualifie. Observé, jamais modifié."
+    terraform: not-evaluated
+
+  iam_apiaccesspolicy_max_key_expiration:
+    live:
+      status: evaluated
+      perimeter: compte
+      reason: "Même singleton (MaxAccessKeyExpirationSeconds) : observé, jamais modifié."
+    terraform: not-evaluated
+
+  iam_apiaccessrule_defined:
+    # Le compte porte des règles avant le tenant, et le tenant en ajoute deux :
+    # l'écart (aucune règle) n'est pas constructible sans les retirer toutes.
+    live: pass
+    terraform: not-evaluated
+
+  iam_apiaccessrule_no_public_cidr:
+    live:
+      fail: ["${output.api_rule_public_id}"]
+      silent: ["${output.api_rule_private_id}"]
+    # `outscale_api_access_rule` n'est pas mappé sur le plan (#203).
+    terraform: not-evaluated
+
+  # ── Groupes de sécurité ───────────────────────────────────────────────────────
+  # Sujet live = identifiant du groupe ; sujet Terraform = adresse du groupe (les
+  # règles y désignent leur groupe par référence, résolue par l'ADR-0022).
+  network_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
+    live:
+      fail: ["${output.sg_ssh_open_id}", "${output.sg_any_open_id}", "${output.sg_quartet_id}", "${output.sg_net_ssh_open_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_rdp_open_id}", "${output.sg_net_closed_id}"]
+    terraform:
+      fail: [outscale_security_group.ssh_open, outscale_security_group.any_open, outscale_security_group.quartet, outscale_security_group.net_ssh_open]
+      silent: [outscale_security_group.hardened, outscale_security_group.rdp_open, outscale_security_group.net_closed]
+
+  network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
+    live:
+      fail: ["${output.sg_rdp_open_id}", "${output.sg_any_open_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_ssh_open_id}"]
+    terraform:
+      fail: [outscale_security_group.rdp_open, outscale_security_group.any_open]
+      silent: [outscale_security_group.hardened, outscale_security_group.ssh_open]
+
+  network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports:
+    live:
+      fail: ["${output.sg_db_open_id}", "${output.sg_any_open_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_ssh_open_id}"]
+    terraform:
+      fail: [outscale_security_group.db_open, outscale_security_group.any_open]
+      silent: [outscale_security_group.hardened, outscale_security_group.ssh_open]
+
+  network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports:
+    live:
+      fail: ["${output.sg_snmp_open_id}", "${output.sg_any_open_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_db_open_id}"]
+    terraform:
+      fail: [outscale_security_group.snmp_open, outscale_security_group.any_open]
+      silent: [outscale_security_group.hardened, outscale_security_group.db_open]
+
+  network_securitygroup_allow_ingress_from_internet_to_all_ports:
+    live:
+      fail: ["${output.sg_any_open_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_ssh_open_id}", "${output.sg_quartet_id}"]
+    terraform:
+      fail: [outscale_security_group.any_open]
+      silent: [outscale_security_group.hardened, outscale_security_group.ssh_open, outscale_security_group.quartet]
+
+  network_securitygroup_unrestricted_egress:
+    # `egress_any` porte la règle explicitement ; le groupe « default » du Net, créé
+    # par le produit, garde sa règle sortante par défaut — les huit autres l'ont
+    # retirée (`remove_default_outbound_rule`), et c'est le contre-exemple.
+    live:
+      fail: ["${output.sg_egress_any_id}", "${output.sg_net_default_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_ssh_open_id}", "${output.sg_net_closed_id}"]
+    terraform:
+      fail: [outscale_security_group.egress_any]
+      silent: [outscale_security_group.hardened, outscale_security_group.ssh_open]
+
+  network_securitygroup_default_restrict_traffic:
+    # La règle d'usine du groupe « default » du Net (source = lui-même) : écart
+    # contextuel, sur un sujet que Terraform ne gère pas (source de données).
+    live:
+      fail: ["${output.sg_net_default_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_net_closed_id}"]
+    # Le plan ne porte pas `security_group_name` sur les règles.
+    terraform: not-evaluated
+
+  # ── Réseau ────────────────────────────────────────────────────────────────────
+  network_documented:
+    live:
+      fail: ["${output.net_undocumented_id}"]
+      silent: ["${output.net_documented_id}"]
+    terraform:
+      fail: [outscale_net.undocumented]
+      silent: [outscale_net.documented]
+
+  network_subnet_no_public_ip_by_default:
+    live:
+      fail: ["${output.subnet_autoip_id}"]
+      silent: ["${output.subnet_main_id}"]
+    terraform:
+      fail: [outscale_subnet.autoip]
+      silent: [outscale_subnet.main]
+
+  network_peering_cross_organization:
+    # Deux Nets du même compte : source_account = accepter_account, muet. L'écart
+    # exigerait un second compte.
+    live: pass
+    # `outscale_net_peering` n'est pas mappé sur le plan (#203).
+    terraform: not-evaluated
+
+  # ── Calcul ────────────────────────────────────────────────────────────────────
+  compute_instance_public_ip_with_open_securitygroup:
+    # `exposed` par sa carte primaire ; `two_nics` par sa carte SECONDAIRE (#187) —
+    # l'inverse (`two_nics_inverse`) ne doit pas parler.
+    live:
+      fail: ["${output.vm_exposed_id}", "${output.vm_two_nics_id}"]
+      silent: ["${output.vm_private_id}", "${output.vm_hardened_id}", "${output.vm_two_nics_inverse_id}"]
+    # Le plan ne porte pas l'IP publique d'une VM (elle naît d'un lien).
+    terraform: not-evaluated
+
+  compute_instance_has_security_group:
+    live: pass
+    terraform: pass
+
+  compute_instance_no_secrets_in_user_data:
+    live:
+      fail: ["${output.vm_secrets_id}"]
+      silent: ["${output.vm_hardened_id}", "${output.vm_exposed_id}"]
+    terraform:
+      fail: ['outscale_vm.public["secrets"]']
+      silent: ['outscale_vm.public["hardened"]', 'outscale_vm.public["exposed"]']
+
+  compute_instance_deletion_protection:
+    # `unprotected` (Env=prod, sans protection) est l'écart ; `hardened` (Env=prod,
+    # protégée) le contre-exemple ; `untagged` n'a pas d'environnement lisible : la
+    # règle dit qu'elle ne sait pas conclure (ADR-0015).
+    live:
+      fail: ["${output.vm_unprotected_id}"]
+      silent: ["${output.vm_hardened_id}", "${output.vm_exposed_id}"]
+      inconclusive: ["${output.vm_untagged_id}"]
+    # Le plan ne mappe pas `deletion_protection`, que `outscale_vm` porte pourtant (#203).
+    terraform: not-evaluated
+
+  compute_image_not_public:
+    live:
+      fail: ["${output.image_public_id}"]
+      silent: ["${output.image_private_id}"]
+    terraform:
+      fail: [outscale_image.public]
+      silent: [outscale_image.private]
+
+  # ── Stockage block ────────────────────────────────────────────────────────────
+  blockstorage_volume_snapshots_exist:
+    # Tout volume en usage sans snapshot fraîche et terminée : le volume de données
+    # `unsnapshotted` et les huit volumes racine (les OMI sont construites depuis la
+    # snapshot gérée, aucun volume racine n'est sauvegardé).
+    live:
+      fail: ["${output.volume_unsnapshotted_id}", "${output.root_volume_exposed_id}", "${output.root_volume_private_id}", "${output.root_volume_hardened_id}", "${output.root_volume_untagged_id}", "${output.root_volume_secrets_id}", "${output.root_volume_unprotected_id}", "${output.root_volume_two_nics_id}", "${output.root_volume_two_nics_inverse_id}"]
+      silent: ["${output.volume_snapshotted_id}"]
+    terraform: not-evaluated
+
+  blockstorage_snapshot_not_public:
+    live:
+      fail: ["${output.snapshot_public_id}"]
+      silent: ["${output.snapshot_private_id}"]
+    terraform: not-evaluated
+
+  blockstorage_volume_encryption:
+    live: not-applicable
+    terraform: not-applicable
+
+  # ── Stockage objet (OOS, créé par le crochet `extra`) ─────────────────────────
+  objectstorage_bucket_public_access:
+    live:
+      fail: ["${output.bucket_public}", "${output.bucket_policy}"]
+      silent: ["${output.bucket_hardened}", "${output.bucket_unversioned}"]
+    terraform: not-evaluated
+
+  objectstorage_bucket_versioning_enabled:
+    live:
+      fail: ["${output.bucket_unversioned}"]
+      silent: ["${output.bucket_hardened}", "${output.bucket_unlocked}"]
+    terraform: not-evaluated
+
+  objectstorage_bucket_object_lock_enabled:
+    live:
+      fail: ["${output.bucket_unlocked}", "${output.bucket_unversioned}"]
+      silent: ["${output.bucket_hardened}", "${output.bucket_public}"]
+    terraform: not-evaluated
+
+  objectstorage_bucket_default_encryption:
+    # Actif pour Outscale : SSE opt-in par bucket, `unencrypted` ne l'a pas.
+    live:
+      fail: ["${output.bucket_unencrypted}"]
+      silent: ["${output.bucket_hardened}", "${output.bucket_public}"]
+    terraform: not-evaluated
+
+  objectstorage_bucket_kms_encryption:
+    live: not-applicable
+    terraform: not-applicable
+
+  # ── Répartiteurs de charge ────────────────────────────────────────────────────
+  loadbalancer_ssl_listeners:
+    # `http` : écouteur HTTP seul. `tcp443` : candidat au passthrough TLS, que la
+    # règle refuse de trancher — non concluant (ADR-0015).
+    live:
+      fail: ["${output.lb_http_name}"]
+      inconclusive: ["${output.lb_tcp443_name}"]
+    # `outscale_load_balancer` n'est pas mappé sur le plan (#203).
+    terraform: not-evaluated
+
+  loadbalancer_logging_enabled:
+    live:
+      fail: ["${output.lb_http_name}", "${output.lb_tcp443_name}"]
+    terraform: not-evaluated
+
+  loadbalancer_http_redirect_to_https:
+    live: not-applicable
+    terraform: not-applicable
+
+  # ── Gouvernance ───────────────────────────────────────────────────────────────
+  governance_resource_required_tags:
+    live:
+      fail: ["${output.vm_untagged_id}"]
+      silent: ["${output.vm_exposed_id}", "${output.root_volume_exposed_id}", "${output.volume_snapshotted_id}", "${output.snapshot_private_id}", "${output.image_private_id}", "${output.bucket_hardened}", "${output.lb_http_name}"]
+    terraform:
+      fail: ['outscale_vm.public["untagged"]']
+      silent: ['outscale_vm.public["exposed"]']
+
+  governance_resource_region_in_eu:
+    live: pass
+    # Le mapping Terraform ne projette pas la région (#203 ; #194 pour Scaleway).
+    terraform: not-evaluated
+
+  governance_provider_sovereignty:
+    live: pass
+    terraform: pass
+
+  # ── Déclarés non applicables, ou sans ressource ───────────────────────────────
+  iam_user_mfa_enabled:
+    live: not-applicable
+    terraform: not-applicable
+
+  kubernetes_cluster_not_publicly_accessible:
+    live: not-evaluated
+    terraform: not-evaluated
+
+  kubernetes_cluster_control_plane_highly_available:
+    live: not-evaluated
+    terraform: not-evaluated
+
+  kubernetes_cluster_auto_upgrade_enabled:
+    live: not-evaluated
+    terraform: not-evaluated
+
+  kubernetes_cluster_deletion_protection:
+    live: not-evaluated
+    terraform: not-evaluated

--- a/references/qualification/outscale/hooks.py
+++ b/references/qualification/outscale/hooks.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Crochets Outscale du tenant de qualification : identité, variables, extra,
+inventaire, nettoyage.
+
+    identity                      quel compte les identifiants natifs ouvrent-ils,
+                                  d'après l'API (ReadAccounts), jamais d'après un profil
+    variables --live|--plan-only <identity.json>
+                                  les variables Terraform propres au tenant, et
+                                  l'échéance à attendre avant de scanner
+    extra apply|destroy <outputs.json>
+                                  ce que le provider Terraform ne sait pas créer :
+                                  les buckets OOS et la politique EIM INLINE
+    inventory <tenant.yaml>       ce que le compte contient, famille par famille, et
+                                  ce qui, dedans, appartient au tenant (tag / préfixe)
+    cleanup <tenant.yaml> [leftovers.json]
+                                  supprime ce qui appartient au tenant, ou ce qui est
+                                  apparu pendant le run — chemin de SECOURS
+
+# L'OAPI directement, comme le crochet Scaleway parle à son API
+
+Les identifiants sont résolus EXACTEMENT comme `pepin scan --live` et le provider
+Terraform le font : variables OSC_ACCESS_KEY / OSC_SECRET_KEY / OSC_REGION d'abord,
+puis ~/.osc/config.json (profil OSC_PROFILE, « default » à défaut ; OSC_CONFIG_FILE
+surcharge le chemin). Chaque appel est POST /api/v1/<Call> signé en V4 (service
+« oapi »), c'est-à-dire ce que le descripteur providers/outscale.yaml déclare.
+Aucun identifiant n'est écrit, affiché ni journalisé — et l'on n'appelle jamais
+`octl profile current`, qui imprime la clé secrète en clair.
+
+La CLI de référence du fournisseur est `octl` ; elle sert aux listings lisibles
+qu'un mainteneur rejoue à la main (README). Ici, l'API : un crochet qui prouve le
+vide ne doit dépendre d'aucun outil dont la surface peut bouger.
+
+# Ce que Terraform ne sait pas exprimer, et que `extra` crée
+
+Le provider outscale/outscale 1.8.0 n'a aucune ressource de bucket OOS, et aucune
+ressource de politique EIM INLINE (l'incident fondateur de l'ADR-0006 : une politique
+inline `Action: *` échappait à tous les contrôles). Les deux sont créés ici, après
+l'apply, et supprimés avant le destroy — OOS par la CLI `aws` (S3 sur
+oos.<région>.outscale.com), la politique inline par l'OAPI (PutUserPolicy). Ils
+portent le préfixe du tenant, donc la preuve de destruction les relit.
+"""
+import base64
+import datetime as dt
+import hashlib
+import hmac
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+import yaml
+
+# ─── identifiants natifs ───────────────────────────────────────────────────────
+
+def creds():
+    """(access_key, secret_key, region) : environnement d'abord, fichier ensuite."""
+    ak = os.environ.get("OSC_ACCESS_KEY")
+    sk = os.environ.get("OSC_SECRET_KEY")
+    region = os.environ.get("OSC_REGION")
+    if not (ak and sk):
+        path = os.environ.get("OSC_CONFIG_FILE") or os.path.expanduser("~/.osc/config.json")
+        try:
+            d = json.load(open(path))
+        except FileNotFoundError:
+            sys.exit("aucun identifiant Outscale : OSC_ACCESS_KEY/OSC_SECRET_KEY ou ~/.osc/config.json")
+        prof = d.get(os.environ.get("OSC_PROFILE") or "default") or {}
+        ak, sk = ak or prof.get("access_key"), sk or prof.get("secret_key")
+        region = region or prof.get("region") or prof.get("region_name")
+    if not (ak and sk):
+        sys.exit("aucun identifiant Outscale utilisable")
+    return ak, sk, region or "eu-west-2"
+
+
+def _sign(key, msg):
+    return hmac.new(key, msg.encode(), hashlib.sha256).digest()
+
+
+def _sigv4(method, host, path, body, service, region, ak, sk, extra_headers=None, query=""):
+    now = dt.datetime.now(dt.timezone.utc)
+    amz_date, date = now.strftime("%Y%m%dT%H%M%SZ"), now.strftime("%Y%m%d")
+    payload_hash = hashlib.sha256(body).hexdigest()
+    headers = {"host": host, "x-amz-content-sha256": payload_hash, "x-amz-date": amz_date}
+    headers.update({k.lower(): v for k, v in (extra_headers or {}).items()})
+    signed = ";".join(sorted(headers))
+    canonical_headers = "".join(f"{k}:{headers[k].strip()}\n" for k in sorted(headers))
+    canonical = f"{method}\n{path}\n{query}\n{canonical_headers}\n{signed}\n{payload_hash}"
+    scope = f"{date}/{region}/{service}/aws4_request"
+    to_sign = f"AWS4-HMAC-SHA256\n{amz_date}\n{scope}\n{hashlib.sha256(canonical.encode()).hexdigest()}"
+    k = _sign(_sign(_sign(_sign(("AWS4" + sk).encode(), date), region), service), "aws4_request")
+    sig = hmac.new(k, to_sign.encode(), hashlib.sha256).hexdigest()
+    headers["authorization"] = f"AWS4-HMAC-SHA256 Credential={ak}/{scope}, SignedHeaders={signed}, Signature={sig}"
+    return headers
+
+
+def oapi(call, body=None):
+    """POST /api/v1/<Call>, signé V4 (service oapi, région du profil)."""
+    ak, sk, region = creds()
+    host = f"api.{region}.outscale.com"
+    data = json.dumps(body or {}).encode()
+    headers = _sigv4("POST", host, f"/api/v1/{call}", data, "oapi", region, ak, sk,
+                     {"content-type": "application/json"})
+    req = urllib.request.Request(f"https://{host}/api/v1/{call}", data=data, method="POST")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=120) as r:
+            return json.loads(r.read() or b"{}")
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")[:400]
+        raise RuntimeError(f"{call} → HTTP {e.code} : {detail}") from None
+
+
+def paged(call, key, body=None, per_page=1000):
+    """Toutes les pages d'un listing OAPI (NextPageToken)."""
+    out, token = [], None
+    body = dict(body or {})
+    while True:
+        b = dict(body, ResultsPerPage=per_page)
+        if token:
+            b["NextPageToken"] = token
+        d = oapi(call, b)
+        out.extend(d.get(key) or [])
+        token = d.get("NextPageToken")
+        if not token:
+            return out
+
+
+# ─── OOS (S3) par la CLI aws, identifiants passés par l'environnement ─────────
+
+def aws_env():
+    ak, sk, region = creds()
+    env = dict(os.environ, AWS_ACCESS_KEY_ID=ak, AWS_SECRET_ACCESS_KEY=sk, AWS_DEFAULT_REGION=region,
+               AWS_EC2_METADATA_DISABLED="true")
+    env.pop("AWS_PROFILE", None)
+    env.pop("AWS_SESSION_TOKEN", None)
+    return env, f"https://oos.{region}.outscale.com"
+
+
+def s3(*args, check=True, capture=True):
+    env, endpoint = aws_env()
+    r = subprocess.run(["aws", "--endpoint-url", endpoint, "s3api", *args], env=env, capture_output=capture, text=True)
+    if check and r.returncode != 0:
+        raise RuntimeError(f"aws s3api {' '.join(args[:2])} : {r.stderr.strip()[:300]}")
+    return r
+
+
+def s3_buckets():
+    r = s3("list-buckets", "--query", "Buckets[].Name", "--output", "json")
+    return json.loads(r.stdout or "[]")
+
+
+# ─── identité ──────────────────────────────────────────────────────────────────
+
+def identity():
+    d = oapi("ReadAccounts")
+    accts = d.get("Accounts") or []
+    if not accts:
+        sys.exit("ReadAccounts ne rend aucun compte")
+    a = accts[0]
+    _, _, region = creds()
+    return {"account_id": a.get("AccountId"), "region": region, "label": f"région {region}"}
+
+
+# ─── variables propres au tenant ───────────────────────────────────────────────
+
+def variables(mode, identity_path):
+    """Échéance de la clé conforme (J+2), et rien d'autre : chez Outscale, la clé
+    sans échéance se crée (le contrôle CLD-IAM-2 s'exerce en live), la rotation ne
+    se construit pas (une date de création ne s'antidate pas)."""
+    now = dt.datetime.now(dt.timezone.utc)
+    rfc = "%Y-%m-%dT%H:%M:%SZ"
+    return {
+        "tf_vars": {"key_expires_at": (now + dt.timedelta(days=2)).strftime(rfc)},
+        "wait_until": None,
+        "note": "1 variable ; rien à attendre",
+    }
+
+
+# ─── hors Terraform : buckets OOS et politique EIM inline ──────────────────────
+
+def _bucket_names(outputs):
+    sfx = outputs["bucket_suffix"]
+    return {
+        "public": f"pepin-qual-{sfx}-public",
+        "policy": f"pepin-qual-{sfx}-policy",
+        "unversioned": f"pepin-qual-{sfx}-unversioned",
+        "unlocked": f"pepin-qual-{sfx}-unlocked",
+        "unencrypted": f"pepin-qual-{sfx}-unencrypted",
+        "hardened": f"pepin-qual-{sfx}-hardened",
+    }
+
+
+GOV_TAGS = [{"Key": "CostCenter", "Value": "qualification"}, {"Key": "Project", "Value": "pepin"},
+            {"Key": "Env", "Value": "qualification"}, {"Key": "Owner", "Value": "pepin-maintainer"},
+            {"Key": "pepin-qual", "Value": "tenant"}]
+
+
+def extra_apply(outputs):
+    created = []
+    names = _bucket_names(outputs)
+    # Six buckets vides. Une faute par bucket ; `hardened` est le contre-exemple de
+    # tous : privé, versionné, verrouillé, chiffré (SSE opt-in chez OOS), étiqueté.
+    # Verrou d'objets : partout où le versioning existe, sauf `unlocked` (sa faute) ;
+    # `unversioned` ne peut pas en avoir (pas de verrou sans versioning : deux écarts
+    # structurellement liés). SSE : partout sauf `unencrypted` (sa faute).
+    lock = {"public", "policy", "unencrypted", "hardened"}
+    for role, name in names.items():
+        args = ["create-bucket", "--bucket", name]
+        if role in lock:
+            args += ["--object-lock-enabled-for-bucket"]
+        s3(*args)
+        created.append(name)
+        s3("put-bucket-tagging", "--bucket", name, "--tagging", json.dumps({"TagSet": GOV_TAGS}))
+        # Mesuré : un bucket créé avec Object Lock a son versioning activé d'office et
+        # FIGÉ (« InvalidBucketState … the versioning state cannot be changed »). Seul
+        # `unlocked` reçoit le versioning explicitement.
+        if role == "unlocked":
+            s3("put-bucket-versioning", "--bucket", name, "--versioning-configuration", "Status=Enabled")
+        if role != "unencrypted":
+            s3("put-bucket-encryption", "--bucket", name, "--server-side-encryption-configuration",
+               json.dumps({"Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]}))
+    s3("put-bucket-acl", "--bucket", names["public"], "--acl", "public-read")
+    s3("put-bucket-policy", "--bucket", names["policy"], "--policy", json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [{"Sid": "AnyoneReads", "Effect": "Allow", "Principal": "*",
+                       "Action": ["s3:GetObject"], "Resource": [f"arn:aws:s3:::{names['policy']}/*"]}]}))
+    # La politique EIM INLINE `Action: *` sur l'utilisateur du tenant (l'incident
+    # fondateur) : hors Terraform, par l'OAPI.
+    user = outputs["user_name"]
+    oapi("PutUserPolicy", {"UserName": user, "PolicyName": "pepin-qual-inline-admin",
+                           "PolicyDocument": json.dumps({"Statement": [{"Effect": "Allow", "Action": ["*"], "Resource": ["*"]}]})})
+    created.append(f"{user}/pepin-qual-inline-admin")
+    return {"created": created}
+
+
+def extra_destroy(outputs):
+    deleted, left = [], []
+    names = _bucket_names(outputs)
+    for name in names.values():
+        try:
+            s3("delete-bucket-policy", "--bucket", name, check=False)
+            s3("delete-bucket", "--bucket", name)
+            deleted.append(name)
+        except RuntimeError as e:
+            if "NoSuchBucket" in str(e):
+                continue
+            left.append(f"{name} ({e})")
+    user = outputs.get("user_name")
+    if user:
+        try:
+            oapi("DeleteUserPolicy", {"UserName": user, "PolicyName": "pepin-qual-inline-admin"})
+            deleted.append(f"{user}/pepin-qual-inline-admin")
+        except RuntimeError as e:
+            # 5105 : « The policy doesn't exist for the specified entity » — déjà absente
+            # (un apply interrompu avant sa création, par exemple) : rien à laisser.
+            if "5105" not in str(e) and "doesn't exist" not in str(e):
+                left.append(f"inline policy ({e})")
+    return {"deleted": deleted, "left": left}
+
+
+# ─── inventaire ────────────────────────────────────────────────────────────────
+
+def _tagged(item, tag):
+    return any(t.get("Key") == tag for t in item.get("Tags") or [])
+
+
+def inventory(tenant):
+    tag, prefix = tenant["tag"], tenant["name_prefix"]
+    me = identity()["account_id"]
+    fam = {}
+
+    def put(family, items, key_id, owned=None):
+        owned = owned or (lambda i: _tagged(i, tag))
+        fam[family] = {
+            "all": sorted(str(i.get(key_id)) for i in items),
+            "tenant": [{"id": i.get(key_id), "name": next((t["Value"] for t in i.get("Tags") or [] if t.get("Key") == "Name"), None)}
+                       for i in items if owned(i)],
+        }
+
+    put("vms", [v for v in paged("ReadVms", "Vms") if v.get("State") != "terminated"], "VmId")
+    put("nics", paged("ReadNics", "Nics"), "NicId")
+    put("public_ips", paged("ReadPublicIps", "PublicIps"), "PublicIpId")
+    put("security_groups", paged("ReadSecurityGroups", "SecurityGroups"), "SecurityGroupId",
+        owned=lambda s: _tagged(s, tag) or str(s.get("SecurityGroupName", "")).startswith(prefix))
+    put("volumes", paged("ReadVolumes", "Volumes"), "VolumeId")
+    put("snapshots", paged("ReadSnapshots", "Snapshots", {"Filters": {"AccountIds": [me]}}), "SnapshotId")
+    put("images", paged("ReadImages", "Images", {"Filters": {"AccountIds": [me]}}), "ImageId",
+        owned=lambda i: _tagged(i, tag) or str(i.get("ImageName", "")).startswith(prefix))
+    put("nets", paged("ReadNets", "Nets"), "NetId")
+    put("subnets", paged("ReadSubnets", "Subnets"), "SubnetId")
+    put("internet_services", paged("ReadInternetServices", "InternetServices"), "InternetServiceId")
+    put("nat_services", paged("ReadNatServices", "NatServices"), "NatServiceId")
+    put("route_tables", paged("ReadRouteTables", "RouteTables"), "RouteTableId")
+    # Un appairage supprimé reste listé un moment en état « deleted » : ce n'est pas un reste.
+    put("net_peerings", [p for p in paged("ReadNetPeerings", "NetPeerings")
+                         if (p.get("State") or {}).get("Name") not in ("deleted", "rejected", "expired", "failed")], "NetPeeringId")
+    put("load_balancers", oapi("ReadLoadBalancers").get("LoadBalancers") or [], "LoadBalancerName",
+        owned=lambda l: _tagged(l, tag) or str(l.get("LoadBalancerName", "")).startswith(prefix))
+    put("keypairs", paged("ReadKeypairs", "Keypairs"), "KeypairName",
+        owned=lambda k: str(k.get("KeypairName", "")).startswith(prefix))
+    put("api_access_rules", oapi("ReadApiAccessRules").get("ApiAccessRules") or [], "ApiAccessRuleId",
+        owned=lambda r: str(r.get("Description", "")).startswith(prefix))
+    users = oapi("ReadUsers").get("Users") or []
+    put("users", users, "UserName", owned=lambda u: str(u.get("UserName", "")).startswith(prefix))
+    put("policies", oapi("ReadPolicies", {"Filters": {"Scope": "LOCAL"}}).get("Policies") or [], "PolicyName",
+        owned=lambda p: str(p.get("PolicyName", "")).startswith(prefix))
+    keys = []
+    for k in oapi("ReadAccessKeys").get("AccessKeys") or []:
+        keys.append(dict(k, owner="<root>"))
+    for u in users:
+        for k in oapi("ReadAccessKeys", {"UserName": u["UserName"]}).get("AccessKeys") or []:
+            keys.append(dict(k, owner=u["UserName"]))
+    put("access_keys", keys, "AccessKeyId",
+        owned=lambda k: str(k.get("owner", "")).startswith(prefix) or str(k.get("Tag") or "").startswith(prefix))
+    put("buckets", [{"Name": b} for b in s3_buckets()], "Name", owned=lambda b: b["Name"].startswith(prefix))
+    return fam
+
+
+# ─── nettoyage de secours ──────────────────────────────────────────────────────
+
+def cleanup(tenant, leftovers_path=None):
+    inv = inventory(tenant)
+    rest = {f: [x["id"] for x in v["tenant"]] for f, v in inv.items() if v["tenant"]}
+    if leftovers_path:
+        delta = json.load(open(leftovers_path)).get("delta") or {}
+        for f, ids in delta.items():
+            rest.setdefault(f, [])
+            rest[f] = sorted(set(rest[f]) | set(ids))
+    if not any(rest.values()):
+        print("rien à nettoyer : aucune ressource du tenant")
+        return True
+    ok = True
+
+    def do(label, call, body):
+        nonlocal ok
+        try:
+            oapi(call, body)
+            print(f"  ✔ {label}")
+        except RuntimeError as e:
+            ok = False
+            print(f"  ✘ {label} : {e}")
+
+    # L'ordre est celui des dépendances. Une VM protégée se déprotège d'abord (#88).
+    for vm in rest.get("vms", []):
+        do(f"UpdateVm {vm} DeletionProtection=false", "UpdateVm", {"VmId": vm, "DeletionProtection": False})
+    if rest.get("vms"):
+        do(f"DeleteVms {rest['vms']}", "DeleteVms", {"VmIds": rest["vms"]})
+        # Attendre la terminaison avant de toucher NIC, SG, subnet et net.
+        import time
+        for _ in range(60):
+            live = [v for v in paged("ReadVms", "Vms", {"Filters": {"VmIds": rest["vms"]}}) if v.get("State") != "terminated"]
+            if not live:
+                break
+            time.sleep(5)
+    for ip in rest.get("public_ips", []):
+        do(f"UnlinkPublicIp/DeletePublicIp {ip}", "DeletePublicIp", {"PublicIpId": ip})
+    for nic in rest.get("nics", []):
+        do(f"DeleteNic {nic}", "DeleteNic", {"NicId": nic})
+    for lb in rest.get("load_balancers", []):
+        do(f"DeleteLoadBalancer {lb}", "DeleteLoadBalancer", {"LoadBalancerName": lb})
+    for img in rest.get("images", []):
+        do(f"DeleteImage {img}", "DeleteImage", {"ImageId": img})
+    for vol in rest.get("volumes", []):
+        do(f"DeleteVolume {vol}", "DeleteVolume", {"VolumeId": vol})
+    for snap in rest.get("snapshots", []):
+        do(f"DeleteSnapshot {snap}", "DeleteSnapshot", {"SnapshotId": snap})
+    for sg in rest.get("security_groups", []):
+        do(f"DeleteSecurityGroup {sg}", "DeleteSecurityGroup", {"SecurityGroupId": sg})
+    for pe in rest.get("net_peerings", []):
+        do(f"DeleteNetPeering {pe}", "DeleteNetPeering", {"NetPeeringId": pe})
+    for rt in rest.get("route_tables", []):
+        for link in (oapi("ReadRouteTables", {"Filters": {"RouteTableIds": [rt]}}).get("RouteTables") or [{}])[0].get("LinkRouteTables") or []:
+            if not link.get("Main"):
+                do(f"UnlinkRouteTable {link.get('LinkRouteTableId')}", "UnlinkRouteTable", {"LinkRouteTableId": link.get("LinkRouteTableId")})
+        do(f"DeleteRouteTable {rt}", "DeleteRouteTable", {"RouteTableId": rt})
+    for isvc in rest.get("internet_services", []):
+        for net in rest.get("nets", []):
+            oapi_try("UnlinkInternetService", {"InternetServiceId": isvc, "NetId": net})
+        do(f"DeleteInternetService {isvc}", "DeleteInternetService", {"InternetServiceId": isvc})
+    for sn in rest.get("subnets", []):
+        do(f"DeleteSubnet {sn}", "DeleteSubnet", {"SubnetId": sn})
+    for net in rest.get("nets", []):
+        do(f"DeleteNet {net}", "DeleteNet", {"NetId": net})
+    for b in rest.get("buckets", []):
+        try:
+            s3("delete-bucket-policy", "--bucket", b, check=False)
+            s3("delete-bucket", "--bucket", b)
+            print(f"  ✔ DeleteBucket {b}")
+        except RuntimeError as e:
+            ok = False
+            print(f"  ✘ DeleteBucket {b} : {e}")
+    for rule in rest.get("api_access_rules", []):
+        do(f"DeleteApiAccessRule {rule}", "DeleteApiAccessRule", {"ApiAccessRuleId": rule})
+    for k in rest.get("access_keys", []):
+        # Une clé du tenant appartient au root (clé `root`) ou à l'utilisateur du tenant :
+        # l'appel sans UserName vise le root, celui de l'utilisateur suit plus bas.
+        do(f"DeleteAccessKey {k}", "DeleteAccessKey", {"AccessKeyId": k})
+    for u in rest.get("users", []):
+        for pol in (oapi_try("ReadUserPolicies", {"UserName": u}) or {}).get("PolicyNames") or []:
+            do(f"DeleteUserPolicy {u}/{pol}", "DeleteUserPolicy", {"UserName": u, "PolicyName": pol})
+        for k in (oapi_try("ReadAccessKeys", {"UserName": u}) or {}).get("AccessKeys") or []:
+            do(f"DeleteAccessKey {u}/{k['AccessKeyId']}", "DeleteAccessKey", {"UserName": u, "AccessKeyId": k["AccessKeyId"]})
+        for lp in (oapi_try("ReadLinkedPolicies", {"UserName": u}) or {}).get("Policies") or []:
+            do(f"UnlinkPolicy {u}/{lp.get('PolicyName')}", "UnlinkPolicy", {"UserName": u, "PolicyOrn": lp.get("Orn")})
+        do(f"DeleteUser {u}", "DeleteUser", {"UserName": u})
+    for pol in rest.get("policies", []):
+        orn = next((p.get("Orn") for p in oapi("ReadPolicies", {"Filters": {"Scope": "LOCAL"}}).get("Policies") or [] if p.get("PolicyName") == pol), None)
+        if orn:
+            do(f"DeletePolicy {pol}", "DeletePolicy", {"PolicyOrn": orn})
+    return ok
+
+
+def oapi_try(call, body):
+    try:
+        return oapi(call, body)
+    except RuntimeError:
+        return None
+
+
+# ─── point d'entrée ────────────────────────────────────────────────────────────
+
+def main(argv):
+    if len(argv) < 2 or argv[1] not in ("identity", "inventory", "cleanup", "variables", "extra"):
+        sys.exit(__doc__)
+    if argv[1] == "identity":
+        print(json.dumps(identity(), indent=2))
+        return 0
+    if argv[1] == "variables":
+        print(json.dumps(variables(argv[2], argv[3])))
+        return 0
+    if argv[1] == "extra":
+        outputs = json.load(open(argv[3]))
+        print(json.dumps(extra_apply(outputs) if argv[2] == "apply" else extra_destroy(outputs)))
+        return 0
+    tenant = yaml.safe_load(open(argv[2]))
+    if argv[1] == "inventory":
+        print(json.dumps(inventory(tenant), indent=2, sort_keys=True))
+        return 0
+    return 0 if cleanup(tenant, argv[3] if len(argv) > 3 else None) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/references/qualification/outscale/iam.tf
+++ b/references/qualification/outscale/iam.tf
@@ -1,0 +1,107 @@
+# EIM — un utilisateur, trois clés d'accès, cinq politiques managées, deux règles
+# d'accès API (portée : COMPTE, ressources gratuites).
+#
+# Les clés sont créées INACTIVES : la règle CLD-IAM-2 « sans échéance » et la
+# dérivation root_owned ne lisent pas l'état, donc la faute se mesure sans mettre
+# un secret utilisable en circulation. La clé ROOT (sans `user_name`, c'est celle du
+# compte qui exécute) est l'écart CLD-IAM-1 ; elle porte une échéance pour ne porter
+# QUE cet écart.
+#
+# Les politiques managées ne sont attachées à personne : la collecte lit
+# ReadPolicies (Scope LOCAL), pas les liaisons, et une politique orpheline n'ouvre
+# rien. La politique INLINE `Action: *` — l'incident fondateur de l'ADR-0006 — n'a
+# pas de ressource Terraform : le crochet `extra` la pose sur l'utilisateur après
+# l'apply (PutUserPolicy) et la retire avant le destroy.
+
+resource "outscale_user" "qual" {
+  user_name = "pepin-qual-user"
+  path      = "/pepin_qual/"
+}
+
+# ÉCART iam_accesskey_expiration_set (CLD-IAM-2, critical) : clé sans échéance.
+resource "outscale_access_key" "no_expiry" {
+  user_name = outscale_user.qual.user_name
+  state     = "INACTIVE"
+  tag       = "pepin-qual-key-no-expiry"
+}
+
+# CONTRE-EXEMPLE : la même clé, avec une échéance à venir (J+2, posée par le runner).
+resource "outscale_access_key" "expiring" {
+  user_name       = outscale_user.qual.user_name
+  expiration_date = var.key_expires_at
+  state           = "INACTIVE"
+  tag             = "pepin-qual-key-expiring"
+}
+
+# ÉCART iam_no_root_access_key (CLD-IAM-1, high) : clé du compte root (l'appelant).
+resource "outscale_access_key" "root" {
+  expiration_date = var.key_expires_at
+  state           = "INACTIVE"
+  tag             = "pepin-qual-key-root"
+}
+
+# ÉCART iam_policy_no_administrative_privileges (critical) : tout sur tout.
+resource "outscale_policy" "admin" {
+  policy_name = "pepin-qual-policy-admin"
+  description = "Tenant de qualification Pepin : administration totale"
+  path        = "/pepin_qual/"
+  document = jsonencode({
+    Statement = [{ Effect = "Allow", Action = ["*"], Resource = ["*"] }]
+  })
+}
+
+# ÉCART iam_policy_no_wildcard_resource (high) : actions bornées, ressource « * ».
+resource "outscale_policy" "wildcard" {
+  policy_name = "pepin-qual-policy-wildcard"
+  description = "Tenant de qualification Pepin : ressource joker"
+  path        = "/pepin_qual/"
+  document = jsonencode({
+    Statement = [{ Effect = "Allow", Action = ["api:ReadVms", "api:ReadVolumes"], Resource = ["*"] }]
+  })
+}
+
+# ÉCART iam_policy_no_notaction_notresource (critical) : inversion NotAction.
+resource "outscale_policy" "notaction" {
+  policy_name = "pepin-qual-policy-notaction"
+  description = "Tenant de qualification Pepin : tout sauf"
+  path        = "/pepin_qual/"
+  document = jsonencode({
+    Statement = [{ Effect = "Allow", NotAction = ["api:DeleteVms"], Resource = ["*"] }]
+  })
+}
+
+# ÉCART iam_policy_no_privilege_escalation (high) : créer une clé, lier une
+# politique — le chemin d'élévation (porte aussi la ressource « * »).
+resource "outscale_policy" "escalation" {
+  policy_name = "pepin-qual-policy-escalation"
+  description = "Tenant de qualification Pepin : elevation de privileges"
+  path        = "/pepin_qual/"
+  document = jsonencode({
+    Statement = [{ Effect = "Allow", Action = ["api:CreateAccessKey", "api:LinkPolicy"], Resource = ["*"] }]
+  })
+}
+
+# CONTRE-EXEMPLE des quatre contrôles iam_policy_* : actions bornées, ressource
+# NOMMÉE (un bucket OOS), aucune inversion, aucune action d'identité.
+resource "outscale_policy" "scoped" {
+  policy_name = "pepin-qual-policy-scoped"
+  description = "Tenant de qualification Pepin : lecture d un bucket nomme"
+  path        = "/pepin_qual/"
+  document = jsonencode({
+    Statement = [{ Effect = "Allow", Action = ["oos:GetObject"], Resource = ["arn:aws:s3:::pepin-qual-${local.bucket_suffix}-hardened/*"] }]
+  })
+}
+
+# ÉCART iam_apiaccessrule_no_public_cidr (CLD-IAM-4, high) : règle d'accès API
+# ouverte à tout Internet. Les règles s'ajoutent (OU logique) : celle-ci n'enferme
+# personne dehors, et elle est retirée avec le tenant.
+resource "outscale_api_access_rule" "public" {
+  ip_ranges   = ["0.0.0.0/0"]
+  description = "pepin-qual-rule-public"
+}
+
+# CONTRE-EXEMPLE : une plage privée.
+resource "outscale_api_access_rule" "private" {
+  ip_ranges   = ["10.0.0.0/8"]
+  description = "pepin-qual-rule-private"
+}

--- a/references/qualification/outscale/lb.tf
+++ b/references/qualification/outscale/lb.tf
@@ -1,0 +1,51 @@
+# Répartiteurs de charge (LBU, 0,03 EUR/h pièce), dans le cloud public.
+#
+# `http` : un écouteur HTTP seul, sans journal d'accès → deux écarts sur un sujet
+# (loadbalancer_ssl_listeners, loadbalancer_logging_enabled). `tcp443` : un écouteur
+# TCP 443 — un candidat au passthrough TLS, que la règle refuse de trancher (statut
+# non concluant, ADR-0015). Le contre-exemple du journal (bucket OOS cible +
+# outscale_load_balancer_attributes) n'est pas construit : tenant.yaml le dit.
+#
+# Pas de politique de stickiness : leur destruction échouait (issue #663).
+
+resource "outscale_load_balancer" "http" {
+  load_balancer_name = "pepin-qual-lb-http"
+  load_balancer_type = "internet-facing"
+  subregion_names    = [var.subregion]
+
+  listeners {
+    backend_port           = 80
+    backend_protocol       = "HTTP"
+    load_balancer_port     = 80
+    load_balancer_protocol = "HTTP"
+  }
+
+  dynamic "tags" {
+    for_each = merge(local.tagged, { Name = "pepin-qual-lb-http" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_load_balancer" "tcp443" {
+  load_balancer_name = "pepin-qual-lb-tcp443"
+  load_balancer_type = "internet-facing"
+  subregion_names    = [var.subregion]
+
+  listeners {
+    backend_port           = 443
+    backend_protocol       = "TCP"
+    load_balancer_port     = 443
+    load_balancer_protocol = "TCP"
+  }
+
+  dynamic "tags" {
+    for_each = merge(local.tagged, { Name = "pepin-qual-lb-tcp443" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}

--- a/references/qualification/outscale/network.tf
+++ b/references/qualification/outscale/network.tf
@@ -1,0 +1,413 @@
+# Réseau — groupes de sécurité (tous dans le Net), Nets, sous-réseaux, appairage.
+#
+# UN groupe par écart. Chez Outscale, TOUT groupe naît avec une règle sortante par
+# défaut « tout vers 0.0.0.0/0 » : elle est le contrôle CLD-NET-4 en personne, donc
+# chaque groupe la RETIRE (`remove_default_outbound_rule`) sauf `egress_any`, qui
+# porte la faute explicitement — visible sur le plan comme en live. Le groupe
+# « default » du Net, créé par le produit, la garde et porte en plus la règle
+# d'usine (source = lui-même) : deux écarts attendus sur un sujet que Terraform ne
+# gère pas (sa lecture passe par une source de données, son identifiant par une
+# sortie).
+
+# Huit groupes NOMMÉS, pas un for_each : sur le plan, une référence vers une instance
+# de for_each est ambiguë (ADR-0022) et le sujet retombait sur l'adresse de la RÈGLE ;
+# nommés, le sujet est le groupe, comme en live. Dans le Net, et pas dans le cloud
+# public : mesuré, un groupe du cloud public ne peut PAS retirer sa règle sortante
+# par défaut (`remove_default_outbound_rule` exige `net_id`) — tout groupe y porte
+# donc l'écart CLD-NET-4 par construction.
+resource "outscale_security_group" "ssh_open" {
+  security_group_name          = "pepin-qual-sg-ssh-open"
+  description                  = "SSH ouvert a Internet"
+  net_id                       = outscale_net.documented.net_id
+  remove_default_outbound_rule = true
+
+  dynamic "tags" {
+    for_each = local.untagged
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_security_group" "rdp_open" {
+  security_group_name          = "pepin-qual-sg-rdp-open"
+  description                  = "RDP ouvert a Internet"
+  net_id                       = outscale_net.documented.net_id
+  remove_default_outbound_rule = true
+
+  dynamic "tags" {
+    for_each = local.untagged
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_security_group" "db_open" {
+  security_group_name          = "pepin-qual-sg-db-open"
+  description                  = "PostgreSQL ouvert a Internet"
+  net_id                       = outscale_net.documented.net_id
+  remove_default_outbound_rule = true
+
+  dynamic "tags" {
+    for_each = local.untagged
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_security_group" "snmp_open" {
+  security_group_name          = "pepin-qual-sg-snmp-open"
+  description                  = "SNMP ouvert a Internet"
+  net_id                       = outscale_net.documented.net_id
+  remove_default_outbound_rule = true
+
+  dynamic "tags" {
+    for_each = local.untagged
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_security_group" "any_open" {
+  security_group_name          = "pepin-qual-sg-any-open"
+  description                  = "Tout le trafic entrant accepte depuis Internet"
+  net_id                       = outscale_net.documented.net_id
+  remove_default_outbound_rule = true
+
+  dynamic "tags" {
+    for_each = local.untagged
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_security_group" "quartet" {
+  security_group_name          = "pepin-qual-sg-quartet"
+  description                  = "SSH ouvert a Internet par quatre /2"
+  net_id                       = outscale_net.documented.net_id
+  remove_default_outbound_rule = true
+
+  dynamic "tags" {
+    for_each = local.untagged
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_security_group" "egress_any" {
+  security_group_name          = "pepin-qual-sg-egress-any"
+  description                  = "Tout le trafic sortant accepte vers Internet"
+  net_id                       = outscale_net.documented.net_id
+  remove_default_outbound_rule = true
+
+  dynamic "tags" {
+    for_each = local.untagged
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_security_group" "hardened" {
+  security_group_name          = "pepin-qual-sg-hardened"
+  description                  = "Refus par defaut, SSH prive, HTTPS public"
+  net_id                       = outscale_net.documented.net_id
+  remove_default_outbound_rule = true
+
+  dynamic "tags" {
+    for_each = local.untagged
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+# ÉCART …_tcp_port_22 (high).
+resource "outscale_security_group_rule" "ssh_open" {
+  flow              = "Inbound"
+  security_group_id = outscale_security_group.ssh_open.security_group_id
+  ip_protocol       = "tcp"
+  from_port_range   = 22
+  to_port_range     = 22
+  ip_range          = "0.0.0.0/0"
+}
+
+# ÉCART …_tcp_port_3389 (high).
+resource "outscale_security_group_rule" "rdp_open" {
+  flow              = "Inbound"
+  security_group_id = outscale_security_group.rdp_open.security_group_id
+  ip_protocol       = "tcp"
+  from_port_range   = 3389
+  to_port_range     = 3389
+  ip_range          = "0.0.0.0/0"
+}
+
+# ÉCART …_high_risk_tcp_ports (high) : PostgreSQL exposé.
+resource "outscale_security_group_rule" "db_open" {
+  flow              = "Inbound"
+  security_group_id = outscale_security_group.db_open.security_group_id
+  ip_protocol       = "tcp"
+  from_port_range   = 5432
+  to_port_range     = 5432
+  ip_range          = "0.0.0.0/0"
+}
+
+# ÉCART …_high_risk_udp_ports (high) : SNMP exposé.
+resource "outscale_security_group_rule" "snmp_open" {
+  flow              = "Inbound"
+  security_group_id = outscale_security_group.snmp_open.security_group_id
+  ip_protocol       = "udp"
+  from_port_range   = 161
+  to_port_range     = 161
+  ip_range          = "0.0.0.0/0"
+}
+
+# ÉCART …_all_ports (critical) — et, par construction, les quatre autres contrôles
+# d'entrée : une règle any/any couvre tout port et tout protocole.
+resource "outscale_security_group_rule" "any_open" {
+  flow              = "Inbound"
+  security_group_id = outscale_security_group.any_open.security_group_id
+  ip_protocol       = "-1"
+  ip_range          = "0.0.0.0/0"
+}
+
+# ÉCART …_tcp_port_22 par ÉVASION : quatre /2 couvrent tout l'espace IPv4 sans
+# qu'aucun ne soit 0.0.0.0/0 (cas #D de l'audit externe).
+resource "outscale_security_group_rule" "quartet" {
+  for_each          = toset(["0.0.0.0/2", "64.0.0.0/2", "128.0.0.0/2", "192.0.0.0/2"])
+  flow              = "Inbound"
+  security_group_id = outscale_security_group.quartet.security_group_id
+  ip_protocol       = "tcp"
+  from_port_range   = 22
+  to_port_range     = 22
+  ip_range          = each.value
+}
+
+# ÉCART network_securitygroup_unrestricted_egress (medium) : la règle sortante
+# « tout vers Internet », écrite explicitement.
+resource "outscale_security_group_rule" "egress_any" {
+  flow              = "Outbound"
+  security_group_id = outscale_security_group.egress_any.security_group_id
+  ip_protocol       = "-1"
+  ip_range          = "0.0.0.0/0"
+}
+
+# CONTRE-EXEMPLE de TOUS les contrôles de groupe : SSH depuis un /8 PRIVÉ, HTTPS
+# depuis Internet (un port servi, pas un port sensible), sortie TCP 443 seulement.
+resource "outscale_security_group_rule" "hardened_ssh_private" {
+  flow              = "Inbound"
+  security_group_id = outscale_security_group.hardened.security_group_id
+  ip_protocol       = "tcp"
+  from_port_range   = 22
+  to_port_range     = 22
+  ip_range          = "10.0.0.0/8"
+}
+
+resource "outscale_security_group_rule" "hardened_https" {
+  flow              = "Inbound"
+  security_group_id = outscale_security_group.hardened.security_group_id
+  ip_protocol       = "tcp"
+  from_port_range   = 443
+  to_port_range     = 443
+  ip_range          = "0.0.0.0/0"
+}
+
+resource "outscale_security_group_rule" "hardened_egress_https" {
+  flow              = "Outbound"
+  security_group_id = outscale_security_group.hardened.security_group_id
+  ip_protocol       = "tcp"
+  from_port_range   = 443
+  to_port_range     = 443
+  ip_range          = "0.0.0.0/0"
+}
+
+# ── Nets ───────────────────────────────────────────────────────────────────────
+
+# ÉCART network_documented (CLD-NET-5, low) : Net sans étiquettes de cartographie.
+resource "outscale_net" "undocumented" {
+  ip_range = "10.10.0.0/16"
+
+  dynamic "tags" {
+    for_each = merge(local.untagged, { Name = "pepin-qual-net-undocumented" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+# CONTRE-EXEMPLE : cartographié (Owner, Project, Env). C'est lui qui porte les
+# sous-réseaux, les VM à deux cartes et le SG « default » observé.
+resource "outscale_net" "documented" {
+  ip_range = "10.20.0.0/16"
+
+  dynamic "tags" {
+    for_each = merge(local.tagged, { Name = "pepin-qual-net-documented" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+# ÉCART network_subnet_no_public_ip_by_default (CLD-NET-3, medium) : IP publique
+# attribuée d'office à toute VM lancée ici. Aucune VM n'y est lancée : la faute est
+# le réglage, pas une exposition.
+resource "outscale_subnet" "autoip" {
+  net_id                  = outscale_net.documented.net_id
+  ip_range                = "10.20.1.0/24"
+  subregion_name          = var.subregion
+  map_public_ip_on_launch = true
+
+  dynamic "tags" {
+    for_each = merge(local.untagged, { Name = "pepin-qual-subnet-autoip" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+# CONTRE-EXEMPLE, et le sous-réseau de travail des VM à deux cartes.
+resource "outscale_subnet" "main" {
+  net_id                  = outscale_net.documented.net_id
+  ip_range                = "10.20.2.0/24"
+  subregion_name          = var.subregion
+  map_public_ip_on_launch = false
+
+  dynamic "tags" {
+    for_each = merge(local.untagged, { Name = "pepin-qual-subnet-main" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+# Sortie Internet du Net : pour qu'une IP publique liée à une carte soit réelle.
+resource "outscale_internet_service" "documented" {
+  dynamic "tags" {
+    for_each = merge(local.untagged, { Name = "pepin-qual-igw" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_internet_service_link" "documented" {
+  internet_service_id = outscale_internet_service.documented.internet_service_id
+  net_id              = outscale_net.documented.net_id
+}
+
+resource "outscale_route_table" "main" {
+  net_id = outscale_net.documented.net_id
+
+  dynamic "tags" {
+    for_each = merge(local.untagged, { Name = "pepin-qual-rt-main" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_route" "default" {
+  destination_ip_range = "0.0.0.0/0"
+  gateway_id           = outscale_internet_service.documented.internet_service_id
+  route_table_id       = outscale_route_table.main.route_table_id
+  depends_on           = [outscale_internet_service_link.documented]
+}
+
+resource "outscale_route_table_link" "main" {
+  route_table_id = outscale_route_table.main.route_table_id
+  subnet_id      = outscale_subnet.main.subnet_id
+}
+
+# Groupes du Net : `net_ssh_open` porte SSH ouvert (la faute que la carte secondaire
+# rend joignable), `net_closed` n'admet rien. Défaut sortant retiré sur les deux.
+resource "outscale_security_group" "net_ssh_open" {
+  security_group_name          = "pepin-qual-sg-net-ssh-open"
+  description                  = "SSH ouvert a Internet, dans le Net"
+  net_id                       = outscale_net.documented.net_id
+  remove_default_outbound_rule = true
+
+  dynamic "tags" {
+    for_each = local.untagged
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_security_group_rule" "net_ssh_open" {
+  flow              = "Inbound"
+  security_group_id = outscale_security_group.net_ssh_open.security_group_id
+  ip_protocol       = "tcp"
+  from_port_range   = 22
+  to_port_range     = 22
+  ip_range          = "0.0.0.0/0"
+}
+
+resource "outscale_security_group" "net_closed" {
+  security_group_name          = "pepin-qual-sg-net-closed"
+  description                  = "Aucune regle entrante, dans le Net"
+  net_id                       = outscale_net.documented.net_id
+  remove_default_outbound_rule = true
+
+  dynamic "tags" {
+    for_each = local.untagged
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+# Le SG « default » que le produit crée avec le Net : lu, jamais géré. Il porte la
+# règle d'usine (ÉCART network_securitygroup_default_restrict_traffic, contextuel)
+# et la règle sortante par défaut (ÉCART unrestricted_egress).
+data "outscale_security_group" "net_default" {
+  filter {
+    name   = "net_ids"
+    values = [outscale_net.documented.net_id]
+  }
+  filter {
+    name   = "security_group_names"
+    values = ["default"]
+  }
+}
+
+# CONTRE-EXEMPLE de network_peering_cross_organization : un appairage entre deux
+# Nets du MÊME compte (source_account = accepter_account). L'écart exigerait un
+# second compte.
+resource "outscale_net_peering" "same_account" {
+  source_net_id   = outscale_net.documented.net_id
+  accepter_net_id = outscale_net.undocumented.net_id
+
+  dynamic "tags" {
+    for_each = merge(local.untagged, { Name = "pepin-qual-peering" })
+    content {
+      key   = tags.key
+      value = tags.value
+    }
+  }
+}
+
+resource "outscale_net_peering_acceptation" "same_account" {
+  net_peering_id = outscale_net_peering.same_account.net_peering_id
+}

--- a/references/qualification/outscale/outputs.tf
+++ b/references/qualification/outscale/outputs.tf
@@ -1,0 +1,68 @@
+# Sorties : les identifiants que la collecte LIVE emploie comme sujets, connus
+# après apply. expected.yaml les cite sous la forme `${output.<nom>}`. À plat, une
+# sortie par sujet. Aucune sortie sensible.
+
+output "sg_ssh_open_id" { value = outscale_security_group.ssh_open.security_group_id }
+output "sg_rdp_open_id" { value = outscale_security_group.rdp_open.security_group_id }
+output "sg_db_open_id" { value = outscale_security_group.db_open.security_group_id }
+output "sg_snmp_open_id" { value = outscale_security_group.snmp_open.security_group_id }
+output "sg_any_open_id" { value = outscale_security_group.any_open.security_group_id }
+output "sg_quartet_id" { value = outscale_security_group.quartet.security_group_id }
+output "sg_egress_any_id" { value = outscale_security_group.egress_any.security_group_id }
+output "sg_hardened_id" { value = outscale_security_group.hardened.security_group_id }
+output "sg_net_ssh_open_id" { value = outscale_security_group.net_ssh_open.security_group_id }
+output "sg_net_closed_id" { value = outscale_security_group.net_closed.security_group_id }
+output "sg_net_default_id" { value = data.outscale_security_group.net_default.security_group_id }
+
+output "vm_exposed_id" { value = outscale_vm.public["exposed"].vm_id }
+output "vm_private_id" { value = outscale_vm.public["private"].vm_id }
+output "vm_hardened_id" { value = outscale_vm.public["hardened"].vm_id }
+output "vm_untagged_id" { value = outscale_vm.public["untagged"].vm_id }
+output "vm_secrets_id" { value = outscale_vm.public["secrets"].vm_id }
+output "vm_unprotected_id" { value = outscale_vm.public["unprotected"].vm_id }
+output "vm_two_nics_id" { value = outscale_vm.two_nics.vm_id }
+output "vm_two_nics_inverse_id" { value = outscale_vm.two_nics_inverse.vm_id }
+
+# Volumes racine, un par VM : tous en usage, aucun sauvegardé.
+output "root_volume_exposed_id" { value = tolist(outscale_vm.public["exposed"].block_device_mappings_created[0].bsu)[0].volume_id }
+output "root_volume_private_id" { value = tolist(outscale_vm.public["private"].block_device_mappings_created[0].bsu)[0].volume_id }
+output "root_volume_hardened_id" { value = tolist(outscale_vm.public["hardened"].block_device_mappings_created[0].bsu)[0].volume_id }
+output "root_volume_untagged_id" { value = tolist(outscale_vm.public["untagged"].block_device_mappings_created[0].bsu)[0].volume_id }
+output "root_volume_secrets_id" { value = tolist(outscale_vm.public["secrets"].block_device_mappings_created[0].bsu)[0].volume_id }
+output "root_volume_unprotected_id" { value = tolist(outscale_vm.public["unprotected"].block_device_mappings_created[0].bsu)[0].volume_id }
+output "root_volume_two_nics_id" { value = tolist(outscale_vm.two_nics.block_device_mappings_created[0].bsu)[0].volume_id }
+output "root_volume_two_nics_inverse_id" { value = tolist(outscale_vm.two_nics_inverse.block_device_mappings_created[0].bsu)[0].volume_id }
+
+output "volume_unsnapshotted_id" { value = outscale_volume.unsnapshotted.volume_id }
+output "volume_snapshotted_id" { value = outscale_volume.snapshotted.volume_id }
+output "snapshot_public_id" { value = outscale_snapshot.public.snapshot_id }
+output "snapshot_private_id" { value = outscale_snapshot.private.snapshot_id }
+output "image_public_id" { value = outscale_image.public.image_id }
+output "image_private_id" { value = outscale_image.private.image_id }
+
+output "net_undocumented_id" { value = outscale_net.undocumented.net_id }
+output "net_documented_id" { value = outscale_net.documented.net_id }
+output "subnet_autoip_id" { value = outscale_subnet.autoip.subnet_id }
+output "subnet_main_id" { value = outscale_subnet.main.subnet_id }
+output "peering_id" { value = outscale_net_peering.same_account.net_peering_id }
+output "nic_two_nics_id" { value = outscale_nic.two_nics_secondary.nic_id }
+output "nic_two_nics_inverse_id" { value = outscale_nic.two_nics_inverse_secondary.nic_id }
+
+output "api_key_no_expiry" { value = outscale_access_key.no_expiry.access_key_id }
+output "api_key_expiring" { value = outscale_access_key.expiring.access_key_id }
+output "api_key_root" { value = outscale_access_key.root.access_key_id }
+output "api_rule_public_id" { value = outscale_api_access_rule.public.api_access_rule_id }
+output "api_rule_private_id" { value = outscale_api_access_rule.private.api_access_rule_id }
+output "user_name" { value = outscale_user.qual.user_name }
+
+# Suffixe des noms de buckets OOS (créés par le crochet `extra`, hors Terraform).
+output "bucket_suffix" { value = local.bucket_suffix }
+output "bucket_public" { value = "pepin-qual-${local.bucket_suffix}-public" }
+output "bucket_policy" { value = "pepin-qual-${local.bucket_suffix}-policy" }
+output "bucket_unversioned" { value = "pepin-qual-${local.bucket_suffix}-unversioned" }
+output "bucket_unlocked" { value = "pepin-qual-${local.bucket_suffix}-unlocked" }
+output "bucket_unencrypted" { value = "pepin-qual-${local.bucket_suffix}-unencrypted" }
+output "bucket_hardened" { value = "pepin-qual-${local.bucket_suffix}-hardened" }
+
+output "lb_http_name" { value = outscale_load_balancer.http.load_balancer_name }
+output "lb_tcp443_name" { value = outscale_load_balancer.tcp443.load_balancer_name }

--- a/references/qualification/outscale/tenant.yaml
+++ b/references/qualification/outscale/tenant.yaml
@@ -1,0 +1,103 @@
+# Tenant de QUALIFICATION Outscale — métadonnées lues par tools/qualification/qualify.py.
+#
+# Même doctrine que le tenant Scaleway (references/qualification/README.fr.md) : une
+# faute par ressource, un contre-exemple par contrôle, appliqué puis détruit, comparé
+# à expected.yaml. La différence : chez Outscale, la collecte live lit tout ce que la
+# stack crée (16 types au contrat), donc les deux passes voient à peu près la même
+# chose, et c'est ici que se trouvent les cas que Scaleway ne sait pas exercer — la
+# VM à deux cartes, la clé root, la famille iam_policy_* par les documents EIM, les
+# snapshots, l'image publique.
+provider: outscale
+title: "Tenant de qualification Outscale : une faute par ressource, un contre-exemple par contrôle"
+title_en: "Outscale qualification tenant: one fault per resource, one counterexample per control"
+
+region: eu-west-2
+zone: eu-west-2a
+
+# Étiquette posée sur toute ressource étiquetable (bloc `tags` Outscale) ; préfixe
+# des noms pour ce qui ne s'étiquette pas (utilisateurs, politiques, clés, buckets,
+# règles d'accès API).
+tag: pepin-qual
+name_prefix: pepin-qual-
+
+provider_version: "1.8.0"
+
+# Outil requis par le crochet `extra` (les buckets OOS, que le provider Terraform ne
+# sait pas créer, passent par la CLI `aws` sur oos.<région>.outscale.com). La preuve
+# de destruction et le nettoyage de secours passent par l'OAPI : `octl`, la CLI de
+# référence du fournisseur, sert aux listings qu'un mainteneur rejoue à la main.
+required_tools: [aws]
+
+# Rien n'est « plan seulement » chez Outscale (variables.tf) : la variable est passée
+# pour l'uniformité du runner.
+applied_vars:
+  terraform_only_resources: false
+
+# À appliquer AVANT le destroy : la protection contre la suppression de la VM
+# `hardened` (issue #88 du provider, ouverte — une VM protégée ne se détruit pas).
+pre_destroy_vars:
+  deletion_protection: false
+
+# Budget mur. Les images (création depuis une VM, ~3-5 min) et les load balancers
+# sont les étapes lentes de l'apply et du destroy.
+budget_minutes: 40
+
+# Coût : tarifs horaires du catalogue (ReadCatalog, 2026-09-09) sur ce qui est
+# appliqué. Le type de VM est celui que le mainteneur a donné pour son compte.
+cost:
+  currency: EUR
+  hourly:
+    - family: vms
+      count: 8
+      unit_price: 0.09       # tinav6.c2r4p2 : 2 × CustomCore:v6-p2 (0,035) + 4 × CustomRam (0,005)
+      source: "ReadCatalog TinaOS-FCU RunInstances-OD CustomCore:v6-p2 / CustomRam"
+    - family: load_balancers
+      count: 2
+      unit_price: 0.03       # LBU:Usage
+      source: "ReadCatalog TinaOS-LBU CreateLoadBalancer LBU:Usage"
+    - family: public_ips
+      count: 4
+      unit_price: 0.005      # ElasticIP (IdleAddress/AdditionalAddress)
+      source: "ReadCatalog TinaOS-FCU AssociateAddress ElasticIP"
+    - family: volumes_gb
+      count: 100             # ~8 volumes racine de 10 Go + 2 volumes de données
+      unit_price: 0.00015    # gp2 : 0,11 EUR/Go/mois ≈ 0,00015 EUR/Go/h
+      source: "ReadCatalog TinaOS-FCU CreateVolume BSU:VolumeUsage:gp2 (PER_MONTH)"
+
+resources:
+  applied:
+    - { family: security_groups, count: 10, note: "8 en cloud public (ssh/rdp/db/snmp/any/quartet/egress_any ⇒ 7 contrôles ; hardened = contre-exemple) + 2 dans le Net (net_ssh_open, net_closed) ; le SG « default » du Net ⇒ CLD-NET-4 (règle d'usine) et egress par défaut" }
+    - { family: vms, count: 8, note: "exposed ⇒ CLD-NET-3 ; two_nics ⇒ CLD-NET-3 par la carte secondaire ; untagged ⇒ CLD-GVN-1 ; secrets ⇒ CLD-CMP-9 ; unprotected ⇒ CLD-CMP-10 ; private, hardened (protégée, Env=prod), two_nics_inverse = contre-exemples" }
+    - { family: nics, count: 2, note: "cartes secondaires des deux VM à deux cartes (outscale_nic + outscale_nic_link)" }
+    - { family: public_ips, count: 4 }
+    - { family: volumes, count: 2, note: "unsnapshotted ⇒ CLD-STO-3 ; snapshotted (snapshot privée) = contre-exemple ; les volumes racine des 8 VM ⇒ CLD-STO-3 aussi" }
+    - { family: snapshots, count: 2, note: "public (GlobalPermission) ⇒ CLD-STO-2 ; private = contre-exemple" }
+    - { family: images, count: 2, note: "public (launch permission globale) ⇒ CLD-STO-2 ; private = contre-exemple" }
+    - { family: nets, count: 2, note: "undocumented ⇒ CLD-NET-5 ; documented = contre-exemple ; peering entre les deux (même compte) = contre-exemple de CLD-NET-7" }
+    - { family: subnets, count: 2, note: "public (MapPublicIpOnLaunch) ⇒ CLD-NET-3 ; private = contre-exemple" }
+    - { family: load_balancers, count: 2, note: "http (écouteur HTTP seul, sans journal) ⇒ CLD-CHF-1 et CLD-LOG-1 ; tcp443 (passthrough TLS) ⇒ CLD-CHF-1 non concluant" }
+    - { family: iam, count: 9, note: "1 utilisateur ; 3 clés (no_expiry ⇒ CLD-IAM-2 ; root ⇒ CLD-IAM-1 ; expiring = contre-exemple) ; 5 politiques (admin, wildcard, notaction, escalation ⇒ iam_policy_* ; scoped = contre-exemple)" }
+    - { family: api_access_rules, count: 2, note: "public (0.0.0.0/0) ⇒ CLD-IAM-4 ; private = contre-exemple" }
+  extra:   # hors Terraform (crochet `extra`) : le provider 1.8.0 n'a pas ces ressources
+    - { family: buckets, count: 6, note: "public/policy ⇒ CLD-STO-1 ; unversioned ⇒ CLD-STO-4 (+ STO-8) ; unlocked ⇒ CLD-STO-8 ; unencrypted ⇒ CLD-CHF-2 ; hardened = contre-exemple" }
+    - { family: inline_policies, count: 1, note: "politique EIM inline `Action: *` sur l'utilisateur du tenant (incident fondateur, ADR-0006) ⇒ iam_policy_no_administrative_privileges" }
+
+not_exercised:
+  - control: governance_resource_region_in_eu
+    reason: "Un compte Outscale n'existe que dans sa région (eu-west-2, UE) : aucune ressource hors UE n'est constructible ; seul le pass est prouvé."
+  - control: iam_accesskey_rotated
+    reason: "Une date de création ne s'antidate pas : aucune clé du tenant ne peut avoir plus de 90 jours. Le contrôle s'observe sur les clés existantes du compte (hors tenant)."
+  - control: network_peering_cross_organization
+    reason: "Un appairage entre deux comptes exige un second compte : seul le contre-exemple (deux Nets du même compte) est construit."
+  - control: iam_account_mfa_enforced
+    reason: "ApiAccessPolicy est un singleton du compte : forcer RequireTrustedEnv=true fermerait l'API à toute clé sans MFA, y compris celle qui qualifie. Observé tel quel, hors tenant."
+  - control: iam_apiaccesspolicy_max_key_expiration
+    reason: "Même singleton : observé tel quel, hors tenant."
+  - control: iam_apiaccessrule_defined
+    reason: "Le compte porte déjà des règles d'accès API : le pass est observé, l'écart (aucune règle) n'est pas constructible sans les retirer toutes — et c'est exactement le geste qu'on ne fait pas sur le compte d'un mainteneur."
+  - control: loadbalancer_logging_enabled
+    reason: "Le contre-exemple (journal d'accès activé) exige un bucket OOS cible et outscale_load_balancer_attributes : non construit, seul l'écart est prouvé."
+  - control: network_securitygroup_default_restrict_traffic
+    reason: "Le contre-exemple (SG « default » vidé de sa règle d'usine) n'est pas exprimable par le provider, qui ne sait qu'ajouter des règles."
+  - control: kubernetes_*
+    reason: "Aucun cluster OKS : coût et durée hors de proportion avec ce que les quatre contrôles mesureraient. not-evaluated épinglé."

--- a/references/qualification/outscale/variables.tf
+++ b/references/qualification/outscale/variables.tf
@@ -1,0 +1,95 @@
+# Variables du tenant de qualification Outscale.
+#
+# Celles qui identifient le compte ou portent une échéance sont injectées par
+# tools/qualification/qualify.py (TF_VAR_*), APRÈS que la porte a vérifié que le
+# compte observé par l'API (ReadAccounts) est celui que l'environnement attend.
+
+variable "account_id" {
+  description = "Compte Outscale (AccountId) sur lequel le tenant est créé — confirmé par l'API avant tout apply ; sert aussi de suffixe aux noms de buckets, globaux chez OOS"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]{12}$", var.account_id))
+    error_message = "account_id doit être un identifiant de compte Outscale (12 chiffres)."
+  }
+}
+
+variable "region" {
+  description = "Région du tenant. Un compte Outscale n'existe que dans SA région : aucun contre-exemple hors UE (CLD-GVN-3) n'est constructible avec ce compte"
+  type        = string
+  default     = "eu-west-2"
+}
+
+variable "subregion" {
+  description = "Sous-région (AZ) des ressources zonales"
+  type        = string
+  default     = "eu-west-2a"
+}
+
+variable "osc_profile" {
+  description = "Profil de ~/.osc/config.json lu par le provider — le même que celui des crochets (OSC_PROFILE) et de `pepin scan --live --profile`"
+  type        = string
+  default     = "default"
+}
+
+variable "tenant_tag" {
+  description = "Étiquette posée sur TOUTE ressource étiquetable du tenant : c'est sur elle que la preuve de destruction filtre"
+  type        = string
+  default     = "pepin-qual"
+}
+
+variable "instance_type" {
+  description = "Gamme des VM, donnée par le mainteneur pour son compte : tinav6.c2r4p2 (2 cœurs v6 perf 2, 4 Go) — 2 × 0,035 + 4 × 0,005 = 0,09 EUR/h au catalogue (ReadCatalog, 2026-09-09)"
+  type        = string
+  default     = "tinav6.c2r4p2"
+}
+
+variable "image_id" {
+  description = "OMI de base des VM — Ubuntu-22.04-2026-01-12 publiée par Outscale en eu-west-2 (ReadImages, 2026-09-09). Une région autre exige son propre identifiant"
+  type        = string
+  default     = "ami-9afa3d5c"
+}
+
+variable "key_expires_at" {
+  description = "Échéance RFC 3339 de la clé d'accès CONFORME (contre-exemple de CLD-IAM-2) — calculée par le runner à J+2, jamais écrite en dur"
+  type        = string
+}
+
+# La protection contre la suppression du contre-exemple `hardened`. Le provider
+# refuse de supprimer une VM protégée (issue #88, ouverte) : le runner applique
+# `deletion_protection = false` AVANT le destroy (tenant.yaml `pre_destroy_vars`).
+variable "deletion_protection" {
+  description = "Protection contre la suppression des VM qui la portent (contre-exemple CLD-CMP-10) ; passée à false par le runner juste avant le destroy"
+  type        = bool
+  default     = true
+}
+
+# Uniformité avec les autres tenants : chez Outscale, la collecte live lit TOUT ce que
+# la stack crée (le contrat de providers/outscale.yaml couvre les 16 types), donc
+# rien n'est « plan seulement » — la variable existe pour que le runner soit
+# identique d'un fournisseur à l'autre, et elle n'est lue nulle part.
+variable "terraform_only_resources" {
+  description = "Inclure les ressources que seul le chemin Terraform sait lire : aucune chez Outscale"
+  type        = bool
+  default     = true
+}
+
+locals {
+  # Étiquettes de gouvernance CONFORMES au profil par défaut de Pépin (CostCenter,
+  # Project, Env, Owner). Chez Outscale, une étiquette est un bloc `tags { key value }`.
+  governance = {
+    CostCenter = "qualification"
+    Project    = "pepin"
+    Env        = "qualification"
+    Owner      = "pepin-maintainer"
+  }
+  production = merge(local.governance, { Env = "prod" })
+
+  # Toute ressource étiquetable porte le tag du tenant : c'est lui que le listing de
+  # sortie filtre. `tagged` = gouvernance complète ; `untagged` = le tag du tenant seul.
+  tagged            = merge({ (var.tenant_tag) = "tenant" }, local.governance)
+  production_tagged = merge({ (var.tenant_tag) = "tenant" }, local.production)
+  untagged          = { (var.tenant_tag) = "tenant" }
+
+  bucket_suffix = substr(var.account_id, 0, 8)
+}

--- a/references/qualification/outscale/versions.tf
+++ b/references/qualification/outscale/versions.tf
@@ -1,0 +1,36 @@
+# Tenant de qualification Outscale — épinglage du provider.
+#
+# Version ÉPINGLÉE À L'EXACT, jamais en `~>` : une contrainte flottante laisse une
+# publication amont changer ce que ce tenant mesure (c'est ainsi que la régression
+# de destruction du provider Scaleway 2.81.0 est arrivée). Le lockfile à côté est
+# versionné : il garantit que la qualification installe le binaire validé.
+#
+# Ce que ce tenant ÉVITE, parce que les issues du provider disent que ça ne se
+# détruit pas (détail et liens dans README.md) :
+#   - `outscale_nic_private_ip` (#28, #137 : 400/409 au destroy, ouvertes) ;
+#   - les blocs `nics` / `primary_nic` mêlés dans `outscale_vm` (#778, #424, #50,
+#     #448 : remplacement de la VM, NIC « oubliée ») → `outscale_nic` + `outscale_nic_link` ;
+#   - une VM protégée contre la suppression au moment du destroy (#88 : « Error
+#     deleting the VM ») → la protection est LEVÉE par un apply avant le destroy
+#     (`pre_destroy_vars` de tenant.yaml), et le nettoyage de secours fait UpdateVm ;
+#   - les politiques de stickiness sur le LBU (#663).
+terraform {
+  required_version = ">= 1.11"
+
+  backend "local" {}
+
+  required_providers {
+    outscale = {
+      source  = "outscale/outscale"
+      version = "1.8.0"
+    }
+  }
+}
+
+# Aucun identifiant ici (ADR-0012) : le provider lit OSC_ACCESS_KEY/OSC_SECRET_KEY,
+# ou le profil de ~/.osc/config.json, exactement comme `pepin scan --live`, les
+# crochets et `octl`. Le compte est confirmé par l'API avant tout apply (runner).
+provider "outscale" {
+  profile = var.osc_profile
+  region  = var.region
+}

--- a/references/qualification/scaleway/hooks.py
+++ b/references/qualification/scaleway/hooks.py
@@ -5,9 +5,15 @@ Trois sous-commandes, appelées par tools/qualification/qualify.py :
 
     identity                      quel compte les identifiants natifs désignent-ils,
                                   d'après l'API (jamais d'après une variable locale)
+    variables --live|--plan-only <identity.json>
+                                  les variables Terraform propres au tenant, et
+                                  l'échéance à attendre avant de scanner
+    extra apply|destroy <outputs.json>
+                                  ce que Terraform ne sait pas créer (rien ici)
     inventory <tenant.yaml>       ce que le compte contient, famille par famille, et
                                   ce qui, dedans, appartient au tenant (tag / préfixe)
-    cleanup <tenant.yaml>         supprime ce qui appartient au tenant — chemin de
+    cleanup <tenant.yaml> [leftovers.json]
+                                  supprime ce qui appartient au tenant — chemin de
                                   SECOURS quand `terraform destroy` n'a pas fini
 
 # Pourquoi l'API plutôt qu'une variable
@@ -280,13 +286,49 @@ def cleanup(tenant):
     return ok
 
 
+# ─── variables propres au tenant ───────────────────────────────────────────────
+
+def variables(mode, identity_path):
+    """Les variables Terraform que ce tenant calcule à chaque run, jamais écrites :
+    les deux échéances de clé d'API, le principal de politique de bucket (l'identité
+    qui qualifie, lue dans identity.json), et un mot de passe jetable pour les bases
+    managées du plan complet. Le runner les passe à Terraform par l'environnement.
+
+    La clé « expirée » : une échéance que l'apply précède et que le scan suit — le
+    runner attend `wait_until`. En mode plan seul, rien n'est appliqué et le scan du
+    plan a lieu tout de suite : l'échéance est posée dans le passé."""
+    import datetime as dt
+    import secrets
+    who = json.load(open(identity_path))
+    now = dt.datetime.now(dt.timezone.utc)
+    rfc = "%Y-%m-%dT%H:%M:%SZ"
+    expired = now + (dt.timedelta(minutes=3) if mode == "--live" else -dt.timedelta(minutes=1))
+    return {
+        "tf_vars": {
+            "key_expires_at": (now + dt.timedelta(days=2)).strftime(rfc),
+            "key_expired_at": expired.strftime(rfc),
+            "bucket_policy_principal": who["principal"],
+            "rdb_password": secrets.token_urlsafe(24) + "Aa1!",
+        },
+        "wait_until": expired.strftime(rfc) if mode == "--live" else None,
+        "note": f"4 variables ; clé expirée à {expired.strftime('%H:%M:%SZ')}",
+    }
+
+
 # ─── point d'entrée ────────────────────────────────────────────────────────────
 
 def main(argv):
-    if len(argv) < 2 or argv[1] not in ("identity", "inventory", "cleanup"):
+    if len(argv) < 2 or argv[1] not in ("identity", "inventory", "cleanup", "variables", "extra"):
         sys.exit(__doc__)
     if argv[1] == "identity":
         print(json.dumps(identity(), indent=2))
+        return 0
+    if argv[1] == "variables":
+        print(json.dumps(variables(argv[2], argv[3])))
+        return 0
+    if argv[1] == "extra":
+        # Tout ce que ce tenant crée passe par Terraform : rien hors Terraform.
+        print(json.dumps({"created": [], "deleted": [], "left": []}))
         return 0
     tenant = yaml.safe_load(open(argv[2]))
     if argv[1] == "inventory":

--- a/references/qualification/scaleway/tenant.yaml
+++ b/references/qualification/scaleway/tenant.yaml
@@ -26,6 +26,15 @@ name_prefix: pepin-qual-
 # contrainte flottante (issue scaleway/terraform-provider-scaleway#4338).
 provider_version: "2.82.0"
 
+# Outil requis par le chemin de SECOURS du nettoyage (jamais par la preuve, qui
+# passe par l'API) : le runner refuse de démarrer sans lui.
+required_tools: [scw]
+
+# Les `-var` de la stack APPLIQUÉE (le plan complet n'en reçoit aucun) : ce qui n'est
+# lu que sur un plan reste hors du compte réel — cf. variables.tf.
+applied_vars:
+  terraform_only_resources: false
+
 # Budget mur : au-delà, la porte dit NO-GO même si tout le reste est vert. Mesuré
 # (apply ≈ 3,5 min pour 27 ressources, attente de l'échéance de la clé ≈ 1 min,
 # scans + bundle ≈ 1 min, destroy ≈ 1 min) avec de la marge.

--- a/tools/qualification/qualify.py
+++ b/tools/qualification/qualify.py
@@ -158,8 +158,14 @@ def compare(expected, results, source, exit_code, outputs, prefix, owned=None):
         # Il est dit à chaque run, pour ne jamais passer pour une attente ordinaire.
         if isinstance(want, dict) and want.get("known_defect"):
             v.info(f"[{source}] {code} : épinglé comme DÉFAUT CONNU — {want['known_defect']}")
-        tenant_fails = [r for r in got if r["status"] == "fail" and tenant_subject(r.get("subject", ""), prefix, owned)]
-        foreign_fails = [r for r in got if r["status"] == "fail" and not tenant_subject(r.get("subject", ""), prefix, owned)]
+        # Un sujet que l'attente NOMME est du tenant, même sans préfixe : le
+        # fournisseur lui-même, sujet du contrôle de souveraineté, en est le cas.
+        named = set()
+        if isinstance(want, dict):
+            for key in ("fail", "silent", "inconclusive"):
+                named |= {resolve_subject(s, outputs) for s in (want.get(key) or [])} - {None}
+        tenant_fails = [r for r in got if r["status"] == "fail" and (tenant_subject(r.get("subject", ""), prefix, owned) or r.get("subject", "") in named)]
+        foreign_fails = [r for r in got if r["status"] == "fail" and r not in tenant_fails]
         for r in foreign_fails:
             v.info(f"[{source}] {code} : écart HORS tenant sur « {r.get('subject')} » (non gardé)")
 
@@ -210,7 +216,24 @@ def compare(expected, results, source, exit_code, outputs, prefix, owned=None):
         for s in want_silent:
             if s in failing:
                 v.problem(f"[{source}] {code} : le CONTRE-EXEMPLE « {s} » parle — la règle ne discrimine pas")
-        others = {r["status"] for r in got if r["status"] != "fail"}
+        # `inconclusive:` — les sujets du tenant sur lesquels la règle DIT ne pas savoir
+        # conclure (ADR-0015 : un finding inconcluant devient un not-evaluated à sujet).
+        # Chacun doit être là, et aucun autre sujet du tenant ne doit l'être.
+        want_inc = []
+        for s in want.get("inconclusive") or []:
+            r = resolve_subject(s, outputs)
+            if r is None:
+                v.problem(f"[{source}] {code} : sujet irrésoluble {s} (sortie Terraform absente)")
+            else:
+                want_inc.append(r)
+        inconclusive = {r.get("subject", "") for r in got
+                        if r["status"] == "not-evaluated" and tenant_subject(r.get("subject", ""), prefix, owned)}
+        for s in want_inc:
+            if s not in inconclusive:
+                v.problem(f"[{source}] {code} : attendu « ne sait pas conclure » sur « {s} », rien d'inconcluant")
+        for s in sorted(inconclusive - set(want_inc)):
+            v.problem(f"[{source}] {code} : « ne sait pas conclure » sur « {s} », que rien n'attend")
+        others = {r["status"] for r in got if r["status"] != "fail" and r.get("subject", "") not in inconclusive}
         if others and not tenant_fails and not foreign_fails:
             v.problem(f"[{source}] {code} : attendu des écarts, obtenu {published_status(got)}")
     return v
@@ -262,6 +285,7 @@ class Run:
         self.t0 = time.time()
         self.applied = False
         self.destroyed = False
+        self.wait_until = None
         self.tenant = yaml.safe_load((self.tenant_dir / "tenant.yaml").read_text())
         self.expected = yaml.safe_load((self.tenant_dir / "expected.yaml").read_text())
         self.outputs = {}
@@ -302,9 +326,18 @@ class Run:
 
     # ─── étapes ────────────────────────────────────────────────────────────
     def preflight(self):
-        for tool in ("terraform", "go", "scw"):
+        # Un tenant dont tenant.yaml dit `live: unavailable` n'a pas de compte : il
+        # s'éprouve en plan seul, et un run réel est REFUSÉ — il n'y aurait ni
+        # identité à confronter ni preuve de destruction possible.
+        self.no_account = str(self.tenant.get("live", "")).lower() == "unavailable"
+        if self.no_account and not self.plan_only:
+            raise StageFailed("REFUS : tenant.yaml déclare `live: unavailable` (aucun compte) — seul `--plan-only` est possible")
+        for tool in ("terraform", "go"):
             if not shutil.which(tool):
-                raise StageFailed(f"{tool} absent du PATH ({'chemin de secours du nettoyage' if tool == 'scw' else 'requis'})")
+                raise StageFailed(f"{tool} absent du PATH (requis)")
+        for tool in self.tenant.get("required_tools") or []:
+            if not shutil.which(tool):
+                raise StageFailed(f"{tool} absent du PATH (tenant.yaml `required_tools` : chemin de secours du nettoyage)")
         lock = self.tenant_dir / ".terraform.lock.hcl"
         want = str(self.tenant["provider_version"])
         if not lock.exists() or f'version     = "{want}"' not in lock.read_text() and f'version = "{want}"' not in lock.read_text():
@@ -315,26 +348,41 @@ class Run:
         return f"pepin {ver} · terraform {tf} · provider {want}"
 
     def identity(self):
+        """Le compte que les identifiants natifs ouvrent, demandé à l'API par le crochet
+        du tenant, confronté champ par champ à ce que l'environnement attend. Les champs
+        sont ceux qu'`expected.yaml` nomme (`organization_id`/`project_id` chez Scaleway,
+        `account_id` chez Outscale…) : le runner n'en connaît aucun par avance."""
+        if self.no_account:
+            (self.run_dir / "identity.json").write_text("{}")
+            return "sauté : aucun compte (tenant.yaml `live: unavailable`), plan seul"
         who = self.hook("identity")
+        (self.run_dir / "identity.json").write_text(json.dumps(who, indent=2, sort_keys=True))
         acct = self.compte_attendu()
-        if who["project_id"] != acct["project_id"] or who["organization_id"] != acct["organization_id"]:
-            raise StageFailed(
-                "REFUS : les identifiants natifs désignent le projet "
-                f"{who['project_id']} (org {who['organization_id']}), et le compte attendu est "
-                f"{acct['project_id']} (org {acct['organization_id']}). Rien n'a été appliqué.")
-        self.env["TF_VAR_project_id"] = acct["project_id"]
-        self.env["TF_VAR_organization_id"] = acct["organization_id"]
-        now = dt.datetime.now(dt.timezone.utc)
-        rfc = "%Y-%m-%dT%H:%M:%SZ"
-        self.env["TF_VAR_key_expires_at"] = (now + dt.timedelta(days=2)).strftime(rfc)
-        # La clé « expirée » : une échéance que l'apply précède et que le scan suit —
-        # le runner attend qu'elle soit passée. En mode plan seul, rien n'est appliqué
-        # et le scan du plan a lieu tout de suite : l'échéance est posée dans le passé.
-        self.key_expired_at = now + (dt.timedelta(minutes=3) if not self.plan_only else -dt.timedelta(minutes=1))
-        self.env["TF_VAR_key_expired_at"] = self.key_expired_at.strftime(rfc)
-        self.env["TF_VAR_bucket_policy_principal"] = who["principal"]
-        self.env["TF_VAR_rdb_password"] = secrets.token_urlsafe(24) + "Aa1!"
-        return f"compte confirmé par l'API : projet « {who.get('project_name')} » {who['project_id']} (porteur : {who['bearer']})"
+        for champ, attendu in acct.items():
+            observe = str(who.get(champ, ""))
+            if observe != attendu:
+                raise StageFailed(
+                    f"REFUS : les identifiants natifs désignent {champ}={observe or '?'}, et le "
+                    f"compte attendu est {champ}={attendu}. Rien n'a été appliqué.")
+            self.env[f"TF_VAR_{champ}"] = attendu
+        return "compte confirmé par l'API : " + ", ".join(f"{k}={v}" for k, v in acct.items()) \
+            + (f" ({who['label']})" if who.get("label") else "")
+
+    def variables(self):
+        """Les variables PROPRES au tenant (échéances, secrets jetables, principaux…),
+        calculées par son crochet `variables` et passées à Terraform par
+        l'environnement. Le crochet peut aussi demander une ATTENTE avant le scan
+        (`wait_until`, RFC 3339) : une clé qui doit être expirée au moment du scan,
+        par exemple. Rien de tout cela n'est écrit ni journalisé."""
+        got = self.hook("variables", "--plan-only" if self.plan_only else "--live", str(self.run_dir / "identity.json"))
+        for k, v in (got.get("tf_vars") or {}).items():
+            self.env[f"TF_VAR_{k}"] = str(v)
+        for k, v in (got.get("env") or {}).items():
+            self.env[k] = str(v)
+        self.wait_until = None
+        if got.get("wait_until"):
+            self.wait_until = dt.datetime.fromisoformat(got["wait_until"].replace("Z", "+00:00"))
+        return got.get("note") or f"{len(got.get('tf_vars') or {})} variable(s) posée(s)"
 
     def compte_attendu(self):
         """Le compte sur lequel la porte accepte de tourner, lu dans l'ENVIRONNEMENT.
@@ -350,14 +398,13 @@ class Run:
         appliquer un tenant délibérément fautif sur un compte non confirmé est
         exactement ce que cette étape existe pour empêcher.
         """
-        acct = self.expected["account"]
+        acct = self.expected.get("account") or {}
         out = {}
-        for champ in ("organization_id", "project_id"):
-            var = acct.get(f"{champ}_env")
-            if not var:
-                raise StageFailed(
-                    f"expected.yaml ne nomme pas la variable qui fournit {champ} "
-                    f"(clé attendue : {champ}_env)")
+        champs = [k[:-4] for k in acct if k.endswith("_env")]
+        if not champs:
+            raise StageFailed("expected.yaml ne nomme aucune variable de compte (clés `<champ>_env`)")
+        for champ in champs:
+            var = acct[f"{champ}_env"]
             val = os.environ.get(var, "").strip()
             if not val:
                 raise StageFailed(
@@ -368,6 +415,8 @@ class Run:
         return out
 
     def snapshot_before(self):
+        if self.no_account:
+            return "sauté : aucun compte, rien à inventorier"
         inv = self.hook("inventory", str(self.tenant_dir / "tenant.yaml"))
         (self.run_dir / "inventory-before.json").write_text(json.dumps(inv, indent=2, sort_keys=True))
         owned = {f: v["tenant"] for f, v in inv.items() if v["tenant"]}
@@ -379,7 +428,10 @@ class Run:
 
     def plan(self):
         state = self.run_dir / "terraform.tfstate"
-        self.sh(["terraform", "init", "-input=false", "-lockfile=readonly",
+        # `-reconfigure` : le backend local pointe vers le dossier du run ; un init
+        # précédent (à la main, dans le dossier du tenant) aurait laissé une autre
+        # configuration, et Terraform refuserait de la changer sans le dire.
+        self.sh(["terraform", "init", "-input=false", "-lockfile=readonly", "-reconfigure",
                  f"-backend-config=path={state}"], log="terraform-init.log")
         self.sh(["terraform", "validate"])
 
@@ -405,9 +457,19 @@ class Run:
                 self.outputs[name] = o["value"]
         note = f"plan complet : {sum(self.counts.values())} ressources (" + ", ".join(f"{t}×{n}" for t, n in sorted(self.counts.items())) + ")"
         if not self.plan_only:
-            _, self.counts_applied = one("applied", ["-var", "terraform_only_resources=false"], "tfplan.bin", "plan-applied.json")
+            _, self.counts_applied = one("applied", self.applied_vars(), "tfplan.bin", "plan-applied.json")
             note += f" ; plan appliqué : {sum(self.counts_applied.values())} ressources"
         return note
+
+    def applied_vars(self, extra=None):
+        """Les `-var` de la stack APPLIQUÉE (tenant.yaml `applied_vars`), plus ceux
+        d'une étape (pré-destroy). Le plan complet, lui, n'en reçoit aucun."""
+        vals = dict(self.tenant.get("applied_vars") or {})
+        vals.update(extra or {})
+        out = []
+        for k, v in vals.items():
+            out += ["-var", f"{k}={json.dumps(v) if isinstance(v, bool) else v}"]
+        return out
 
     def apply(self):
         self.applied = True  # dès qu'on tente : un apply à moitié fait se détruit aussi
@@ -418,19 +480,40 @@ class Run:
         (self.run_dir / "outputs.json").write_text(json.dumps(self.outputs, indent=2, sort_keys=True))
         return f"{len(self.outputs)} sorties capturées"
 
+    def extra_apply(self):
+        """Ce que Terraform ne sait pas exprimer chez ce fournisseur (un bucket OOS, une
+        politique EIM inline…), créé par le crochet `extra` du tenant, APRÈS l'apply et
+        à partir de ses sorties. Le crochet rend la liste de ce qu'il a créé ; la preuve
+        de destruction le relit comme le reste."""
+        self.extra_applied = True
+        got = self.hook("extra", "apply", str(self.run_dir / "outputs.json"))
+        created = got.get("created") or []
+        (self.run_dir / "extra.json").write_text(json.dumps(got, indent=2, sort_keys=True))
+        return f"{len(created)} ressource(s) hors Terraform" + (" : " + ", ".join(created[:8]) if created else "")
+
+    def extra_destroy(self):
+        got = self.hook("extra", "destroy", str(self.run_dir / "outputs.json"))
+        left = got.get("left") or []
+        if left:
+            raise StageFailed("le crochet n'a pas pu supprimer : " + ", ".join(left))
+        return f"{len(got.get('deleted') or [])} ressource(s) hors Terraform supprimée(s)"
+
     def scan(self, args, out, log):
         r = self.sh([str(self.pepin), "scan", self.provider, *args], cwd=ROOT, check=False)
         (self.run_dir / out).write_text(r.stdout)
         (self.run_dir / log).write_text(r.stderr)
         return r.returncode
 
-    def wait_for_expiry(self):
-        """La clé « expirée » doit l'être AVANT le scan : on attend l'échéance, plus une marge."""
-        target = self.key_expired_at + dt.timedelta(seconds=20)
+    def wait_for(self):
+        """Ce que le crochet `variables` a demandé d'attendre avant de scanner (une
+        échéance de clé, par exemple), plus une marge."""
+        if not self.wait_until:
+            return "rien à attendre"
+        target = self.wait_until + dt.timedelta(seconds=20)
         delay = (target - dt.datetime.now(dt.timezone.utc)).total_seconds()
         if delay > 0:
             time.sleep(delay)
-        return f"échéance {self.key_expired_at.strftime('%H:%M:%SZ')} passée" + (f" (attente {round(delay)}s)" if delay > 0 else "")
+        return f"échéance {self.wait_until.strftime('%H:%M:%SZ')} passée" + (f" (attente {round(delay)}s)" if delay > 0 else "")
 
     def scan_live(self):
         region = self.tenant["region"]
@@ -472,13 +555,21 @@ class Run:
     def destroy(self):
         if not self.applied:
             return "rien n'a été appliqué"
-        r = self.sh(["terraform", "destroy", "-input=false", "-auto-approve"], check=False, log="terraform-destroy.log")
-        note = f"terraform destroy rc={r.returncode}"
+        note = ""
+        # Ce qu'il faut DÉFAIRE avant de détruire : une protection contre la suppression
+        # (Outscale refuse de supprimer une VM protégée, provider #88) se lève par un
+        # apply, jamais par le destroy. tenant.yaml le déclare (`pre_destroy_vars`).
+        pre = self.tenant.get("pre_destroy_vars") or {}
+        if pre:
+            r0 = self.sh(["terraform", "apply", "-input=false", "-auto-approve", *self.applied_vars(pre)], check=False, log="terraform-pre-destroy.log")
+            note += f"pré-destroy ({', '.join(f'{k}={v}' for k, v in pre.items())}) rc={r0.returncode} ; "
+        r = self.sh(["terraform", "destroy", "-input=false", "-auto-approve", *self.applied_vars(pre)], check=False, log="terraform-destroy.log")
+        note += f"terraform destroy rc={r.returncode}"
         if r.returncode != 0:
             print("  ✘ destroy en échec : nettoyage de secours par l'API, puis second destroy")
             rescue = subprocess.run([sys.executable, str(self.tenant_dir / "hooks.py"), "cleanup",
                                      str(self.tenant_dir / "tenant.yaml")], cwd=ROOT, env=self.env)
-            r2 = self.sh(["terraform", "destroy", "-input=false", "-auto-approve", "-refresh=true"], check=False, log="terraform-destroy-2.log")
+            r2 = self.sh(["terraform", "destroy", "-input=false", "-auto-approve", "-refresh=true", *self.applied_vars(pre)], check=False, log="terraform-destroy-2.log")
             note += f" ; cleanup rc={rescue.returncode} ; second destroy rc={r2.returncode}"
         left = self.sh(["terraform", "state", "list"], check=False).stdout.strip().splitlines()
         self.destroy_finished = time.time()
@@ -494,22 +585,51 @@ class Run:
         return note + f" ; état vide ; {purged} fichier(s) d'état purgé(s)"
 
     def leftovers(self):
-        inv = self.hook("inventory", str(self.tenant_dir / "tenant.yaml"))
-        (self.run_dir / "inventory-after.json").write_text(json.dumps(inv, indent=2, sort_keys=True))
         before = json.loads((self.run_dir / "inventory-before.json").read_text())
-        owned = {f: v["tenant"] for f, v in inv.items() if v["tenant"]}
-        delta = {}
-        for f, v in inv.items():
-            new = sorted(set(v["all"]) - set(before.get(f, {}).get("all", [])))
-            if new:
-                delta[f] = new
+
+        def measure():
+            inv = self.hook("inventory", str(self.tenant_dir / "tenant.yaml"))
+            owned = {f: v["tenant"] for f, v in inv.items() if v["tenant"]}
+            delta = {}
+            for f, v in inv.items():
+                new = sorted(set(v["all"]) - set(before.get(f, {}).get("all", [])))
+                if new:
+                    delta[f] = new
+            return inv, owned, delta
+
+        # Une suppression est ASYNCHRONE chez plus d'un fournisseur : mesuré chez Outscale,
+        # load balancers, volumes et snapshots restaient listés 26 s après un destroy
+        # réussi et « n'existaient plus » deux minutes plus tard. Le vide se constate
+        # donc en relisant, bornée : ce qui reste au bout du délai est un reste.
+        deadline = time.time() + (self.tenant.get("settle_seconds") or 240)
+        waited = 0
+        while True:
+            inv, owned, delta = measure()
+            if not owned and not delta or time.time() >= deadline:
+                break
+            time.sleep(20)
+            waited += 20
+        (self.run_dir / "inventory-after.json").write_text(json.dumps(inv, indent=2, sort_keys=True))
         self.leftover_report = {"tagged": owned, "delta": delta}
         if owned or delta:
+            # Un reste est un défaut du chemin de destruction, donc un NO-GO. Mais il
+            # coûte à l'heure : le crochet de nettoyage est tenté sur ce qui porte le tag
+            # ET sur ce qui est apparu pendant le run, puis le compte est relu.
+            (self.run_dir / "leftovers.json").write_text(json.dumps(self.leftover_report, indent=2, sort_keys=True))
+            rescue = subprocess.run([sys.executable, str(self.tenant_dir / "hooks.py"), "cleanup",
+                                     str(self.tenant_dir / "tenant.yaml"), str(self.run_dir / "leftovers.json")], cwd=ROOT, env=self.env)
+            after = self.hook("inventory", str(self.tenant_dir / "tenant.yaml"))
+            still = {f: v["tenant"] for f, v in after.items() if v["tenant"]}
+            still_delta = {f: sorted(set(v["all"]) - set(before.get(f, {}).get("all", []))) for f, v in after.items()}
+            still_delta = {f: v for f, v in still_delta.items() if v}
+            self.leftover_report["after_cleanup"] = {"tagged": still, "delta": still_delta, "cleanup_rc": rescue.returncode}
             raise StageFailed("RESTES après destroy — " + "; ".join(
                 [f"{f} (tag) : {[x['id'] for x in v]}" for f, v in owned.items()]
-                + [f"{f} (delta) : {v}" for f, v in delta.items()]))
+                + [f"{f} (delta) : {v}" for f, v in delta.items()])
+                + (" — nettoyage de secours : compte propre" if not still and not still_delta
+                   else f" — nettoyage de secours INCOMPLET : {still} {still_delta}"))
         families = sum(1 for _ in inv)
-        return f"{families} familles listées, aucune ressource du tenant, aucun delta avant/après"
+        return f"{families} familles listées, aucune ressource du tenant, aucun delta avant/après" + (f" (après {waited}s de suppressions asynchrones)" if waited else "")
 
     def compare_all(self):
         prefix = self.tenant["name_prefix"]
@@ -588,16 +708,20 @@ class Run:
         try:
             ok &= self.stage("préflight : outils, lockfile, binaire", self.preflight)
             ok = ok and self.stage("identité : le compte que les identifiants désignent", self.identity)
+            ok = ok and self.stage("variables du tenant", self.variables)
             ok = ok and self.stage("inventaire AVANT", self.snapshot_before)
             ok = ok and self.stage("plan", self.plan)
             if ok and not self.plan_only:
                 ok = ok and self.stage("apply", self.apply)
-                ok = ok and self.stage("attente de l'échéance de la clé expirée", self.wait_for_expiry)
+                ok = ok and self.stage("hors Terraform : ce que le crochet crée", self.extra_apply)
+                ok = ok and self.stage("attente demandée par le tenant", self.wait_for)
                 ok = ok and self.stage("scan --live, 5 formats, bundle scellé", self.scan_live)
                 ok = ok and self.stage("bundle : verify --re-derive, refus de l'altération", self.bundle)
             if ok:
                 ok = ok and self.stage("scan --terraform sur le même plan", self.scan_terraform)
         finally:
+            if getattr(self, "extra_applied", False):
+                ok = self.stage("hors Terraform : ce que le crochet supprime", self.extra_destroy) and ok
             if self.applied:
                 ok = self.stage("destroy", self.destroy) and ok
                 ok = self.stage("preuve de destruction : listing par famille + delta", self.leftovers) and ok
@@ -633,6 +757,7 @@ def selftest():
             "e_na": {"live": "not-applicable"},
             "f_absent": {"live": "absent"},
             "g_defect": {"live": {"fail": ["pepin-qual-vm-defect"], "known_defect": "#0 exemple"}},
+            "h_inc": {"live": {"fail": ["pepin-qual-vm-prod"], "inconclusive": ["pepin-qual-vm-noenv"]}},
         },
     }
     good = [
@@ -642,6 +767,8 @@ def selftest():
         {"control": "d_eval", "status": "fail", "subject": "someone@example.org"},
         {"control": "e_na", "status": "not-applicable", "subject": "scaleway"},
         {"control": "g_defect", "status": "fail", "subject": "pepin-qual-vm-defect"},
+        {"control": "h_inc", "status": "fail", "subject": "pepin-qual-vm-prod"},
+        {"control": "h_inc", "status": "not-evaluated", "subject": "pepin-qual-vm-noenv"},
     ]
 
     def mutate(fn):
@@ -664,6 +791,8 @@ def selftest():
         ("« evaluated » refuse un not-evaluated", expected, mutate(lambda r: r.__setitem__(3, {"control": "d_eval", "status": "not-evaluated", "subject": "scaleway"})), 1, False),
         ("« absent » refuse un contrôle qui apparaît", expected, good + [{"control": "f_absent", "status": "pass", "subject": "scaleway"}], 1, False),
         ("un défaut connu corrigé rend NO-GO (la correction se dit)", expected, mutate(lambda r: r.__setitem__(5, {"control": "g_defect", "status": "pass", "subject": "scaleway"})), 1, False),
+        ("un inconcluant attendu qui disparaît rend NO-GO", expected, mutate(lambda r: r.__setitem__(7, {"control": "h_inc", "status": "fail", "subject": "pepin-qual-vm-noenv"})), 1, False),
+        ("un inconcluant que rien n'attend rend NO-GO", expected, good + [{"control": "a_fail", "status": "not-evaluated", "subject": "pepin-qual-vm-x"}], 1, False),
     ]
     failures = 0
     for case in cases:


### PR DESCRIPTION
Closes #198. Stage 3 of the release gate (#178) now covers the three providers.

## What a release can be validated against

- **Outscale** — 79 Terraform resources, plus 6 OOS buckets and one inline EIM policy
  through the `extra` hook (the provider has neither). Applied, scanned in five formats,
  sealed, verified, re-scanned as a plan, **destroyed**, compared to `expected.yaml`.
- **Exoscale** — **plan only** (`live: unavailable`, a real run is refused). 37
  resources pinning the Terraform source of 26 controls. No account was available, and
  the READMEs say so rather than implying live coverage.
- **Scaleway** — replayed live after the runner was made generic: **GO**, 0.0035 EUR.

The runner is now provider-agnostic: identity fields named by `expected.yaml`,
`variables`/`extra` hooks, `applied_vars`/`pre_destroy_vars`, bounded re-listing for
asynchronous deletions, `inconclusive:` and `absent` statuses. `qualify:selftest` is at
**17 cases**, wired into `prepush`.

## Nothing was left behind

Run 4 (GO) applied: 10 SGs + 14 rules, 8 VMs, 2 NICs, 4 IPs, 2 volumes (+8 tagged root
volumes), 2 snapshots, 2 OMIs, 2 Nets, 2 subnets, IGW/route, 1 peering, 2 LBUs, 1 user,
3 keys (INACTIVE), 5 policies, 2 API access rules, 6 buckets, 1 inline policy.

Proof: `terraform destroy` rc 0, state purged, **20 families read through the API with
zero tenant resources and zero delta** before/after, `octl` confirming. Both accounts are
clean. Cost: **≈ 0.30 EUR** over four runs (three applies, two of which failed and were
destroyed).

## What the provider does on destroy, measured rather than assumed

Issues read and linked in the tenant README: **#88** (a protected VM cannot be
destroyed — worked around with `pre_destroy_vars`), **#28/#137** (`nic_private_ip`,
avoided), **#778/#424/#50/#448** (`nics` blocks; the maintainers' workaround
`outscale_nic` + `nic_link` is the one used), #622, #663, #6.

And four things measured on four runs that no issue told us:

- **an accepted peering survives `terraform destroy` rc 0** — the destroy reports
  success and the resource is still there; caught by the rescue path, and worth
  reporting upstream;
- `DeleteImage` does not delete the implicit snapshot of an OMI created from a VM (OMIs
  are now built from the managed snapshot);
- deletions are **asynchronous** — LBUs, volumes and snapshots still listed 26 s after a
  successful destroy, gone two minutes later;
- `LinkPublicIp` by `VmId` is refused on a two-NIC VM: the IP must precede the second
  card.

## The gate says NO-GO

Committed file → GO. Two expectations broken (`public_ip_with_open_securitygroup: pass`,
`iam_no_root_access_key: not-evaluated`) → **NO-GO on 2 differences**, named on the
two-NIC VM and the root key. Plus 3+3 automatic mutations per run.

## No account identifier is committed

`expected.yaml` names the variable (`PEPIN_QUAL_OSC_ACCOUNT`), not the value — this
repository is public, and an identifier published does not get unpublished. **A missing
variable is a refusal, never a pass**, measured on this branch:

```
✘ REFUS : la variable PEPIN_QUAL_OSC_ACCOUNT n'est pas posée, donc le compte attendu
  est inconnu. Rien n'a été appliqué.
```

## What this tenant found

Three defects, filed with reproductions: **#201** (P0 — a `pass` nothing establishes: a
rule without a description gets `network_flow_matrix_documented = pass`; **I reproduced
it independently before relaying it**), **#202** (two controls that can never fire on
Exoscale are declared ✅), **#203** (13 controls `not-evaluated` on Outscale plans for
attributes the plan does carry).

That is what a qualification tenant is for: the audit that motivated #178 found five such
defects by hand in a day.

## Not done, and why

Exoscale's live half (no account; the hooks refuse it explicitly), cross-account peering,
a key older than 90 days, account singletons (MFA, expiry ceiling — forcing them would
lock out the very key that qualifies), the LBU access-log and default-SG
counterexamples, OKS, a non-EU region. All recorded in `tenant.yaml` rather than left
implicit.

## Gates

`prepush` green on a full clone. `TestGeneratedDocsAreUpToDate` diverges in a linked
worktree only (the provenance digest is not redacted there); **this branch touches no Go
file at all**, so it cannot move that output.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)
