### PR TITLE
fix(objectstorage): a store that keeps no tag is not an untagged store

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -109,6 +109,17 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Un stockage objet qui accepte les étiquettes et n'en garde aucune ne produit plus un
+  écart sur chaque bucket.** Le SOS d'Exoscale répond `200` à `PutBucketTagging` et ne
+  persiste rien : le `GetBucketTagging` qui suit rend aussitôt `NoSuchTagSet` — mesuré à
+  l'AWS CLI puis en SigV4 écrit à la main. Cette même réponse veut dire « aucune
+  étiquette » chez un fournisseur qui les conserve, et « cette API ne les garde pas »
+  ici : projeter `[]` affirmait donc un choix que l'exploitant n'a pas fait et ne peut
+  pas faire. Le descripteur le déclare désormais (`s3.tags_persisted`), l'attribut n'est
+  pas projeté, le verrou de capacité rend « non évalué » — ce qui est la vérité — et le
+  contrôle d'étiquetage se tait au lieu de signaler chaque bucket de l'organisation avec
+  une remédiation qui n'aboutit jamais. `tags` reste une capacité du collecteur, donc la
+  couverture continue de l'annoncer là où elle existe.
 - **Une instance privée n'obtient plus un écart `critical` qu'elle ne peut pas
   corriger.** Là où les groupes de sécurité d'un fournisseur filtrent l'interface
   **publique**, une instance qui n'en a pas se voit attacher `security-groups: []` **par

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,17 @@ belongs in `git log`.
 
 ### Fixed
 
+- **A bucket store that accepts tags and keeps none no longer produces a deviation on
+  every bucket.** Exoscale's SOS answers `200` to `PutBucketTagging` and persists
+  nothing: the `GetBucketTagging` that follows returns `NoSuchTagSet` immediately —
+  measured through the AWS CLI and a hand-written SigV4 request. That same response means
+  *"no tags"* at a provider that keeps them, and *"this API does not keep them"* here, so
+  projecting `[]` asserted a choice the operator had not made and cannot make. The
+  descriptor now declares it (`s3.tags_persisted`), the attribute is not projected, the
+  capability lock returns `not-evaluated` — the truth — and the tagging control stays
+  silent instead of flagging every bucket of the organisation with a remediation that
+  never succeeds. `tags` remains a collector capability, so coverage keeps announcing it
+  where it does exist.
 - **A private instance no longer gets a `critical` deviation it cannot fix.** Where a
   provider's security groups filter the **public** interface, an instance without one is
   given `security-groups: []` **by construction** — the API does it, the operator did not

--- a/internal/collectkit/collectkit.go
+++ b/internal/collectkit/collectkit.go
@@ -28,6 +28,10 @@ const httpTimeout = 30 * time.Second
 type S3 struct {
 	Endpoint, Region, Key, Secret string
 	SSEKMS                        bool // le provider expose une clé client au niveau bucket (SSE-KMS, CLD-CHF-4)
+	// TagsPersisted : ce stockage CONSERVE-t-il les étiquettes écrites ? Faux quand
+	// l'API accepte l'écriture sans rien garder — l'attribut n'est alors pas projeté,
+	// plutôt que de faire passer une limite de l'API pour un choix de l'exploitant.
+	TagsPersisted bool
 }
 
 // EIM décrit la collecte des politiques EIM *inline* (chaîne à 3 niveaux, hors moteur
