### PR TITLE
fix(tfmap): one database, one subject

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -124,6 +124,18 @@ l'une ni l'autre appartient au `git log`.
   bucket qui porte des étiquettes ne prouve rien d'une instance, ce sont deux API et deux
   collectes. Le contre-exemple que chaque garde protégeait tient toujours, avec son
   propre test : un fournisseur qui n'expose la capacité nulle part ne déclenche rien.
+- **Une même base obtenait deux sujets sur un plan Terraform.** L'écart dérivé de l'ACL
+  nommait la ressource ACL, ceux dérivés de l'instance nommaient la base : trois écarts,
+  deux noms — et une dérogation écrite sur l'un ratait l'autre, en silence. Il fallait
+  deux choses. Un mapping qui lit son porteur par `_parent.<champ>` voit désormais ce
+  champ comblé depuis la référence déclarée, comme n'importe quel autre argument
+  (l'ADR-0022 ne comblait que les chemins simples). Et l'adresse ainsi obtenue est
+  ensuite résolue vers l'**identité que la ressource visée porte dans l'inventaire** —
+  une base qui a un `name` est nommée par lui, pas par son adresse Terraform. La
+  réécriture est bornée aux attributs réellement comblés depuis une référence : une
+  valeur qui ressemble seulement à une adresse n'est jamais touchée. La même correction
+  fait lire `backups-prod` au sujet d'un bucket Scaleway au lieu de
+  `scaleway_object_bucket.backups`, ce qu'un lecteur cherche effectivement.
 - **Un contrôle émettait six écarts justes chez un fournisseur pour lequel le
   référentiel ne le déclarait pas.** `objectstorage_bucket_default_encryption` se
   déclenche chez Scaleway — le collecteur S3 commun pose `default_encryption_enabled`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,17 @@ belongs in `git log`.
   carrying tags proves nothing about an instance, since those are two APIs and two
   collections. The counterexample each guard protected still holds, with its own test: a
   provider that exposes the capability nowhere still fires nothing.
+- **One database got two subjects on a Terraform plan.** The ACL-derived deviation named
+  the ACL resource, the instance-derived ones named the database: three deviations, two
+  names — and an exception written on one missed the other, silently. Two things were
+  needed. A mapping that reads its carrier through `_parent.<field>` now gets that field
+  filled from the declared reference, like any other argument (ADR-0022 filled simple
+  paths only). And the address so obtained is then resolved to the **identity the target
+  carries in the inventory** — a database that has a `name` is named by it, not by its
+  Terraform address. The rewrite is bounded to attributes actually filled from a
+  reference: a value that merely looks like an address is never touched. The same fix
+  makes a Scaleway bucket's subject read `backups-prod` instead of
+  `scaleway_object_bucket.backups`, which is what a reader is looking for.
 - **A control emitted six correct deviations on a provider the reference did not
   declare it for.** `objectstorage_bucket_default_encryption` fires on Scaleway — the
   shared S3 collector sets `default_encryption_enabled` on every bucket, and SSE is

--- a/cmd/testdata/lang/scan-fr.stdout
+++ b/cmd/testdata/lang/scan-fr.stdout
@@ -7,8 +7,8 @@
  ⚡ Action immédiate — les 3 écarts les plus graves
 ──────────────────────────────────────────────────────────────────────────────
 
-  1. 🔴 CRIT  CLD-STO-1 — Bucket « scaleway_object_bucket.backups » accessible publiqueme…
-     subject: scaleway_object_bucket.backups
+  1. 🔴 CRIT  CLD-STO-1 — Bucket « backups-prod » accessible publiquement (ACL publique).
+     subject: backups-prod
   2. 🟠 HIGH  CLD-CMP-9 — secret en clair dans user-data (mot de passe en clair).
      subject: scaleway_instance_server.web
   3. 🟠 HIGH  CLD-STO-3 — sauvegardes automatiques désactivées.
@@ -22,7 +22,7 @@
   Écarts au total : 1
 
   Détail :
-      CRIT  scaleway_object_bucket.backups — Bucket « scaleway_object_bucket.backups » accessible publiquement (ACL publique).
+      CRIT  backups-prod — Bucket « backups-prod » accessible publiquement (ACL publique).
 
   Remédiation
     Rendre le bucket privé (ACL private, retrait du grant AllUsers, suppression de la policy publique) ; servir via des URLs pré-signées si nécessaire.

--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -205,7 +205,7 @@ ressources, pas une liste à cocher de contrôles.
   "control": "objectstorage_bucket_public_access",
   "evidence": {
     "attribute": "acl",
-    "observed": "Bucket « scaleway_object_bucket.backups » accessible publiquement (ACL publique).",
+    "observed": "Bucket « backups-prod » accessible publiquement (ACL publique).",
     "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
@@ -213,7 +213,7 @@ ressources, pas une liste à cocher de contrôles.
     "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
-    "tf_line": "81"
+    "tf_line": "77"
   },
   "references": [
     {
@@ -248,7 +248,7 @@ ressources, pas une liste à cocher de contrôles.
   "remediation": "Rendre le bucket privé (ACL private, retrait du grant AllUsers, suppression de la policy publique) ; servir via des URLs pré-signées si nécessaire.",
   "severity": "critical",
   "status": "fail",
-  "subject": "scaleway_object_bucket.backups",
+  "subject": "backups-prod",
   "title": "Stockage objet exposé publiquement"
 }
 ```

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -205,7 +205,7 @@ resources, not a checklist of controls.
   "control": "objectstorage_bucket_public_access",
   "evidence": {
     "attribute": "acl",
-    "observed": "Bucket \"scaleway_object_bucket.backups\" is publicly accessible (public ACL).",
+    "observed": "Bucket \"backups-prod\" is publicly accessible (public ACL).",
     "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
@@ -213,7 +213,7 @@ resources, not a checklist of controls.
     "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
-    "tf_line": "81"
+    "tf_line": "77"
   },
   "references": [
     {
@@ -248,7 +248,7 @@ resources, not a checklist of controls.
   "remediation": "Make the bucket private (private ACL, remove the AllUsers grant, delete the public policy); serve through pre-signed URLs if needed.",
   "severity": "critical",
   "status": "fail",
-  "subject": "scaleway_object_bucket.backups",
+  "subject": "backups-prod",
   "title": "Object storage publicly exposed"
 }
 ```

--- a/docs/getting-started/quickstart.fr.md
+++ b/docs/getting-started/quickstart.fr.md
@@ -76,8 +76,8 @@ actionnable.
  ⚡ Action immédiate — les 3 écarts les plus graves
 ──────────────────────────────────────────────────────────────────────────────
 
-  1. 🔴 CRIT  CLD-STO-1 — Bucket « scaleway_object_bucket.backups » accessible publiqueme…
-     subject: scaleway_object_bucket.backups
+  1. 🔴 CRIT  CLD-STO-1 — Bucket « backups-prod » accessible publiquement (ACL publique).
+     subject: backups-prod
   2. 🟠 HIGH  CLD-CMP-9 — secret en clair dans user-data (mot de passe en clair).
      subject: scaleway_instance_server.web
   3. 🟠 HIGH  CLD-STO-3 — sauvegardes automatiques désactivées.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -72,8 +72,8 @@ actionable:
  ⚡ Immediate action — top 3 most severe deviations
 ──────────────────────────────────────────────────────────────────────────────
 
-  1. 🔴 CRIT  CLD-STO-1 — Bucket "scaleway_object_bucket.backups" is publicly accessible …
-     subject: scaleway_object_bucket.backups
+  1. 🔴 CRIT  CLD-STO-1 — Bucket "backups-prod" is publicly accessible (public ACL).
+     subject: backups-prod
   2. 🟠 HIGH  CLD-CMP-9 — VM "scaleway_instance_server.web": cleartext secret in user-dat…
      subject: scaleway_instance_server.web
   3. 🟠 HIGH  CLD-STO-3 — Managed database "pepin-test-rdb": automatic backups are disabl…

--- a/docs/getting-started/understanding-a-scan.fr.md
+++ b/docs/getting-started/understanding-a-scan.fr.md
@@ -57,8 +57,8 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
  ⚡ Action immédiate — les 3 écarts les plus graves
 ──────────────────────────────────────────────────────────────────────────────
 
-  1. 🔴 CRIT  CLD-STO-1 — Bucket « scaleway_object_bucket.backups » accessible publiqueme…
-     subject: scaleway_object_bucket.backups
+  1. 🔴 CRIT  CLD-STO-1 — Bucket « backups-prod » accessible publiquement (ACL publique).
+     subject: backups-prod
   2. 🟠 HIGH  CLD-CMP-9 — secret en clair dans user-data (mot de passe en clair).
      subject: scaleway_instance_server.web
   3. 🟠 HIGH  CLD-STO-3 — sauvegardes automatiques désactivées.
@@ -72,7 +72,7 @@ gros tenant, vous voulez savoir que l'outil a démarré. La dernière ligne est
   Écarts au total : 1
 
   Détail :
-      CRIT  scaleway_object_bucket.backups — Bucket « scaleway_object_bucket.backups » accessible publiquement (ACL publique).
+      CRIT  backups-prod — Bucket « backups-prod » accessible publiquement (ACL publique).
 
   Remédiation
     Rendre le bucket privé (ACL private, retrait du grant AllUsers, suppression de la policy publique) ; servir via des URLs pré-signées si nécessaire.
@@ -270,7 +270,7 @@ premier écran d'un long rapport soit déjà actionnable.
   Écarts au total : 1
 
   Détail :
-      CRIT  scaleway_object_bucket.backups — Bucket « scaleway_object_bucket.backups » accessible publiquement (ACL publique).
+      CRIT  backups-prod — Bucket « backups-prod » accessible publiquement (ACL publique).
 
   Remédiation
     Rendre le bucket privé (ACL private, retrait du grant AllUsers, suppression de la policy publique) ; servir via des URLs pré-signées si nécessaire.
@@ -405,7 +405,7 @@ mot.
   "control": "objectstorage_bucket_public_access",
   "evidence": {
     "attribute": "acl",
-    "observed": "Bucket « scaleway_object_bucket.backups » accessible publiquement (ACL publique).",
+    "observed": "Bucket « backups-prod » accessible publiquement (ACL publique).",
     "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
@@ -413,7 +413,7 @@ mot.
     "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
-    "tf_line": "81"
+    "tf_line": "77"
   },
   "references": [
     {
@@ -448,7 +448,7 @@ mot.
   "remediation": "Rendre le bucket privé (ACL private, retrait du grant AllUsers, suppression de la policy publique) ; servir via des URLs pré-signées si nécessaire.",
   "severity": "critical",
   "status": "fail",
-  "subject": "scaleway_object_bucket.backups",
+  "subject": "backups-prod",
   "title": "Stockage objet exposé publiquement"
 }
 ```

--- a/docs/getting-started/understanding-a-scan.md
+++ b/docs/getting-started/understanding-a-scan.md
@@ -58,8 +58,8 @@ large tenant, you want to know the tool started. The closing line is
  ⚡ Immediate action — top 3 most severe deviations
 ──────────────────────────────────────────────────────────────────────────────
 
-  1. 🔴 CRIT  CLD-STO-1 — Bucket "scaleway_object_bucket.backups" is publicly accessible …
-     subject: scaleway_object_bucket.backups
+  1. 🔴 CRIT  CLD-STO-1 — Bucket "backups-prod" is publicly accessible (public ACL).
+     subject: backups-prod
   2. 🟠 HIGH  CLD-CMP-9 — VM "scaleway_instance_server.web": cleartext secret in user-dat…
      subject: scaleway_instance_server.web
   3. 🟠 HIGH  CLD-STO-3 — Managed database "pepin-test-rdb": automatic backups are disabl…
@@ -73,7 +73,7 @@ large tenant, you want to know the tool started. The closing line is
   Total deviations: 1
 
   Details:
-      CRIT  scaleway_object_bucket.backups — Bucket "scaleway_object_bucket.backups" is publicly accessible (public ACL).
+      CRIT  backups-prod — Bucket "backups-prod" is publicly accessible (public ACL).
 
   Remediation
     Make the bucket private (private ACL, remove the AllUsers grant, delete the public policy); serve through pre-signed URLs if needed.
@@ -270,7 +270,7 @@ screen of a long report is already actionable.
   Total deviations: 1
 
   Details:
-      CRIT  scaleway_object_bucket.backups — Bucket "scaleway_object_bucket.backups" is publicly accessible (public ACL).
+      CRIT  backups-prod — Bucket "backups-prod" is publicly accessible (public ACL).
 
   Remediation
     Make the bucket private (private ACL, remove the AllUsers grant, delete the public policy); serve through pre-signed URLs if needed.
@@ -402,7 +402,7 @@ documented in
   "control": "objectstorage_bucket_public_access",
   "evidence": {
     "attribute": "acl",
-    "observed": "Bucket \"scaleway_object_bucket.backups\" is publicly accessible (public ACL).",
+    "observed": "Bucket \"backups-prod\" is publicly accessible (public ACL).",
     "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
@@ -410,7 +410,7 @@ documented in
     "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
-    "tf_line": "81"
+    "tf_line": "77"
   },
   "references": [
     {
@@ -445,7 +445,7 @@ documented in
   "remediation": "Make the bucket private (private ACL, remove the AllUsers grant, delete the public policy); serve through pre-signed URLs if needed.",
   "severity": "critical",
   "status": "fail",
-  "subject": "scaleway_object_bucket.backups",
+  "subject": "backups-prod",
   "title": "Object storage publicly exposed"
 }
 ```

--- a/docs/guides/remediation.fr.md
+++ b/docs/guides/remediation.fr.md
@@ -53,7 +53,7 @@ Avant, sur `examples/scaleway/terraform/plan.json` :
   "control": "objectstorage_bucket_public_access",
   "evidence": {
     "attribute": "acl",
-    "observed": "Bucket « scaleway_object_bucket.backups » accessible publiquement (ACL publique).",
+    "observed": "Bucket « backups-prod » accessible publiquement (ACL publique).",
     "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
@@ -61,7 +61,7 @@ Avant, sur `examples/scaleway/terraform/plan.json` :
     "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
-    "tf_line": "81"
+    "tf_line": "77"
   },
   "references": [
     {
@@ -96,7 +96,7 @@ Avant, sur `examples/scaleway/terraform/plan.json` :
   "remediation": "Rendre le bucket privé (ACL private, retrait du grant AllUsers, suppression de la policy publique) ; servir via des URLs pré-signées si nécessaire.",
   "severity": "critical",
   "status": "fail",
-  "subject": "scaleway_object_bucket.backups",
+  "subject": "backups-prod",
   "title": "Stockage objet exposé publiquement"
 }
 ```

--- a/docs/guides/remediation.md
+++ b/docs/guides/remediation.md
@@ -51,7 +51,7 @@ Before, on `examples/scaleway/terraform/plan.json`:
   "control": "objectstorage_bucket_public_access",
   "evidence": {
     "attribute": "acl",
-    "observed": "Bucket \"scaleway_object_bucket.backups\" is publicly accessible (public ACL).",
+    "observed": "Bucket \"backups-prod\" is publicly accessible (public ACL).",
     "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
@@ -59,7 +59,7 @@ Before, on `examples/scaleway/terraform/plan.json`:
     "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
-    "tf_line": "81"
+    "tf_line": "77"
   },
   "references": [
     {
@@ -94,7 +94,7 @@ Before, on `examples/scaleway/terraform/plan.json`:
   "remediation": "Make the bucket private (private ACL, remove the AllUsers grant, delete the public policy); serve through pre-signed URLs if needed.",
   "severity": "critical",
   "status": "fail",
-  "subject": "scaleway_object_bucket.backups",
+  "subject": "backups-prod",
   "title": "Object storage publicly exposed"
 }
 ```

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -100,12 +100,12 @@ Forme gelée : `{"findings": [...], "summary": {...}}`.
     "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
-    "tf_line": "81"
+    "tf_line": "77"
   },
-  "message": "Bucket « scaleway_object_bucket.backups » accessible publiquement (ACL publique).",
+  "message": "Bucket « backups-prod » accessible publiquement (ACL publique).",
   "remediation": "Rendre le bucket privé (ACL private, retrait du grant AllUsers, suppression de la policy publique) ; servir via des URLs pré-signées si nécessaire.",
   "severity": "critical",
-  "subject": "scaleway_object_bucket.backups",
+  "subject": "backups-prod",
   "title": "Stockage objet exposé publiquement"
 }
 ```
@@ -255,7 +255,7 @@ Un résultat :
   "control": "objectstorage_bucket_public_access",
   "evidence": {
     "attribute": "acl",
-    "observed": "Bucket « scaleway_object_bucket.backups » accessible publiquement (ACL publique).",
+    "observed": "Bucket « backups-prod » accessible publiquement (ACL publique).",
     "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
@@ -263,7 +263,7 @@ Un résultat :
     "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
-    "tf_line": "81"
+    "tf_line": "77"
   },
   "references": [
     {
@@ -298,7 +298,7 @@ Un résultat :
   "remediation": "Rendre le bucket privé (ACL private, retrait du grant AllUsers, suppression de la policy publique) ; servir via des URLs pré-signées si nécessaire.",
   "severity": "critical",
   "status": "fail",
-  "subject": "scaleway_object_bucket.backups",
+  "subject": "backups-prod",
   "title": "Stockage objet exposé publiquement"
 }
 ```
@@ -410,13 +410,13 @@ SARIF 2.1.0, le format que lit l'onglet Code Scanning de GitHub. C'est celui à 
                   "uri": "main.tf"
                 },
                 "region": {
-                  "startLine": 81
+                  "startLine": 77
                 }
               }
             }
           ],
           "message": {
-            "text": "Bucket « scaleway_object_bucket.backups » accessible publiquement (ACL publique)."
+            "text": "Bucket « backups-prod » accessible publiquement (ACL publique)."
           },
 […]
 ```
@@ -435,13 +435,13 @@ Un résultat :
           "uri": "main.tf"
         },
         "region": {
-          "startLine": 81
+          "startLine": 77
         }
       }
     }
   ],
   "message": {
-    "text": "Bucket « scaleway_object_bucket.backups » accessible publiquement (ACL publique)."
+    "text": "Bucket « backups-prod » accessible publiquement (ACL publique)."
   },
   "ruleId": "CLD-STO-1"
 }

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -100,12 +100,12 @@ Frozen shape: `{"findings": [...], "summary": {...}}`.
     "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
-    "tf_line": "81"
+    "tf_line": "77"
   },
-  "message": "Bucket \"scaleway_object_bucket.backups\" is publicly accessible (public ACL).",
+  "message": "Bucket \"backups-prod\" is publicly accessible (public ACL).",
   "remediation": "Make the bucket private (private ACL, remove the AllUsers grant, delete the public policy); serve through pre-signed URLs if needed.",
   "severity": "critical",
-  "subject": "scaleway_object_bucket.backups",
+  "subject": "backups-prod",
   "title": "Object storage publicly exposed"
 }
 ```
