### PR TITLE
feat(qualification): a known defect declares whether it blocks a release

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -493,6 +493,19 @@ l'une ni l'autre appartient au `git log`.
 
 ### Modifié
 
+- **La porte de qualification disait GO alors qu'un faux vert connu subsistait.** Elle
+  comparait un run à `expected.yaml` et concluait GO dès qu'ils coïncidaient — un bon
+  **contrat de non-régression**, mais présenté comme une **porte de qualité de release**.
+  Un défaut épinglé s'y reproduit à l'identique, la comparaison ne trouve aucune
+  différence, et la porte disait GO : elle vérifiait que le produit ment de la même façon
+  qu'hier. Les deux questions reçoivent désormais deux réponses, côte à côte dans le
+  rapport. Un défaut connu déclare sa **classe** et s'il bloque une release : un
+  `false_green` bloque **toujours** et ne se déroge pas — c'est la promesse sur laquelle
+  le produit est bâti —, un `false_positive` bloque par défaut et peut se déroger
+  explicitement, et un `coverage_gap` ne bloque pas, parce qu'un `not-evaluated` justifié
+  est une limite nommée, ce que le produit exige précisément de lui-même. Une chaîne
+  nue, ou une classe que personne n'a déclarée, bloque : un épinglage qui ne dit pas ce
+  qu'il est ne doit pas valoir laissez-passer.
 - **Plans Terraform : une référence déclarée ferme la corrélation qui n'a jamais
   fonctionné.** Un plan ne peut pas connaître l'identifiant d'une ressource qu'il va
   créer — cet attribut n'est pas résolu, il est **absent**. Mesuré sur un tenant de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -457,6 +457,18 @@ belongs in `git log`.
 
 ### Changed
 
+- **The qualification gate said GO while a known false green stood.** It compared a run
+  to `expected.yaml` and concluded GO when they matched — a good **non-regression
+  contract**, but presented as a **release quality gate**. A pinned defect reproduces
+  identically, the comparison finds no difference, and the gate said GO: it verified that
+  the product lies the same way it did yesterday. The two questions are now answered
+  separately, side by side in the report. A known defect declares its **class** and
+  whether it blocks a release: a `false_green` **always** blocks and cannot be waived — it
+  is the promise the product is built on — a `false_positive` blocks by default and can be
+  waived explicitly, and a `coverage_gap` does not block, because a justified
+  `not-evaluated` is a named limit, which is exactly what the product asks of itself.
+  A bare string, or a class nobody declared, blocks: a pin that does not say what it is
+  must not act as a pass.
 - **Terraform plans: a declared reference now closes the correlation that never worked.**
   A plan cannot know the id of a resource it is about to create — that attribute is not
   resolved, it is **absent**. Measured on a reference tenant built from third-party HCL:

--- a/references/qualification/exoscale/expected.yaml
+++ b/references/qualification/exoscale/expected.yaml
@@ -222,8 +222,17 @@ controls:
     # « conforme » sur le seul cluster observé (`observed=1/2`). Le plan, lui, échoue
     # sur `weak`. Issue #209.
     live:
-      status: pass
-      known_defect: "#209 — faux vert live : audit_enabled dérivé de audit.endpoint, absent quand l'audit est désactivé (API : audit {}) ; le cluster sans audit n'est pas évalué, le contrôle rend pass"
+      # #209 CORRIGÉE (#215) : la règle demande désormais à l'INVENTAIRE si le
+      # fournisseur expose la capacité, au lieu de le demander à chaque ressource. Un
+      # cluster sans `audit_enabled`, à côté d'un cluster qui le porte, est donc un
+      # écart et non plus un silence.
+      #
+      # Le statut attendu passe de `pass` à `fail` sur `weak`. C'est ce que la règle
+      # produit — mesuré sur un inventaire à deux clusters —, mais SEUL un run réel le
+      # confirme de bout en bout. La porte dira NO-GO jusqu'à ce run, et c'est le sens
+      # voulu : une correction se réconcilie par une mesure, pas par une prédiction.
+      status: fail
+      fail: ["${output.sks_weak_name}"]
     terraform:
       fail: [pepin-qual-sks-weak]
       silent: [pepin-qual-sks-strong]

