### PR TITLE
fix(rules): a rule without a description is a deviation, not a pass

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -88,6 +88,19 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Une règle de security group sans description obtenait `pass` — du contrôle qui
+  existe pour attraper exactement ça.** La règle se gardait par
+  `"description" in object.keys(...)`, censé répondre « ce fournisseur expose-t-il le
+  champ », mais posé **par ressource**. Sur un plan Terraform, un exploitant qui n'écrit
+  aucune description ne produit tout simplement pas le champ : la règle se taisait — et
+  le silence devenait un `pass`, le verrou de capacité voyant `description` collectée
+  sur le type (une autre règle la portait) et laissant l'assessment conclure faute de
+  finding. Un `pass` que rien n'établissait, sur l'écart même que le contrôle vise. La
+  question se pose désormais à l'échelle de l'**inventaire** : si une règle porte la
+  clé, le fournisseur expose le champ, et une règle qui n'en a pas n'est pas
+  documentée. Aucune règle ne lit la provenance — l'ADR-0017 l'interdit — et le
+  contre-exemple que la garde d'origine protégeait tient toujours : un fournisseur qui
+  n'expose ce champ nulle part ne déclenche rien.
 - **Un sujet fautif par plusieurs voies ne se lit plus comme plusieurs écarts.** Trois
   blocs `deny` d'`objectstorage_bucket_public_access` — ACL prédéfinie, grant, politique
   de bucket — concluent sur le même bucket, et chaque cause est réelle. Mais un bucket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,18 @@ belongs in `git log`.
 
 ### Fixed
 
+- **A security group rule with no description got `pass` — from the control that
+  exists to catch exactly that.** The rule guarded itself with `"description" in
+  object.keys(...)`, meant to answer "does this provider expose the field at all", but
+  asked **per resource**. On a Terraform plan an operator who writes no description
+  simply produces no field, so the rule stayed silent — and the silence became a
+  `pass`, because the capability lock saw `description` collected on the type (another
+  rule carried it) and let the assessment conclude with no finding. A `pass` nothing
+  established, on the very deviation the control targets. The question is now asked of
+  the **inventory**: if any rule carries the key, the provider exposes the field, and a
+  rule without one is undocumented. No rule reads the provenance — ADR-0017 forbids it —
+  and the counterexample the original guard protected still holds: a provider that
+  exposes the field nowhere still fires nothing.
 - **A subject at fault by several routes no longer reads as several deviations.** Three
   `deny` blocks of `objectstorage_bucket_public_access` — a canned ACL, a grant, a bucket
   policy — conclude on the same bucket, and each cause is real. But a public bucket is

--- a/internal/assess/attested_absence_test.go
+++ b/internal/assess/attested_absence_test.go
@@ -193,7 +193,7 @@ func TestNoRuleReadsProvenance(t *testing.T) {
 			t.Fatalf("lecture de %s : %v", e.Name(), err)
 		}
 		lues++