@@ -252,7 +252,7 @@ One result:
   "control": "objectstorage_bucket_public_access",
   "evidence": {
     "attribute": "acl",
-    "observed": "Bucket \"scaleway_object_bucket.backups\" is publicly accessible (public ACL).",
+    "observed": "Bucket \"backups-prod\" is publicly accessible (public ACL).",
     "source": "acl=terraform-plan:scaleway_object_bucket + terraform-plan:scaleway_object_bucket_acl observed=2/2"
   },
   "labels": {
@@ -260,7 +260,7 @@ One result:
     "confidence": "confirmed",
     "provider": "scaleway",
     "tf_file": "main.tf",
-    "tf_line": "81"
+    "tf_line": "77"
   },
   "references": [
     {
@@ -295,7 +295,7 @@ One result:
   "remediation": "Make the bucket private (private ACL, remove the AllUsers grant, delete the public policy); serve through pre-signed URLs if needed.",
   "severity": "critical",
   "status": "fail",
-  "subject": "scaleway_object_bucket.backups",
+  "subject": "backups-prod",
   "title": "Object storage publicly exposed"
 }
 ```
@@ -406,13 +406,13 @@ SARIF 2.1.0, the format GitHub's Code Scanning tab reads. This is the one to upl
                   "uri": "main.tf"
                 },
                 "region": {
-                  "startLine": 81
+                  "startLine": 77
                 }
               }
             }
           ],
           "message": {
-            "text": "Bucket \"scaleway_object_bucket.backups\" is publicly accessible (public ACL)."
+            "text": "Bucket \"backups-prod\" is publicly accessible (public ACL)."
           },
 […]
 ```
@@ -431,13 +431,13 @@ One result:
           "uri": "main.tf"
         },
         "region": {
-          "startLine": 81
+          "startLine": 77
         }
       }
     }
   ],
   "message": {
-    "text": "Bucket \"scaleway_object_bucket.backups\" is publicly accessible (public ACL)."
+    "text": "Bucket \"backups-prod\" is publicly accessible (public ACL)."
   },
   "ruleId": "CLD-STO-1"
 }