--- a/references/qualification/scaleway/expected.yaml
+++ b/references/qualification/scaleway/expected.yaml
@@ -227,7 +227,9 @@ controls:
       # Le contre-exemple existe : SSE-ONE configuré, la règle se tait. C'est ce qui
       # permettra d'activer le contrôle pour Scaleway avec sa preuve.
       silent: ["${output.bucket_encrypted}"]
-      known_defect: "#192 — contrôle mesuré et juste sur Scaleway, mais déclaré pour Outscale seul (référentiel + matrice ✗)"
+      # #192 CORRIGÉE (#206) : le contrôle est désormais déclaré pour Scaleway, et la
+      # matrice ne dit plus ✗ là où l'outil mesure. Les six écarts étaient JUSTES —
+      # seule la déclaration était fausse —, donc ce pin de statut ne bouge pas.
     terraform: absent
 
   # ── Bases managées (PLAN SEULEMENT : aucune collecte live RDB, et rien n'est

--- a/tools/qualification/qualify.py
+++ b/tools/qualification/qualify.py
@@ -68,10 +68,70 @@ OUTPUT_REF = re.compile(r"^\$\{output\.([A-Za-z0-9_]+)\}$")
 # Comparaison — fonctions PURES, éprouvées par `selftest`
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# Classes de défaut connu, et ce que chacune vaut pour une RELEASE.
+#
+# La porte comparait un run à `expected.yaml` et disait GO dès qu'ils coïncidaient.
+# C'est un contrat de NON-RÉGRESSION, et c'en est un bon. Mais un défaut épinglé s'y
+# reproduit à l'identique, la comparaison ne trouve aucune différence, et la porte
+# concluait GO : elle vérifiait que le produit ment de la même façon qu'hier.
+#
+# Les deux questions sont distinctes et méritent deux verdicts :
+#
+#   contrat de non-régression : le run dit-il ce qu'on attendait ?
+#   verdict de release        : ce qu'on attendait est-il publiable ?
+#
+# Un `not-evaluated` justifié est une limite de couverture nommée : elle se documente et
+# se publie. Un `pass` que rien n'établit, non — c'est l'affirmation que le produit
+# promet de ne jamais faire.
+CLASSES_DEFAUT = {
+    # Un `pass` que rien n'établit. TOUJOURS bloquant, sans dérogation possible :
+    # c'est la promesse centrale du produit, et la renier une fois suffit à la perdre.
+    "false_green": {"bloquant_toujours": True},
+    # Un écart que l'utilisateur ne peut pas faire disparaître — parce que la
+    # plateforme l'impose, ou que la remédiation proposée n'aboutit jamais. Bloquant
+    # par défaut : dix de ces findings apprennent à ignorer l'outil.
+    "false_positive": {"bloquant_toujours": False},
+    # Une donnée que la source n'expose pas, rendue « non évalué ». Honnête, nommée,
+    # publiable — c'est exactement ce que l'ADR-0006 demande.
+    "coverage_gap": {"bloquant_toujours": False, "bloquant_defaut": False},
+    # Le verdict est juste, sa DÉCLARATION ne l'est pas (référentiel, matrice).
+    # Trompeur pour qui lit la doc, sans jamais mentir sur un tenant.
+    "declaration_gap": {"bloquant_toujours": False, "bloquant_defaut": False},
+}
+
+
+def defaut_connu(want):
+    """Normalise l'épinglage d'un défaut connu, ou None.
+
+    Deux formes acceptées. Une CHAÎNE, historique : elle ne dit pas sa classe, donc
+    elle est traitée comme BLOQUANTE — un épinglage qui ne se prononce pas ne doit pas
+    valoir laissez-passer. Un MAPPING `{issue, class, release_blocker, note}` dit ce
+    qu'il est, et c'est la forme à écrire.
+    """
+    kd = want.get("known_defect") if isinstance(want, dict) else None
+    if not kd:
+        return None
+    if isinstance(kd, str):
+        return {"issue": None, "class": None, "bloquant": True, "note": kd}
+    classe = kd.get("class")
+    regles = CLASSES_DEFAUT.get(classe)
+    if regles is None:
+        return {"issue": kd.get("issue"), "class": classe, "bloquant": True,
+                "note": f"classe inconnue {classe!r} (valeurs : {', '.join(sorted(CLASSES_DEFAUT))}) — traitée comme bloquante",
+                "invalide": True}
+    bloquant = kd.get("release_blocker", regles.get("bloquant_defaut", True))
+    if regles["bloquant_toujours"] and not bloquant:
+        return {"issue": kd.get("issue"), "class": classe, "bloquant": True,
+                "note": f"un défaut de classe {classe} ne se dérroge pas : release_blocker ignoré",
+                "invalide": True}
+    return {"issue": kd.get("issue"), "class": classe, "bloquant": bool(bloquant), "note": kd.get("note", "")}
+
+
 class Verdict:
     def __init__(self):
