### PR TITLE
feat(collect): an identity the platform manages is not the operator's to harden

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -119,6 +119,18 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Une identité que la plateforme crée, utilise et supprime n'apporte plus deux écarts
+  irréparables par cluster.** Le SKS d'Exoscale crée un rôle `sks-ccm-<cluster>` pour le
+  cloud controller manager du cluster et le supprime avec lui. Il est `editable: true`,
+  donc le filtre des rôles prédéfinis ne le couvrait pas — et chaque cluster apportait
+  deux findings IAM que personne ne pouvait faire disparaître : borner le rôle à une IP
+  source exigerait de deviner les adresses du plan de contrôle, et ajouter une clause de
+  durée casserait le composant. Dix clusters valaient vingt findings irréparables. Le
+  fait est désormais **collecté** (`provider_managed`) et **déclaré au descripteur du
+  fournisseur avec sa source**, jamais codé en préfixe de nom dans une règle — une règle
+  commune ne connaît aucune convention de nommage, et un préfixe répété dans chacune
+  divergerait au premier changement. Un helper partagé le lit, et le même rôle **sans**
+  la marque continue de produire les trois findings.
 - **Un stockage objet qui accepte les étiquettes et n'en garde aucune ne produit plus un
   écart sur chaque bucket.** Le SOS d'Exoscale répond `200` à `PutBucketTagging` et ne
   persiste rien : le `GetBucketTagging` qui suit rend aussitôt `NoSuchTagSet` — mesuré à

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,17 @@ belongs in `git log`.
 
 ### Fixed
 
+- **An identity the platform creates, uses and deletes no longer brings two unfixable
+  deviations per cluster.** Exoscale's SKS creates an `sks-ccm-<cluster>` role for the
+  cluster's cloud controller manager and removes it with the cluster. It is
+  `editable: true`, so the predefined-role filter did not cover it — and every cluster
+  brought two IAM findings nobody could clear: binding the role to a source IP would mean
+  guessing the control plane's addresses, and adding a lifetime clause would break the
+  component. Ten clusters meant twenty irreparable findings. The fact is now **collected**
+  (`provider_managed`) and **declared in the provider descriptor with its source**, never
+  hardcoded as a name prefix inside a rule — a common rule knows no provider's naming
+  convention, and a prefix repeated in each would diverge at the first change. A shared
+  helper reads it, and the same role **without** the mark still raises all three findings.
 - **A bucket store that accepts tags and keeps none no longer produces a deviation on
   every bucket.** Exoscale's SOS answers `200` to `PutBucketTagging` and persists
   nothing: the `GetBucketTagging` that follows returns `NoSuchTagSet` immediately —

--- a/cmd/testdata/frozen/inventory.json
+++ b/cmd/testdata/frozen/inventory.json
@@ -1796,6 +1796,243 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 9,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "source": {
+                "file": "string",
+                "line": "number",
+                "module": "string"
+              },
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v9",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "creation_date",
+            "expiration_date",
+            "owner_user",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "state",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_interface",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud",
+            "secnumcloud_regions"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "provider_managed",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_interface": [
+            "nic_id",
+            "public_ip",
+            "security_group_ids",
+            "vm_id"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "inbound_default_policy",
+            "security_group_id"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "peer_security_group_ids",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
+        }
+      }
     }
   ]
 }

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -58,7 +58,7 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v8",
+  "inventory_schema": "pepin-inventory/v9",
   "disclaimer": "Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -56,7 +56,7 @@ raises a version number and gets a CHANGELOG line.
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v8",
+  "inventory_schema": "pepin-inventory/v9",
   "disclaimer": "This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -43,7 +43,7 @@ séparément :
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v8** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v9** |
 <!-- /pepin:gen surface-versions -->
 
 Un numéro monte à **tout** changement de forme, ajout compris : il signifie « la surface a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,7 +43,7 @@ independently:
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v8** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v9** |
 <!-- /pepin:gen surface-versions -->
 
 A version rises on **any** shape change, additions included: the number means "the surface has

