### PR TITLE
fix(rules): a capability nobody exposes is not a compliance

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -109,6 +109,21 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Deux `pass` de plus que rien n'établissait, de la même forme que celui de la règle
+  sans description.** Une garde posait *par ressource* une question qui est *par
+  fournisseur*, et le verrou de capacité — voyant l'attribut collecté sur le type grâce
+  à un voisin — laissait l'assessment conclure faute de finding.
+  `kubernetes_cluster_audit_logging_enabled` prenait un `audit_enabled` absent pour
+  **vrai**, alors que l'API SKS **omet l'objet `audit` quand l'audit est coupé** : un
+  cluster sans audit n'avait pas l'attribut, la règle supposait « activé », et le rapport
+  concluait `pass` sur le cas même qu'elle existe pour attraper.
+  `governance_resource_required_tags` sautait en silence toute ressource dont le type ne
+  porte pas `tags` — mesuré sur un tenant Exoscale où les buckets SOS en portent quand
+  les instances, volumes et clusters n'en portent pas. Les deux questions se posent
+  désormais à l'échelle de l'**inventaire**, et celle des étiquettes **par type** : un
+  bucket qui porte des étiquettes ne prouve rien d'une instance, ce sont deux API et deux
+  collectes. Le contre-exemple que chaque garde protégeait tient toujours, avec son
+  propre test : un fournisseur qui n'expose la capacité nulle part ne déclenche rien.
 - **Un contrôle émettait six écarts justes chez un fournisseur pour lequel le
   référentiel ne le déclarait pas.** `objectstorage_bucket_default_encryption` se
   déclenche chez Scaleway — le collecteur S3 commun pose `default_encryption_enabled`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,20 @@ belongs in `git log`.
 
 ### Fixed
 
+- **Two more `pass` verdicts nothing established, both from the same shape as the audit
+  of a rule without a description.** A guard asked *per resource* a question that is
+  *per provider*, and the capability lock — seeing the attribute collected on the type
+  thanks to a neighbour — let the assessment conclude with no finding.
+  `kubernetes_cluster_audit_logging_enabled` defaulted an absent `audit_enabled` to
+  **true**, while the SKS API **omits the `audit` object when audit is off**: a cluster
+  with no audit had no attribute, the rule assumed "enabled", and the report said `pass`
+  on the very case it exists to catch. `governance_resource_required_tags` skipped, in
+  silence, every resource whose type does not carry `tags` — measured on an Exoscale
+  tenant where SOS buckets carry them and instances, volumes and clusters do not. Both
+  questions are now asked of the **inventory**, and the tags one **per type**: a bucket
+  carrying tags proves nothing about an instance, since those are two APIs and two
+  collections. The counterexample each guard protected still holds, with its own test: a
+  provider that exposes the capability nowhere still fires nothing.
 - **A control emitted six correct deviations on a provider the reference did not
   declare it for.** `objectstorage_bucket_default_encryption` fires on Scaleway — the
   shared S3 collector sets `default_encryption_enabled` on every bucket, and SSE is

--- a/internal/commonrules/rules/governance_resource_required_tags.rego
+++ b/internal/commonrules/rules/governance_resource_required_tags.rego
@@ -25,10 +25,7 @@ import rego.v1
 deny contains f if {
 	some r in input.resources
 	r.type in tagged_resource_types
-	"tags" in object.keys(r.attributes) # garde de capacité : le provider EXPOSE les étiquettes
-
-	# (sinon, un provider qui ne collecte pas les tags — ex. Exoscale live — déclencherait un
-	# finding « 4 étiquettes manquantes » sur CHAQUE ressource : tempête de faux positifs).
+	_tags_exposees(r.type) # le fournisseur expose les étiquettes POUR CE TYPE (cf. plus bas)
 	missing := missing_required_tags(object.get(r.attributes, "tags", []), required_tags_billable)
 	count(missing) > 0
 	name := object.get(r, "name", r.id)
@@ -46,4 +43,30 @@ deny contains f if {
 			"remediation_en": sprintf("Add the mandatory tags (%s) to the resource.", [required_tags_label(required_tags_billable)]),
 		},
 	}
