### PR TITLE
fix(rules): a private instance has nothing to filter

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -109,6 +109,17 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Une instance privée n'obtient plus un écart `critical` qu'elle ne peut pas
+  corriger.** Là où les groupes de sécurité d'un fournisseur filtrent l'interface
+  **publique**, une instance qui n'en a pas se voit attacher `security-groups: []` **par
+  construction** — l'API le fait, l'exploitant ne l'a pas choisi, et aucune remédiation
+  n'y change rien. Dix instances privées valaient dix findings `critical` impossibles à
+  faire disparaître, ce qui est le plus court chemin vers un outil qu'on ignore. Le fait
+  est désormais **observé** (`public_interface`, dérivé du `public-ip-assignment`
+  d'Exoscale), et non déduit d'un `public_ip` absent — qui ne distinguerait pas
+  « privée » de « non collectée ». Là où un fournisseur ne publie pas ce champ, rien ne
+  change ; et une instance **avec** interface publique et sans groupe reste un écart
+  `critical`.
 - **Deux `pass` de plus que rien n'établissait, de la même forme que celui de la règle
   sans description.** Une garde posait *par ressource* une question qui est *par
   fournisseur*, et le verrou de capacité — voyant l'attribut collecté sur le type grâce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,15 @@ belongs in `git log`.
 
 ### Fixed
 
+- **A private instance no longer gets a `critical` deviation it cannot fix.** Where a
+  provider's security groups filter the **public** interface, an instance without one is
+  given `security-groups: []` **by construction** — the API does it, the operator did not
+  choose it, and no remediation changes it. Ten private instances meant ten unfixable
+  `critical` findings, which is the shortest path to a tool being ignored. The fact is
+  now **observed** (`public_interface`, derived from Exoscale's `public-ip-assignment`),
+  not inferred from a missing `public_ip`, which would not tell "private" from "not
+  collected". Where a provider does not publish that field, nothing changes; and an
+  instance **with** a public interface and no group is still a `critical` deviation.
 - **Two more `pass` verdicts nothing established, both from the same shape as the audit
   of a rule without a description.** A guard asked *per resource* a question that is
   *per provider*, and the capability lock — seeing the attribute collected on the type

--- a/cmd/testdata/frozen/inventory.json
+++ b/cmd/testdata/frozen/inventory.json
@@ -1560,6 +1560,242 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 8,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "source": {
+                "file": "string",
+                "line": "number",
+                "module": "string"
+              },
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v8",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "creation_date",
+            "expiration_date",
+            "owner_user",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "state",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_interface",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud",
+            "secnumcloud_regions"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_interface": [
+            "nic_id",
+            "public_ip",
+            "security_group_ids",
+            "vm_id"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "inbound_default_policy",
+            "security_group_id"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "peer_security_group_ids",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
+        }
+      }
     }
   ]
 }

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -58,7 +58,7 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v7",
+  "inventory_schema": "pepin-inventory/v8",
   "disclaimer": "Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -56,7 +56,7 @@ raises a version number and gets a CHANGELOG line.
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v7",
+  "inventory_schema": "pepin-inventory/v8",
   "disclaimer": "This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -43,7 +43,7 @@ séparément :
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v7** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v8** |
 <!-- /pepin:gen surface-versions -->
 
 Un numéro monte à **tout** changement de forme, ajout compris : il signifie « la surface a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,7 +43,7 @@ independently:
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v7** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v8** |
 <!-- /pepin:gen surface-versions -->
 
 A version rises on **any** shape change, additions included: the number means "the surface has

--- a/docs/reference/inventory.fr.md
+++ b/docs/reference/inventory.fr.md
@@ -12,7 +12,7 @@ gelée, avec les mêmes égards que la surface CLI.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v7
+pepin-inventory/v8
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -156,7 +156,7 @@ code.
 | `blockstorage_snapshot` | `creation_date` `global_permission` `snapshot_id` `state` `volume_id` |
 | `blockstorage_volume` | `encrypted` `state` `tags` `volume_id` |
 | `compute_image` | `image_id` `public` `state` `tags` |