--- a/docs/reference/inventory.fr.md
+++ b/docs/reference/inventory.fr.md
@@ -12,7 +12,7 @@ gelée, avec les mêmes égards que la surface CLI.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v8
+pepin-inventory/v9
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -159,7 +159,7 @@ code.
 | `compute_instance` | `deletion_protection` `nic_public_ips` `public_interface` `public_ip` `security_group_ids` `state` `tags` `user_data` `vm_id` |
 | `governance_provider` | `capital_control` `eu_established` `extraterritorial_exposure` `jurisdiction` `secnumcloud` `secnumcloud_regions` |
 | `iam_policy` | `manages_iam` `owner_group` `owner_user` `policy_id` `policy_name` `scope` `statements` |
-| `iam_role` | `admin_privileges` `editable` `manages_iam` `max_session_ttl` `name` `policy_has_expiration` `role_id` `source_ip_restricted` |
+| `iam_role` | `admin_privileges` `editable` `manages_iam` `max_session_ttl` `name` `policy_has_expiration` `provider_managed` `role_id` `source_ip_restricted` |
 | `iam_user` | `mfa_enabled` `user_id` `username` |
 | `k8s_cluster_role_binding` | `name` `role_ref` `subjects` |
 | `k8s_crd` | `name` |

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -12,7 +12,7 @@ with the same regard as the CLI surface.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v8
+pepin-inventory/v9
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -151,7 +151,7 @@ descriptors and from the Go collectors — never a hand-kept list beside the cod
 | `compute_instance` | `deletion_protection` `nic_public_ips` `public_interface` `public_ip` `security_group_ids` `state` `tags` `user_data` `vm_id` |
 | `governance_provider` | `capital_control` `eu_established` `extraterritorial_exposure` `jurisdiction` `secnumcloud` `secnumcloud_regions` |
 | `iam_policy` | `manages_iam` `owner_group` `owner_user` `policy_id` `policy_name` `scope` `statements` |
-| `iam_role` | `admin_privileges` `editable` `manages_iam` `max_session_ttl` `name` `policy_has_expiration` `role_id` `source_ip_restricted` |
+| `iam_role` | `admin_privileges` `editable` `manages_iam` `max_session_ttl` `name` `policy_has_expiration` `provider_managed` `role_id` `source_ip_restricted` |
 | `iam_user` | `mfa_enabled` `user_id` `username` |
 | `k8s_cluster_role_binding` | `name` `role_ref` `subjects` |
 | `k8s_crd` | `name` |

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -30,7 +30,7 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v8** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v9** |
 <!-- /pepin:gen surface-versions -->
 
 « Gelé » signifie qu'un test échoue quand la forme bouge sans que sa version ait suivi : les

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -30,7 +30,7 @@ See [Exit codes](exit-codes.md).
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v8** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v9** |
 <!-- /pepin:gen surface-versions -->
 
 "Frozen" means a test fails when the shape moves and its version has not: field paths and JSON

--- a/internal/collect/engine.go
+++ b/internal/collect/engine.go
@@ -786,7 +786,7 @@ var knownBareTransforms = map[string]bool{
 }
 
 // knownTransformPrefixes : préfixes de transforms paramétrés (`default:val`, `equals:val`…).
-var knownTransformPrefixes = []string{"equals:", "default:", "pluck:", "contains:"}
+var knownTransformPrefixes = []string{"equals:", "default:", "pluck:", "contains:", "matches:"}
 
 // ValidateTransform retourne les noms de transforms INCONNUS d'une spec (chaîne, chaînage
 // []any, ou table de remplacement map). Un transform inconnu (typo `lowercase`) serait un
@@ -845,6 +845,24 @@ func applyTransform(v any, spec any) any {
 				}
 			}
 			return out