--- a/internal/tfmap/references_test.go
+++ b/internal/tfmap/references_test.go
@@ -119,3 +119,94 @@ func TestAResourceWithoutReferencesIsUntouched(t *testing.T) {
 		t.Fatalf("ressource modifiée sans raison : id=%q attrs=%v", r.ID, r.Attributes)
 	}
 }
+
+// ── UN SUJET, PAS DEUX (#193) ─────────────────────────────────────────────────
+
+// specParent : un mapping en mode `items` qui lit son porteur par `_parent.<champ>`,
+// et le mapping de la ressource que ce champ référence.
+func specParent(t *testing.T) Spec {
+	t.Helper()
+	s, err := Parse([]byte(`
+provider: essai
+resources:
+  - tf_type: essai_db_acl
+    type: managed_database
+    items: acl_rules[*]
+    id: database_id
+    map:
+      database_id: _parent.instance_id
+      ip_filter: ip
+  - tf_type: essai_db
+    type: managed_database
+    id: database_id
+    map:
+      database_id: name
+      disable_backup: disable_backup
+`))
+	if err != nil {
+		t.Fatalf("spec illisible : %v", err)
+	}
+	return s
+}
+
+// Une même base obtenait DEUX sujets sur un plan : la règle dérivée de l'ACL nommait la
+// ressource ACL, celles dérivées de l'instance nommaient la base. Trois écarts, deux
+// noms — et une dérogation écrite sur l'un ratait l'autre, en silence.
+//
+// Deux choses le corrigent, et il faut les deux : combler `_parent.<champ>` depuis la
+// référence, puis résoudre l'adresse obtenue vers l'IDENTITÉ que la ressource visée
+// porte dans l'inventaire — ici son `name`, pas son adresse.
+func TestOneDatabaseGetsOneSubject(t *testing.T) {
+	inv := Apply(specParent(t), []tfparse.Resource{
+		{Type: "essai_db", Name: "exposed", Address: "essai_db.exposed",
+			Values: map[string]any{"name": "ma-base", "disable_backup": true}},
+		{Type: "essai_db_acl", Name: "exposed", Address: "essai_db_acl.exposed",
+			Values:     map[string]any{"acl_rules": []any{map[string]any{"ip": "0.0.0.0/0"}}},
+			References: map[string][]string{"instance_id": {"essai_db.exposed"}}},
+	})
+	if len(inv.Resources) != 2 {
+		t.Fatalf("%d ressource(s), 2 attendues", len(inv.Resources))
+	}
+	for _, r := range inv.Resources {
+		if r.ID != "ma-base" {
+			t.Errorf("sujet %q, attendu \"ma-base\" : la base porte deux noms", r.ID)
+		}
+	}
+}
+
+// LE CONTRE-EXEMPLE de la seconde passe : une valeur qui n'a PAS été comblée depuis une
+// référence n'est jamais réécrite, même si elle ressemble à une adresse. Réécrire à
+// l'aveugle ferait basculer une donnée du tenant sur une identité qui n'est pas la
+// sienne.
+func TestAValueThatLooksLikeAnAddressIsNeverRewritten(t *testing.T) {
+	inv := Apply(specParent(t), []tfparse.Resource{
+		{Type: "essai_db", Name: "exposed", Address: "essai_db.exposed",
+			Values: map[string]any{"name": "ma-base", "disable_backup": true}},
+		// `instance_id` est PRÉSENT et vaut littéralement une adresse : aucune
+		// référence n'a été consultée, donc rien ne doit bouger.
+		{Type: "essai_db_acl", Name: "acl", Address: "essai_db_acl.acl",
+			Values: map[string]any{"instance_id": "essai_db.exposed", "acl_rules": []any{map[string]any{"ip": "10.0.0.0/8"}}}},
+	})
+	var vu bool
+	for _, r := range inv.Resources {
+		if r.ID == "essai_db.exposed" {
+			vu = true
+		}
+	}
+	if !vu {
+		t.Error("une valeur littérale a été réécrite : la seconde passe déborde des attributs injectés")
+	}
+}
+
+// Un chemin qui DESCEND dans une structure reste écarté : une référence n'y répond pas.
+func TestACompoundPathBeyondParentIsStillNeverFilled(t *testing.T) {
+	if _, ok := champArgument("audit.0.endpoint"); ok {
+		t.Error("un chemin de descente a été pris pour un argument")
+	}
+	if c, ok := champArgument("_parent.instance_id"); !ok || c != "instance_id" {
+		t.Errorf("champArgument(_parent.instance_id) = %q,%v", c, ok)
+	}
+	if c, ok := champArgument("vm_id"); !ok || c != "vm_id" {
+		t.Errorf("champArgument(vm_id) = %q,%v", c, ok)
+	}
+}