+}
+
+# _tags_exposees — ce fournisseur expose-t-il les étiquettes POUR CE TYPE ?
+#
+# La garde d'origine testait la clé SUR LA RESSOURCE, et son intention était juste : un
+# fournisseur qui ne collecte pas les étiquettes déclencherait « 4 étiquettes
+# manquantes » sur CHAQUE ressource, une tempête de faux positifs. Mais c'est un test
+# par RESSOURCE qui répond à une question par FOURNISSEUR, et une ressource sans
+# étiquette est précisément l'écart visé — la règle se taisait donc dessus.
+#
+# Mesuré sur un tenant Exoscale : les buckets SOS portent `tags`, les instances, les
+# volumes et les clusters non. La règle évaluait les buckets et sautait tout le reste en
+# silence, sans que rien ne le dise.
+#
+# La question se pose donc à l'échelle de l'INVENTAIRE, et PAR TYPE. Un bucket qui porte
+# des étiquettes ne prouve rien d'une instance : ce sont deux API, deux collectes, et
+# l'une peut les exposer quand l'autre les ignore. Ce raffinement distingue cette
+# correction de celle du contrôle de matrice des flux, où un seul type était en jeu.
+#
+# Aucune provenance n'est lue — l'ADR-0017 l'interdit aux règles. Là où le type n'expose
+# les étiquettes NULLE PART, la règle se tait toujours, et c'est au verrou de capacité
+# de dire « non évalué » plutôt qu'à elle de conclure.
+_tags_exposees(typ) if {
+	some r in input.resources
+	r.type == typ
+	"tags" in object.keys(r.attributes)
 }

--- a/internal/commonrules/rules/governance_resource_required_tags_test.rego
+++ b/internal/commonrules/rules/governance_resource_required_tags_test.rego
@@ -103,3 +103,50 @@ test_configured_scope_still_denies if {
 	some f in deny with input as inv
 	f.code == "governance_resource_required_tags"
 }
+
+# ── LE SILENCE PAR TYPE (#211) ─────────────────────────────────────────────────
+
+_ress(rs) := {"resources": rs}
+
+_tags_code := "governance_resource_required_tags"
+
+_tags_findings(rs) := {f | some f in deny with input as _ress(rs); f.code == _tags_code}
+
+_etiquetee := [{"key": "cost-center", "value": "R&D"}, {"key": "project", "value": "pepin"}, {"key": "environment", "value": "prod"}, {"key": "owner", "value": "sre"}]
+
+# ✗ Mesuré sur un tenant Exoscale : les buckets SOS portent `tags`, les instances non.
+# La garde testait la clé SUR LA RESSOURCE, donc la règle évaluait les buckets et
+# sautait les instances EN SILENCE — sur l'écart même qu'elle vise.
+#
+# La question est posée PAR TYPE : une instance sans étiquette, à côté d'une instance
+# qui en porte, est un écart.
+test_an_untagged_instance_is_denied_when_the_type_exposes_tags if {
+	fs := _tags_findings([
+		{"provider": "exoscale", "type": "compute_instance", "id": "vm-ok", "name": "vm-ok", "attributes": {"tags": _etiquetee}},
+		{"provider": "exoscale", "type": "compute_instance", "id": "vm-nue", "name": "vm-nue", "attributes": {}},
+	])
+	count(fs) == 1
+	some f in fs
+	f.subject == "vm-nue"
+}
+
+# LE CONTRE-EXEMPLE que la garde protégeait, et qui doit tenir : un fournisseur qui ne
+# collecte pas les étiquettes d'un type ne déclenche RIEN dessus. Sans lui, la
+# correction produirait « 4 étiquettes manquantes » sur chaque ressource — la tempête
+# de faux positifs que la garde d'origine évitait.
+test_a_type_that_never_exposes_tags_stays_silent if {
+	count(_tags_findings([
+		{"provider": "exoscale", "type": "compute_instance", "id": "vm-1", "name": "vm-1", "attributes": {}},
+		{"provider": "exoscale", "type": "compute_instance", "id": "vm-2", "name": "vm-2", "attributes": {}},
+	])) == 0
+}
+
+# LA NUANCE qui distingue cette correction de celle de la matrice des flux : la question
+# se pose PAR TYPE. Un bucket qui porte des étiquettes ne prouve RIEN d'une instance —
+# ce sont deux API, deux collectes, et l'une peut les exposer quand l'autre les ignore.
+test_one_type_exposing_tags_says_nothing_of_another if {
+	count(_tags_findings([
+		{"provider": "exoscale", "type": "object_storage_bucket", "id": "b", "name": "b", "attributes": {"tags": _etiquetee}},
+		{"provider": "exoscale", "type": "compute_instance", "id": "vm-nue", "name": "vm-nue", "attributes": {}},
+	])) == 0
+}