-| `compute_instance` | `deletion_protection` `nic_public_ips` `public_ip` `security_group_ids` `state` `tags` `user_data` `vm_id` |
+| `compute_instance` | `deletion_protection` `nic_public_ips` `public_interface` `public_ip` `security_group_ids` `state` `tags` `user_data` `vm_id` |
 | `governance_provider` | `capital_control` `eu_established` `extraterritorial_exposure` `jurisdiction` `secnumcloud` `secnumcloud_regions` |
 | `iam_policy` | `manages_iam` `owner_group` `owner_user` `policy_id` `policy_name` `scope` `statements` |
 | `iam_role` | `admin_privileges` `editable` `manages_iam` `max_session_ttl` `name` `policy_has_expiration` `role_id` `source_ip_restricted` |

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -12,7 +12,7 @@ with the same regard as the CLI surface.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v7
+pepin-inventory/v8
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -148,7 +148,7 @@ descriptors and from the Go collectors — never a hand-kept list beside the cod
 | `blockstorage_snapshot` | `creation_date` `global_permission` `snapshot_id` `state` `volume_id` |
 | `blockstorage_volume` | `encrypted` `state` `tags` `volume_id` |
 | `compute_image` | `image_id` `public` `state` `tags` |
-| `compute_instance` | `deletion_protection` `nic_public_ips` `public_ip` `security_group_ids` `state` `tags` `user_data` `vm_id` |
+| `compute_instance` | `deletion_protection` `nic_public_ips` `public_interface` `public_ip` `security_group_ids` `state` `tags` `user_data` `vm_id` |
 | `governance_provider` | `capital_control` `eu_established` `extraterritorial_exposure` `jurisdiction` `secnumcloud` `secnumcloud_regions` |
 | `iam_policy` | `manages_iam` `owner_group` `owner_user` `policy_id` `policy_name` `scope` `statements` |
 | `iam_role` | `admin_privileges` `editable` `manages_iam` `max_session_ttl` `name` `policy_has_expiration` `role_id` `source_ip_restricted` |

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -30,7 +30,7 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v7** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v8** |
 <!-- /pepin:gen surface-versions -->
 
 « Gelé » signifie qu'un test échoue quand la forme bouge sans que sa version ait suivi : les

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -30,7 +30,7 @@ See [Exit codes](exit-codes.md).
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v7** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v8** |
 <!-- /pepin:gen surface-versions -->
 
 "Frozen" means a test fails when the shape moves and its version has not: field paths and JSON

--- a/internal/commonrules/rules/compute_instance_has_security_group.rego
+++ b/internal/commonrules/rules/compute_instance_has_security_group.rego
@@ -15,6 +15,20 @@ deny contains f if {
 	# planned_values ; sans cette garde, une VM pourtant rattachée serait faussement « sans SG ».
 	"security_group_ids" in object.keys(vm.attributes)
 	count(object.get(vm.attributes, "security_group_ids", [])) == 0
+
+	# ...et la machine a bien quelque chose à filtrer. Chez un fournisseur dont les
+	# groupes de sécurité filtrent l'INTERFACE PUBLIQUE, une instance qui n'en a pas
+	# se voit attacher une liste vide PAR CONSTRUCTION : l'API le fait, l'exploitant
+	# ne l'a pas choisi, et aucune remédiation ne peut y changer quoi que ce soit.
+	#
+	# Crier dessus était le pire des faux positifs — systématique, reproductible, et
+	# impossible à faire disparaître. Dix instances privées, dix findings `critical`
+	# que personne ne peut corriger, et l'outil se fait ignorer.
+	#
+	# Le fait est OBSERVÉ (`public_interface`, dérivé de `public-ip-assignment`), pas
+	# déduit d'une absence de `public_ip` — qui ne distinguerait pas « privée » de
+	# « non collectée ». Là où le fournisseur ne publie pas ce champ, rien ne change.
+	not _sans_interface_publique(vm)
 	id := object.get(vm.attributes, "vm_id", vm.id)
 	f := {
 		"code": "compute_instance_has_security_group",
@@ -30,4 +44,15 @@ deny contains f if {
 			"remediation_en": "Attach a restrictive security group (deny by default) to the VM.",
 		},
 	}
+}
+
+# _sans_interface_publique — la machine n'a AUCUNE interface publique, et le
+# fournisseur le dit explicitement.
+#
+# Vrai seulement si l'attribut est présent ET faux. Un attribut absent ne rend pas
+# vrai : ne pas savoir n'est pas savoir que non, et le contrôle continue alors de
+# parler comme avant (ADR-0014).
+_sans_interface_publique(vm) if {
+	"public_interface" in object.keys(vm.attributes)
+	not truthy(object.get(vm.attributes, "public_interface", true))
 }