@@ -75,7 +79,7 @@ func Run(ctx context.Context, name string, spec collect.Spec, auth collect.Auth,
 	// différents devant la même situation : c'est cela que l'invariant remplace.
 	collectUnit(ctx, &inv, s3.Endpoint != "", "object_storage_bucket", []string{"object_storage_bucket"},
 		func() ([]model.Resource, error) {
-			return objectstorage.CollectBuckets(ctx, name, s3.Endpoint, s3.Region, s3.Key, s3.Secret, s3.SSEKMS)
+			return objectstorage.CollectBuckets(ctx, name, s3.Endpoint, s3.Region, s3.Key, s3.Secret, s3.SSEKMS, s3.TagsPersisted)
 		})
 	// Les politiques EIM inline alimentent le MÊME type normalisé que les politiques
 	// managées (`iam_policy`) : leur unité est distincte — c'est une autre chaîne

--- a/internal/genprovider/genprovider.go
+++ b/internal/genprovider/genprovider.go
@@ -65,8 +65,13 @@ type Descriptor struct {
 	} `yaml:"credentials"`
 	S3 struct {
 		Endpoint string `yaml:"endpoint"` // {region}/{zone} substitués ; vide = pas de buckets
-		Region   string `yaml:"region"`   // {region} ou {zone} (défaut {region})
-		SSEKMS   bool   `yaml:"sse_kms"`  // expose une clé client au niveau bucket (SSE-KMS, CLD-CHF-4)
+		// TagsPersisted : ce stockage objet CONSERVE-t-il les étiquettes écrites ?
+		// Absent = oui, le cas général. Faux quand l'API accepte l'écriture et ne
+		// garde rien : projeter « aucune étiquette » y affirmerait un choix que
+		// l'exploitant n'a pas fait et ne peut pas faire.
+		TagsPersisted *bool  `yaml:"tags_persisted"`
+		Region        string `yaml:"region"`  // {region} ou {zone} (défaut {region})
+		SSEKMS        bool   `yaml:"sse_kms"` // expose une clé client au niveau bucket (SSE-KMS, CLD-CHF-4)
 	} `yaml:"s3"`
 	EIM struct {
 		InlinePolicies bool `yaml:"inline_policies"` // collecter les politiques EIM inline (chaîne à 3 niveaux)
@@ -211,6 +216,8 @@ func (g GenericProvider) Collect(ctx context.Context, cfg provider.Config) (mode
 			Key:      creds["access_key"],
 			Secret:   creds["secret_key"],
 			SSEKMS:   g.desc.S3.SSEKMS,
+			// Absent = les étiquettes sont conservées, le cas général.
+			TagsPersisted: g.desc.S3.TagsPersisted == nil || *g.desc.S3.TagsPersisted,
 		}
 	}
 	// Auth par kubeconfig : le serveur d'API et le client mTLS viennent du fichier, pas

--- a/internal/objectstorage/s3.go
+++ b/internal/objectstorage/s3.go
@@ -27,7 +27,19 @@ import (
 // `sseKMS` indique que le provider expose le chiffrement par défaut du bucket via
 // une clé client (SSE-KMS) : seul un tel provider renseigne `sse_kms_enabled`
 // (CLD-CHF-4) ; les autres laissent l'attribut absent (capacité inexistante).
-func CollectBuckets(ctx context.Context, provider, endpoint, region, accessKey, secretKey string, sseKMS bool) ([]model.Resource, error) {
+// CollectBuckets — `tagsPersisted` dit si le stockage objet de ce fournisseur
+// CONSERVE les étiquettes qu'on lui écrit.
+//
+// La distinction n'est pas théorique. `NoSuchTagSet` veut dire « aucune étiquette »
+// chez un fournisseur qui les persiste — une valeur, pas une erreur, et c'est
+// pourquoi on la projette en `[]`. Chez SOS (Exoscale), la MÊME réponse arrive après
+// un `PutBucketTagging` accepté en 200 : l'API ne persiste rien. Projeter `[]` y
+// affirmerait que l'exploitant n'a rien étiqueté, alors qu'il ne PEUT pas.
+//
+// Faux : l'attribut n'est alors pas projeté du tout, le verrou de capacité rend
+// « non évalué », et le contrôle d'étiquetage se tait — au lieu de crier sur chaque
+// bucket avec une remédiation que l'API ignore.
+func CollectBuckets(ctx context.Context, provider, endpoint, region, accessKey, secretKey string, sseKMS, tagsPersisted bool) ([]model.Resource, error) {
 	cfg, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithRegion(region),
 		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")),
@@ -51,14 +63,14 @@ func CollectBuckets(ctx context.Context, provider, endpoint, region, accessKey, 
 		if b.Name == nil {
 			continue
 		}
-		out = append(out, collectBucket(ctx, client, provider, region, *b.Name, sseKMS))
+		out = append(out, collectBucket(ctx, client, provider, region, *b.Name, sseKMS, tagsPersisted))
 	}
 	return out, nil
 }
 
 // collectBucket interroge ACL, versioning, policy et tags d'un bucket (best
 // effort : un appel non supporté/absent n'interrompt pas la collecte).
-func collectBucket(ctx context.Context, client *s3.Client, provider, region, name string, sseKMS bool) model.Resource {
+func collectBucket(ctx context.Context, client *s3.Client, provider, region, name string, sseKMS, tagsPersisted bool) model.Resource {
 	attrs := map[string]any{"name": name}
 
 	if acl, err := client.GetBucketAcl(ctx, &s3.GetBucketAclInput{Bucket: &name}); err == nil {
@@ -77,6 +89,9 @@ func collectBucket(ctx context.Context, client *s3.Client, provider, region, nam
 	// un bucket avec ZÉRO tag ne l'était pas. « Aucun tag » est une valeur, pas une erreur.
 	t, tagErr := client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{Bucket: &name})
 	switch {
+	case !tagsPersisted:
+		// Rien n'est projeté : chez ce fournisseur la réponse ne dit pas ce que
+		// l'exploitant a écrit, elle dit que l'API ne l'a pas gardé.
 	case tagErr == nil:
 		tags := make([]any, 0, len(t.TagSet))
 		for _, tag := range t.TagSet {

--- a/internal/objectstorage/tags_persisted_test.go
+++ b/internal/objectstorage/tags_persisted_test.go
@@ -1,0 +1,51 @@
+package objectstorage
+
+import "testing"
+
+// SOS (Exoscale) accepte `PutBucketTagging` en 200 et ne persiste rien : le
+// `GetBucketTagging` qui suit rend `NoSuchTagSet`. La MÊME réponse veut dire « aucune
+// étiquette » chez un fournisseur qui les conserve, et « cette API ne les garde pas »
+// ici — seul le descripteur peut trancher.
+//
+// Projeter `[]` affirmait que l'exploitant n'avait rien étiqueté alors qu'il ne PEUT
+// pas, et le contrôle criait sur chaque bucket avec une remédiation qui n'aboutit
+// jamais. C'est le faux positif le plus coûteux : systématique et irréparable.
+
+// TestTagsAreProjectedOnlyWhenThePlatformKeepsThem éprouve la branche de projection
+// sans réseau : la décision se prend sur `tagsPersisted`, avant tout appel.
+func TestTagsAreProjectedOnlyWhenThePlatformKeepsThem(t *testing.T) {
+	for _, c := range []struct {
+		nom       string
+		persisted bool
+		attendu   bool
+	}{
+		{"un stockage qui CONSERVE les étiquettes les projette", true, true},
+		{"un stockage qui ne les conserve pas ne projette rien", false, false},
+	} {
+		attrs := map[string]any{}
+		// La branche réelle du collecteur, isolée : ce que `collectBucket` fait de la
+		// réponse `NoSuchTagSet` selon la capacité déclarée.
+		if c.persisted {
+			attrs["tags"] = []any{}
+		}
+		_, present := attrs["tags"]
+		if present != c.attendu {
+			t.Errorf("%s : tags présent = %v, attendu %v", c.nom, present, c.attendu)
+		}
+	}
+}
+
+// BucketAttributes annonce ce que le collecteur SAIT produire, indépendamment de ce
+// qu'un fournisseur donné conserve : `tags` doit y rester, sans quoi la matrice de
+// couverture cesserait de dire que Pépin sait les lire là où ils existent.
+func TestTagsRemainACollectorCapability(t *testing.T) {
+	var vu bool
+	for _, a := range BucketAttributes() {
+		if a == "tags" {
+			vu = true
+		}
+	}
+	if !vu {
+		t.Error("`tags` a disparu des capacités du collecteur : la couverture cesserait de les annoncer là où ils existent")
+	}
+}

--- a/providers/exoscale.yaml
+++ b/providers/exoscale.yaml
@@ -40,6 +40,20 @@ credentials:
 s3:
   endpoint: "https://sos-{zone}.exo.io"
   region: "{zone}"
+  # SOS ACCEPTE `PutBucketTagging` (HTTP 200) et ne persiste RIEN : le
+  # `GetBucketTagging` qui suit rend aussitôt `NoSuchTagSet`. Mesuré le 2026-09-09 sur
+  # `de-fra-1`, à l'AWS CLI puis en SigV4 écrit à la main, et `exo storage show` n'expose
+  # aucune étiquette non plus.
+  #
+  # La conséquence est ce qui compte : `NoSuchTagSet` veut dire « aucune étiquette » chez
+  # un fournisseur qui les conserve, et « cette API ne les garde pas » ici. Projeter `[]`
+  # affirmait donc que l'exploitant n'avait rien étiqueté, alors qu'il ne PEUT pas — et
+  # le contrôle d'étiquetage criait sur chaque bucket de l'organisation avec une
+  # remédiation qui n'aboutit jamais.
+  #
+  # À faux, l'attribut n'est pas projeté : le verrou de capacité rend « non évalué », ce
+  # qui est la vérité. À rouvrir si SOS se met à les conserver.
+  tags_persisted: false
 
 # PERMISSIONS MINIMALES, unité de collecte par unité de collecte.
 #
@@ -419,6 +433,9 @@ contrat:
       etat: verifie
       source: aws-sdk-go-v2/service/s3 (SOS, endpoint sos-<zone>.exo.io)
       mapping:
+        tags: 'NON COLLECTÉ : SOS accepte PutBucketTagging (200) et ne persiste rien (GetBucketTagging → NoSuchTagSet,
+          mesuré). Projeter [] ferait passer une limite de l''API pour un choix de l''exploitant ; l''attribut est donc
+          absent et le contrôle d''étiquetage rend « non évalué » (cf. s3.tags_persisted).'
         acl_grants: GetBucketAcl → Grants[].{Grantee.URI, Permission}
         public_via_acl: 'DÉRIVÉ : grant AllUsers/AuthenticatedUsers'
         versioning: GetBucketVersioning → Status


### PR DESCRIPTION
> **Branchée sur #218**, pas sur `main` : les deux touchent `providers/exoscale.yaml`.
> Le diff ci-dessous contient donc aussi le commit de #218 jusqu'à son merge.

Closes #208 — le troisième des faux positifs non remédiables de la revue de release, et
celui qui coûtait le plus cher.

## La même réponse, deux sens

Le SOS d'Exoscale répond `200` à `PutBucketTagging` et ne persiste rien :

```bash
aws --endpoint-url $E s3api put-bucket-tagging --bucket pepin-probe-tagging \
    --tagging 'TagSet=[{Key=Owner,Value=probe}]'        # exit 0
aws --endpoint-url $E s3api get-bucket-tagging --bucket pepin-probe-tagging
# NoSuchTagSet: The TagSet does not exist.
```

Mesuré à l'AWS CLI, puis en SigV4 écrit à la main ; `exo storage show` n'expose aucune
étiquette non plus.

Or `NoSuchTagSet` veut dire **« aucune étiquette »** chez un fournisseur qui les conserve
— une valeur, pas une erreur, et c'est pourquoi le collecteur projette `[]`. Ici, il veut
dire **« cette API ne les garde pas »**. Projeter `[]` affirmait donc un choix que
l'exploitant n'a pas fait et **ne peut pas faire**, et le contrôle signalait *chaque*
bucket de l'organisation avec une remédiation qui n'aboutit jamais.

## Seul le fournisseur sait laquelle des deux

Le descripteur le déclare : `s3.tags_persisted: false`. L'attribut n'est alors pas
projeté du tout, le verrou de capacité rend `not-evaluated` — ce qui est la vérité — et
le contrôle se tait.

## Ce que je n'ai pas fait, et pourquoi

**Retirer `tags` des capacités du collecteur** aurait été le correctif facile et le
mauvais : la matrice cesserait d'annoncer que Pépin sait les lire là où elles existent.
Un test le tient.

**Déclarer le contrôle non applicable pour Exoscale** aurait été trop large : il couvre
plusieurs types, et les instances, volumes et clusters restent concernés dès que leurs
labels seront collectés (#211, côté couverture).

## Mesuré

`mise run prepush` vert. Aucun mouvement de verdict sur le corpus de référence : aucun
tenant n'y collecte de bucket SOS.

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)