--- a/internal/tfmap/tfmap.go
+++ b/internal/tfmap/tfmap.go
@@ -63,6 +63,14 @@ func Parse(raw []byte) (Spec, error) {
 // que personne ne lit.
 func Apply(spec Spec, resources []tfparse.Resource) model.Inventory {
 	var inv model.Inventory
+	// idParAdresse : l'identité que CHAQUE ressource du plan prend dans l'inventaire.
+	// Sert à la seconde passe, qui remplace une adresse injectée par cette identité.
+	idParAdresse := map[string]string{}
+	// injectes[i] : les attributs de `inv.Resources[i]` comblés depuis une référence.
+	// On ne réécrit qu'eux : une valeur qui ressemblerait à une adresse sans en venir
+	// ne doit pas être touchée.
+	var injectes []map[string]bool
+	var idAttr []string
 	declared := map[string]bool{}
 	for _, rs := range spec.Resources {
 		declared[rs.TFType] = true
@@ -79,9 +87,14 @@ func Apply(spec Spec, resources []tfparse.Resource) model.Inventory {
 			if rs.TFType != res.Type {
 				continue
 			}
-			items := []any{any(res.Values)}
+			// Les références comblent les valeurs AVANT l'extraction des items : un
+			// mapping en mode `items` lit son porteur par `_parent.<champ>`, et
+			// `_parent` est cette carte de valeurs, attachée à chaque item. Combler
+			// après l'extraction ne toucherait que l'item, jamais son parent.
+			valeurs := withReferences(res.Values, rs.Map, res.References)
+			items := []any{any(valeurs)}
 			if rs.Items != "" {
-				items = collect.ExtractItems(res.Values, rs.Items)
+				items = collect.ExtractItems(valeurs, rs.Items)
 			}
 			region := regionOf(rs, res.Values)
 			// La source atteste le TYPE de ressource du plan, pas l'adresse : l'adresse
@@ -90,7 +103,6 @@ func Apply(spec Spec, resources []tfparse.Resource) model.Inventory {
 			// la configuration effective, et l'origine `terraform-plan` le porte.
 			src := collect.Source{Origin: model.OriginTerraform, Ref: res.Type}
 			for _, it := range items {
-				it = withReferences(it, rs.Map, res.References)
 				attrs, prov := collect.ProjectAttested(it, rs.Map, rs.Transforms, src)
 				attestReferences(&prov, rs.Map, res)
 				for k, v := range rs.Const {
@@ -105,6 +117,9 @@ func Apply(spec Spec, resources []tfparse.Resource) model.Inventory {
 				if n, ok := res.Values["name"].(string); ok && n != "" {
 					name = n
 				}
+				idParAdresse[res.Address] = id
+				injectes = append(injectes, champsInjectes(rs.Map, res))
+				idAttr = append(idAttr, rs.ID)
 				inv.Resources = append(inv.Resources, model.Resource{
 					Provider: spec.Provider, Type: rs.Type, ID: id, Name: name, Region: region,
 					Attributes: attrs, Provenance: prov,
@@ -117,7 +132,78 @@ func Apply(spec Spec, resources []tfparse.Resource) model.Inventory {
 			}
 		}
 	}
+	resoudreVersLIdentite(inv.Resources, injectes, idAttr, idParAdresse)
 	return inv
+}
+
+// resoudreVersLIdentite remplace, dans les attributs comblés depuis une référence,
+// l'ADRESSE de la ressource visée par l'IDENTITÉ qu'elle porte dans l'inventaire.
+//
+// Une référence désigne une ressource ; ce qui la nomme dans l'inventaire n'est pas
+// forcément son adresse. Une instance de base managée qui porte un `name` s'identifie
+// par ce nom, quand une ressource sans identifiant lisible retombe sur son adresse.
+//
+// Sans cette passe, une même base obtenait DEUX sujets sur un plan : la règle dérivée
+// de son ACL la nommait `scaleway_rdb_instance.exposed`, celles dérivées de l'instance
+// `pepin-rdb`. Trois écarts, deux noms — et une dérogation écrite sur l'un ratait
+// l'autre, en silence.
+//
+// La réécriture est bornée aux attributs INJECTÉS : une valeur qui ressemblerait à une
+// adresse sans en venir n'est jamais touchée.
+func resoudreVersLIdentite(rs []model.Resource, injectes []map[string]bool, idAttr []string, idParAdresse map[string]string) {
+	if len(idParAdresse) == 0 {
+		return
+	}
+	for i := range rs {
+		if i >= len(injectes) || len(injectes[i]) == 0 {
+			continue
+		}
+		// L'IDENTITÉ d'abord : elle est dérivée d'un attribut, donc si cet attribut a
+		// été comblé par une référence, l'identité porte une adresse. La recalculer
+		// après coup serait fragile ; la réécrire ici la garde alignée sur l'attribut.
+		if injectes[i][idAttr[i]] {
+			if id, ok := idParAdresse[rs[i].ID]; ok {
+				if rs[i].Name == rs[i].ID {
+					rs[i].Name = id
+				}
+				rs[i].ID = id
+			}
+		}
+		for attr := range injectes[i] {
+			switch v := rs[i].Attributes[attr].(type) {
+			case string:
+				if id, ok := idParAdresse[v]; ok {
+					rs[i].Attributes[attr] = id
+				}
+			case []any:
+				for j, e := range v {
+					if adr, ok := e.(string); ok {
+						if id, ok := idParAdresse[adr]; ok {
+							v[j] = id
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// champsInjectes rend les attributs qu'une référence a comblés sur cette ressource.
+func champsInjectes(mapping map[string]string, res tfparse.Resource) map[string]bool {
+	out := map[string]bool{}
+	for attr, brut := range mapping {
+		chemin, ok := champArgument(brut)
+		if !ok {
+			continue
+		}
+		if _, present := res.Values[chemin]; present {
+			continue
+		}
+		if len(res.References[chemin]) > 0 {
+			out[attr] = true
+		}
+	}
+	return out
 }
 
 // sourceRefOf transpose l'origine d'une ressource du plan vers le modèle commun.
@@ -142,23 +228,24 @@ func sourceRefOf(o tfparse.Origin) *model.SourceRef {
 //
 //   - on ne complète QUE ce que le plan n'a pas. Une valeur présente gagne toujours,
 //     donc un plan appliqué (`values`, tout résolu) est strictement inchangé ;
-//   - on ne complète que les chemins SIMPLES. `_parent.x` ou `a.b` désignent une
-//     structure, pas un argument de la configuration : les compléter mêlerait deux
-//     espaces de noms ;
+//   - on ne complète que ce qui désigne un ARGUMENT de la ressource : un chemin
+//     simple (`vm_id`), ou `_parent.<champ>` — qui, en mode `items`, désigne un
+//     argument du porteur et non une structure imbriquée. `a.b` reste écarté : il
+//     descend dans une structure, et le compléter mêlerait deux espaces de noms.
+//     Sans le cas `_parent.`, une base de données obtenait DEUX sujets sur un plan :
+//     la règle dérivée de l'ACL nommait la ressource ACL, celles dérivées de
+//     l'instance nommaient la base, et une dérogation écrite sur l'une ratait l'autre ;
 //   - une seule adresse est projetée comme SCALAIRE, plusieurs comme LISTE. C'est la
 //     forme que la spec attend de la source native, et le transform `list` de la spec
 //     retombe sur ses pieds dans les deux cas.
-func withReferences(item any, mapping map[string]string, refs map[string][]string) any {
-	if len(refs) == 0 {
-		return item
-	}
-	valeurs, ok := item.(map[string]any)
-	if !ok {
-		return item
+func withReferences(valeurs map[string]any, mapping map[string]string, refs map[string][]string) map[string]any {
+	if len(refs) == 0 || valeurs == nil {
+		return valeurs
 	}
 	var complete map[string]any
-	for _, chemin := range mapping {
-		if chemin == "" || strings.ContainsAny(chemin, ".[") {
+	for _, brut := range mapping {
+		chemin, ok := champArgument(brut)
+		if !ok {
 			continue
 		}
 		if _, present := valeurs[chemin]; present {
@@ -185,9 +272,24 @@ func withReferences(item any, mapping map[string]string, refs map[string][]strin
 		complete[chemin] = liste
 	}
 	if complete == nil {
-		return item
+		return valeurs
 	}
 	return complete
+}
+
+// champArgument rend le nom de l'ARGUMENT qu'un chemin de mapping désigne, et faux si
+// le chemin descend dans une structure.
+//
+// `vm_id` désigne un argument. `_parent.instance_id` aussi : en mode `items`, `_parent`
+// est la carte des valeurs du porteur, donc son suffixe est un argument de la
+// ressource. `audit.0.endpoint` non — c'est une descente, et une référence n'y répond
+// pas.
+func champArgument(chemin string) (string, bool) {
+	chemin = strings.TrimPrefix(chemin, "_parent.")
+	if chemin == "" || strings.ContainsAny(chemin, ".[") {
+		return "", false
+	}
+	return chemin, true
 }
 
 // attestReferences corrige l'attestation des attributs COMPLÉTÉS par une référence.
@@ -198,8 +300,9 @@ func withReferences(item any, mapping map[string]string, refs map[string][]strin
 // mauvais endroit est pire que son absence — c'est la règle que le modèle de
 // provenance énonce lui-même pour les appels d'API.
 func attestReferences(prov *model.Provenance, mapping map[string]string, res tfparse.Resource) {
-	for attr, chemin := range mapping {
-		if chemin == "" || strings.ContainsAny(chemin, ".[") {
+	for attr, brut := range mapping {
+		chemin, ok := champArgument(brut)
+		if !ok {
 			continue
 		}
 		if _, present := res.Values[chemin]; present {


### PR DESCRIPTION
Closes #193.

## Three deviations, two names

On a Terraform plan a single managed database got **two subjects**:

```
database_service_not_open_to_internet   fail  subject=scaleway_rdb_acl.exposed[0]
database_encryption_at_rest_enabled     fail  subject=pepin-qual-rdb-exposed
database_backup_enabled                 fail  subject=pepin-qual-rdb-exposed
```

An exception written on one missed the other, silently.

## Two things were needed, and the first alone was not enough

**1. `_parent.<field>` is an argument.** ADR-0022 filled simple paths only, deliberately
(*"`_parent.x` ou `a.b` désignent une structure"*) — but that boundary was drawn one
notch too wide. In item mode `_parent` **is** the carrier's value map, so its suffix is
an argument of the resource, exactly what a reference answers. `a.b` stays excluded: it
descends into a structure, and a reference does not answer that.

**2. An address is not an identity.** The first change moved the subject onto the right
resource, but under its *address*, while the instance identifies itself by its `name`.
Still two names. The address is now resolved to the identity the target carries in the
inventory.

```
before  managed_database id = scaleway_rdb_acl.exposed   +  id = pepin-rdb
step 1  managed_database id = scaleway_rdb_instance.exposed + id = pepin-rdb
after   managed_database id = pepin-rdb                  +  id = pepin-rdb
```

## The rewrite is bounded, and a test says so

Only attributes **actually filled from a reference** are rewritten. A value that merely
*looks* like an address is never touched — reading it as one would move a tenant's own
data onto an identity that is not its own.

## A case nobody had reported

The same fix makes a Scaleway bucket's subject read `backups-prod` instead of
`scaleway_object_bucket.backups`. That is what a reader is looking for, and the French
reference output moved by exactly those lines — nothing else.

## Measured

**Zero verdict movement** on the reference corpus: no tenant there has an item-mode
mapping reading a parent whose id is unknown at plan time.

`mise run prepush` green.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)