-        self.problems = []   # ce qui rend NO-GO
+        self.problems = []   # ce qui rend NO-GO le contrat de non-régression
         self.infos = []      # ce qui mérite d'être lu sans rendre NO-GO
+        self.defauts = []    # défauts connus rencontrés, normalisés
 
     @property
     def ok(self):
@@ -156,8 +216,14 @@ def compare(expected, results, source, exit_code, outputs, prefix, owned=None):
         # Un défaut CONNU est épinglé tel qu'il est mesuré, avec le numéro de l'issue
         # qui le suit : la porte reste GO, et la correction la fera rougir sciemment.
         # Il est dit à chaque run, pour ne jamais passer pour une attente ordinaire.
-        if isinstance(want, dict) and want.get("known_defect"):
-            v.info(f"[{source}] {code} : épinglé comme DÉFAUT CONNU — {want['known_defect']}")
+        d = defaut_connu(want)
+        if d:
+            d = dict(d, control=code, source=source)
+            v.defauts.append(d)
+            marque = "BLOQUE LA RELEASE" if d["bloquant"] else "n'empêche pas la release"
+            v.info(f"[{source}] {code} : DÉFAUT CONNU ({d['class'] or 'classe non dite'}, {marque})"
+                   + (f" — {d['note']}" if d.get("note") else "")
+                   + (f" — issue #{d['issue']}" if d.get("issue") else ""))
         # Un sujet que l'attente NOMME est du tenant, même sans préfixe : le
         # fournisseur lui-même, sujet du contrôle de souveraineté, en est le cas.
         named = set()
@@ -643,6 +709,7 @@ class Run:
             results = load_results(self.run_dir / fname)
             v = compare(self.expected, results, source, rc, self.outputs, prefix, owned)
             self.comparison[source] = {"ok": v.ok, "problems": v.problems, "infos": v.infos,
+                                       "known_defects": v.defauts,
                                        "results": len(results), "exit_code": rc}
             for p in v.problems:
                 print(f"  ✘ {p}")
@@ -670,11 +737,19 @@ class Run:
                 "estimate": round(hours * rate, 4),
                 "note": "estimation : durée apply→destroy × tarifs horaires de tenant.yaml ; la facture à 48 h tranche"}
 
-    def report(self, verdict):
+    def report(self, verdict, release=None, bloquants=None):
         duration = round(time.time() - self.t0, 1)
+        release = release or verdict
+        bloquants = bloquants or []
+        tous = [d for src in getattr(self, "comparison", {}).values() for d in src.get("known_defects", [])]
+        par_classe = {}
+        for d in tous:
+            par_classe.setdefault(d["class"] or "classe non dite", []).append(d)
         rep = {
             "stage": f"qualification-{self.provider}",
-            "verdict": verdict,
+            "regression_contract": verdict,
+            "verdict": release,
+            "known_defects": tous,
             "plan_only": self.plan_only,
             "started": dt.datetime.fromtimestamp(self.t0, dt.timezone.utc).isoformat(timespec="seconds"),
             "duration_seconds": duration,
@@ -690,9 +765,27 @@ class Run:
         }
         out = self.run_dir.parent / f"qualification-{self.provider}.json"
         out.write_text(json.dumps(rep, indent=2, ensure_ascii=False))