--- a/internal/commonrules/rules/kubernetes_cluster_audit_logging_enabled.rego
+++ b/internal/commonrules/rules/kubernetes_cluster_audit_logging_enabled.rego
@@ -12,11 +12,27 @@ package pepin.rules
 import rego.v1
 
 # Audit Kubernetes non configuré (aucun endpoint d'audit) sur un cluster managé.
-# Ne se déclenche que si le collecteur a renseigné `audit_enabled` (provider qui
-# expose la capacité) ; un provider sans cet attribut ne déclenche pas la règle.
+#
+# # Le faux vert que ce contrôle a produit
+#
+# Le défaut par ressource était `true` : attribut absent ⇒ on suppose l'audit activé.
+# L'intention était de ne pas crier chez un fournisseur qui n'expose pas la capacité —
+# mais l'API SKS OMET l'objet `audit` quand l'audit est coupé, et `audit_enabled` en est
+# DÉRIVÉ. Un cluster sans audit n'avait donc pas l'attribut, la règle supposait
+# « activé », et le rapport concluait `pass` sur le cas le plus courant : celui qu'il
+# existe pour attraper.
+#
+# Le silence devenait un vert parce que le verrou de capacité, lui, voyait l'attribut
+# collecté sur le type — un cluster voisin, audité, suffisait à le poser.
+#
+# La question « ce fournisseur expose-t-il la capacité » se pose donc à l'échelle de
+# l'INVENTAIRE, pas de la ressource. Si un cluster porte l'attribut, le fournisseur
+# l'expose, et un cluster qui ne le porte pas n'a pas d'audit. Là où aucun cluster ne le
+# porte, la règle se tait toujours et c'est au verrou de dire « non évalué ».
 deny contains f if {
 	some c in resources_of_type("kubernetes_cluster")
-	not truthy(object.get(c.attributes, "audit_enabled", true))
+	_audit_expose
+	not truthy(object.get(c.attributes, "audit_enabled", false))
 	name := object.get(c.attributes, "name", c.id)
 	f := {
 		"code": "kubernetes_cluster_audit_logging_enabled",
@@ -32,4 +48,14 @@ deny contains f if {
 			"remediation_en": "Configure the cluster's Kubernetes audit (collection endpoint) and centralise the logs according to the retention policy.",
 		},
 	}
+}
+
+# _audit_expose — ce fournisseur expose-t-il la capacité d'audit ?
+#
+# Vrai dès qu'UN cluster de l'inventaire porte l'attribut, quelle que soit sa valeur :
+# `audit_enabled: false` prouve à lui seul que la capacité est lue. Aucune provenance
+# n'est consultée (ADR-0017).
+_audit_expose if {
+	some c in resources_of_type("kubernetes_cluster")
+	"audit_enabled" in object.keys(c.attributes)
 }