--- a/internal/commonrules/rules/compute_instance_has_security_group_test.rego
+++ b/internal/commonrules/rules/compute_instance_has_security_group_test.rego
@@ -1,0 +1,41 @@
+package pepin.rules
+
+import rego.v1
+
+# ── UNE MACHINE PRIVÉE N'A RIEN À FILTRER (#212) ──────────────────────────────
+
+_vms(vs) := {"resources": [{"provider": "exoscale", "type": "compute_instance", "id": v.vm_id, "attributes": v} | some v in vs]}
+
+_sg_code := "compute_instance_has_security_group"
+
+_sg_findings(vs) := {f | some f in deny with input as _vms(vs); f.code == _sg_code}
+
+# ✓ Une instance sans interface publique se voit attacher une liste vide PAR
+# CONSTRUCTION : l'API le fait, l'exploitant ne l'a pas choisi, et aucune remédiation
+# n'y change rien. Le pire des faux positifs — systématique et impossible à corriger.
+test_a_private_instance_has_nothing_to_filter if {
+	count(_sg_findings([{"vm_id": "i-privee", "security_group_ids": [], "public_interface": false}])) == 0
+}
+
+# ✗ LE CONTRE-EXEMPLE, et c'est lui qui garde le contrôle utile : une instance AVEC une
+# interface publique et sans groupe reste un écart critique. Sans lui, la correction
+# éteindrait le contrôle au lieu de le préciser.
+test_a_public_instance_without_a_group_is_still_denied if {
+	fs := _sg_findings([{"vm_id": "i-publique", "security_group_ids": [], "public_interface": true}])
+	count(fs) == 1
+	some f in fs
+	f.severity == "critical"
+}
+
+# L'attribut ABSENT ne vaut pas « privée » : ne pas savoir n'est pas savoir que non, et
+# le contrôle continue de parler comme avant chez les fournisseurs qui ne publient pas
+# ce champ.
+test_an_absent_attribute_does_not_silence_the_control if {
+	count(_sg_findings([{"vm_id": "i-inconnue", "security_group_ids": []}])) == 1
+}
+
+# Une instance privée QUI PORTE un groupe n'est pas concernée non plus : le contrôle ne
+# vise que l'absence de filtrage.
+test_a_private_instance_with_a_group_stays_silent if {
+	count(_sg_findings([{"vm_id": "i-p", "security_group_ids": ["sg-1"], "public_interface": false}])) == 0
+}