-        lines = [f"# Qualification {self.provider} — {verdict}", ""]
+        lines = [f"# Qualification {self.provider} — {release}", ""]
         for s in self.stages:
             lines.append(f"- {'✔' if s['rc'] == 0 else '✘'} {s['name']} ({s['seconds']}s) — {s['note']}")
+        # Les deux verdicts, côte à côte : le contrat de non-régression répond « le run
+        # dit-il ce qu'on attendait », le verdict de release « ce qu'on attend est-il
+        # publiable ». Les afficher ensemble empêche de lire l'un pour l'autre.
+        lines += ["", f"- contrat de non-régression : {verdict}"]
+        if tous:
+            lines.append("- défauts connus :")
+            for classe in sorted(par_classe):
+                ds = par_classe[classe]
+                bloque = sum(1 for d in ds if d["bloquant"])
+                marque = "❌" if bloque else "⚠"
+                lines.append(f"    {marque} {classe} : {len(ds)}" + (f" (dont {bloque} bloquant(s))" if bloque else ""))
+            for d in bloquants:
+                ref = f" (#{d['issue']})" if d.get("issue") else ""
+                lines.append(f"    ↳ BLOQUE : {d['control']} [{d['source']}]{ref}"
+                             + (f" — {d['note']}" if d.get("note") else ""))
+        else:
+            lines.append("- défauts connus : aucun")
+        lines.append(f"- VERDICT DE RELEASE : {release}")
         c = rep["cost"]
         if c:
             lines.append(f"- coût estimé : {c['estimate']} {c['currency']} ({c['billed_hours']} h × {c['hourly_rate']} {c['currency']}/h)")
@@ -731,9 +824,30 @@ class Run:
         if ok and budget and (time.time() - self.t0) > budget * 60:
             self.stages.append({"name": "budget", "rc": 1, "seconds": 0, "note": f"{round((time.time() - self.t0) / 60, 1)} min > {budget} min"})
             ok = False
+        # DEUX verdicts, et la distinction est le sujet.
+        #
+        # Le contrat de NON-RÉGRESSION dit si le run coïncide avec `expected.yaml`.
+        # Le verdict de RELEASE dit si ce qu'on attend est publiable. Un défaut connu
+        # épinglé satisfait le premier — c'est même sa raison d'être, il se reproduit à
+        # l'identique — et ne dit rien du second. Les confondre revenait à conclure GO
+        # parce que le produit ment de la même façon qu'hier.
+        bloquants = self.defauts_bloquants()
         verdict = "GO" if ok else ("NO-GO" if self.destroyed or not self.applied else "NO-GO (RESTES À NETTOYER)")
-        self.report(verdict)
-        return 0 if ok else 1
+        release = verdict
+        if ok and bloquants:
+            release = "NO-GO"
+            self.stages.append({"name": "défauts connus bloquants", "rc": 1, "seconds": 0,
+                                "note": "; ".join(f"{d['control']} [{d['source']}] {d['class'] or 'classe non dite'}"
+                                                  + (f" #{d['issue']}" if d.get("issue") else "") for d in bloquants)})
+        self.report(verdict, release, bloquants)
+        return 0 if release == "GO" else 1
+
+    def defauts_bloquants(self):
+        """Les défauts connus qui interdisent une release, tous tenants confondus."""
+        out = []
+        for src in getattr(self, "comparison", {}).values():
+            out += [d for d in src.get("known_defects", []) if d["bloquant"]]
+        return out
 
 
 class StageFailed(Exception):
@@ -795,6 +909,32 @@ def selftest():
         ("un inconcluant que rien n'attend rend NO-GO", expected, good + [{"control": "a_fail", "status": "not-evaluated", "subject": "pepin-qual-vm-x"}], 1, False),
     ]
     failures = 0