+		}
+		if motif, ok := strings.CutPrefix(t, "matches:"); ok {
+			// Booléen : la valeur correspond-elle au MOTIF. Sert à dériver un fait
+			// qu'un fournisseur n'expose pas en champ mais qu'il énonce dans une
+			// convention de nommage — une identité que la plateforme crée et gère
+			// elle-même, par exemple.
+			//
+			// Le motif vit dans le DESCRIPTEUR, avec sa source, jamais dans une règle :
+			// une règle commune ne connaît aucune convention de fournisseur, et coder
+			// un préfixe dans chacune les ferait diverger au premier changement.
+			//
+			// Un motif invalide rend faux plutôt que de paniquer : c'est une entrée du
+			// dépôt, mais le moteur lit aussi des descripteurs externes.
+			re, err := regexp.Compile(motif)
+			if err != nil {
+				return false
+			}
+			return re.MatchString(toStr(v))
 		}
 		if sub, ok := strings.CutPrefix(t, "contains:"); ok {
 			// Booléen : la représentation de la valeur contient-elle le motif.

--- a/internal/commonrules/rules/iam_role_key_lifetime_bounded.rego
+++ b/internal/commonrules/rules/iam_role_key_lifetime_bounded.rego
@@ -20,6 +20,12 @@ import rego.v1
 deny contains f if {
 	some r in resources_of_type("iam_role")
 	truthy(object.get(r.attributes, "editable", true)) # rôles prédéfinis (non éditables) hors scope
+
+	# Même raisonnement que la garde ci-dessus, autre mécanisme : une identité que
+	# la PLATEFORME crée, utilise et supprime pour son propre composant ne se durcit
+	# pas depuis le compte. La remédiation n'aboutirait pas, et un écart
+	# irréparable coûte plus cher que le contrôle ne rapporte (cf. lib.rego).
+	not gere_par_le_fournisseur(r)
 	_role_exposes_lifetime(r)
 	not _lifetime_bounded(r)
 	name := object.get(r.attributes, "name", r.id)

--- a/internal/commonrules/rules/iam_role_no_admin_privileges.rego
+++ b/internal/commonrules/rules/iam_role_no_admin_privileges.rego
@@ -15,6 +15,12 @@ import rego.v1
 deny contains f if {
 	some r in resources_of_type("iam_role")
 	truthy(object.get(r.attributes, "editable", true)) # rôles prédéfinis (non éditables) hors scope
+
+	# Même raisonnement que la garde ci-dessus, autre mécanisme : une identité que
+	# la PLATEFORME crée, utilise et supprime pour son propre composant ne se durcit
+	# pas depuis le compte. La remédiation n'aboutirait pas, et un écart
+	# irréparable coûte plus cher que le contrôle ne rapporte (cf. lib.rego).
+	not gere_par_le_fournisseur(r)
 	truthy(object.get(r.attributes, "admin_privileges", false))
 	name := object.get(r.attributes, "name", r.id)
 	f := {

--- a/internal/commonrules/rules/iam_role_source_ip_restricted.rego
+++ b/internal/commonrules/rules/iam_role_source_ip_restricted.rego
@@ -15,6 +15,12 @@ import rego.v1
 deny contains f if {
 	some r in resources_of_type("iam_role")
 	truthy(object.get(r.attributes, "editable", true)) # rôles prédéfinis (non éditables) hors scope
+
+	# Même raisonnement que la garde ci-dessus, autre mécanisme : une identité que
+	# la PLATEFORME crée, utilise et supprime pour son propre composant ne se durcit
+	# pas depuis le compte. La remédiation n'aboutirait pas, et un écart
+	# irréparable coûte plus cher que le contrôle ne rapporte (cf. lib.rego).
+	not gere_par_le_fournisseur(r)
 	not truthy(object.get(r.attributes, "source_ip_restricted", true))
 	name := object.get(r.attributes, "name", r.id)
 	f := {

--- a/internal/commonrules/rules/lib.rego
+++ b/internal/commonrules/rules/lib.rego
@@ -582,3 +582,21 @@ environment_of(attrs) := lower(v) if {
 is_production(attrs) if environment_of(attrs) in production_values
 
 environment_known(attrs) if environment_of(attrs)
+
+# gere_par_le_fournisseur — cette ressource est-elle créée, utilisée et supprimée par
+# la PLATEFORME, pour un composant que l'exploitant ne fait pas tourner ?
+#
+# Le cas fondateur : SKS crée un rôle `sks-ccm-<cluster>` pour le cloud controller
+# manager, s'en sert, et le supprime avec le cluster. Il est `editable: true`, donc le
+# filtre des rôles prédéfinis ne le couvrait pas — et chaque cluster apportait deux
+# écarts IAM que personne ne pouvait faire disparaître. Dix clusters, vingt findings
+# irréparables : c'est ainsi qu'un CSPM se fait ignorer.
+#
+# Le FAIT est collecté (`provider_managed`), déclaré dans le descripteur du
+# fournisseur avec sa source. Aucune règle ne connaît de convention de nommage : coder
+# un préfixe dans chacune les ferait diverger au premier changement, et c'est
+# précisément ce que la revue de release demandait d'éviter.
+#
+# Vrai seulement si l'attribut est présent ET vrai. Absent ne vaut pas vrai : un
+# fournisseur qui ne déclare rien ne voit aucun changement.
+gere_par_le_fournisseur(r) if truthy(object.get(r.attributes, "provider_managed", false))

--- a/internal/commonrules/rules/provider_managed_test.rego
+++ b/internal/commonrules/rules/provider_managed_test.rego
@@ -1,0 +1,56 @@
+package pepin.rules
+
+import rego.v1
+
+# ── UNE IDENTITÉ QUE LA PLATEFORME GÈRE (#213) ────────────────────────────────
+#
+# SKS crée un rôle `sks-ccm-<cluster>` pour son cloud controller manager, s'en sert et
+# le supprime avec le cluster. Il est `editable: true`, donc le filtre des rôles
+# prédéfinis ne le couvrait pas — et chaque cluster apportait DEUX écarts IAM que
+# personne ne pouvait faire disparaître. Dix clusters, vingt findings irréparables.
+
+_role_gere := {"resources": [{"provider": "exoscale", "type": "iam_role", "id": "sks-ccm-abc", "attributes": {
+	"name": "sks-ccm-abc",
+	"role_id": "sks-ccm-abc",
+	"editable": true,
+	"provider_managed": true,
+	"source_ip_restricted": false,
+	"policy_has_expiration": false,
+	"max_session_ttl": 0,
+	"admin_privileges": true,
+}}]}
+
+_role_exploitant := {"resources": [{"provider": "exoscale", "type": "iam_role", "id": "ci-deployer", "attributes": {
+	"name": "ci-deployer",
+	"role_id": "ci-deployer",
+	"editable": true,
+	"source_ip_restricted": false,
+	"policy_has_expiration": false,
+	"max_session_ttl": 0,
+	"admin_privileges": true,
+}}]}
+
+_codes_role := {"iam_role_source_ip_restricted", "iam_role_key_lifetime_bounded", "iam_role_no_admin_privileges"}
+
+# ✓ Le rôle géré par la plateforme ne produit AUCUN des trois écarts : sa remédiation
+# n'aboutirait pas — borner l'IP source exigerait de deviner les adresses du plan de
+# contrôle, et une clause de durée casserait le composant.
+test_a_provider_managed_role_raises_nothing if {
+	count({f | some f in deny with input as _role_gere; f.code in _codes_role}) == 0
+}
+
+# ✗ LE CONTRE-EXEMPLE, et c'est lui qui garde les trois contrôles utiles : le MÊME rôle,
+# aux mêmes attributs, sans la marque. Sans ce test, la correction éteindrait trois
+# contrôles au lieu d'en préciser un.
+test_the_same_role_without_the_mark_still_raises_all_three if {
+	fs := {f.code | some f in deny with input as _role_exploitant; f.code in _codes_role}
+	count(fs) == 3
+}
+
+# L'attribut ABSENT ne vaut pas « géré par la plateforme » : un fournisseur qui ne
+# déclare rien ne voit aucun changement. C'est ce que `_role_exploitant` montre déjà,
+# et l'énoncer séparément évite qu'un jour un défaut de collecte fasse taire les trois.
+test_an_absent_mark_never_silences_a_control if {
+	not gere_par_le_fournisseur({"attributes": {"name": "sks-ccm-abc"}})
+	gere_par_le_fournisseur({"attributes": {"provider_managed": true}})
+}

--- a/internal/model/schema.go
+++ b/internal/model/schema.go
@@ -131,7 +131,17 @@ import (
 //	contrôle « VM sans groupe de sécurité » criait alors sur chaque instance privée,
 //	avec une remédiation que l'API ignore. Déduire le fait d'une absence de
 //	`public_ip` ne distinguerait pas « privée » de « non collectée ».
-const InventoryFormat = "pepin-inventory/v8"
+//
+// v9 : une ressource peut porter `provider_managed`, le fait qu'elle soit créée,
+//
+//	utilisée et supprimée par la PLATEFORME pour un composant que l'exploitant ne
+//	fait pas tourner (Exoscale : le rôle `sks-ccm-<cluster>` du cloud controller
+//	manager, GET /v2/iam-role). Ajout PUR. Il est nécessaire parce que ce rôle est
+//	`editable: true` : le filtre des rôles prédéfinis ne le couvrait pas, et chaque
+//	cluster apportait deux écarts IAM que personne ne pouvait faire disparaître. Le
+//	fait est déclaré par le descripteur, avec sa source ; aucune règle ne connaît de
+//	convention de nommage.
+const InventoryFormat = "pepin-inventory/v9"
 
 // InventorySchemaVersion extrait le N du suffixe `/vN`. Comme pour le bundle, la
 // constante et le signal sur le fil sont la même chose : impossible de faire

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -1178,7 +1178,8 @@
         }
       ],
       "rego_tests": [
-        "internal/commonrules/rules/iam_role_key_lifetime_bounded_test.rego"
+        "internal/commonrules/rules/iam_role_key_lifetime_bounded_test.rego",
+        "internal/commonrules/rules/provider_managed_test.rego"
       ]
     },
     "iam_role_no_admin_privileges": {
@@ -1205,7 +1206,8 @@
         }
       ],
       "rego_tests": [
-        "internal/commonrules/rules/iam_role_no_admin_privileges_test.rego"
+        "internal/commonrules/rules/iam_role_no_admin_privileges_test.rego",
+        "internal/commonrules/rules/provider_managed_test.rego"
       ]
     },
     "iam_role_source_ip_restricted": {
@@ -1232,7 +1234,8 @@
         }
       ],
       "rego_tests": [
-        "internal/commonrules/rules/iam_role_source_ip_restricted_test.rego"
+        "internal/commonrules/rules/iam_role_source_ip_restricted_test.rego",
+        "internal/commonrules/rules/provider_managed_test.rego"
       ]
     },
     "iam_user_mfa_enabled": {

--- a/providers/exoscale.yaml
+++ b/providers/exoscale.yaml
@@ -230,12 +230,23 @@ collecte:
         source_ip_restricted: policy
         policy_has_expiration: policy
         manages_iam: policy
+        provider_managed: name
       transforms:
         max_session_ttl: ["default:0", to_int]
         admin_privileges: "equals:allow"   # default allow = tout autorisé sauf deny ciblés (CLD-IAM-1)
         source_ip_restricted: "contains:source_ip"
         policy_has_expiration: "contains:duration("
         manages_iam: "contains:iam-role"   # autorise la gestion des rôles IAM = escalade (CLD-IAM-12)
+        # Identité GÉRÉE PAR LA PLATEFORME : SKS crée un rôle `sks-ccm-<cluster>` pour
+        # le cloud controller manager du cluster, s'en sert, et le supprime avec lui.
+        # Observé le 2026-09-09 (GET /v2/iam-role) : `editable: true`, donc le filtre
+        # des rôles prédéfinis ne le couvre pas — et pourtant l'exploitant ne le crée
+        # pas, ne l'utilise pas, et ne peut pas le durcir sans casser le composant.
+        #
+        # Le MOTIF vit ici, avec sa source, jamais dans une règle : une règle commune ne
+        # connaît aucune convention de nommage de fournisseur, et coder le préfixe dans
+        # chacune les ferait diverger au premier changement.
+        provider_managed: "matches:^sks-ccm-"
 
     # Volumes block storage → blockstorage_volume. state natif (block-storage-volume) :
     # attached|detached|creating|... ; « attached » = rattaché à une instance (en usage,
@@ -452,6 +463,9 @@ contrat:
         permissions[]}. Policy = {default-service-strategy (allow|deny), services{<svc>:{type, rules:[{action, expression,
         resources}]}}} ; expression en CEL. Réf : references/docs/exoscale/reference-api-schemas-iam-role.md + iam-policy.md.'
       mapping:
+        provider_managed: 'DÉRIVÉ : name correspond à ^sks-ccm- — rôle que SKS crée pour le cloud controller
+          manager du cluster, utilise et supprime avec lui (GET /v2/iam-role, observé). `editable: true`, donc le
+          filtre des rôles prédéfinis ne le couvre pas, alors que l''exploitant ne peut ni le créer ni le durcir.'
         role_id: id
         name: name
         editable: 'editable (bool) : un rôle PRÉDÉFINI (non éditable, ex. « Billing », « Owner ») a une policy non modifiable


### PR DESCRIPTION
Closes #213 — le dernier des cinq bloqueurs de la revue de release.

## Vingt findings irréparables pour dix clusters

Le SKS d'Exoscale crée un rôle `sks-ccm-<cluster>` pour le cloud controller manager du
cluster, s'en sert, et le supprime avec lui. Il est **`editable: true`**, donc le filtre
des rôles prédéfinis ne le couvrait pas :

```
CLD-IAM-4  IAM role "sks-ccm-…": no source IP restriction
CLD-IAM-2  IAM role "sks-ccm-…": no bound on credential lifetime
```

Borner ce rôle à une IP source exigerait de deviner les adresses du plan de contrôle ;
ajouter une clause de durée casserait le composant. **Aucune des deux remédiations
n'aboutit**, et c'est ainsi qu'un CSPM apprend à ses utilisateurs à l'ignorer.

## La notion est modélisée, pas codée en dur

La revue demandait explicitement de **ne pas** écrire
`strings.has_prefix(role.name, "sks-ccm-")` dans chaque règle. Elle a raison : une règle
commune ne connaît aucune convention de nommage de fournisseur, et un préfixe répété
dans trois règles diverge au premier changement.

```
descripteur   provider_managed: name  +  transform 'matches:^sks-ccm-'   (avec sa source)
        ↓
collecteur    provider_managed: true
        ↓
lib.rego      gere_par_le_fournisseur(r)          ← un seul helper
        ↓
3 règles      not gere_par_le_fournisseur(r)
```

Le transform `matches:` est générique et réutilisable ; la notion l'est aussi, pour toute
ressource qu'un fournisseur administre lui-même.

Elle se range **à côté d'une garde qui existait déjà** et dit la même chose par un autre
mécanisme : un rôle prédéfini est hors scope parce que l'exploitant ne peut pas le
changer — un rôle que la plateforme possède aussi.

## Le contre-exemple garde les trois contrôles utiles

Le **même** rôle, aux mêmes attributs, **sans** la marque, produit toujours les trois
findings. Sans ce test, la correction éteindrait trois contrôles au lieu d'en préciser
un. Et une marque **absente** ne vaut pas « géré par la plateforme » : un fournisseur qui
ne déclare rien ne voit aucun changement.

## Mesuré

380 tests Rego (378 avant). Schéma d'inventaire **v8 → v9**. **Aucun mouvement de
verdict** sur le corpus de référence.

`mise run prepush` vert.

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)