--- a/internal/model/schema.go
+++ b/internal/model/schema.go
@@ -121,7 +121,17 @@ import (
 //	désormais rendu POUR la région scannée (`qualifie` | `hors_perimetre` |
 //	`perimetre_inconnu`), et le périmètre voyage à côté pour qu'un consommateur
 //	puisse le vérifier plutôt que de croire le statut sur parole.
-const InventoryFormat = "pepin-inventory/v7"
+//
+// v8 : une `compute_instance` peut porter `public_interface`, le fait qu'elle ait ou
+//
+//	non une interface PUBLIQUE (Exoscale : public-ip-assignment none|inet4|dual, API
+//	v2 Compute get-instance). Ajout PUR. Il est nécessaire parce que, chez un
+//	fournisseur dont les groupes de sécurité filtrent l'interface publique, une
+//	instance qui n'en a pas se voit attacher une liste vide PAR CONSTRUCTION : le
+//	contrôle « VM sans groupe de sécurité » criait alors sur chaque instance privée,
+//	avec une remédiation que l'API ignore. Déduire le fait d'une absence de
+//	`public_ip` ne distinguerait pas « privée » de « non collectée ».
+const InventoryFormat = "pepin-inventory/v8"
 
 // InventorySchemaVersion extrait le N du suffixe `/vN`. Comme pour le bundle, la
 // constante et le signal sur le fil sont la même chose : impossible de faire

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -364,7 +364,8 @@
         "outscale/ztiac-two-tier"
       ],
       "rego_tests": [
-        "internal/commonrules/rules/compute_blockstorage_test.rego"
+        "internal/commonrules/rules/compute_blockstorage_test.rego",
+        "internal/commonrules/rules/compute_instance_has_security_group_test.rego"
       ]
     },
     "compute_instance_no_secrets_in_user_data": {

--- a/providers/exoscale.yaml
+++ b/providers/exoscale.yaml
@@ -151,10 +151,22 @@ collecte:
       map:
         vm_id: id
         public_ip: public-ip
+        # `public-ip-assignment` dit si l'instance a une interface PUBLIQUE : `none`,
+        # `inet4` ou `dual` (API v2 Compute, opération get-instance). Le fait est
+        # OBSERVÉ, pas déduit d'une absence de `public-ip` — qui ne distinguerait pas
+        # « privée » de « non collectée ».
+        #
+        # Il compte parce que chez Exoscale les groupes de sécurité filtrent
+        # l'interface publique : une instance qui n'en a pas se voit attacher
+        # `security-groups: []` PAR CONSTRUCTION. Sans ce champ, le contrôle « VM sans
+        # groupe de sécurité » criait sur chaque instance privée, avec une remédiation
+        # que l'API ignore.
+        public_interface: public-ip-assignment
         security_group_ids: security-groups
         state: state
         user_data: user-data
       transforms:
+        public_interface: { none: false, inet4: true, dual: true }
         security_group_ids: pluck:id   # [{id,...}] -> [id]
   
     # Utilisateurs de l'organisation → iam_user (MFA).
@@ -370,6 +382,9 @@ contrat:
       etat: verifie
       source: egoscale/v3 Instance
       mapping:
+        public_interface: 'DÉRIVÉ : public-ip-assignment (none|inet4|dual) → false|true. Les groupes de sécurité
+          filtrent l''interface PUBLIQUE : une instance sans interface se voit attacher security-groups: [] par
+          construction (API v2 Compute, get-instance).'
         vm_id: ID (UUID)
         state: State (InstanceState)
         public_ip: PublicIP (net.IP)


### PR DESCRIPTION
Closes #212 — the second of the three unremediable false positives the release review
lists as blockers.

## Ten private instances, ten findings nobody can fix

Where a provider's security groups filter the **public** interface, an instance without
one is given `security-groups: []` **by construction**. The API does it, the operator did
not choose it, and no remediation changes it.

Pépin reported a `critical` on each, and told the reader to attach a group the API will
ignore. That is the worst kind of false positive — **systematic, reproducible,
unfixable** — and it is the shortest path to a tool being ignored, which costs more than
the control was ever worth.

## The fact is observed, not inferred

`public-ip-assignment` (`none` | `inet4` | `dual`) says it outright in Exoscale's v2
Compute API. Deducing it from a **missing** `public_ip` would not tell *private* from
*not collected* — and that exact confusion is the one this wave has now spent three fixes
undoing (#201, #209, #211).

## The counterexample keeps the control worth having

Measured on the binary, two instances with an empty group list:

```
i-privee    public_interface=false  → silent
i-publique  public_interface=true   → critical
```

An **absent** attribute does not mean "private" either — not knowing is not knowing that
not — so a provider that does not publish the field sees no change at all. Four tests
hold those boundaries, including that one.

## Measured

377 Rego tests (was 373). Inventory schema **v7 → v8**. **Zero verdict movement** on the
reference corpus, whose tenants carry no such attribute.

`mise run prepush` green.

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