+    # ── Ce qu'un défaut connu vaut pour une RELEASE ────────────────────────────
+    #
+    # Le contrat de non-régression et le verdict de release répondent à deux
+    # questions. Ces cas éprouvent la seconde, qui n'existait pas : un défaut épinglé
+    # se reproduisait, la comparaison ne trouvait aucune différence, et la porte
+    # concluait GO — elle vérifiait que le produit ment de la même façon qu'hier.
+    for label, kd, bloquant_attendu in [
+        ("une chaîne ne dit pas sa classe : traitée comme BLOQUANTE",
+         "#0 exemple", True),
+        ("un faux vert bloque",
+         {"issue": 209, "class": "false_green"}, True),
+        ("un faux vert ne se déroge PAS, même demandé",
+         {"issue": 209, "class": "false_green", "release_blocker": False}, True),
+        ("un faux positif bloque par défaut",
+         {"issue": 208, "class": "false_positive"}, True),
+        ("un faux positif peut se déroger, explicitement",
+         {"issue": 208, "class": "false_positive", "release_blocker": False}, False),
+        ("une lacune de couverture ne bloque pas",
+         {"issue": 210, "class": "coverage_gap"}, False),
+        ("une classe inconnue est traitée comme BLOQUANTE",
+         {"issue": 1, "class": "inventee"}, True),
+    ]:
+        d = defaut_connu({"known_defect": kd})
+        ok = d is not None and d["bloquant"] == bloquant_attendu
+        failures += not ok
+        print(f"  {'✔' if ok else '✘'} {label}" + ("" if ok else f" — obtenu bloquant={d and d['bloquant']}"))
     for case in cases:
         label, exp, results, rc, want_ok = case[:5]
         outs = case[5] if len(case) > 5 else outputs
@@ -809,7 +949,7 @@ def selftest():
     if failures:
         print(f"\n{failures} cas en échec : la comparaison ne mesure pas ce qu'elle prétend", file=sys.stderr)
         return 1
-    print(f"\n{len(cases) + 1} cas, tous conformes.")
+    print(f"\n{len(cases) + 8} cas, tous conformes.")
     return 0
 
 


### PR DESCRIPTION
An external release review found the sharpest defect in the gate I shipped this week, and
it was not any of the five verdicts it listed as blockers. It was this:

> `expected.yaml` contains today's known bugs **as expected results**.

It is right. I built a **non-regression contract** and presented it as a **release
quality gate**. A pinned defect reproduces identically, the comparison finds no
difference, and the gate said `GO` — it verified that the product lies the same way it
did yesterday.

## Two questions, two answers

```
contrat de non-régression : le run dit-il ce qu'on attendait ?
verdict de release        : ce qu'on attend est-il publiable ?
```

Both are now printed, side by side, so neither can be read for the other:

```
- contrat de non-régression : GO
- défauts connus :
    ❌ false_green : 1 (dont 1 bloquant(s))
    ⚠ coverage_gap : 2
    ↳ BLOQUE : kubernetes_cluster_audit_logging_enabled [live] (#209)
- VERDICT DE RELEASE : NO-GO
```

## The policy, and the one line that cannot be waived

| class | blocks | why |
|---|---|---|
| `false_green` | **always**, no waiver | a `pass` nothing establishes is the promise the product is built on; reneging once is enough to lose it |
| `false_positive` | by default, waivable explicitly | ten unfixable findings teach a user to ignore the tool |
| `coverage_gap` | no | a justified `not-evaluated` is a *named* limit — exactly what this repository asks of itself |

**Anything that does not say what it is blocks.** A bare string — the historical form —
and a class nobody declared both fail closed. A pin that stays silent about its own
nature must not act as a pass.

Seven selftest cases hold it, including the one that matters: a `false_green` carrying
`release_blocker: false` **still blocks**. 24 cases total.

## Two pins reconciled with corrections that have landed

- **#192** — the verdicts were *right*, only the declaration was wrong (fixed in #206).
  Its status pin does not move; only the note goes.
- **#209** — a real false green, fixed in #215. Its expected status moves from `pass` to
  `fail` on the unaudited cluster.

The second is what the rule now produces, measured on a two-cluster inventory, **but only
a real run confirms it end to end**. The gate will say NO-GO until that run, and that is
the intended meaning: a correction is reconciled by a measurement, not by a prediction.

## What this does not do

It does not fix #208, #212 or #213 — the three unremediable false positives the review
also lists as blockers. It makes them **visible in the verdict** instead of dissolved into
a green one, which is the prerequisite for the release decision to mean anything.

`mise run prepush` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