-		if strings.Contains(string(b), "provenance") {
+		if strings.Contains(codeSansCommentaires(string(b)), "provenance") {
 			t.Errorf("%s lit `provenance`.\n"+
 				"  L'ADR-0007 a choisi un index PARALLÈLE pour que l'entrée des règles ne bouge\n"+
 				"  pas, et l'ADR-0017 n'a levé cette borne pour personne : la distinction\n"+
@@ -205,4 +205,41 @@ func TestNoRuleReadsProvenance(t *testing.T) {
 		t.Fatal("aucune règle lue : la garde ne mesure rien")
 	}
 	t.Logf("%d fichier(s) de règles vérifié(s)", lues)
+}
+
+// codeSansCommentaires retire les commentaires Rego avant de chercher un accès.
+//
+// La garde cherchait le MOT dans tout le fichier, commentaires compris. Elle a donc
+// rougi sur une règle dont le commentaire expliquait qu'elle ne lit PAS la
+// provenance — et l'incitation qui en découle est mauvaise : pour rester vert, un
+// auteur devrait éviter de nommer l'invariant qu'il respecte, donc renoncer à
+// l'expliquer là où il compte.
+//
+// Retirer les commentaires RESSERRE la garde plutôt que de la relâcher : un
+// commentaire ne lit rien, et tout accès réel reste dans le code. Rego commente du
+// `#` à la fin de ligne, et il n'y a pas de forme block, donc la coupe est exacte.
+func codeSansCommentaires(src string) string {
+	var b strings.Builder
+	for _, ligne := range strings.Split(src, "\n") {
+		if i := strings.Index(ligne, "#"); i >= 0 {
+			ligne = ligne[:i]
+		}
+		b.WriteString(ligne)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// TestTheProvenanceGuardStillCatchesARealAccess : une garde assouplie doit prouver
+// qu'elle mord encore. Celle-ci ignore désormais les commentaires ; si elle ignorait
+// aussi le code, elle passerait en ne mesurant rien.
+func TestTheProvenanceGuardStillCatchesARealAccess(t *testing.T) {
+	hostile := "package pepin.rules\n\n# ceci ne lit pas la provenance\ndeny contains x if {\n\tsome r in input.resources\n\tr.provenance.description.observed\n\tx := 1\n}\n"
+	if !strings.Contains(codeSansCommentaires(hostile), "provenance") {
+		t.Error("la garde ne verrait plus un accès RÉEL à la provenance")
+	}
+	commentaire := "package pepin.rules\n\n# la provenance ne se lit pas ici, et c'est le sujet\ndeny contains x if { x := 1 }\n"
+	if strings.Contains(codeSansCommentaires(commentaire), "provenance") {
+		t.Error("la garde rougit encore sur un simple commentaire")
+	}
 }

--- a/internal/commonrules/rules/network_flow_matrix_documented.rego
+++ b/internal/commonrules/rules/network_flow_matrix_documented.rego
@@ -1,8 +1,28 @@
 # Matrice des flux documentée : chaque flux entrant autorisé (règle de security
 #   group) doit porter une justification. Type normalisé `security_group_rule`,
 #   attribut `description` (justification du flux). Ne se déclenche que pour les
-#   providers qui exposent ce champ (la clé `description` est présente) — un
-#   provider sans description par règle ne déclenche pas la règle.
+#   providers qui exposent ce champ — un provider sans description par règle ne
+#   déclenche pas la règle.
+#
+# # Le faux vert que ce contrôle a produit, et ce qui le corrigeait mal
+#
+# La garde « ce provider expose-t-il le champ » était écrite `"description" in
+# object.keys(r.attributes)` : un test PAR RESSOURCE répondant à une question PAR
+# FOURNISSEUR. Sur un plan, une règle dont l'exploitant n'a écrit aucune description
+# n'a tout simplement pas la clé — donc la règle se taisait sur l'écart même qu'elle
+# existe pour attraper.
+#
+# Et le silence devenait un VERT. Le verrou de capacité voyait `description`
+# collectée sur le type (une autre règle la portait, et la provenance attestait
+# qu'on l'avait cherchée sur celle-ci), il levait donc la garde, et l'assessment
+# concluait `pass` faute de finding. Un `pass` que rien n'établissait.
+#
+# La question se pose donc à l'échelle de l'INVENTAIRE : si une seule règle porte une
+# description, le fournisseur expose le champ, et une règle qui n'en a pas n'est pas
+# documentée. Aucune provenance n'est lue — l'ADR-0017 l'interdit aux règles — et la
+# distinction que la garde d'origine cherchait est préservée : un fournisseur qui
+# n'expose ce champ nulle part ne déclenche toujours rien, et c'est alors au verrou
+# de capacité de dire « non évalué » plutôt qu'à la règle de conclure.
 # Ancrage Exoscale : Security Group rule `description` (max 255), schéma
 #   reference-api-schemas-security-group-rule. SCSL : CLD-NET-5 (matrice des flux
 #   autorisés — services/protocoles/ports + justification).
@@ -13,7 +33,7 @@ import rego.v1
 deny contains f if {
 	some r in resources_of_type("security_group_rule")
 	object.get(r.attributes, "direction", "inbound") == "inbound"
-	"description" in object.keys(r.attributes) # provider exposant la justification
+	_description_exposee # le FOURNISSEUR expose la justification (cf. en-tête)
 	object.get(r.attributes, "description", "") == ""
 	port := object.get(r.attributes, "port_from", "?")
 	f := {
@@ -30,4 +50,24 @@ deny contains f if {
 			"remediation_en": "Document every security group rule (service, reason) in its description; keep the flow matrix up to date.",
 		},
 	}
+}
+
+# _description_exposee — ce fournisseur expose-t-il une description par règle ?
+#
+# Vrai dès qu'UNE règle de l'inventaire porte la CLÉ, vide ou non. C'est la seule
+# forme sous laquelle la question se laisse poser sans lire la provenance : le champ
+# existe chez ce fournisseur si on l'a vu au moins une fois.
+#
+# La clé PRÉSENTE ET VIDE compte, et c'est le contre-exemple qui l'a imposé : une
+# règle dont l'exploitant a effacé la description prouve à elle seule que le champ
+# existe. Ne compter que les descriptions non vides rendait la règle muette sur un
+# inventaire d'une seule règle non documentée — soit exactement le cas qu'elle vise.
+#
+# Sa limite est réelle et assumée : un inventaire où le champ n'apparaît NULLE PART
+# ne permet pas de trancher, et la règle s'y tait. Ce n'est pas un silence de plus —
+# le verrou de capacité exige `description` sur le type, et rend « non évalué ». Le
+# faux vert, lui, a disparu.
+_description_exposee if {
+	some r in resources_of_type("security_group_rule")
+	"description" in object.keys(r.attributes)
 }

--- a/internal/commonrules/rules/network_flow_matrix_documented_test.rego
+++ b/internal/commonrules/rules/network_flow_matrix_documented_test.rego
@@ -24,3 +24,55 @@ test_flow_egress_ok if {
 test_flow_no_description_field_ok if {
 	count({f | some f in deny; f.code == "network_flow_matrix_documented"}) == 0 with input as _rule({"direction": "inbound", "port_from": 22})
 }
+
+# ── LE FAUX VERT (#201), et ce qui le tenait ────────────────────────────────────
+
+_deux_regles(a, b) := {"resources": [
+	{"provider": "exoscale", "type": "security_group_rule", "id": "sg-doc", "attributes": a},
+	{"provider": "exoscale", "type": "security_group_rule", "id": "sg-nodoc", "attributes": b},
+]}
+
+_net5 := "network_flow_matrix_documented"
+
+# ✗ Une règle SANS clé `description`, à côté d'une règle qui en porte une. C'est le
+# cas d'un plan Terraform : l'exploitant qui n'écrit pas de description ne produit
+# tout simplement pas le champ.
+#
+# La garde d'origine testait la clé SUR LA RESSOURCE, donc elle se taisait — et le
+# silence devenait un `pass`, le verrou de capacité voyant l'attribut collecté sur le
+# type. Un `pass` que rien n'établissait, sur l'écart même que ce contrôle vise.
+test_a_rule_without_the_key_is_denied_when_the_provider_exposes_it if {
+	fs := {f |
+		some f in deny with input as _deux_regles(
+			{"direction": "inbound", "port_from": 443, "description": "HTTPS public"},
+			{"direction": "inbound", "port_from": 22},
+		)
+		f.code == _net5
+	}
+	count(fs) == 1
+	some f in fs
+	f.subject == "sg-nodoc"
+}
+
+# LE CONTRE-EXEMPLE que la garde d'origine protégeait, et qui doit tenir : un
+# fournisseur qui n'expose ce champ NULLE PART ne déclenche rien. Sans lui, la
+# correction échangerait un faux vert contre une pluie de faux positifs sur les deux
+# fournisseurs qui n'ont pas de description par règle.
+test_a_provider_without_the_field_anywhere_stays_silent if {
+	count({f |
+		some f in deny with input as _deux_regles(
+			{"direction": "inbound", "port_from": 443},
+			{"direction": "inbound", "port_from": 22},
+		)
+		f.code == _net5
+	}) == 0
+}
+
+# La clé PRÉSENTE ET VIDE prouve à elle seule que le champ existe : un inventaire
+# d'une seule règle non documentée doit rougir. Ne compter que les descriptions non
+# vides rendait la règle muette sur exactement le cas qu'elle vise — c'est le test
+# `test_flow_undocumented_denied` qui l'a attrapé.
+test_an_empty_description_alone_proves_the_field_exists if {
+	some f in deny with input as {"resources": [{"provider": "exoscale", "type": "security_group_rule", "id": "sg-1", "attributes": {"direction": "inbound", "port_from": 443, "description": ""}}]}
+	f.code == _net5
+}


### PR DESCRIPTION
Closes #201 (P0). Found by the Outscale qualification tenant, **reproduced independently before being touched**:

| input | verdict before | after |
|---|---|---|
| description absent, provenance attesting it was sought | **`pass`** | `fail` |
| same, no provenance | `not-evaluated` | `not-evaluated` |

## Two mechanisms, each right, composing into a lie

The rule guarded itself with `"description" in object.keys(r.attributes)`. That guard
means *"does this provider expose the field at all"* — a good question, since two of the
three providers have no description per rule and firing on them would be a flood of false
positives. **But it was asked per resource, while the question is per provider.**

On a Terraform plan, an operator who writes no description simply produces no field. The
rule stayed silent on the very deviation it targets — and the silence became a `pass`,
because the capability lock saw `description` collected on the type (another rule carried
it, and provenance attested it had been sought on this one) and let the assessment
conclude with no finding.

Neither mechanism is broken. Their composition is. That is the class this wave is about,
and it is why the qualification tenant exists: no existing gate could see it.

## The fix

The question is asked of the **inventory**: if any rule carries the key, the provider
exposes the field, and a rule without one is undocumented. **No rule reads the
provenance** — ADR-0017 forbids it — and the counterexample the original guard protected
still holds, with its own test: a provider that exposes the field nowhere fires nothing,
and the capability lock says `not-evaluated` there rather than the rule concluding.

**My first version counted only non-empty descriptions, and the existing test caught it.**
A single rule whose description was emptied is proof enough that the field exists; counting
only non-empty ones made the rule mute on exactly the case it targets.

## One guard tightened rather than obeyed

`TestNoRuleReadsProvenance` searched the word across the whole file, comments included, so
it went red on a comment explaining that the rule does **not** read provenance. The
incentive that creates is bad: to stay green, an author would have to avoid naming the
invariant they respect — precisely where it deserves explaining.

Stripping comments makes the guard **more precise, not laxer** — a comment reads nothing,
and Rego has no block comments — and a second test proves it still catches a real
`r.provenance.description.observed` access.

## Impact ADR

- **ADR-0017** (provenance attests a search) — invariant *"aucune règle ne lit la
  provenance"* respected; its guard is now precise instead of textual.
- **ADR-0006** (never an unproven `pass`) — this is the repair of a violation of it.

## Measured

361 Rego tests (was 358). **Zero verdict movement** on the reference corpus: no tenant
there has a rule with the key absent next to one carrying it — which is exactly why this
survived until a qualification tenant looked.

`mise run prepush` green.

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)