### PR TITLE
fix(collect): compute a call signature before the credential is attached

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -70,6 +70,16 @@ l'une ni l'autre appartient au `git log`.
 
 ### Sécurité
 
+- **Un collecteur ne relit plus une requête dans laquelle il vient d'écrire un secret.**
+  CodeQL signalait, en `high`, une clé secrète atteignant un rapport publié : un
+  collecteur posait son identifiant en en-tête, puis rebâtissait la signature de l'appel
+  depuis ce même objet requête pour l'enregistrer en provenance. L'alerte est un **faux
+  positif** — seuls la méthode, le schéma, l'hôte et le chemin sont lus, jamais un
+  en-tête ni la requête —, mais l'analyse a raison sur le principe, et une chaîne bâtie
+  avant que l'identifiant ne soit posé ne peut pas devenir fausse un jour. La signature
+  est désormais calculée **avant** l'authentification, dans un helper partagé par les
+  trois collecteurs qui l'enregistrent. La provenance ne nomme toujours aucun appel qui
+  n'a pas eu lieu : la chaîne est calculée tôt et n'est utilisée qu'après une réponse.
 - **`verify` n'accepte plus un bundle qui se contredit.** Réécrire quatre résultats
   `fail` en `pass` puis recalculer l'empreinte du fichier touché produisait un bundle
   déclaré « cohérent en interne », code 0 — alors que son propre `manifest.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,15 @@ belongs in `git log`.
 
 ### Security
 
+- **A collector no longer reads back a request it has just put a secret into.** CodeQL
+  reported, at `high`, a secret key reaching a published report: a collector set its
+  credential as a header, then rebuilt the call signature from that same request object
+  to record it as provenance. The alert is a **false positive** — only method, scheme,
+  host and path are read, never a header or a query — but the analysis is right in
+  principle, and a string built before the credential is attached cannot become wrong
+  later. The signature is now computed **before** authentication is applied, in one
+  shared helper used by the three collectors that record it. Provenance still never names
+  a call that did not happen: the string is computed early and used only after a response.
 - **`verify` no longer accepts a bundle that contradicts itself.** Rewriting four
   `fail` results into `pass` and recomputing the digest of the file touched produced a
   bundle reported as "internally consistent", exit 0 — while its own `manifest.json`

--- a/internal/collect/engine.go
+++ b/internal/collect/engine.go
@@ -578,6 +578,8 @@ func fetch(ctx context.Context, hc *http.Client, rawURL string, auth Auth, p *Pa
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	// Signature de l'appel calculée AVANT l'authentification (cf. callSignature).
+	called := CallSignature(req.Method, req.URL)
 	if auth != nil {
 		if err := auth.Apply(req); err != nil {
 			return nil, "", err
@@ -588,10 +590,6 @@ func fetch(ctx context.Context, hc *http.Client, rawURL string, auth Auth, p *Pa
 		return nil, "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	// La requête telle qu'elle a été émise. Les paramètres de requête (page, jeton)
-	// sont écartés : ils varient d'une page à l'autre alors que l'endpoint, lui, est
-	// ce qui atteste la donnée.
-	called := req.Method + " " + req.URL.Scheme + "://" + req.URL.Host + req.URL.Path
 	respBody, rerr := io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
 	if rerr != nil {
 		return nil, called, fmt.Errorf(i18n.T("lecture de la reponse de %s : %w", "reading the response from %s: %w"), u.Host, rerr)
@@ -1065,3 +1063,21 @@ func regionOfZone(zone string) string {
 // régions des descripteurs. Exposée pour être ÉPROUVÉE, pas pour être appelée : les
 // specs la demandent par le transform `region_of_zone`.
 func RegionOfZone(zone string) string { return regionOfZone(zone) }
+
+// CallSignature rend la requête telle qu'elle a été ÉMISE : méthode, schéma, hôte et
+// chemin. Les paramètres de requête sont écartés — ils varient d'une page à l'autre
+// alors que l'endpoint, lui, est ce qui atteste la donnée.
+//
+// Elle est construite AVANT que l'authentification ne soit posée sur la requête, et
+// c'est délibéré. Une analyse de flot de données considère qu'un objet dans lequel on
+// a écrit un secret est teinté TOUT ENTIER : relire ensuite `req.URL` pour bâtir une
+// chaîne qui finit dans un rapport publié fait remonter une alerte de fuite en clair.
+// Elle est fausse ici — ni en-tête ni requête ne sont lus —, mais l'analyse a raison
+// sur le principe, et une chaîne bâtie avant l'auth ne peut pas être fausse pour de
+// bon un jour. Le coût est nul, la propriété est structurelle.
+//
+// La provenance ne nomme pour autant jamais un appel qui n'a pas eu lieu : la chaîne
+// est CALCULÉE tôt et n'est UTILISÉE qu'après une réponse.
+func CallSignature(method string, u *url.URL) string {
+	return method + " " + u.Scheme + "://" + u.Host + u.Path
+}

--- a/internal/eimpolicy/eimpolicy.go
+++ b/internal/eimpolicy/eimpolicy.go
@@ -281,6 +281,8 @@ func post(ctx context.Context, hc *http.Client, auth collect.Auth, url, body str
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	// Signature de l'appel calculée AVANT l'authentification (cf. collect.CallSignature).
+	called := collect.CallSignature(req.Method, req.URL)
 	if auth != nil {
 		if err := auth.Apply(req); err != nil {
 			return err
@@ -299,7 +301,6 @@ func post(ctx context.Context, hc *http.Client, auth collect.Auth, url, body str
 		// Erreur TYPÉE : le statut range l'échec dans sa classe, et l'état de collecte
 		// publie cette classe. C'est ce collecteur-ci qui a motivé l'invariant — un 403
 		// sur ReadUserPolicies faisait échouer tout le scan, ou pire, laissait conclure.
-		called := req.Method + " " + req.URL.Scheme + "://" + req.URL.Host + req.URL.Path
 		return &collect.HTTPError{Status: resp.StatusCode, Call: called, Body: strings.TrimSpace(string(raw))}
 	}
 	return json.Unmarshal(raw, into)

--- a/internal/oks/oks.go
+++ b/internal/oks/oks.go
@@ -34,6 +34,10 @@ func CollectClusters(ctx context.Context, hc *http.Client, provider, endpoint, r
 	if err != nil {
 		return nil, err
 	}
+	// Signature de l'appel calculée AVANT l'authentification (cf. collect.CallSignature) :
+	// un objet dans lequel on a écrit un secret est teinté tout entier pour une analyse
+	// de flot, et cette chaîne finit dans un rapport publié.
+	called := collect.CallSignature(req.Method, req.URL)
 	// Auth OKS : deux en-têtes en clair (pas de SigV4). Confirmé sur l'API réelle.
 	req.Header.Set("AccessKey", accessKey)
 	req.Header.Set("SecretKey", secretKey)
@@ -42,9 +46,6 @@ func CollectClusters(ctx context.Context, hc *http.Client, provider, endpoint, r
 		return nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	// La requête telle qu'elle a été RÉELLEMENT émise, lue après réponse : une
-	// provenance ne nomme jamais un appel qui n'a pas eu lieu (cf. model.Provenance).
-	called := req.Method + " " + req.URL.Scheme + "://" + req.URL.Host + req.URL.Path
 	body, rerr := io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
 	if rerr != nil {
 		return nil, fmt.Errorf(i18n.T("lecture de la reponse OKS : %w", "reading the OKS response: %w"), rerr)


### PR DESCRIPTION
Traite l'alerte CodeQL [`go/clear-text-logging`](https://github.com/stephrobert/pepin/security/code-scanning/14), `high` : *"Sensitive data returned by an access to SecretKey flows to a logging call"*, `cmd/scan.go:1595`.

## Ce que faisait le code

Un collecteur posait son identifiant en en-tête, puis rebâtissait la signature de l'appel
**depuis ce même objet requête** pour l'enregistrer en provenance — provenance publiée
dans `--format json`.

## L'alerte est un faux positif, et c'est la raison de ne PAS la supprimer

La signature lit méthode, schéma, hôte et chemin. **Jamais un en-tête, jamais la
requête.** Rien de sensible ne circule. Une analyse de flot teinte un objet **tout
entier** dès qu'on y écrit un secret, donc relire `req.URL` ensuite ressemble à une fuite.

Mais l'analyse a raison sur le principe : une chaîne bâtie **avant** que l'identifiant ne
soit posé ne peut pas devenir fausse un jour, là où une chaîne bâtie après dépend de ce
que personne ne lise jamais un champ teinté. Le coût est nul, la propriété est
structurelle. C'est plus solide qu'un `nolint` justifié.

## Ce qui change

La signature est calculée **avant** l'authentification, dans un helper partagé
(`collect.CallSignature`) par les trois collecteurs qui l'enregistrent : `collect`,
`oks`, `eimpolicy`.

**L'invariant pour lequel elle existe tient inchangé** : la provenance ne nomme jamais un
appel qui n'a pas eu lieu — la chaîne est *calculée* tôt et *utilisée* seulement après une
réponse.

Un `grep` confirme que plus rien ne relit une requête après l'auth.

`mise run prepush` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)