### PR TITLE
feat(release): Exoscale qualification tenant, live half, applied then destroyed

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -33,6 +33,27 @@ l'une ni l'autre appartient au `git log`.
   effectives. Exoscale : plan seul, 37 ressources, sans compte — la source Terraform
   est épinglée, la moitié live attend un compte.
 
+- **Tenant de qualification Exoscale, moitié live** (issue #198) : 40 ressources dans
+  le plan complet, 39 appliquées (le quota de l'organisation est de quatre instances ;
+  l'instance suisse n'est que sur le plan, par `terraform_only_resources`), plus 3
+  buckets SOS créés par le crochet `extra` (dont un avec Object Lock, par l'API S3),
+  appliqués, scannés en `--live` dans les cinq formats, scellés, détruits et prouvés
+  détruits sur deux zones (15 familles d'API + buckets, delta avant/après).
+  L'organisation attendue vient de `PEPIN_QUAL_EXO_ORG`, confirmée par
+  `GET /api-key/{key}` → `org-id` avant tout apply. Ce que la passe live a trouvé,
+  épinglé tel que mesuré et consigné : SOS accepte `PutBucketTagging` et ne persiste
+  rien (#208, tout bucket SOS échoue `governance_resource_required_tags`) ;
+  `kubernetes_cluster_audit_logging_enabled` passe en live sur un cluster dont l'audit
+  est désactivé (#209, faux vert : l'API rend `audit: {}` et `audit_enabled` est dérivé
+  de `audit.endpoint`) ; `region` n'est projetée sur aucune ressource live (#210,
+  `governance_resource_region_in_eu` not-evaluated) ; les labels des instances ne sont
+  pas collectés en live (#211, une instance sans étiquette passe) ; une instance privée
+  n'a pas de groupe de sécurité par construction (#212, `compute_instance_has_security_group`
+  parle avec une remédiation inexécutable) ; chaque cluster SKS crée un rôle IAM
+  `sks-ccm-*` qui échoue deux contrôles `iam_role_*` (#213). Les deux changements de
+  règle de #206 sont épinglés : `…_all_ports` est `not-applicable` chez Exoscale,
+  `network_securitygroup_unrestricted_egress` échoue sur `tcp 1-65535`.
+
 - **Un tenant de qualification, appliqué et détruit sur un compte réel** (issue #178,
   étape 3). `PEPIN_GATE_LIVE=1 mise run qualify` applique la stack Terraform committée
   sous `references/qualification/scaleway/` — 40 ressources dans le plan, dont 29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,26 @@ belongs in `git log`.
   provider #88) and re-lists until deletions settle. Exoscale: plan-only, 37 resources,
   no account — the Terraform source is pinned, the live half waits for an account.
 
+- **Exoscale qualification tenant, live half** (issue #198): 40 resources in the full
+  plan, 39 applied (the organisation's quota is four instances; the Swiss instance is
+  plan-only through `terraform_only_resources`) plus 3 SOS buckets created by the
+  `extra` hook (one of them with Object Lock, through the S3 API), applied, scanned
+  `--live` in five formats, sealed, destroyed and proven destroyed across two zones
+  (15 API families + buckets, before/after delta). The expected organisation comes
+  from `PEPIN_QUAL_EXO_ORG` and is confirmed by `GET /api-key/{key}` → `org-id`
+  before any apply. What the live pass found, pinned as measured and filed: SOS
+  accepts `PutBucketTagging` and persists nothing (#208, every SOS bucket fails
+  `governance_resource_required_tags`); `kubernetes_cluster_audit_logging_enabled`
+  passes live on a cluster whose audit is disabled (#209, false green: the API returns
+  `audit: {}` and `audit_enabled` is derived from `audit.endpoint`); `region` is
+  projected on no live resource (#210, `governance_resource_region_in_eu`
+  not-evaluated); instance labels are not collected live (#211, an untagged instance
+  passes); a private instance carries no security group by construction (#212,
+  `compute_instance_has_security_group` fires with an impossible remediation); every
+  SKS cluster creates an `sks-ccm-*` IAM role that fails two `iam_role_*` controls
+  (#213). The two rule changes of #206 are pinned: `…_all_ports` is `not-applicable`
+  on Exoscale, `network_securitygroup_unrestricted_egress` fails on `tcp 1-65535`.
+
 - **A qualification tenant, applied and destroyed on a real account** (issue #178,
   stage 3). `PEPIN_GATE_LIVE=1 mise run qualify` applies the Terraform stack committed
   under `references/qualification/scaleway/` — 40 resources in the plan, 29 of them

--- a/references/qualification/exoscale/README.fr.md
+++ b/references/qualification/exoscale/README.fr.md
@@ -1,67 +1,168 @@
 > [🇬🇧 English](README.md) · 🇫🇷 Français
 
-# Tenant de qualification Exoscale (source Terraform seulement)
+# Tenant de qualification Exoscale
 
-**Aucun compte Exoscale n'est disponible.** Ce tenant se qualifie donc en
-`--plan-only` : 37 ressources sont planifiées, rien n'est créé, et
-[`expected.yaml`](expected.yaml) épingle ce que `pepin scan exoscale --terraform`
-rend sur ce plan — le chemin qu'un utilisateur suit sans compte
-([ADR-0012](../../docs/adr/0012-aucun-identifiant-en-ci.md) le préfère). Cela a déjà
-de la valeur : les verdicts Terraform de 26 contrôles sont fixés, avec leurs
-contre-exemples.
-
-Ce qu'il ne fait **pas**, et le dit (`tenant.yaml` : `live: unavailable`) :
-appliquer, scanner en `--live`, sceller un bundle, détruire, prouver la destruction.
-`mise run qualify` sur ce tenant est refusé ; `mise run qualify:plan`
-(`PROVIDER=exoscale`) est le seul mode. [`hooks.py`](hooks.py) fournit les
-identifiants factices qu'un plan exige et refuse tout le reste. La lecture des
-issues de `exoscale/terraform-provider-exoscale` sur `destroy` est due avant le
-premier apply, pas avant le premier plan.
+Une organisation Exoscale délibérément fautive : **une faute par ressource, un
+contre-exemple par contrôle**, appliquée sur un compte réel, scannée en `--live` dans
+les cinq formats, scellée, vérifiée, rescannée en `--terraform` sur le même plan,
+détruite, prouvée détruite, et comparée à [`expected.yaml`](expected.yaml). Toute
+différence est NO-GO. La doctrine et le runner sont décrits dans
+[`../README.fr.md`](../README.fr.md) ; ce qui suit est ce qui est propre à Exoscale.
 
 ```bash
-PROVIDER=exoscale mise run qualify:plan
+PROVIDER=exoscale mise run qualify:plan                       # plan + scan --terraform, rien n'est créé
+PEPIN_GATE_LIVE=1 PROVIDER=exoscale mise run qualify           # apply, scan, scelle, détruit, prouve, compare
 ```
 
-## Ce que le plan porte
+Le compte se confirme avant tout apply : l'API rattache la clé à une organisation
+(`GET /api-key/{key}` → `org-id` — `GET /organization` est refusé à une clé dont le
+rôle ne couvre pas l'organisation, et une clé de qualification n'a aucune raison de le
+couvrir), et cet identifiant doit être égal à **`PEPIN_QUAL_EXO_ORG`**. La variable
+absente est un refus, rien n'est appliqué
+([ADR-0012](../../docs/adr/0012-aucun-identifiant-en-ci.md) : aucun identifiant de
+compte n'est committé). Les identifiants natifs sont ceux de `~/.config/exoscale/exoscale.toml`
+ou de `EXOSCALE_API_KEY`/`EXOSCALE_API_SECRET` ; le provider Terraform ne lisant pas le
+fichier, le crochet `variables` les lui passe par l'environnement du run, sans les
+écrire.
+
+## Ce que la stack crée
 
 | Famille | Nombre | Ressource fautive → contrôle | Contre-exemple (doit rester muet) |
 |---|---:|---|---|
-| Groupes de sécurité | 9 (+ 15 règles) | `ssh_open` → `…tcp_port_22` · `rdp_open` → `…tcp_port_3389` · `db_open` (5432) → `…high_risk_tcp_ports` · `snmp_open` (UDP 161) → `…high_risk_udp_ports` · `any_open` (tout TCP et tout UDP) → les quatre précédents · `quartet` (quatre `/2`) → `…tcp_port_22` par évasion · `undocumented_flow` (règle sans description, port 443) → `network_flow_matrix_documented` | `hardened` (SSH depuis `10.0.0.0/8`, HTTPS depuis Internet, sortie TCP 443, chaque flux décrit) |
+| Groupes de sécurité | 9 (+ 15 règles) | `ssh_open` → `…tcp_port_22` · `rdp_open` → `…tcp_port_3389` · `db_open` (5432) → `…high_risk_tcp_ports` · `snmp_open` (UDP 161) → `…high_risk_udp_ports` · `any_open` (tout TCP et tout UDP) → les quatre précédents · `quartet` (quatre `/2`) → `…tcp_port_22` par évasion · `egress_any` (sortie TCP 1-65535 vers Internet) → `network_securitygroup_unrestricted_egress` · `undocumented_flow` (règle sans description, port 443) → `network_flow_matrix_documented` | `hardened` (SSH depuis `10.0.0.0/8`, HTTPS depuis Internet, sortie TCP 443, chaque flux décrit) |
 | Réseaux privés | 2 | `undocumented` → `network_documented` | `documented` (Owner, Project, Env, description) |
-| Instances | 4 | `untagged` → `governance_resource_required_tags` · `secrets` (cloud-init avec mot de passe) → `compute_instance_no_secrets_in_user_data` · `swiss` (zone `ch-gva-2`) → `governance_resource_region_in_eu` (low : hors UE, espace européen de confiance) | `hardened` (étiquetée, `de-fra-1`, cloud-init anodin) |
-| Volume block storage | 1 | — (chiffré par construction : `blockstorage_volume_encryption` passe) | — |
-| Clusters SKS | 2 | `weak` (`starter`, sans auto-upgrade, audit désactivé) → `kubernetes_cluster_control_plane_highly_available`, `…auto_upgrade_enabled`, `…audit_logging_enabled` | `strong` (`pro`, auto-upgrade, endpoint d'audit) |
+| Instances | 4 appliquées + 1 sur le plan | `exposed` (IP publique, SSH ouvert) → `compute_instance_public_ip_with_open_securitygroup` · `untagged` → `governance_resource_required_tags` · `secrets` (cloud-init avec mot de passe) → `compute_instance_no_secrets_in_user_data` · `swiss` (zone `ch-gva-2`, **plan seulement**) → `governance_resource_region_in_eu` (low : hors UE, espace européen de confiance) | `hardened` (IP publique derrière un groupe fermé, étiquetée, `de-fra-1`, cloud-init anodin) ; `untagged` est aussi le contre-exemple de NET-3 : même SSH ouvert qu'`exposed`, mais `private = true`, donc sans IP publique |
+| Volumes block storage | 2 (+ 1 snapshot) | `unsnapshotted` (attaché à `secrets`, jamais sauvegardé) → `blockstorage_volume_snapshots_exist` | `snapshotted` (attaché à `hardened`, une snapshot terminée du jour) ; les deux chiffrés par construction (`blockstorage_volume_encryption` passe) |
+| Clusters SKS | 2, sans nodepool | `weak` (`starter`, sans auto-upgrade, audit désactivé) → `kubernetes_cluster_control_plane_highly_available`, `…auto_upgrade_enabled`, `…audit_logging_enabled` | `strong` (`pro`, auto-upgrade, endpoint d'audit) |
 | Rôles IAM | 4 | `admin` (`allow` par défaut) → `iam_role_no_admin_privileges` · `no_source_ip` → `iam_role_source_ip_restricted` · `unbounded` (sans `duration(`) → `iam_role_key_lifetime_bounded` | `restricted` (`deny` par défaut, `source_ip`, `duration(`) |
+| Buckets SOS (crochet `extra`, hors Terraform) | 3 | `public` (ACL `public-read`) → `objectstorage_bucket_public_access` · `unversioned` → `objectstorage_bucket_versioning_enabled` · `public` et `unversioned` (sans verrou) → `objectstorage_bucket_object_lock_enabled` | `hardened` (privé, créé avec Object Lock — par l'API S3, `exo storage` ne le sait pas —, donc versionné) |
 | Fournisseur | — | `governance_provider_sovereignty` échoue sur `exoscale` lui-même : siège en Suisse, contrôle capitalistique extra-UE — des faits du descripteur, pas du tenant | — |
+
+Ce qui est propre à Exoscale, et qui a dessiné cette stack :
+
+- **Quatre instances.** C'est le quota de l'organisation (`GET /quota` : `instance` 4),
+  découvert au premier apply (`Usage of resource 'instance' has been exceeded`, deux
+  instances refusées, tout le reste détruit et prouvé détruit). D'où un contre-exemple
+  porté par une ressource déjà fautive ailleurs (`untagged`, privée), un volume fautif
+  porté par `secrets`, et `swiss` sur le plan seulement (`terraform_only_resources`,
+  que le runner passe à `false` pour appliquer).
+- **Une zone scannée.** Les ressources sont zonales et `scan --live --region de-fra-1`
+  ne lit que cette zone : une instance de `ch-gva-2` lui serait invisible, et
+  `governance_resource_region_in_eu` n'est prouvé en écart que sur le plan. L'inventaire
+  de la preuve de destruction, lui, parcourt les deux zones (`zones:` de `tenant.yaml`).
+- **Pas de protocole « tout ».** Une règle de groupe n'accepte que `tcp`, `udp`,
+  `icmp`, `icmpv6`, `ah`, `esp`, `gre`, `ipip` (provider 0.71.0 et API v2).
+  `network_securitygroup_allow_ingress_from_internet_to_all_ports` est donc **non
+  applicable** chez Exoscale (#202, #206) — `any_open` ouvre tout TCP et tout UDP, et
+  ce sont les quatre contrôles par famille de ports qui parlent. La sortie « tout »
+  s'écrit `tcp 1-65535 → 0.0.0.0/0`, et `network_securitygroup_unrestricted_egress`
+  reconnaît cette forme (#206) : `egress_any` est un écart.
+- **Les buckets SOS ne s'étiquettent pas.** SOS accepte `PutBucketTagging` (200, par
+  SigV4 comme par la CLI `aws`) et ne persiste rien : `GetBucketTagging` rend
+  `NoSuchTagSet` juste après. Un bucket SOS n'a donc jamais d'étiquette, quoi qu'on
+  fasse, et `governance_resource_required_tags` échoue sur les trois buckets **par
+  construction** — épinglé tel que mesuré dans `expected.yaml`, faux positif non
+  remédiable, issue #208.
+- **Un cluster SKS crée un rôle IAM `sks-ccm-<cluster>`** (éditable, `deny` par
+  défaut, sans borne d'origine ni de durée) et le supprime avec lui : chaque cluster
+  apporte deux écarts `iam_role_*` par construction, hors tenant ici (sujets non
+  préfixés), rapportés et non gardés — issue #213. Le rôle de la clé qui
+  qualifie (`deny` par défaut, sans règle CEL) porte les mêmes deux écarts.
+- **Une instance privée n'a pas de groupe de sécurité.** `private = true`
+  (`public-ip-assignment: none`) : l'API ignore les groupes déclarés et rend
+  `security-groups: []`. `compute_instance_has_security_group` en fait un écart, avec
+  une remédiation inexécutable — épinglé tel que mesuré sur `untagged`, issue
+  #212.
+- **Faux vert live sur l'audit SKS.** L'API rend `audit: {}` pour un cluster dont
+  l'audit est désactivé ; la collecte dérive `audit_enabled` de `audit.endpoint`,
+  absent, ne projette rien sur `weak`, et `kubernetes_cluster_audit_logging_enabled`
+  conclut `pass` sur le seul cluster observé (`observed=1/2`) — le plan, lui, échoue
+  sur `weak`. Épinglé comme **défaut connu** (#209) ; la correction fera
+  rougir cette porte sciemment.
+- **Faux vert live sur l'étiquetage des instances.** La collecte live ne projette pas
+  `labels` sur les instances, volumes et clusters (le contrat les dit `a_verifier`) ;
+  seuls les buckets portent `tags`, la règle saute le reste en silence, et `untagged`
+  passe — issue #211. Le plan, lui, l'attrape.
+- **`region` n'est projetée sur rien en live** : `governance_resource_region_in_eu`
+  rend `not-evaluated` sur toute organisation Exoscale (dette de collecte nommée,
+  ADR-0010, issue #210).
+
+## Ce que le provider amont est connu pour laisser derrière lui au `destroy`
+
+Lu avant de choisir les types de ressources, dans `exoscale/terraform-provider-exoscale`
+(0.71.0 épinglé, lockfile committé). Ce que chacune a changé dans cette stack :
+
+| Amont | État | Ce que ça fait | Ce que ce tenant en fait |
+|---|---|---|---|
+| [#453](https://github.com/exoscale/terraform-provider-exoscale/issues/453) le provider ne détache pas avant de supprimer (IP élastiques, groupes de sécurité) ; [#537](https://github.com/exoscale/terraform-provider-exoscale/issues/537) `Cannot delete group when it's in use by virtual machines` | #453 fermée 2025-08 (IP corrigée en 0.69.2, [#460](https://github.com/exoscale/terraform-provider-exoscale/pull/460)) ; #537 ouverte | Un groupe référencé par une instance ne se détruit ni ne se renomme. | Aucune IP élastique ; chaque groupe n'est attaché qu'à des instances Terraform, détruites d'abord par dépendance. Le nettoyage de secours supprime les instances, attend, puis les groupes. |
+| [#375](https://github.com/exoscale/terraform-provider-exoscale/issues/375) une instance trop petite pour un volume block storage disparaît de l'état (`Instance size must be at least small`) | ouverte | Une instance `micro` avec `block_storage_volume_ids` est créée, puis perdue par Terraform : un reste. | Les deux instances qui portent un volume sont `standard.small` (`instance_type_with_volume`). |
+| [#207](https://github.com/exoscale/terraform-provider-exoscale/issues/207) le destroy n'attend pas les ressources dépendantes ; [#210](https://github.com/exoscale/terraform-provider-exoscale/issues/210) un NLB créé par le CCM d'un cluster SKS survit au destroy ; [#240](https://github.com/exoscale/terraform-provider-exoscale/issues/240) destroy d'un cluster en `context deadline exceeded` | fermées (2022-2023) | Ce qu'un cluster crée hors Terraform lui survit. | Clusters **sans nodepool** et `create_default_security_group = false` : rien n'est créé hors Terraform, et l'inventaire liste NLB, pools et groupes pour le prouver. |
+| [#438](https://github.com/exoscale/terraform-provider-exoscale/issues/438) `aws_s3_bucket` ne termine jamais sur SOS | fermée 2025-06 | Un bucket par le provider `aws` n'est ni fiable ni détruit proprement. | Les buckets passent par `exo storage` (CLI de référence) et l'API S3, hors Terraform, dans le crochet `extra` ; supprimés récursivement et relistés. |
+| [#76](https://github.com/exoscale/terraform-provider-exoscale/issues/76) destroy en échec après suppression manuelle d'un réseau privé | fermée 2020 | — | Rien n'est supprimé à la main pendant un run ; le nettoyage de secours ne s'exécute qu'après le destroy. |
+| Mesuré ici : **`GET /private-network` sur `api-de-fra-1` reste parfois sans réponse** (une fois sur trois ou quatre), puis répond en 0,2 s | à signaler en amont | Un listing de preuve qui rendrait « inconnu » sur un aléa. | Le crochet réessaie trois fois (60 s de délai) avant de conclure. |
+| Mesuré ici : **SOS active le versioning d'un bucket créé avec Object Lock** | — | Le contre-exemple des buckets est versionné par construction. | `hardened` sert de contre-exemple aux trois contrôles de bucket. |
+| Mesuré ici : **le quota `instance` compte encore, plusieurs minutes après un destroy réussi, des instances qu'aucun listing ne montre** (`GET /quota` : usage 2, 0 instance listée, 5 min après) | à signaler à Exoscale | L'apply suivant est refusé (`Usage of resource 'instance' has been exceeded`) alors que le compte est vide : un run 4 l'a subi. | Le crochet `variables` attend (borné à 15 min) que le compteur retombe à zéro avant que le runner n'applique. |
+| Mesuré ici (une fois, sur un cluster hors tenant) : **la clé d'API `sks-ccm-<cluster>` que SKS crée pour le CCM a survécu une vingtaine de minutes à son cluster** ; son rôle, lui, était supprimé, et `DELETE /api-key` répondait 403 `API Key not in organization`, par l'API comme par `exo iam api-key delete` ; elle a fini par disparaître d'elle-même | — (suppression asynchrone, côté plateforme) | Pendant ce délai, une clé inerte (son rôle n'existe plus) est listée, et l'organisation ne peut pas la retirer. Les clusters du tenant n'en ont laissé aucune dans la fenêtre de la preuve (delta `api_keys` vide à chaque run). | L'inventaire liste les clés d'API : une survivante apparaît dans le delta, et le nettoyage de secours tente la suppression et dit le 403 sans bloquer. |
+
+La preuve de destruction liste 15 familles par l'API v2 (instances, réseaux privés,
+volumes, snapshots, clusters SKS, IP élastiques, pools d'instances, NLB, modèles
+privés, clés SSH, groupes d'anti-affinité, groupes de sécurité, rôles IAM, clés d'API)
+et les buckets par `exo storage list`, dans les deux zones, filtrées sur l'étiquette et
+le préfixe du tenant, et compare le listing entier à celui pris avant apply. `exo`, la
+CLI de référence du fournisseur, est ce qu'un mainteneur rejoue à la main :
+
+```bash
+exo compute instance list -O table
+exo compute security-group list -O table
+exo compute private-network list -O table
+exo compute block-storage list -O table
+exo compute block-storage snapshot list -O table
+exo compute sks list -O table
+exo compute elastic-ip list -O table
+exo iam role list -O table
+exo iam api-key list -O table
+exo storage list -O table
+```
+
+Chaque commande liste toutes les zones par défaut (`-z` pour une seule).
 
 ## Ce que ce tenant ne peut pas exercer, et pourquoi
 
-- **`network_securitygroup_allow_ingress_from_internet_to_all_ports` et
-  `network_securitygroup_unrestricted_egress` ne peuvent pas se déclencher chez
-  Exoscale**, sur aucune source : une règle de groupe n'a pas de protocole « tout »
-  (`tcp`, `udp`, `icmp`, `icmpv6`, `ah`, `esp`, `gre`, `ipip` seulement, provider
-  0.71.0 et API), et les deux règles communes exigent `protocol == all`. `any_open`
-  ouvre tout TCP et tout UDP, les quatre autres contrôles d'entrée parlent ; ces deux-là
-  sont épinglés `pass` par absence, ce que le référentiel et la matrice de couverture
-  devraient cesser de présenter comme de la couverture (#202).
-- **`network_flow_matrix_documented` rend `pass` sur un plan dont la règle
-  `undocumented_flow` n'a pas de description** : une description non écrite est
-  *calculée* sur un plan, l'attribut n'est pas projeté, la garde de capacité se tait,
-  et l'assessment conclut « conforme » — le faux vert que l'intersection de
-  l'[ADR-0006](../../docs/adr/0006-jamais-un-pass-non-prouve.md) existe pour empêcher.
-  Épinglé comme **défaut connu** (#201) ; la correction fera rougir cette porte
-  sciemment.
-- L'IP publique d'une instance et l'état d'usage d'un volume sont calculés à
-  l'apply : `compute_instance_public_ip_with_open_securitygroup` et
-  `blockstorage_volume_snapshots_exist` attendent la moitié live.
-- Buckets SOS : le provider n'a pas de ressource de bucket (`exoscale_sos_bucket_policy`
-  seulement) ; ils seront créés par un crochet `extra`, comme chez Outscale, quand un
-  compte existera.
-- Les utilisateurs IAM sont des personnes réelles, pas des ressources Terraform.
+`tenant.yaml`, `not_exercised:` — `…_all_ports` (non applicable : aucun protocole
+« tout »), `governance_resource_region_in_eu` en live (`region` non collectée ; et une
+seule zone lue, quatre instances au quota), le MFA des utilisateurs (des personnes), les
+écarts du rôle de la clé qui qualifie et des rôles `sks-ccm-*`, l'étiquetage des
+buckets SOS (impossible par construction), la souveraineté du fournisseur (un fait du
+descripteur).
+
+## Coût et budget
+
+Tarifs horaires dans [`tenant.yaml`](tenant.yaml), lus sur l'API de tarification du
+portail (EUR) : 2 × `standard.micro` à 0,0073 EUR/h, 2 × `standard.small` à 0,0233 EUR/h,
+40 Go de disque local et 30 Go de block storage à 0,00014 EUR/Go/h, un plan de contrôle
+SKS Pro à 0,055 EUR/h (Starter est gratuit) — environ **0,13 EUR par heure** de vie du
+tenant. Budget : 20 minutes mur, sinon NO-GO.
 
 ## Mesuré
 
-Run plan seul (`PROVIDER=exoscale mise run qualify:plan`) : 37 ressources planifiées,
-`scan --terraform` en code 1, 26 contrôles épinglés sur la source Terraform, GO, avec
-une attente cassée en mémoire qui rend NO-GO. Rien de créé, rien à détruire, aucun
-coût.
+<!-- qualification:measured -->
+Run du 2026-09-09 (`GO`), sur l'organisation que l'environnement nomme :
+
+| | |
+|---|---|
+| Ressources | 40 dans le plan complet, 39 appliquées (`swiss` n'est que sur le plan), plus 3 ressource(s) hors Terraform : pepin-qual-<org>-public, pepin-qual-<org>-unversioned, pepin-qual-<org>-hardened |
+| `apply` | 40.6 s |
+| `scan --live` × 5 formats + scellement | 11.3 s, code de sortie 1 dans chaque format |
+| bundle | `verify --re-derive` passe ; le bundle altéré d'un octet est refusé |
+| `scan --terraform` | code de sortie 1 |
+| `destroy` | 50.7 s — terraform destroy rc=0 ; état vide ; 2 fichier(s) d'état purgé(s) |
+| preuve de destruction | 15 familles listées, aucune ressource du tenant, aucun delta avant/après |
+| comparaison | live : 46 résultats, 0 différence ; terraform : 37 résultats, 0 différence |
+| falsification | 3 attentes cassées en mémoire sur chaque source, toutes NO-GO |
+| durée mur | 183.8 s (budget 20 min) |
+| coût estimé | 0.0037 EUR (0.029 h × 0.126 EUR/h) |
+
+Écarts hors tenant rapportés par le scan live et non gardés : 7
+(l'utilisateur de l'organisation sans MFA, le rôle de la clé qui qualifie et les deux rôles
+`sks-ccm-*` des clusters, sans borne d'origine ni de durée — #213).
+<!-- /qualification:measured -->

--- a/references/qualification/exoscale/README.md
+++ b/references/qualification/exoscale/README.md
@@ -1,63 +1,167 @@
 > 🇬🇧 English · [🇫🇷 Français](README.fr.md)
 
-# Exoscale qualification tenant (Terraform source only)
+# Exoscale qualification tenant
 
-**No Exoscale account is available.** This tenant is therefore qualified in
-`--plan-only` mode: 37 resources are planned, nothing is created, and
-[`expected.yaml`](expected.yaml) pins what `pepin scan exoscale --terraform` returns
-on that plan — the path a user follows without an account
-([ADR-0012](../../docs/adr/0012-aucun-identifiant-en-ci.md) prefers it). That already
-has value: it fixes the Terraform verdicts of 26 controls, with counterexamples.
-
-What it does **not** do, and says so (`tenant.yaml`: `live: unavailable`): apply,
-`scan --live`, seal a bundle, destroy, prove the destruction. `mise run qualify` on this
-tenant is refused; `mise run qualify:plan` (`PROVIDER=exoscale`) is the only mode.
-[`hooks.py`](hooks.py) provides the placeholder credentials a plan needs and refuses
-everything else. Reading the `exoscale/terraform-provider-exoscale` issues on `destroy`
-is due before the first apply, not before the first plan.
+A deliberately faulty Exoscale organisation: **one fault per resource, one
+counterexample per control**, applied on a real account, scanned `--live` in all five
+formats, sealed, verified, rescanned `--terraform` on the same plan, destroyed, proven
+destroyed, and compared with [`expected.yaml`](expected.yaml). Any difference is NO-GO.
+The doctrine and the runner are described in [`../README.md`](../README.md); what
+follows is what is specific to Exoscale.
 
 ```bash
-PROVIDER=exoscale mise run qualify:plan
+PROVIDER=exoscale mise run qualify:plan                       # plan + scan --terraform, nothing is created
+PEPIN_GATE_LIVE=1 PROVIDER=exoscale mise run qualify           # apply, scan, seal, destroy, prove, compare
 ```
 
-## What the plan carries
+The account is confirmed before any apply: the API binds the key to an organisation
+(`GET /api-key/{key}` → `org-id` — `GET /organization` is refused to a key whose role
+does not cover the organisation, and a qualification key has no reason to), and that
+identifier must equal **`PEPIN_QUAL_EXO_ORG`**. A missing variable is a refusal,
+nothing is applied ([ADR-0012](../../docs/adr/0012-aucun-identifiant-en-ci.md): no
+account identifier is committed). The native credentials are those of
+`~/.config/exoscale/exoscale.toml` or `EXOSCALE_API_KEY`/`EXOSCALE_API_SECRET`; since
+the Terraform provider does not read the file, the `variables` hook hands them to it
+through the run environment, without writing them.
+
+## What the stack creates
 
 | Family | Count | Faulty resource → control | Counterexample (must stay silent) |
 |---|---:|---|---|
-| Security groups | 9 (+ 15 rules) | `ssh_open` → `…tcp_port_22` · `rdp_open` → `…tcp_port_3389` · `db_open` (5432) → `…high_risk_tcp_ports` · `snmp_open` (UDP 161) → `…high_risk_udp_ports` · `any_open` (all TCP and all UDP ports) → the four above · `quartet` (four `/2`) → `…tcp_port_22` by evasion · `undocumented_flow` (a rule without description, on port 443) → `network_flow_matrix_documented` | `hardened` (SSH from `10.0.0.0/8`, HTTPS from anywhere, egress TCP 443, every flow described) |
+| Security groups | 9 (+ 15 rules) | `ssh_open` → `…tcp_port_22` · `rdp_open` → `…tcp_port_3389` · `db_open` (5432) → `…high_risk_tcp_ports` · `snmp_open` (UDP 161) → `…high_risk_udp_ports` · `any_open` (all TCP and all UDP) → the four above · `quartet` (four `/2`) → `…tcp_port_22` by evasion · `egress_any` (egress TCP 1-65535 to the Internet) → `network_securitygroup_unrestricted_egress` · `undocumented_flow` (a rule without description, port 443) → `network_flow_matrix_documented` | `hardened` (SSH from `10.0.0.0/8`, HTTPS from anywhere, egress TCP 443, every flow described) |
 | Private networks | 2 | `undocumented` → `network_documented` | `documented` (Owner, Project, Env, description) |
-| Instances | 4 | `untagged` → `governance_resource_required_tags` · `secrets` (cloud-init with a password) → `compute_instance_no_secrets_in_user_data` · `swiss` (zone `ch-gva-2`) → `governance_resource_region_in_eu` (low: outside the EU, inside the European trusted area) | `hardened` (labelled, `de-fra-1`, plain cloud-init) |
-| Block storage volume | 1 | — (encrypted by construction: `blockstorage_volume_encryption` passes) | — |
-| SKS clusters | 2 | `weak` (`starter`, no auto-upgrade, audit disabled) → `kubernetes_cluster_control_plane_highly_available`, `…auto_upgrade_enabled`, `…audit_logging_enabled` | `strong` (`pro`, auto-upgrade, audit endpoint) |
+| Instances | 4 applied + 1 on the plan | `exposed` (public IP, open SSH) → `compute_instance_public_ip_with_open_securitygroup` · `untagged` → `governance_resource_required_tags` · `secrets` (cloud-init with a password) → `compute_instance_no_secrets_in_user_data` · `swiss` (zone `ch-gva-2`, **plan only**) → `governance_resource_region_in_eu` (low: outside the EU, inside the European trusted area) | `hardened` (public IP behind a closed group, labelled, `de-fra-1`, plain cloud-init); `untagged` is also the NET-3 counterexample: the same open SSH group as `exposed`, but `private = true`, hence no public IP |
+| Block storage volumes | 2 (+ 1 snapshot) | `unsnapshotted` (attached to `secrets`, never backed up) → `blockstorage_volume_snapshots_exist` | `snapshotted` (attached to `hardened`, one completed snapshot of the day); both encrypted by construction (`blockstorage_volume_encryption` passes) |
+| SKS clusters | 2, no nodepool | `weak` (`starter`, no auto-upgrade, audit disabled) → `kubernetes_cluster_control_plane_highly_available`, `…auto_upgrade_enabled`, `…audit_logging_enabled` | `strong` (`pro`, auto-upgrade, audit endpoint) |
 | IAM roles | 4 | `admin` (`allow` by default) → `iam_role_no_admin_privileges` · `no_source_ip` → `iam_role_source_ip_restricted` · `unbounded` (no `duration(`) → `iam_role_key_lifetime_bounded` | `restricted` (`deny` by default, `source_ip`, `duration(`) |
+| SOS buckets (`extra` hook, outside Terraform) | 3 | `public` (ACL `public-read`) → `objectstorage_bucket_public_access` · `unversioned` → `objectstorage_bucket_versioning_enabled` · `public` and `unversioned` (no lock) → `objectstorage_bucket_object_lock_enabled` | `hardened` (private, created with Object Lock — through the S3 API, `exo storage` cannot —, hence versioned) |
 | Provider | — | `governance_provider_sovereignty` fails on `exoscale` itself: head office in Switzerland, decisive non-EU capital control — facts of the descriptor, not of the tenant | — |
+
+What is specific to Exoscale, and shaped this stack:
+
+- **Four instances.** That is the organisation's quota (`GET /quota`: `instance` 4),
+  discovered at the first apply (`Usage of resource 'instance' has been exceeded`, two
+  instances refused, everything else destroyed and proven destroyed). Hence a
+  counterexample carried by a resource already faulty elsewhere (`untagged`, private),
+  a faulty volume carried by `secrets`, and `swiss` on the plan only
+  (`terraform_only_resources`, which the runner sets to `false` to apply).
+- **One zone scanned.** Resources are zonal and `scan --live --region de-fra-1` reads
+  that zone only: an instance in `ch-gva-2` would be invisible to it, and
+  `governance_resource_region_in_eu` is proven to fail on the plan only. The inventory
+  of the destruction proof, on the other hand, walks both zones (`zones:` in
+  `tenant.yaml`).
+- **No "all protocols".** A group rule accepts only `tcp`, `udp`, `icmp`, `icmpv6`,
+  `ah`, `esp`, `gre`, `ipip` (provider 0.71.0 and API v2).
+  `network_securitygroup_allow_ingress_from_internet_to_all_ports` is therefore **not
+  applicable** on Exoscale (#202, #206) — `any_open` opens all TCP and all UDP, and the
+  four port-family controls fire. "All egress" is written `tcp 1-65535 → 0.0.0.0/0`,
+  and `network_securitygroup_unrestricted_egress` recognises that form (#206):
+  `egress_any` is a deviation.
+- **SOS buckets cannot be tagged.** SOS accepts `PutBucketTagging` (200, through SigV4
+  as through the `aws` CLI) and persists nothing: `GetBucketTagging` returns
+  `NoSuchTagSet` right after. An SOS bucket therefore never has a tag, whatever one
+  does, and `governance_resource_required_tags` fails on the three buckets **by
+  construction** — pinned as measured in `expected.yaml`, an unfixable false positive,
+  issue #208.
+- **An SKS cluster creates an IAM role `sks-ccm-<cluster>`** (editable, `deny` by
+  default, no source-IP nor lifetime bound) and deletes it with the cluster: every
+  cluster brings two `iam_role_*` deviations by construction, outside the tenant here
+  (unprefixed subjects), reported and not gated — issue #213. The role of the
+  qualifying key (`deny` by default, no CEL rule) carries the same two deviations.
+- **A private instance has no security group.** `private = true`
+  (`public-ip-assignment: none`): the API ignores the declared groups and returns
+  `security-groups: []`. `compute_instance_has_security_group` turns that into a
+  deviation with an impossible remediation — pinned as measured on `untagged`, issue
+  #212.
+- **Live false green on SKS audit.** The API returns `audit: {}` for a cluster whose
+  audit is disabled; the collector derives `audit_enabled` from `audit.endpoint`,
+  absent, projects nothing on `weak`, and `kubernetes_cluster_audit_logging_enabled`
+  concludes `pass` on the only cluster observed (`observed=1/2`) — the plan fails on
+  `weak`. Pinned as a **known defect** (#209); the fix will turn this gate
+  NO-GO on purpose.
+- **Live false green on instance tagging.** The live collector does not project
+  `labels` on instances, volumes and clusters (the contract says `a_verifier`); only
+  buckets carry `tags`, the rule silently skips the rest, and `untagged` passes — issue
+  #211. The plan catches it.
+- **`region` is projected on nothing live**: `governance_resource_region_in_eu`
+  renders `not-evaluated` on every Exoscale organisation (a named collection debt,
+  ADR-0010, issue #210).
+
+## What the upstream provider is known to leave behind on `destroy`
+
+Read before choosing the resource types, in `exoscale/terraform-provider-exoscale`
+(0.71.0 pinned, lockfile committed). What each one changed in this stack:
+
+| Upstream | State | What it does | What this tenant does about it |
+|---|---|---|---|
+| [#453](https://github.com/exoscale/terraform-provider-exoscale/issues/453) the provider does not detach before deleting (elastic IPs, security groups); [#537](https://github.com/exoscale/terraform-provider-exoscale/issues/537) `Cannot delete group when it's in use by virtual machines` | #453 closed 2025-08 (IP fixed in 0.69.2, [#460](https://github.com/exoscale/terraform-provider-exoscale/pull/460)); #537 open | A group referenced by an instance neither destroys nor renames. | No elastic IP; each group is attached to Terraform instances only, destroyed first by dependency. The rescue cleanup deletes the instances, waits, then the groups. |
+| [#375](https://github.com/exoscale/terraform-provider-exoscale/issues/375) an instance too small for a block storage volume disappears from the state (`Instance size must be at least small`) | open | A `micro` instance with `block_storage_volume_ids` is created, then lost by Terraform: a leftover. | The two instances carrying a volume are `standard.small` (`instance_type_with_volume`). |
+| [#207](https://github.com/exoscale/terraform-provider-exoscale/issues/207) destroy does not wait for dependent resources; [#210](https://github.com/exoscale/terraform-provider-exoscale/issues/210) an NLB created by an SKS cluster's CCM survives the destroy; [#240](https://github.com/exoscale/terraform-provider-exoscale/issues/240) cluster destroy in `context deadline exceeded` | closed (2022-2023) | What a cluster creates outside Terraform outlives it. | Clusters **without nodepool** and `create_default_security_group = false`: nothing is created outside Terraform, and the inventory lists NLBs, pools and groups to prove it. |
+| [#438](https://github.com/exoscale/terraform-provider-exoscale/issues/438) `aws_s3_bucket` never finishes on SOS | closed 2025-06 | A bucket through the `aws` provider is neither reliable nor cleanly destroyed. | Buckets go through `exo storage` (the reference CLI) and the S3 API, outside Terraform, in the `extra` hook; deleted recursively and re-listed. |
+| [#76](https://github.com/exoscale/terraform-provider-exoscale/issues/76) destroy fails after a private network was removed by hand | closed 2020 | — | Nothing is removed by hand during a run; the rescue cleanup only runs after the destroy. |
+| Measured here: **`GET /private-network` on `api-de-fra-1` sometimes never answers** (one call in three or four), then answers in 0.2 s | to report upstream | A proof listing that would return "unknown" on a glitch. | The hook retries three times (60 s timeout) before concluding. |
+| Measured here: **SOS enables versioning on a bucket created with Object Lock** | — | The buckets' counterexample is versioned by construction. | `hardened` is the counterexample of all three bucket controls. |
+| Measured here: **the `instance` quota still counts, minutes after a successful destroy, instances no listing shows** (`GET /quota`: usage 2, 0 instances listed, 5 min later) | to report to Exoscale | The next apply is refused (`Usage of resource 'instance' has been exceeded`) on an empty account: run 4 hit it. | The `variables` hook waits (15 min at most) for the counter to fall back to zero before the runner applies. |
+| Measured here (once, on a cluster outside the tenant): **the `sks-ccm-<cluster>` API key SKS creates for the CCM outlived its cluster by some twenty minutes**; its role was deleted, and `DELETE /api-key` answered 403 `API Key not in organization`, through the API as through `exo iam api-key delete`; it eventually vanished on its own | — (asynchronous deletion, platform side) | Meanwhile an inert key (its role no longer exists) is listed, and the organisation cannot remove it. The tenant's own clusters left none within the proof's window (empty `api_keys` delta on every run). | The inventory lists API keys: a survivor shows up in the delta, and the rescue cleanup attempts the deletion and reports the 403 without blocking. |
+
+The destruction proof lists 15 families through API v2 (instances, private networks,
+volumes, snapshots, SKS clusters, elastic IPs, instance pools, NLBs, private templates,
+SSH keys, anti-affinity groups, security groups, IAM roles, API keys) and the buckets
+through `exo storage list`, in both zones, filtered on the tenant's label and prefix,
+and compares the whole listing with the one taken before apply. `exo`, the provider's
+reference CLI, is what a maintainer replays by hand:
+
+```bash
+exo compute instance list -O table
+exo compute security-group list -O table
+exo compute private-network list -O table
+exo compute block-storage list -O table
+exo compute block-storage snapshot list -O table
+exo compute sks list -O table
+exo compute elastic-ip list -O table
+exo iam role list -O table
+exo iam api-key list -O table
+exo storage list -O table
+```
+
+Each command lists every zone by default (`-z` for one).
 
 ## What this tenant cannot exercise, and why
 
-- **`network_securitygroup_allow_ingress_from_internet_to_all_ports` and
-  `network_securitygroup_unrestricted_egress` cannot fire on Exoscale**, on either
-  source: a security group rule has no "all protocols" value (`tcp`, `udp`, `icmp`,
-  `icmpv6`, `ah`, `esp`, `gre`, `ipip` only, provider 0.71.0 and the API), and both
-  common rules require `protocol == all`. `any_open` opens every TCP and UDP port and
-  the four other ingress controls fire; these two are pinned `pass` by absence, which
-  the referentiel and the coverage matrix should stop presenting as coverage (#202).
-- **`network_flow_matrix_documented` returns `pass` on a plan whose `undocumented_flow`
-  rule has no description**: a description that is not written is *computed* on a
-  plan, so the attribute is not projected, the capability guard stays silent, and the
-  assessment concludes "compliant" — the false green [ADR-0006](../../docs/adr/0006-jamais-un-pass-non-prouve.md)'s
-  intersection exists to prevent. Pinned as a **known defect** (#201); the fix will
-  turn this gate NO-GO on purpose.
-- The public IP of an instance and the attachment state of a volume are computed at
-  apply: `compute_instance_public_ip_with_open_securitygroup` and
-  `blockstorage_volume_snapshots_exist` wait for the live half.
-- SOS buckets: the provider has no bucket resource (`exoscale_sos_bucket_policy`
-  only); they will be created by an `extra` hook, as on Outscale, when an account
-  exists.
-- IAM users are real people, not Terraform resources.
+`tenant.yaml`, `not_exercised:` — `…_all_ports` (not applicable: no "all protocols"),
+`governance_resource_region_in_eu` live (`region` not collected; and one zone read,
+four instances in the quota), users' MFA (real people), the deviations of the
+qualifying key's role and of the `sks-ccm-*` roles, SOS bucket tagging (impossible by
+construction), the provider's sovereignty (a fact of the descriptor).
+
+## Cost and budget
+
+Hourly prices in [`tenant.yaml`](tenant.yaml), read from the portal's pricing API
+(EUR): 2 × `standard.micro` at 0.0073 EUR/h, 2 × `standard.small` at 0.0233 EUR/h,
+40 GB of local disk and 30 GB of block storage at 0.00014 EUR/GB/h, one SKS Pro control
+plane at 0.055 EUR/h (Starter is free) — about **0.13 EUR per hour** of tenant life.
+Budget: 20 minutes wall clock, otherwise NO-GO.
 
 ## Measured
 
-Plan-only run (`PROVIDER=exoscale mise run qualify:plan`): 37 resources planned,
-`scan --terraform` exit code 1, 26 controls pinned on the Terraform source, GO, with
-one expectation broken in memory turning NO-GO. Nothing created, nothing to destroy,
-no cost.
+<!-- qualification:measured -->
+Run of 2026-09-09 (`GO`), on the organisation the environment names:
+
+| | |
+|---|---|
+| Resources | 40 in the full plan, 39 applied (`swiss` is plan-only), plus 3 ressource(s) hors Terraform : pepin-qual-<org>-public, pepin-qual-<org>-unversioned, pepin-qual-<org>-hardened |
+| `apply` | 40.6 s |
+| `scan --live` × 5 formats + seal | 11.3 s, exit code 1 in every format |
+| bundle | `verify --re-derive` passes; the bundle altered by one byte is refused |
+| `scan --terraform` | exit code 1 |
+| `destroy` | 50.7 s — terraform destroy rc=0 ; état vide ; 2 fichier(s) d'état purgé(s) |
+| proof of destruction | 15 familles listées, aucune ressource du tenant, aucun delta avant/après |
+| comparison | live: 46 results, 0 difference; terraform: 37 results, 0 difference |
+| falsification | 3 expectations broken in memory on each source, every one NO-GO |
+| wall clock | 183.8 s (budget 20 min) |
+| cost estimate | 0.0037 EUR (0.029 h × 0.126 EUR/h) |
+
+Deviations outside the tenant reported by the live scan and not gated: 7
+(the organisation's own user without MFA, the role of the qualifying key and the two
+`sks-ccm-*` roles of the clusters, with no source-IP nor lifetime bound — #213).
+<!-- /qualification:measured -->

--- a/references/qualification/exoscale/compute.tf
+++ b/references/qualification/exoscale/compute.tf
@@ -1,12 +1,35 @@
-# Calcul — quatre instances (plan seul : rien n'est créé).
+# Calcul — quatre instances appliquées (le QUOTA de l'organisation est de quatre
+# instances, `GET /quota` : instance 4), une cinquième sur le plan seulement, deux
+# volumes block storage, une snapshot.
 #
-#   untagged  sans étiquettes de gouvernance              → governance_resource_required_tags
-#   secrets   cloud-init avec un mot de passe               → compute_instance_no_secrets_in_user_data
-#   swiss     en ch-gva-2 (Suisse : hors UE, espace de confiance) → governance_resource_region_in_eu (low)
-#   hardened  étiquetée, en zone UE, cloud-init anodin       → silencieuse
+#   exposed   IP publique (défaut) + SG SSH ouvert        → compute_instance_public_ip_with_open_securitygroup
+#   untagged  sans étiquettes de gouvernance              → governance_resource_required_tags ;
+#             et, sans IP publique (`private = true`) derrière le même SG SSH ouvert,
+#             contre-exemple de CLD-NET-3 : le groupe ouvert ne suffit pas, il faut l'IP
+#   secrets   cloud-init avec un mot de passe               → compute_instance_no_secrets_in_user_data ;
+#             porte le volume `unsnapshotted`, dont la faute est la sienne (CLD-STO-3)
+#   hardened  IP publique + SG restrictif, étiquetée, cloud-init anodin, volume
+#             `snapshotted` (avec sa snapshot)             → silencieuse partout
+#   swiss     en ch-gva-2 (Suisse : hors UE, espace de confiance) → governance_resource_region_in_eu
+#             (low) — sur le PLAN seulement (`terraform_only_resources`) : un scan live ne
+#             lit qu'une zone (de-fra-1), elle y serait invisible, et elle compterait
+#             dans le quota
 #
-# L'exposition (CLD-NET-3) ne se juge pas sur un plan : `public_ip_address` est
-# calculée à l'apply. Elle attend la moitié live de ce tenant.
+# Volumes : `unsnapshotted` attaché à `secrets` → blockstorage_volume_snapshots_exist ;
+# `snapshotted` attaché à `hardened`, avec une snapshot → contre-exemple. Une
+# instance qui porte un volume doit être au moins standard.small (provider #375).
+# L'ordre de destruction (instance, puis volume) est celui des dépendances : le
+# provider ne détache pas avant de supprimer (#453), et n'a pas à le faire ici.
+
+data "exoscale_template" "main" {
+  zone = var.zone
+  name = var.template_name
+}
+
+data "exoscale_template" "trusted" {
+  zone = var.trusted_zone
+  name = var.template_name
+}
 
 locals {
   cloud_init_plain = <<-EOT
@@ -24,32 +47,55 @@ locals {
   EOT
 }
 
+# ÉCART compute_instance_public_ip_with_open_securitygroup (CLD-NET-3) : IP publique
+# par défaut, groupe SSH ouvert.
+resource "exoscale_compute_instance" "exposed" {
+  zone               = var.zone
+  name               = "pepin-qual-vm-exposed"
+  template_id        = data.exoscale_template.main.id
+  type               = var.instance_type
+  disk_size          = 10
+  security_group_ids = [exoscale_security_group.ssh_open.id]
+  user_data          = local.cloud_init_plain
+  labels             = local.tagged
+}
+
+# ÉCART governance_resource_required_tags (CLD-GVN-1) : aucune étiquette de
+# gouvernance. Et CONTRE-EXEMPLE de CLD-NET-3 : même groupe SSH ouvert qu'`exposed`,
+# mais aucune IP publique.
 resource "exoscale_compute_instance" "untagged" {
   zone               = var.zone
   name               = "pepin-qual-vm-untagged"
-  template_id        = var.template_id
+  template_id        = data.exoscale_template.main.id
   type               = var.instance_type
   disk_size          = 10
-  security_group_ids = [exoscale_security_group.hardened.id]
+  private            = true
+  security_group_ids = [exoscale_security_group.ssh_open.id]
   user_data          = local.cloud_init_plain
   labels             = local.untagged
 }
 
+# ÉCART compute_instance_no_secrets_in_user_data (CLD-CMP-9) : un mot de passe
+# dans le cloud-init. Porte le volume `unsnapshotted` (la faute est celle du volume).
 resource "exoscale_compute_instance" "secrets" {
-  zone               = var.zone
-  name               = "pepin-qual-vm-secrets"
-  template_id        = var.template_id
-  type               = var.instance_type
-  disk_size          = 10
-  security_group_ids = [exoscale_security_group.hardened.id]
-  user_data          = local.cloud_init_with_secret
-  labels             = local.tagged
+  zone                     = var.zone
+  name                     = "pepin-qual-vm-secrets"
+  template_id              = data.exoscale_template.main.id
+  type                     = var.instance_type_with_volume
+  disk_size                = 10
+  security_group_ids       = [exoscale_security_group.hardened.id]
+  block_storage_volume_ids = [exoscale_block_storage_volume.unsnapshotted.id]
+  user_data                = local.cloud_init_with_secret
+  labels                   = local.tagged
 }
 
+# ÉCART governance_resource_region_in_eu (CLD-GVN-3, mineur) : ch-gva-2. Sur le plan
+# seulement : hors de la zone scannée, et l'organisation n'a que quatre instances.
 resource "exoscale_compute_instance" "swiss" {
+  count              = var.terraform_only_resources ? 1 : 0
   zone               = var.trusted_zone
   name               = "pepin-qual-vm-swiss"
-  template_id        = var.template_id
+  template_id        = data.exoscale_template.trusted.id
   type               = var.instance_type
   disk_size          = 10
   security_group_ids = [exoscale_security_group.hardened.id]
@@ -58,22 +104,39 @@ resource "exoscale_compute_instance" "swiss" {
 }
 
 resource "exoscale_compute_instance" "hardened" {
-  zone               = var.zone
-  name               = "pepin-qual-vm-hardened"
-  template_id        = var.template_id
-  type               = var.instance_type
-  disk_size          = 10
-  security_group_ids = [exoscale_security_group.hardened.id]
-  user_data          = local.cloud_init_plain
-  labels             = local.tagged
+  zone                     = var.zone
+  name                     = "pepin-qual-vm-hardened"
+  template_id              = data.exoscale_template.main.id
+  type                     = var.instance_type_with_volume
+  disk_size                = 10
+  security_group_ids       = [exoscale_security_group.hardened.id]
+  block_storage_volume_ids = [exoscale_block_storage_volume.snapshotted.id]
+  user_data                = local.cloud_init_plain
+  labels                   = local.tagged
 }
 
-# Volume block storage (chiffré par construction chez Exoscale : le mapping le
-# déclare `encrypted: true`, CLD-CHF-2 conforme). Son état d'usage n'est connu qu'à
-# l'apply : CLD-STO-3 attend la moitié live.
-resource "exoscale_block_storage_volume" "data" {
+# ÉCART blockstorage_volume_snapshots_exist (CLD-STO-3) : attaché (à `secrets`),
+# jamais sauvegardé. Chiffré par construction (mapping `encrypted: true`, CLD-CHF-2).
+resource "exoscale_block_storage_volume" "unsnapshotted" {
   zone   = var.zone
-  name   = "pepin-qual-vol-data"
+  name   = "pepin-qual-vol-unsnapshotted"
   size   = 10
   labels = local.tagged
+}
+
+# CONTRE-EXEMPLE : attaché, avec une snapshot fraîche et terminée.
+resource "exoscale_block_storage_volume" "snapshotted" {
+  zone   = var.zone
+  name   = "pepin-qual-vol-snapshotted"
+  size   = 10
+  labels = local.tagged
+}
+
+resource "exoscale_block_storage_volume_snapshot" "private" {
+  zone   = var.zone
+  name   = "pepin-qual-snap-private"
+  labels = local.tagged
+  volume = {
+    id = exoscale_block_storage_volume.snapshotted.id
+  }
 }

--- a/references/qualification/exoscale/expected.yaml
+++ b/references/qualification/exoscale/expected.yaml
@@ -1,162 +1,273 @@
-# Ce que Pépin DOIT rendre sur le tenant de qualification Exoscale — source
-# TERRAFORM seulement : aucun compte, donc aucune source live (tenant.yaml
-# `live: unavailable`). Lu par tools/qualification/qualify.py en `--plan-only`.
+# Ce que Pépin DOIT rendre sur le tenant de qualification Exoscale, source par
+# source. Lu par tools/qualification/qualify.py ; toute différence est NO-GO.
 #
-# Sujets : adresse de la ressource quand l'identifiant n'est pas connu au stade du
-# plan (ADR-0022), nom sinon. Le compte n'est pas épinglé : il n'y en a pas — le
-# jour où il y en aura un, `account:` nommera sa variable d'environnement, et le
-# runner refusera de tourner sans elle.
-account: {}
+# Sujets : en live, l'identifiant natif que la collecte prend pour sujet (instance,
+# volume, groupe de sécurité, réseau privé, rôle), connu après apply — cité sous la
+# forme `${output.<nom>}` ; le nom quand c'est lui le sujet (clusters SKS, buckets).
+# Sur le plan, l'adresse de la ressource quand l'identifiant n'est pas connu au
+# stade du plan (ADR-0022), le nom sinon.
+#
+# Le compte : l'organisation que l'API rattache à la clé (`GET /api-key/{key}` →
+# org-id), confirmée AVANT tout apply contre PEPIN_QUAL_EXO_ORG. La variable
+# absente est un refus (ADR-0012 : aucun identifiant de compte committé).
+account:
+  organization_id_env: PEPIN_QUAL_EXO_ORG
 
 exit_codes:
+  live: 1
   terraform: 1
 
 controls:
-  # ── IAM : rôles (politique lue sur le plan) ───────────────────────────────────
+  # ── IAM : rôles (sujet = le nom du rôle, sur les deux sources) ──────────────────
+  # En live, le rôle de la clé qui qualifie (« deny » par défaut, sans règle CEL) et
+  # les rôles `sks-ccm-<cluster>` que SKS crée pour chaque cluster portent leurs
+  # propres écarts d'origine et de durée : hors tenant, observés, non gardés.
   iam_role_no_admin_privileges:
+    live:
+      fail: [pepin-qual-role-admin]
+      silent: [pepin-qual-role-restricted, pepin-qual-role-no-source-ip]
     terraform:
       fail: [pepin-qual-role-admin]
       silent: [pepin-qual-role-restricted, pepin-qual-role-no-source-ip]
 
   iam_role_source_ip_restricted:
+    live:
+      fail: [pepin-qual-role-no-source-ip]
+      silent: [pepin-qual-role-restricted, pepin-qual-role-admin]
     terraform:
       fail: [pepin-qual-role-no-source-ip]
       silent: [pepin-qual-role-restricted, pepin-qual-role-admin]
 
   iam_role_key_lifetime_bounded:
+    live:
+      fail: [pepin-qual-role-unbounded]
+      silent: [pepin-qual-role-restricted, pepin-qual-role-admin]
     terraform:
       fail: [pepin-qual-role-unbounded]
       silent: [pepin-qual-role-restricted, pepin-qual-role-admin]
 
   iam_user_mfa_enabled:
-    # Les utilisateurs ne sont pas des ressources Terraform.
+    # Les utilisateurs de l'organisation sont des personnes, pas des ressources du
+    # tenant : le contrôle conclut sur eux (pass ou fail), et ce n'est pas gardé.
+    live: evaluated
     terraform: not-evaluated
 
   # ── Groupes de sécurité ───────────────────────────────────────────────────────
-  # Sujet = adresse du groupe (les règles y désignent leur groupe par référence).
+  # Sujet = le groupe (identifiant en live, adresse sur le plan : les règles y
+  # désignent leur groupe par référence).
   network_securitygroup_allow_ingress_from_internet_to_tcp_port_22:
+    live:
+      fail: ["${output.sg_ssh_open_id}", "${output.sg_any_open_id}", "${output.sg_quartet_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_rdp_open_id}", "${output.sg_undocumented_flow_id}"]
     terraform:
       fail: [exoscale_security_group.ssh_open, exoscale_security_group.any_open, exoscale_security_group.quartet]
       silent: [exoscale_security_group.hardened, exoscale_security_group.rdp_open, exoscale_security_group.undocumented_flow]
 
   network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389:
+    live:
+      fail: ["${output.sg_rdp_open_id}", "${output.sg_any_open_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_ssh_open_id}"]
     terraform:
       fail: [exoscale_security_group.rdp_open, exoscale_security_group.any_open]
       silent: [exoscale_security_group.hardened, exoscale_security_group.ssh_open]
 
   network_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports:
+    live:
+      fail: ["${output.sg_db_open_id}", "${output.sg_any_open_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_ssh_open_id}"]
     terraform:
       fail: [exoscale_security_group.db_open, exoscale_security_group.any_open]
       silent: [exoscale_security_group.hardened, exoscale_security_group.ssh_open]
 
   network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports:
+    live:
+      fail: ["${output.sg_snmp_open_id}", "${output.sg_any_open_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_db_open_id}"]
     terraform:
       fail: [exoscale_security_group.snmp_open, exoscale_security_group.any_open]
       silent: [exoscale_security_group.hardened, exoscale_security_group.db_open]
 
   network_securitygroup_allow_ingress_from_internet_to_all_ports:
-    # NON CONSTRUCTIBLE chez Exoscale : une règle n'a pas de protocole « tout »
-    # (tcp, udp, icmp, icmpv6, ah, esp, gre, ipip), et la règle commune exige
-    # `protocol == all`. `any_open` ouvre tout TCP et tout UDP : les quatre autres
-    # contrôles d'entrée parlent, celui-ci ne peut pas. Un pass par absence, donc —
-    # issue #202 (ce contrôle est actif pour Exoscale au référentiel, et la matrice
-    # de couverture le dit ✅).
-    terraform: pass
+    # NON APPLICABLE chez Exoscale : une règle n'a pas de protocole « tout » (tcp,
+    # udp, icmp, icmpv6, ah, esp, gre, ipip), donc la conjonction any/any que ce
+    # contrôle mesure ne se déclare pas ; `any_open` ouvre tout TCP et tout UDP, et
+    # ce sont les quatre contrôles par famille de ports qui parlent (#202, #206).
+    live: not-applicable
+    terraform: not-applicable
 
   network_securitygroup_unrestricted_egress:
-    # Même limite, même raison : `protocol == all` n'existe pas chez Exoscale (#202).
-    terraform: pass
+    # Chez Exoscale, « tout sortant » s'écrit tcp/udp 1-65535 → 0.0.0.0/0, et la
+    # règle commune reconnaît cette forme (#202, #206) ; `hardened` ne sort qu'en 443.
+    live:
+      fail: ["${output.sg_egress_any_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_ssh_open_id}"]
+    terraform:
+      fail: [exoscale_security_group.egress_any]
+      silent: [exoscale_security_group.hardened, exoscale_security_group.ssh_open]
 
   network_flow_matrix_documented:
-    # DÉFAUT CONNU, épinglé tel que mesuré : la règle `undocumented_flow` n'a pas de
-    # description, et le contrôle rend PASS. Sur un plan, une description absente
-    # est « connue après apply » (computed) : l'attribut n'est pas projeté, la garde
-    # de capacité se tait — et l'assessment conclut « conforme » alors qu'une règle
-    # du type n'a pas l'attribut décisif. C'est le faux vert que l'intersection de
-    # l'ADR-0006 (#102) existe pour empêcher. Issue #201.
+    # Une règle sans description est un écart (#201, corrigé par #205) — y compris sur
+    # le plan, où une description non écrite est « connue après apply ».
+    live:
+      fail: ["${output.sg_undocumented_flow_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_ssh_open_id}"]
     terraform:
-      status: pass
-      known_defect: "#201 — faux vert sur le plan : la règle sans description est invisible (secours de provenance), le contrôle conclut pass"
+      fail: [exoscale_security_group.undocumented_flow]
+      silent: [exoscale_security_group.hardened, exoscale_security_group.ssh_open]
 
   # ── Réseau ────────────────────────────────────────────────────────────────────
   network_documented:
+    live:
+      fail: [pepin-qual-pn-undocumented]
+      silent: [pepin-qual-pn-documented]
     terraform:
       fail: [pepin-qual-pn-undocumented]
       silent: [pepin-qual-pn-documented]
 
   # ── Calcul ────────────────────────────────────────────────────────────────────
   compute_instance_public_ip_with_open_securitygroup:
-    # L'IP publique est calculée à l'apply : attend la moitié live.
+    # L'IP publique est un fait d'apply : `exposed` en a une derrière un groupe SSH
+    # ouvert, `untagged` (private = true) n'en a pas derrière le même groupe, et
+    # `hardened` en a une derrière un groupe fermé.
+    live:
+      fail: ["${output.vm_exposed_id}"]
+      silent: ["${output.vm_untagged_id}", "${output.vm_hardened_id}"]
     terraform: not-evaluated
 
   compute_instance_has_security_group:
+    # MESURÉ, FAUX POSITIF : `untagged` est privée (`private = true`, public-ip-assignment
+    # none) ; l'API ignore les groupes déclarés et rend `security-groups: []` — un
+    # groupe ne s'attache pas à une instance sans interface publique. La règle en fait
+    # un écart, avec une remédiation inexécutable. Issue #212 ; sa
+    # correction fera rougir cette porte sciemment.
+    live:
+      fail: ["${output.vm_untagged_id}"]
+      silent: ["${output.vm_exposed_id}", "${output.vm_hardened_id}"]
     terraform: pass
 
   compute_instance_no_secrets_in_user_data:
+    live:
+      fail: ["${output.vm_secrets_id}"]
+      silent: ["${output.vm_hardened_id}", "${output.vm_untagged_id}"]
     terraform:
       fail: [exoscale_compute_instance.secrets]
       silent: [exoscale_compute_instance.hardened, exoscale_compute_instance.untagged]
 
   # ── Stockage ──────────────────────────────────────────────────────────────────
   blockstorage_volume_encryption:
-    # Chiffré par construction (mapping `encrypted: true`).
+    # Chiffré par construction (contrat et mapping `encrypted: true`).
+    live: pass
     terraform: pass
 
   blockstorage_volume_snapshots_exist:
-    # L'état d'usage est calculé à l'apply : attend la moitié live.
+    # `unsnapshotted` est attaché (à `secrets`, en usage) sans snapshot ; `snapshotted`
+    # est attaché (à `hardened`) avec une snapshot terminée du jour. Sur le plan,
+    # l'état d'usage est calculé à l'apply.
+    live:
+      fail: ["${output.volume_unsnapshotted_id}"]
+      silent: ["${output.volume_snapshotted_id}"]
     terraform: not-evaluated
 
   blockstorage_snapshot_not_public:
+    live: not-applicable
     terraform: not-applicable
 
   objectstorage_bucket_public_access:
-    # Pas de ressource de bucket dans le provider : crochet `extra` à écrire avec le compte.
+    # Buckets SOS : créés par le crochet `extra`, hors Terraform (le provider n'a pas
+    # de ressource de bucket) — donc rien sur le plan.
+    live:
+      fail: ["${output.bucket_public}"]
+      silent: ["${output.bucket_unversioned}", "${output.bucket_hardened}"]
     terraform: not-evaluated
 
   objectstorage_bucket_versioning_enabled:
+    live:
+      fail: ["${output.bucket_unversioned}"]
+      silent: ["${output.bucket_public}", "${output.bucket_hardened}"]
     terraform: not-evaluated
 
   objectstorage_bucket_object_lock_enabled:
+    # `hardened` est créé verrouillé (CreateBucket + x-amz-bucket-object-lock-enabled,
+    # la seule façon : `exo storage` ne le sait pas).
+    live:
+      fail: ["${output.bucket_public}", "${output.bucket_unversioned}"]
+      silent: ["${output.bucket_hardened}"]
     terraform: not-evaluated
 
   objectstorage_bucket_kms_encryption:
+    live: not-applicable
     terraform: not-applicable
 
   # ── SKS ───────────────────────────────────────────────────────────────────────
   kubernetes_cluster_control_plane_highly_available:
+    live:
+      fail: [pepin-qual-sks-weak]
+      silent: [pepin-qual-sks-strong]
     terraform:
       fail: [pepin-qual-sks-weak]
       silent: [pepin-qual-sks-strong]
 
   kubernetes_cluster_auto_upgrade_enabled:
+    live:
+      fail: [pepin-qual-sks-weak]
+      silent: [pepin-qual-sks-strong]
     terraform:
       fail: [pepin-qual-sks-weak]
       silent: [pepin-qual-sks-strong]
 
   kubernetes_cluster_audit_logging_enabled:
+    # DÉFAUT CONNU, épinglé tel que mesuré : FAUX VERT en live. L'API rend `audit: {}`
+    # pour un cluster dont l'audit est désactivé ; la collecte dérive `audit_enabled`
+    # de `audit.endpoint` (absent), ne projette rien sur `weak`, et le contrôle conclut
+    # « conforme » sur le seul cluster observé (`observed=1/2`). Le plan, lui, échoue
+    # sur `weak`. Issue #209.
+    live:
+      status: pass
+      known_defect: "#209 — faux vert live : audit_enabled dérivé de audit.endpoint, absent quand l'audit est désactivé (API : audit {}) ; le cluster sans audit n'est pas évalué, le contrôle rend pass"
     terraform:
       fail: [pepin-qual-sks-weak]
       silent: [pepin-qual-sks-strong]
 
   # ── Répartiteurs de charge : absents de l'API Exoscale (contrat) ──────────────
   loadbalancer_ssl_listeners:
+    live: not-applicable
     terraform: not-applicable
 
   loadbalancer_logging_enabled:
+    live: not-applicable
     terraform: not-applicable
 
   loadbalancer_http_redirect_to_https:
+    live: not-applicable
     terraform: not-applicable
 
   # ── Gouvernance ───────────────────────────────────────────────────────────────
   governance_resource_required_tags:
+    # Les trois buckets SOS sont fautifs PAR CONSTRUCTION : SOS accepte
+    # PutBucketTagging et ne persiste rien (NoSuchTagSet juste après, mesuré par SigV4
+    # et par la CLI aws). Un bucket SOS n'a jamais d'étiquette, quoi qu'on fasse ;
+    # épinglé tel que mesuré, faux positif non remédiable — issue #208.
+    # Et FAUX VERT sur `untagged` : la collecte live ne projette pas `labels` sur les
+    # instances (ni volumes, ni clusters), la règle les saute en silence, seuls les
+    # buckets sont jugés — issue #211 ; sa correction ajoutera
+    # `${output.vm_untagged_id}` au `fail` et fera rougir cette porte.
+    live:
+      fail: ["${output.bucket_public}", "${output.bucket_unversioned}", "${output.bucket_hardened}"]
+      silent: ["${output.vm_hardened_id}", "${output.vm_secrets_id}", "${output.volume_unsnapshotted_id}", pepin-qual-sks-weak]
     terraform:
       fail: [pepin-qual-vm-untagged]
       silent: [pepin-qual-vm-hardened, pepin-qual-vm-secrets]
 
   governance_resource_region_in_eu:
     # ch-gva-2 : hors UE, espace européen de confiance — l'écart MINEUR (low), le
-    # seul constructible ici. de-fra-1 est l'UE.
+    # seul constructible. `swiss` n'est que sur le plan (`terraform_only_resources`) :
+    # en live, le scan lit de-fra-1 (UE), elle y serait invisible, et l'organisation
+    # n'a droit qu'à quatre instances.
+    # DETTE DE COLLECTE NOMMÉE (ADR-0010) : en live, la collecte Exoscale ne projette
+    # `region` sur aucun type (instances, volumes, snapshots, clusters) — la zone
+    # scannée n'est pas reportée sur les ressources —, et la garde de capacité rend
+    # not-evaluated. Le jour où le collecteur le fait, cette ligne devient `pass`.
+    live: not-evaluated
     terraform:
       fail: [pepin-qual-vm-swiss]
       silent: [pepin-qual-vm-hardened]
@@ -164,5 +275,7 @@ controls:
   governance_provider_sovereignty:
     # Écart par construction des faits du descripteur (siège en Suisse, contrôle
     # capitalistique extra-UE) : le sujet est le fournisseur lui-même.
+    live:
+      fail: [exoscale]
     terraform:
       fail: [exoscale]

--- a/references/qualification/exoscale/hooks.py
+++ b/references/qualification/exoscale/hooks.py
@@ -1,48 +1,414 @@
 #!/usr/bin/env python3
-"""Crochets Exoscale du tenant de qualification — PLAN SEUL.
+"""Crochets Exoscale du tenant de qualification : identité, variables, extra,
+inventaire, nettoyage.
 
-Aucun compte Exoscale n'est disponible (tenant.yaml `live: unavailable`). Le runner
-ne demande donc à ces crochets que `variables`, pour donner au provider Terraform
-les identifiants FACTICES qu'un plan sans source de données n'emploie jamais (les
-mêmes que scripts/tenant-plan.py). Les autres commandes REFUSENT, explicitement :
-une identité qu'on ne peut pas confronter et un inventaire qu'on ne peut pas relire
-ne se simulent pas.
+    identity                      quelle organisation les identifiants natifs ouvrent-ils,
+                                  d'après l'API, jamais d'après un profil local
+    variables --live|--plan-only <identity.json>
+                                  les variables Terraform propres au tenant (aucune ici)
+    extra apply|destroy <outputs.json>
+                                  les buckets SOS : le provider n'a pas de ressource de bucket
+    inventory <tenant.yaml>       ce que l'organisation contient, famille par famille, dans
+                                  chaque zone que tenant.yaml déclare, et ce qui, dedans,
+                                  appartient au tenant
+    cleanup <tenant.yaml> [leftovers.json]
+                                  supprime ce qui appartient au tenant — chemin de SECOURS
 
-Quand un compte existera : `identity` devra demander l'organisation à l'API v2
-(GET /organization, signature EXO2-HMAC-SHA256 — celle que internal/collectkit
-implémente), `inventory` lister les familles (instances, groupes, réseaux privés,
-volumes et snapshots block, clusters SKS, rôles et clés IAM, buckets SOS par zone),
-`cleanup` supprimer par le préfixe du tenant, et `extra` rester vide si le provider
-sait tout créer. Les issues de destruction de exoscale/terraform-provider-exoscale
-sont à lire d'abord.
+# L'API v2 directement, signée comme le collecteur la signe
+
+Identifiants résolus EXACTEMENT comme `pepin scan --live` et le provider Terraform :
+EXOSCALE_API_KEY / EXOSCALE_API_SECRET d'abord, puis ~/.config/exoscale/exoscale.toml
+(compte EXOSCALE_ACCOUNT ou `defaultaccount` ; EXOSCALE_CONFIG surcharge le chemin).
+Chaque appel est signé EXO2-HMAC-SHA256 — réplique de internal/collect/auth.go, elle-même
+réplique d'egoscale/v3 : « METHOD /path \\n body \\n valeurs des paramètres signés \\n
+en-têtes (aucun) \\n expiration ». Aucun identifiant n'est écrit, affiché ni journalisé.
+
+# L'identité, telle que l'API la donne à CETTE clé
+
+`GET /organization` est refusé à une clé dont le rôle ne couvre pas l'organisation
+(« Forbidden by role policy for organization »), et une clé de qualification n'a
+aucune raison de le couvrir. Ce que l'API expose à toute clé, c'est SA PROPRE fiche :
+`GET /api-key/{key}` rend `org-id`, le nom de la clé et son rôle. C'est cet `org-id`
+que l'environnement doit confirmer (`PEPIN_QUAL_EXO_ORG`), et c'est lui qui suffixe
+les buckets SOS, globaux.
+
+# SOS, par la CLI de référence et par S3
+
+`exo` (egoscale v3) est la CLI de référence : elle crée et supprime les buckets
+(`exo storage mb|rb|setacl|bucket versioning`) et sert aux listings qu'un mainteneur
+rejoue. Elle ne sait pas créer un bucket VERROUILLÉ (Object Lock) : le contre-exemple
+`hardened` passe par l'API S3 de SOS (CreateBucket + x-amz-bucket-object-lock-enabled,
+SigV4, sos-<zone>.exo.io), avec la même clé — SOS l'accepte, et active le versioning
+avec.
+
+Mesuré ici, et à savoir avant de lire un verdict d'étiquetage sur un bucket SOS :
+SOS ACCEPTE PutBucketTagging (200, par SigV4 comme par la CLI aws) et NE PERSISTE PAS
+les tags — GetBucketTagging rend NoSuchTagSet juste après. Un bucket SOS n'a donc
+jamais d'étiquette, quoi qu'on fasse ; les trois buckets du tenant portent
+`governance_resource_required_tags` par construction, et expected.yaml le dit.
+
+# Ce qu'un inventaire couvre
+
+Instances, réseaux privés, volumes et snapshots block storage, clusters SKS, IP
+élastiques, pools d'instances, NLB, modèles privés, clés SSH, groupes d'anti-affinité
+sont listés dans CHAQUE zone de `zones:` ; les groupes de sécurité, rôles IAM et clés
+d'API sont d'organisation (l'API les rend identiques dans toute zone : dédoublonnés
+par identifiant) ; les buckets SOS par `exo storage list`, toutes zones.
 """
+import base64
+import datetime as dt
+import hashlib
+import hmac
 import json
+import os
+import subprocess
 import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
 
+import yaml
+
+# ─── identifiants natifs ───────────────────────────────────────────────────────
+
+def try_creds():
+    key = os.environ.get("EXOSCALE_API_KEY")
+    secret = os.environ.get("EXOSCALE_API_SECRET")
+    zone = os.environ.get("EXOSCALE_ZONE")
+    if not (key and secret):
+        import tomllib
+        path = os.environ.get("EXOSCALE_CONFIG") or os.path.expanduser("~/.config/exoscale/exoscale.toml")
+        try:
+            conf = tomllib.load(open(path, "rb"))
+        except FileNotFoundError:
+            return None
+        want = os.environ.get("EXOSCALE_ACCOUNT") or conf.get("defaultaccount") or ""
+        for a in conf.get("accounts") or []:
+            if not want or a.get("name") == want:
+                key, secret = key or a.get("key"), secret or a.get("secret")
+                zone = zone or a.get("defaultZone")
+                break
+    if not (key and secret):
+        return None
+    return key, secret, zone or "ch-gva-2"
+
+
+def creds():
+    c = try_creds()
+    if c is None:
+        sys.exit("aucun identifiant Exoscale : EXOSCALE_API_KEY/EXOSCALE_API_SECRET ou ~/.config/exoscale/exoscale.toml")
+    return c
+
+
+def api(method, zone, path, params=None, body=None):
+    """Un appel API v2 signé EXO2-HMAC-SHA256 (api-<zone>.exoscale.com/v2)."""
+    key, secret, _ = creds()
+    url = f"https://api-{zone}.exoscale.com/v2{path}"
+    names, values = [], []
+    if params:
+        for k in sorted(params):
+            names.append(k)
+            values.append(str(params[k]))
+        url += "?" + urllib.parse.urlencode(params)
+    data = json.dumps(body).encode() if body is not None else None
+    expires = int(time.time()) + 600
+    sig_parts = [f"{method} /v2{path}", data.decode() if data else "", "".join(values), "", str(expires)]
+    mac = hmac.new(secret.encode(), "\n".join(sig_parts).encode(), hashlib.sha256).digest()
+    header = [f"EXO2-HMAC-SHA256 credential={key}"]
+    if names:
+        header.append("signed-query-args=" + ";".join(names))
+    header += [f"expires={expires}", "signature=" + base64.b64encode(mac).decode()]
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", ",".join(header))
+    req.add_header("Accept", "application/json")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    # Mesuré : GET /private-network sur api-de-fra-1 reste parfois sans réponse
+    # (délai dépassé, une fois sur trois ou quatre), puis répond en 0,2 s. Un listing
+    # de preuve ne doit pas rendre « inconnu » sur un aléa : trois tentatives.
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as r:
+                raw = r.read()
+                return json.loads(raw) if raw else {}
+        except urllib.error.HTTPError as e:
+            detail = e.read().decode(errors="replace")[:300]
+            raise RuntimeError(f"{method} {zone} {path} → HTTP {e.code} : {detail}") from None
+        except (TimeoutError, urllib.error.URLError) as e:
+            if attempt == 2:
+                raise RuntimeError(f"{method} {zone} {path} : sans réponse après 3 tentatives ({e})") from None
+            time.sleep(2)
+
+
+def exo(*args):
+    """La CLI de référence, sortie JSON. Ses identifiants viennent de son propre fichier."""
+    r = subprocess.run(["exo", *args, "-O", "json"], capture_output=True, text=True)
+    if r.returncode != 0:
+        raise RuntimeError(f"exo {' '.join(args[:3])} : {(r.stderr or r.stdout).strip()[:300]}")
+    try:
+        return json.loads(r.stdout or "null")
+    except json.JSONDecodeError:
+        return None
+
+
+# ─── S3 (SigV4 minimal : CreateBucket verrouillé, sondes) ──────────────────────
+
+def _sign(key, msg):
+    return hmac.new(key, msg.encode(), hashlib.sha256).digest()
+
+
+def sos_request(method, zone, bucket, query, body=b"", headers=None):
+    """Requête S3 signée SigV4 vers SOS (path-style, région = zone)."""
+    ak, sk, _ = creds()
+    host = f"sos-{zone}.exo.io"
+    now = dt.datetime.now(dt.timezone.utc)
+    amz_date, date = now.strftime("%Y%m%dT%H%M%SZ"), now.strftime("%Y%m%d")
+    payload_hash = hashlib.sha256(body).hexdigest()
+    extra = dict(sorted((k.lower(), v) for k, v in (headers or {}).items()))
+    all_headers = dict(extra, **{"host": host, "x-amz-content-sha256": payload_hash, "x-amz-date": amz_date})
+    signed = ";".join(sorted(all_headers))
+    canonical_headers = "".join(f"{k}:{all_headers[k]}\n" for k in sorted(all_headers))
+    canonical = f"{method}\n/{bucket}\n{query}\n{canonical_headers}\n{signed}\n{payload_hash}"
+    scope = f"{date}/{zone}/s3/aws4_request"
+    to_sign = f"AWS4-HMAC-SHA256\n{amz_date}\n{scope}\n{hashlib.sha256(canonical.encode()).hexdigest()}"
+    k = _sign(_sign(_sign(_sign(("AWS4" + sk).encode(), date), zone), "s3"), "aws4_request")
+    sig = hmac.new(k, to_sign.encode(), hashlib.sha256).hexdigest()
+    url = f"https://{host}/{bucket}" + (f"?{query}" if query else "")
+    req = urllib.request.Request(url, data=body or None, method=method)
+    for k2, v in all_headers.items():
+        req.add_header(k2, v)
+    req.add_header("Authorization", f"AWS4-HMAC-SHA256 Credential={ak}/{scope}, SignedHeaders={signed}, Signature={sig}")
+    if body:
+        req.add_header("Content-Type", "application/xml")
+        req.add_header("Content-MD5", base64.b64encode(hashlib.md5(body).digest()).decode())  # nosec B324 — exigé par S3, pas cryptographique
+    try:
+        with urllib.request.urlopen(req, timeout=60) as r:
+            return r.status, r.read().decode(errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode(errors="replace")[:300]
+
+
+def create_locked_bucket(zone, bucket):
+    """CreateBucket avec Object Lock dès la création (la seule façon de l'obtenir :
+    PutObjectLockConfiguration exige un bucket créé verrouillé). SOS répond 200 et
+    active le versioning avec."""
+    status, body = sos_request("PUT", zone, bucket, "", b"", headers={"x-amz-bucket-object-lock-enabled": "true"})
+    if status not in (200, 204):
+        raise RuntimeError(f"CreateBucket(object-lock) {bucket} → HTTP {status} : {body}")
+
+
+# ─── identité ──────────────────────────────────────────────────────────────────
+
+def identity():
+    key, _, zone = creds()
+    me = api("GET", zone, f"/api-key/{key}")
+    role = next((r.get("name") for r in api("GET", zone, "/iam-role").get("iam-roles") or [] if r.get("id") == me.get("role-id")), None)
+    return {"organization_id": me.get("org-id"), "api_key_name": me.get("name"), "role": role,
+            "label": f"clé « {me.get('name')} », rôle « {role} »"}
+
+
+# ─── variables propres au tenant ───────────────────────────────────────────────
 
 def variables(mode, identity_path):
-    if mode != "--plan-only":
-        sys.exit("aucun compte Exoscale : ce tenant est plan seul (tenant.yaml `live: unavailable`)")
-    return {
-        "tf_vars": {},
-        # Forme attendue par le provider ; aucune valeur réelle. Un plan n'appelle pas l'API.
-        "env": {"EXOSCALE_API_KEY": "EXOxxxxxxxxxxxxxxxxxxxx",
-                "EXOSCALE_API_SECRET": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
-        "wait_until": None,
-        "note": "plan seul : identifiants factices pour le provider, rien à attendre",
-    }
+    # `organization_id` est posée par le runner lui-même (TF_VAR_organization_id =
+    # l'attendu confirmé par l'API). Rien d'autre n'est propre à ce tenant, et rien
+    # n'est à attendre avant le scan. Les sources de données (modèles) lisent l'API
+    # au plan : le plan seul exige donc les mêmes identifiants que le live.
+    #
+    # Le provider Terraform ne lit PAS ~/.config/exoscale/exoscale.toml (« missing or
+    # incomplete API credentials ») : il attend EXOSCALE_API_KEY / EXOSCALE_API_SECRET.
+    # Le crochet les lui passe par l'environnement du run — le même que `pepin scan`
+    # reçoit —, sans les écrire ni les journaliser, et seulement s'ils n'y sont pas déjà.
+    env = {}
+    if not (os.environ.get("EXOSCALE_API_KEY") and os.environ.get("EXOSCALE_API_SECRET")):
+        key, secret, zone = creds()
+        env = {"EXOSCALE_API_KEY": key, "EXOSCALE_API_SECRET": secret, "EXOSCALE_ZONE": zone}
+    note = "aucune variable propre ; identifiants du fichier exoscale.toml passés au provider par l'environnement"
+    if mode == "--live":
+        note += " ; " + wait_for_quota()
+    return {"tf_vars": {}, "env": env, "wait_until": None, "note": note}
 
+
+def wait_for_quota(max_seconds=900):
+    """Le QUOTA d'instances de l'organisation (GET /quota : `instance`, 4 ici) compte
+    encore, plusieurs minutes après leur suppression, des instances que plus aucun
+    listing ne montre. Mesuré : usage=2 avec 0 instance listée, 5 min après un destroy
+    réussi — et l'apply suivant refusé (« Usage of resource 'instance' has been
+    exceeded »). Un run qui part trop tôt échoue donc à l'apply : on attend que le
+    compteur retombe à ce que les listings montrent, borné."""
+    _, _, zone = creds()
+    t0 = time.time()
+    while True:
+        usage = next((x["usage"] for x in api("GET", zone, "/quota")["quotas"] if x["resource"] == "instance"), 0)
+        if usage == 0 or time.time() - t0 > max_seconds:
+            waited = int(time.time() - t0)
+            return f"quota instance : usage={usage} après {waited}s d'attente" if waited else "quota instance libre"
+        print(f"quota instance : usage={usage}, 0 instance listée ; attente…", file=sys.stderr)
+        time.sleep(30)
+
+
+# ─── hors Terraform : buckets SOS ──────────────────────────────────────────────
+
+def _buckets(outputs):
+    return {"public": outputs["bucket_public"], "unversioned": outputs["bucket_unversioned"], "hardened": outputs["bucket_hardened"]}
+
+
+def extra_apply(outputs):
+    """Trois buckets dans la zone scannée : `public` (ACL public-read, versionné, sans
+    verrou) → CLD-STO-1 ; `unversioned` (jamais versionné, sans verrou) → CLD-STO-4 et
+    CLD-STO-8 ; `hardened` (privé, Object Lock, donc versionné) = contre-exemple.
+    Aucun n'est étiqueté : SOS ne persiste pas les tags de bucket (cf. en-tête)."""
+    zone = outputs["zone"]
+    b = _buckets(outputs)
+    created = []
+    exo("storage", "mb", f"sos://{b['public']}", "--zone", zone, "--acl", "public-read")
+    created.append(b["public"])
+    # `--zone` : sans elle, la CLI adresse la zone par défaut de son profil et SOS répond
+    # 301 PermanentRedirect (mesuré au run 2, bucket en de-fra-1, profil en ch-gva-2).
+    exo("storage", "bucket", "versioning", "enable", f"sos://{b['public']}", "--zone", zone)
+    exo("storage", "mb", f"sos://{b['unversioned']}", "--zone", zone, "--acl", "private")
+    created.append(b["unversioned"])
+    create_locked_bucket(zone, b["hardened"])
+    created.append(b["hardened"])
+    return {"created": created}
+
+
+def _rb(name):
+    r = subprocess.run(["exo", "storage", "rb", f"sos://{name}", "-r", "-f"], capture_output=True, text=True)
+    out = (r.stderr + r.stdout).lower()
+    return r.returncode == 0 or "nosuchbucket" in out or "not found" in out, (r.stderr or r.stdout).strip()[:120]
+
+
+def extra_destroy(outputs):
+    deleted, left = [], []
+    for name in _buckets(outputs).values():
+        ok, msg = _rb(name)
+        (deleted if ok else left).append(name if ok else f"{name} ({msg})")
+    return {"deleted": deleted, "left": left}
+
+
+# ─── inventaire ────────────────────────────────────────────────────────────────
+
+ZONAL = [("instances", "/instance", "instances"), ("private_networks", "/private-network", "private-networks"),
+         ("block_volumes", "/block-storage", "block-storage-volumes"), ("block_snapshots", "/block-storage-snapshot", "block-storage-snapshots"),
+         ("sks_clusters", "/sks-cluster", "sks-clusters"), ("elastic_ips", "/elastic-ip", "elastic-ips"),
+         ("instance_pools", "/instance-pool", "instance-pools"), ("load_balancers", "/load-balancer", "load-balancers"),
+         ("templates", "/template", "templates"), ("ssh_keys", "/ssh-key", "ssh-keys"),
+         ("anti_affinity_groups", "/anti-affinity-group", "anti-affinity-groups"),
+         ("security_groups", "/security-group", "security-groups")]
+GLOBAL = [("iam_roles", "/iam-role", "iam-roles"), ("api_keys", "/api-key", "api-keys")]
+
+
+def _owned(item, tag, prefix):
+    return tag in (item.get("labels") or {}) or str(item.get("name") or "").startswith(prefix)
+
+
+def inventory(tenant):
+    tag, prefix = tenant["tag"], tenant["name_prefix"]
+    zones = tenant.get("zones") or [tenant["zone"]]
+    fam = {}
+
+    def put(family, items):
+        fam[family] = {"all": sorted(items),
+                       "tenant": [{"id": i, "name": v.get("name"), "zone": v.get("zone")} for i, v in sorted(items.items()) if _owned(v, tag, prefix)]}
+
+    for family, path, key in ZONAL:
+        items = {}
+        for z in zones:
+            params = {"visibility": "private"} if family == "templates" else None
+            for i in (api("GET", z, path, params).get(key) or []):
+                iid = str(i.get("id") or i.get("name"))
+                items.setdefault(iid, dict(i, zone=z))   # même id dans deux zones = ressource d'organisation
+        put(family, items)
+    _, _, zone = creds()
+    for family, path, key in GLOBAL:
+        put(family, {str(i.get("id") or i.get("key")): dict(i, zone=None) for i in (api("GET", zone, path).get(key) or [])})
+    buckets = exo("storage", "list") or []
+    put("buckets", {b["name"]: {"name": b["name"], "zone": b.get("zone")} for b in buckets if isinstance(b, dict) and b.get("name")})
+    return fam
+
+
+# ─── nettoyage de secours ──────────────────────────────────────────────────────
+
+ORDER = [("instances", "/instance"), ("sks_clusters", "/sks-cluster"), ("block_snapshots", "/block-storage-snapshot"),
+         ("block_volumes", "/block-storage"), ("elastic_ips", "/elastic-ip"), ("private_networks", "/private-network"),
+         ("security_groups", "/security-group"), ("templates", "/template"), ("ssh_keys", "/ssh-key"),
+         ("anti_affinity_groups", "/anti-affinity-group"), ("iam_roles", "/iam-role"), ("api_keys", "/api-key")]
+
+
+def cleanup(tenant, leftovers_path=None):
+    zones = tenant.get("zones") or [tenant["zone"]]
+    inv = inventory(tenant)
+    rest = {f: {x["id"]: x.get("zone") for x in v["tenant"]} for f, v in inv.items() if v["tenant"]}
+    if leftovers_path:
+        for f, ids in (json.load(open(leftovers_path)).get("delta") or {}).items():
+            for i in ids:
+                rest.setdefault(f, {}).setdefault(i, None)
+    if not any(rest.values()):
+        print("rien à nettoyer : aucune ressource du tenant")
+        return True
+    ok = True
+
+    def delete(family, path, iid, zone):
+        nonlocal ok
+        last = None
+        for z in ([zone] if zone else zones):
+            try:
+                api("DELETE", z, f"{path}/{iid}")
+                print(f"  ✔ DELETE {family} {iid} ({z})")
+                return
+            except RuntimeError as e:
+                last = e
+                if "404" not in str(e):
+                    break
+        ok = False
+        print(f"  ✘ DELETE {family} {iid} : {last}")
+
+    for family, path in ORDER:
+        for iid, zone in (rest.get(family) or {}).items():
+            delete(family, path, iid, zone)
+        if family == "instances" and rest.get("instances"):
+            time.sleep(30)   # les volumes ne se suppriment qu'une fois l'instance partie
+    for name in rest.get("buckets") or {}:
+        done, msg = _rb(name)
+        ok &= done
+        print(("  ✔ " if done else "  ✘ ") + f"exo storage rb {name}" + ("" if done else f" : {msg}"))
+    # Mesuré : SKS crée une clé d'API `sks-ccm-<cluster>` pour le CCM de chaque cluster
+    # et la supprime d'ordinaire avec lui ; une fois, elle a survécu au cluster (rôle
+    # supprimé, clé listée), et DELETE /api-key répond 403 « API Key not in
+    # organization » — gérée par la plateforme. On tente, on dit, on ne bloque pas.
+    roles = {r["id"] for r in api("GET", zones[0], "/iam-role").get("iam-roles") or []}
+    for k in api("GET", zones[0], "/api-key").get("api-keys") or []:
+        if str(k.get("name", "")).startswith("sks-ccm-") and k.get("role-id") not in roles:
+            try:
+                api("DELETE", zones[0], f"/api-key/{k['key']}")
+                print(f"  ✔ DELETE api-key orpheline {k['name']}")
+            except RuntimeError as e:
+                print(f"  ⚠ clé d'API orpheline {k['name']} (rôle supprimé) : {e} — à signaler à Exoscale")
+    return ok
+
+
+# ─── point d'entrée ────────────────────────────────────────────────────────────
 
 def main(argv):
-    if len(argv) < 2:
+    if len(argv) < 2 or argv[1] not in ("identity", "inventory", "cleanup", "variables", "extra"):
         sys.exit(__doc__)
+    if argv[1] == "identity":
+        print(json.dumps(identity(), indent=2))
+        return 0
     if argv[1] == "variables":
         print(json.dumps(variables(argv[2], argv[3])))
         return 0
     if argv[1] == "extra":
-        print(json.dumps({"created": [], "deleted": [], "left": []}))
+        outputs = json.load(open(argv[3]))
+        print(json.dumps(extra_apply(outputs) if argv[2] == "apply" else extra_destroy(outputs)))
         return 0
-    sys.exit(f"{argv[1]} : aucun compte Exoscale — ce tenant est plan seul (tenant.yaml `live: unavailable`)")
+    tenant = yaml.safe_load(open(argv[2]))
+    if argv[1] == "inventory":
+        print(json.dumps(inventory(tenant), indent=2, sort_keys=True))
+        return 0
+    return 0 if cleanup(tenant, argv[3] if len(argv) > 3 else None) else 1
 
 
 if __name__ == "__main__":

--- a/references/qualification/exoscale/outputs.tf
+++ b/references/qualification/exoscale/outputs.tf
@@ -1,14 +1,34 @@
-# Sorties : en plan seul, les identifiants ne sont pas connus ; expected.yaml
-# désigne les ressources par leur adresse ou leur nom. Ces sorties serviront à la
-# moitié live, quand un compte existera.
+# Sorties : les identifiants que la collecte LIVE emploie comme sujets, connus après
+# apply. expected.yaml les cite sous la forme `${output.<nom>}`. Aucune sortie sensible.
 
+output "zone" { value = var.zone }
 output "sg_ssh_open_id" { value = exoscale_security_group.ssh_open.id }
+output "sg_rdp_open_id" { value = exoscale_security_group.rdp_open.id }
+output "sg_db_open_id" { value = exoscale_security_group.db_open.id }
+output "sg_snmp_open_id" { value = exoscale_security_group.snmp_open.id }
+output "sg_any_open_id" { value = exoscale_security_group.any_open.id }
+output "sg_quartet_id" { value = exoscale_security_group.quartet.id }
+output "sg_egress_any_id" { value = exoscale_security_group.egress_any.id }
+output "sg_undocumented_flow_id" { value = exoscale_security_group.undocumented_flow.id }
 output "sg_hardened_id" { value = exoscale_security_group.hardened.id }
+output "vm_exposed_id" { value = exoscale_compute_instance.exposed.id }
 output "vm_untagged_id" { value = exoscale_compute_instance.untagged.id }
 output "vm_secrets_id" { value = exoscale_compute_instance.secrets.id }
-output "vm_swiss_id" { value = exoscale_compute_instance.swiss.id }
 output "vm_hardened_id" { value = exoscale_compute_instance.hardened.id }
-output "volume_data_id" { value = exoscale_block_storage_volume.data.id }
+output "volume_unsnapshotted_id" { value = exoscale_block_storage_volume.unsnapshotted.id }
+output "volume_snapshotted_id" { value = exoscale_block_storage_volume.snapshotted.id }
+output "snapshot_private_id" { value = exoscale_block_storage_volume_snapshot.private.id }
+output "pn_undocumented_id" { value = exoscale_private_network.undocumented.id }
+output "pn_documented_id" { value = exoscale_private_network.documented.id }
 output "sks_weak_name" { value = exoscale_sks_cluster.weak.name }
 output "sks_strong_name" { value = exoscale_sks_cluster.strong.name }
 output "role_admin_id" { value = exoscale_iam_role.admin.id }
+output "role_no_source_ip_id" { value = exoscale_iam_role.no_source_ip.id }
+output "role_unbounded_id" { value = exoscale_iam_role.unbounded.id }
+output "role_restricted_id" { value = exoscale_iam_role.restricted.id }
+
+# Suffixe des noms de buckets SOS (créés par le crochet `extra`, hors Terraform).
+output "bucket_suffix" { value = local.bucket_suffix }
+output "bucket_public" { value = "pepin-qual-${local.bucket_suffix}-public" }
+output "bucket_unversioned" { value = "pepin-qual-${local.bucket_suffix}-unversioned" }
+output "bucket_hardened" { value = "pepin-qual-${local.bucket_suffix}-hardened" }

--- a/references/qualification/exoscale/sks.tf
+++ b/references/qualification/exoscale/sks.tf
@@ -1,19 +1,26 @@
-# SKS — deux clusters (plan seul).
+# SKS — deux clusters, sans nodepool (le plan de contrôle suffit à ce que les
+# trois contrôles lisent : level, auto-upgrade, audit.endpoint).
 #
-#   weak    service_level starter (plan de contrôle non redondant), auto_upgrade
-#           false, audit désactivé → trois écarts sur un sujet
-#   strong  service_level pro, auto_upgrade true, audit vers un endpoint → silencieux
+#   weak    service_level starter (plan de contrôle non redondant, gratuit),
+#           auto_upgrade false, audit désactivé → trois écarts sur un sujet
+#   strong  service_level pro (0,055 EUR/h), auto_upgrade true, audit vers un
+#           endpoint → silencieux
 #
-# Les trois contrôles Kubernetes actifs pour Exoscale lisent ces trois champs
-# (mapping_terraform de providers/exoscale.yaml) : un cluster « faible » les porte
-# tous, parce qu'un cluster par écart n'apprendrait rien de plus sur un plan.
+# Un cluster « faible » porte les trois écarts, parce qu'un cluster par écart
+# n'apprendrait rien de plus et coûterait un plan de contrôle Pro de plus.
+#
+# `create_default_security_group = false` : sans nodepool, le groupe de sécurité
+# ad hoc que le provider créerait ne servirait à rien, et c'est une ressource de
+# plus à prouver détruite. Le provider a laissé des restes derrière des clusters
+# (#210 : un NLB créé par le CCM survivait au destroy) : rien ici n'en crée.
 
 resource "exoscale_sks_cluster" "weak" {
-  zone          = var.zone
-  name          = "pepin-qual-sks-weak"
-  service_level = "starter"
-  auto_upgrade  = false
-  labels        = local.tagged
+  zone                          = var.zone
+  name                          = "pepin-qual-sks-weak"
+  create_default_security_group = false
+  service_level                 = "starter"
+  auto_upgrade                  = false
+  labels                        = local.tagged
 
   audit {
     enabled  = false
@@ -22,11 +29,12 @@ resource "exoscale_sks_cluster" "weak" {
 }
 
 resource "exoscale_sks_cluster" "strong" {
-  zone          = var.zone
-  name          = "pepin-qual-sks-strong"
-  service_level = "pro"
-  auto_upgrade  = true
-  labels        = local.tagged
+  zone                          = var.zone
+  name                          = "pepin-qual-sks-strong"
+  create_default_security_group = false
+  service_level                 = "pro"
+  auto_upgrade                  = true
+  labels                        = local.tagged
 
   audit {
     enabled      = true

--- a/references/qualification/exoscale/tenant.yaml
+++ b/references/qualification/exoscale/tenant.yaml
@@ -1,48 +1,97 @@
 # Tenant de QUALIFICATION Exoscale — métadonnées lues par tools/qualification/qualify.py.
 #
-# PLAN SEUL : aucun compte Exoscale n'est disponible. Ce tenant épingle la source
-# Terraform — ce que `pepin scan exoscale --terraform` rend sur son plan —, ce qui a
-# déjà de la valeur (c'est le chemin qu'un utilisateur emploie sans compte, ADR-0012).
-# La moitié live (apply, scan --live, bundle, destroy, preuve de destruction)
-# attend un compte ; `mise run qualify` sur ce tenant est REFUSÉ tant que
-# `live: unavailable` est là.
+# Même doctrine que les tenants Scaleway et Outscale (references/qualification/README.fr.md) :
+# une faute par ressource, un contre-exemple par contrôle, appliqué puis détruit,
+# comparé à expected.yaml. Ce qui est propre à Exoscale : les ressources sont
+# ZONALES et le scan live ne lit qu'une zone (`--region de-fra-1`) — l'instance de
+# ch-gva-2 n'existe que pour la source Terraform ; les groupes de sécurité et
+# l'IAM sont d'organisation ; les buckets SOS n'ont pas de ressource Terraform
+# (crochet `extra`) ; et rien n'a de protocole « tout ».
 provider: exoscale
-title: "Tenant de qualification Exoscale : une faute par ressource, source Terraform seulement (pas de compte)"
-title_en: "Exoscale qualification tenant: one fault per resource, Terraform source only (no account)"
+title: "Tenant de qualification Exoscale : une faute par ressource, un contre-exemple par contrôle"
+title_en: "Exoscale qualification tenant: one fault per resource, one counterexample per control"
 
-live: unavailable
-live_reason: "Aucun compte Exoscale disponible (2026-09-09). La moitié live n'est ni construite ni prouvée : hooks.py refuse identity/inventory/cleanup."
-
+# La zone scannée, et celles que l'inventaire de la preuve de destruction parcourt :
+# ce que la stack crée en ch-gva-2 (pour la source Terraform) doit être prouvé
+# détruit comme le reste.
 region: de-fra-1
 zone: de-fra-1
+zones: [de-fra-1, ch-gva-2]
 
+# Étiquette posée sur toute ressource étiquetable (`labels` Exoscale) ; préfixe des
+# noms pour ce qui ne s'étiquette pas (groupes de sécurité, buckets).
 tag: pepin-qual
 name_prefix: pepin-qual-
 
 provider_version: "0.71.0"
 
+# Outil requis par le crochet `extra` (les buckets SOS passent par `exo storage`,
+# la CLI de référence du fournisseur) et par le nettoyage de secours des buckets.
+required_tools: [exo]
+
+# Rien n'est « plan seulement » chez Exoscale : la variable est passée pour
+# l'uniformité du runner.
 applied_vars:
   terraform_only_resources: false
 
-budget_minutes: 5
+# Budget mur. Les clusters SKS (~2-3 min chacun à créer, ~1 min à détruire) sont
+# l'étape lente.
+budget_minutes: 20
+
+# Coût : tarifs horaires de l'API de tarification du portail (portal.exoscale.com/
+# api/pricing/{opencompute,blockstorage,sks}, EUR, 2026-09-09) sur ce qui est appliqué.
+cost:
+  currency: EUR
+  hourly:
+    - family: instances_micro
+      count: 2
+      unit_price: 0.00729    # standard.micro (exposed, untagged)
+      source: "pricing/opencompute running_micro"
+    - family: instances_small
+      count: 2
+      unit_price: 0.02333    # standard.small : la taille minimale pour un volume block storage (secrets, hardened)
+      source: "pricing/opencompute running_small"
+    - family: local_storage_gb
+      count: 40              # 4 disques racine de 10 Go
+      unit_price: 0.00014
+      source: "pricing/opencompute volume (par Go.h)"
+    - family: block_storage_gb
+      count: 30              # 2 volumes de 10 Go + 1 snapshot de 10 Go
+      unit_price: 0.00014
+      source: "pricing/blockstorage volume / snapshot (par Go.h)"
+    - family: sks_pro
+      count: 1
+      unit_price: 0.054995   # plan de contrôle Pro (strong) ; starter (weak) est gratuit
+      source: "pricing/sks pro_cluster"
 
 resources:
-  plan:
-    - { family: security_groups, count: 9, note: "ssh/rdp/db/snmp/any/quartet/egress_any ⇒ 6 contrôles réseau ; undocumented_flow ⇒ CLD-NET-5 (matrice des flux) ; hardened = contre-exemple" }
+  applied:
+    - { family: security_groups, count: 9, note: "ssh/rdp/db/snmp/any/quartet ⇒ 5 contrôles d'entrée ; egress_any (TCP 1-65535 sortant) ⇒ CLD-NET-4 ; undocumented_flow ⇒ CLD-NET-5 (matrice des flux) ; hardened = contre-exemple — 15 règles" }
     - { family: private_networks, count: 2, note: "undocumented ⇒ CLD-NET-5 ; documented = contre-exemple" }
-    - { family: instances, count: 4, note: "untagged ⇒ CLD-GVN-1 ; secrets ⇒ CLD-CMP-9 ; swiss (ch-gva-2) ⇒ CLD-GVN-3 mineur ; hardened = contre-exemple" }
-    - { family: block_volumes, count: 1, note: "chiffré par construction (CLD-CHF-2 pass) ; CLD-STO-3 attend le live" }
-    - { family: sks_clusters, count: 2, note: "weak (starter, sans auto-upgrade, sans audit) ⇒ CLD-K8S-2, CLD-K8S-3, CLD-LOG-1 ; strong = contre-exemple" }
+    - { family: instances, count: 4, note: "le quota de l'organisation (GET /quota : instance 4) ; exposed (IP publique + SSH ouvert) ⇒ CLD-NET-3 ; untagged ⇒ CLD-GVN-1, et sans IP publique derrière le même SSH ouvert = contre-exemple de NET-3 ; secrets ⇒ CLD-CMP-9 ; hardened = contre-exemple" }
+    - { family: block_volumes, count: 2, note: "unsnapshotted (attaché à secrets) ⇒ CLD-STO-3 ; snapshotted (attaché à hardened, une snapshot) = contre-exemple ; chiffrés par construction (CLD-CHF-2 pass)" }
+    - { family: block_snapshots, count: 1, note: "la snapshot du contre-exemple" }
+    - { family: sks_clusters, count: 2, note: "weak (starter, sans auto-upgrade, sans audit) ⇒ CLD-K8S-2, CLD-K8S-3, CLD-LOG-1 ; strong (pro, auto-upgrade, audit) = contre-exemple ; sans nodepool" }
     - { family: iam_roles, count: 4, note: "admin ⇒ iam_role_no_admin_privileges ; no_source_ip ⇒ iam_role_source_ip_restricted ; unbounded ⇒ iam_role_key_lifetime_bounded ; restricted = contre-exemple" }
+  terraform_only:   # sur le plan complet seulement (`terraform_only_resources`), jamais appliqué
+    - { family: instances, count: 1, note: "swiss (ch-gva-2) ⇒ CLD-GVN-3 mineur — hors de la zone scannée en live, et hors quota" }
+  extra:   # hors Terraform (crochet `extra`) : le provider 0.71.0 n'a pas de ressource de bucket
+    - { family: buckets, count: 3, note: "public (ACL public-read, versionné) ⇒ CLD-STO-1 et STO-8 ; unversioned ⇒ CLD-STO-4 et STO-8 ; hardened (Object Lock à la création, par S3) = contre-exemple ; aucun n'est étiquetable (SOS ne persiste pas les tags de bucket) ⇒ CLD-GVN-1 sur les trois, par construction" }
 
 not_exercised:
-  - control: compute_instance_public_ip_with_open_securitygroup
-    reason: "L'IP publique d'une instance est calculée à l'apply : le plan ne peut pas conclure. Attend la moitié live."
-  - control: blockstorage_volume_snapshots_exist
-    reason: "L'état d'usage d'un volume (attached) est calculé à l'apply. Attend la moitié live."
-  - control: objectstorage_bucket_*
-    reason: "Le provider exoscale/exoscale n'a pas de ressource de bucket SOS (seulement exoscale_sos_bucket_policy) : les buckets seront créés par un crochet `extra`, comme chez Outscale, quand un compte existera."
+  - control: network_securitygroup_allow_ingress_from_internet_to_all_ports
+    reason: "Non applicable chez Exoscale : une règle n'a pas de protocole « tout » (tcp, udp, icmp, icmpv6, ah, esp, gre, ipip). any_open ouvre tout TCP et tout UDP, et ce sont les contrôles par famille de ports qui parlent."
+  - control: governance_resource_region_in_eu
+    reason: "En live, la collecte ne projette `region` sur aucun type : not-evaluated sur toute organisation (dette nommée, issue #210). Et le scan ne lit qu'une zone (de-fra-1, UE) : une instance de ch-gva-2 lui serait invisible, l'organisation n'a droit qu'à quatre instances. `swiss` n'existe que sur le plan complet ; l'écart (mineur : hors UE, espace de confiance) n'est prouvé que sur la source Terraform."
   - control: iam_user_mfa_enabled
-    reason: "Les utilisateurs IAM ne sont pas des ressources Terraform, et ce sont des personnes réelles de l'organisation."
+    reason: "Les utilisateurs de l'organisation sont des personnes réelles, pas des ressources du tenant : le contrôle est observé tel quel, hors tenant (`evaluated`)."
+  - control: iam_role_*
+    reason: "Le rôle de la clé qui qualifie (deny par défaut, sans règle CEL) et les rôles sks-ccm-<cluster> que SKS crée pour chaque cluster (éditables, sans borne) sont hors tenant : ils portent leurs propres écarts d'origine et de durée, observés et non gardés (issue #213 pour les rôles SKS)."
+  - control: compute_instance_has_security_group
+    reason: "Le contre-exemple de NET-3 (`untagged`, private = true) n'a pas de groupe : l'API ignore ceux qu'on déclare sur une instance sans interface publique (security-groups: []). L'écart est épinglé tel que mesuré, faux positif à remédiation inexécutable (issue #212)."
+  - control: kubernetes_cluster_audit_logging_enabled (live)
+    reason: "Faux vert live épinglé comme défaut connu : l'API rend audit {} sans audit, la collecte dérive audit_enabled de audit.endpoint et ne projette rien sur le cluster fautif (issue #209). Le plan, lui, l'attrape."
+  - control: governance_resource_required_tags
+    reason: "Buckets SOS : SOS accepte PutBucketTagging (200) et ne persiste rien (GetBucketTagging → NoSuchTagSet, mesuré par SigV4 et par la CLI aws) : un bucket SOS n'a jamais d'étiquette, le contre-exemple n'existe pas, l'écart sur les trois buckets est un faux positif par construction, épinglé tel quel (issue #208). Instances : la collecte live ne projette pas labels, `untagged` passe en silence — faux vert, issue #211 ; le plan l'attrape."
   - control: governance_provider_sovereignty
     reason: "Écart par construction des faits du descripteur (siège en Suisse, contrôle capitalistique extra-UE) : épinglé fail, ce n'est pas le tenant qui le construit."

--- a/references/qualification/exoscale/variables.tf
+++ b/references/qualification/exoscale/variables.tf
@@ -1,5 +1,10 @@
 # Variables du tenant de qualification Exoscale (plan seul).
 
+variable "organization_id" {
+  description = "Organisation Exoscale (GET /organization), confirmée par l'API avant tout apply ; ses huit premiers caractères suffixent les buckets SOS, globaux"
+  type        = string
+}
+
 variable "zone" {
   description = "Zone UE des ressources : de-fra-1 (Allemagne). Chez Exoscale, la « région » est la zone"
   type        = string
@@ -12,16 +17,22 @@ variable "trusted_zone" {
   default     = "ch-gva-2"
 }
 
-variable "template_id" {
-  description = "Modèle (image) des instances. Un plan ne le valide pas ; un apply réel exigera l'identifiant d'un modèle Exoscale de la zone (data source exoscale_template), donc un compte"
+variable "template_name" {
+  description = "Modèle (image) des instances, résolu par une source de données dans chaque zone"
   type        = string
-  default     = "00000000-0000-0000-0000-000000000000"
+  default     = "Linux Ubuntu 22.04 LTS 64-bit"
 }
 
 variable "instance_type" {
-  description = "Gamme des instances (plan seul : aucune facturation)"
+  description = "Gamme des instances sans volume attaché"
   type        = string
   default     = "standard.micro"
+}
+
+variable "instance_type_with_volume" {
+  description = "Gamme des instances qui portent un volume block storage : l'API exige au moins standard.small (provider #375, « Instance size must be at least small »)"
+  type        = string
+  default     = "standard.small"
 }
 
 variable "tenant_tag" {
@@ -31,7 +42,7 @@ variable "tenant_tag" {
 }
 
 variable "terraform_only_resources" {
-  description = "Uniformité du runner : rien n'est « plan seulement » ici, puisque tout l'est"
+  description = "Vrai (défaut) : le plan porte aussi ce que seul le chemin Terraform mesure — l'instance de ch-gva-2, hors de la zone scannée et hors quota (l'organisation a droit à quatre instances). Le runner applique avec false"
   type        = bool
   default     = true
 }
@@ -45,4 +56,6 @@ locals {
   }
   tagged   = merge({ (var.tenant_tag) = "tenant" }, local.governance)
   untagged = { (var.tenant_tag) = "tenant" }
+
+  bucket_suffix = substr(var.organization_id, 0, 8)
 }


### PR DESCRIPTION
The Exoscale qualification tenant was delivered **plan-only** in #204, for want of an
account. An account is available now, so the live half exists — and the three providers
are covered end to end.

## The account is empty

Run 6 (GO): **15 resource families listed through the API v2** in `de-fra-1` and
`ch-gva-2`, plus `exo storage list`. Before equals after on every family, empty delta,
zero `pepin-qual` resource. Re-listed afterwards: instances 0, private networks 0, block
storage 0, SKS 0, EIP 0, buckets 0; the account is back to its own `default`/`app`
security groups, three native roles and one key.

All **six** live runs ended `terraform destroy rc=0`, state purged, proof empty. The two
throwaway probes are destroyed and re-listed empty.

**One survivor, worth recording**: an `sks-ccm-*` API key left by a probe (its role
deleted, the key answering 403 "not in organization"). It disappeared on its own after
about twenty minutes. Nothing was left behind, but a destroy that reports success while
a credential lingers for twenty minutes is the kind of thing a report should say rather
than round off.

## What the GO run did

184 s, **0.0037 EUR**. 40 resources in the full plan, 39 applied (9 SGs + 15 rules, 2
private networks, 4 instances — the organisation's quota — 2 block volumes + 1 snapshot,
2 SKS clusters, 4 IAM roles) plus 3 SOS buckets through the `extra` hook, one of them
created Object-Lock-ed through S3.

Live scan in five formats (exit 1), bundle sealed / verified / tampering refused,
Terraform scan (exit 1), comparison over **46 + 37 results, zero difference**.

## The gate says NO-GO

Three expectations broken per source, all NO-GO. Plus a separate demonstration on three
corrupted copies of `expected.yaml` — a false green on egress, `_all_ports` put back to
`pass`, the locked-bucket counterexample — NO-GO every time.

## Platform behaviour recorded in the READMEs

Not Pépin defects, but they cost a run each and are written down rather than
rediscovered: the `instance` quota is 4 per organisation **and the counter lags several
minutes after deletion** (run 4 was refused on an empty account, so the hook now waits
for it to fall back to 0); `GET /private-network` on `api-de-fra-1` fails to answer one
time in three or four (retried in the hook — the live collector has 30 s and no retry,
and was left untouched during scans).

Provider issues read before choosing resource types: #453/#537/#460, #375,
#207/#210/#240, #438, #76 — table with links and workarounds in both READMEs.

## Six findings, all filed

| | |
|---|---|
| **#209** | **false green**: `kubernetes_cluster_audit_logging_enabled` passes on a cluster with no audit — the API returns `audit: {}` and `audit_enabled` is derived from `audit.endpoint`. **I reproduced this independently**; it is the same composition as the #201 P0. |
| **#211** | false green: labels are not collected on instances, volumes and clusters, so the rule skips `untagged` in silence |
| #208 | SOS accepts `PutBucketTagging` and persists nothing → a false positive with no possible remediation |
| #212 | a private instance has no security group by construction (`security-groups: []`) → the control speaks with an impossible remediation |
| #213 | every SKS cluster creates an `sks-ccm-*` role that fails two `iam_role_*` controls |
| #210 | (Wave 5) `region` projected on nothing live → `governance_resource_region_in_eu` never evaluated |

Two of the six are false greens. That is what a qualification tenant is for.

## Checked before delivering

No account identifier and no secret are committed — `expected.yaml` names
`PEPIN_QUAL_EXO_ORG`, and a missing variable is a **refusal**, measured on this branch.
The only `EXO…` literal in the diff is a **deletion**: the plan-only placeholder going
away. `providers/exoscale.yaml` is untouched — in particular no `region_of_zone`, which
would produce `de-fra` and go silent on the one provider where that control works.

`qualify:selftest` 17 cases. This branch touches **no Go file**.

Refs #178, #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)