--- a/internal/commonrules/rules/kubernetes_cluster_audit_logging_enabled_test.rego
+++ b/internal/commonrules/rules/kubernetes_cluster_audit_logging_enabled_test.rego
@@ -19,3 +19,43 @@ test_k8s_audit_enabled_ok if {
 test_k8s_audit_absent_ok if {
 	count({f | some f in deny; f.code == "kubernetes_cluster_audit_logging_enabled"}) == 0 with input as _k8saudit({"name": "prod", "control_plane_multi_az": true})
 }
+
+# ── LE FAUX VERT (#209) ────────────────────────────────────────────────────────
+
+_clusters(cs) := {"resources": [{"provider": "exoscale", "type": "kubernetes_cluster", "id": c.name, "attributes": c} | some c in cs]}
+
+_audit := "kubernetes_cluster_audit_logging_enabled"
+
+_audit_findings(cs) := {f | some f in deny with input as _clusters(cs); f.code == _audit}
+
+# ✗ Un cluster SANS l'attribut, à côté d'un cluster qui le porte. C'est le cas réel :
+# l'API SKS OMET l'objet `audit` quand l'audit est coupé, et `audit_enabled` en est
+# dérivé. Le défaut par ressource étant `true`, la règle supposait « activé » et le
+# rapport concluait `pass` sur le cas même qu'elle vise.
+test_a_cluster_without_the_attribute_is_denied_when_the_provider_exposes_it if {
+	fs := _audit_findings([
+		{"name": "audite", "audit_enabled": true},
+		{"name": "audit-coupe"},
+	])
+	count(fs) == 1
+	some f in fs
+	f.subject == "audit-coupe"
+}
+
+# LE CONTRE-EXEMPLE que la garde d'origine protégeait : un fournisseur qui n'expose la
+# capacité NULLE PART ne déclenche rien. Sans lui, la correction échangerait un faux
+# vert contre une pluie de faux positifs sur tout provider sans audit managé.
+test_a_provider_without_the_capability_stays_silent if {
+	count(_audit_findings([{"name": "c1"}, {"name": "c2"}])) == 0
+}
+
+# `false` explicite prouve à lui seul que la capacité est lue : un inventaire d'un seul
+# cluster sans audit doit rougir.
+test_an_explicit_false_alone_proves_the_capability if {
+	count(_audit_findings([{"name": "seul", "audit_enabled": false}])) == 1
+}
+
+# Un cluster audité ne rougit pas.
+test_an_audited_cluster_stays_silent if {
+	count(_audit_findings([{"name": "ok", "audit_enabled": true}])) == 0
+}


### PR DESCRIPTION
Closes #209 and #211, both bumped to P1. Found by the Exoscale qualification tenant; **#209 reproduced independently before being touched**.

## The same shape, a third time

A rule guards itself with *"does this provider expose the field at all"* — a good
question, since firing on a provider that does not collect it would be a flood of false
positives. **But the guard is written per resource, and a resource without the field is
exactly the deviation.** The rule goes silent on it, and the silence becomes a `pass`:
the capability lock sees the attribute collected on the type — a neighbour carrying it
is enough — and lets the assessment conclude with no finding.

| | before | after |
|---|---|---|
| a cluster with no audit, beside an audited one | **`pass`** | `fail` |
| an untagged instance, beside a tagged one | *silently skipped* | `fail` |

### #209 — the API omits what the rule assumed

`audit_enabled` is **derived** from `audit.endpoint`, and the SKS API **omits the
`audit` object when audit is off**. So a cluster with no audit had no attribute, the
rule defaulted it to `true`, and the report said `pass` on the most common case — the
one it exists to catch.

### #211 — and the refinement that distinguishes it

`governance_resource_required_tags` skipped, in silence, every resource whose type does
not carry `tags`. On an Exoscale tenant: SOS buckets carry them, instances, volumes and
clusters do not. Buckets were judged, everything else passed over without a word.

Its question is asked of the inventory **per type**, and that is the difference with
yesterday's fix: **a bucket carrying tags proves nothing about an instance** — two APIs,
two collections, and one can expose what the other ignores. A test states exactly that.

## The counterexamples still hold

Each guard protected something real, and each keeps its own test: a provider that
exposes the capability **nowhere** fires nothing, and it is then the capability lock's
job to say `not-evaluated` rather than the rule's to conclude. An explicit `false`
proves on its own that the capability is read, so an inventory of a single unaudited
cluster goes red.

No rule reads the provenance — ADR-0017 forbids it, and its guard is now precise enough
to allow saying so in a comment.

## Measured

373 Rego tests (was 366). **Zero verdict movement** on the reference corpus: nothing
there has a resource missing the field next to one carrying it — which is precisely why
these survived until a qualification tenant looked at three real accounts.

`mise run prepush` green.

Closes #209
Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)