### PR TITLE
fix(scan): a bundle handed to a third party does not name a person

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -70,6 +70,18 @@ l'une ni l'autre appartient au `git log`.
 
 ### Sécurité
 
+- **Un bundle de preuve partagé ne nomme plus une personne.** `iam_user.username` est
+  mappé depuis `email` chez Scaleway comme chez Exoscale : le sujet d'un finding MFA
+  était donc une adresse e-mail, et elle voyageait telle quelle dans `assessment.json`,
+  l'OSCAL, le SARIF et l'`input.json` scellé. Un bundle est fait pour être remis à un
+  **tiers** : l'outil y mettait une donnée personnelle sans que personne ne l'ait décidé.
+  `--redact`, qui est déjà l'interrupteur « pour un tiers », y substitue désormais
+  l'**identifiant stable** de l'utilisateur — dans l'inventaire, dans l'assessment
+  scellé, et dans la ligne de preuve qui les cite. L'adresse n'est pas supprimée — un
+  exploitant qui corrige un MFA doit savoir qui — et le **rapport local ne bouge pas** ;
+  seul ce qui quitte le périmètre change. Quel attribut nomme une personne est
+  **déclaré au descripteur du fournisseur avec sa source**, jamais une liste en dur dans
+  la CLI.
 - **Un collecteur ne relit plus une requête dans laquelle il vient d'écrire un secret.**
   CodeQL signalait, en `high`, une clé secrète atteignant un rapport publié : un
   collecteur posait son identifiant en en-tête, puis rebâtissait la signature de l'appel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,17 @@ belongs in `git log`.
 
 ### Security
 
+- **A shared evidence bundle no longer names a person.** `iam_user.username` is mapped
+  from `email` at both Scaleway and Exoscale, so an MFA finding's subject was an e-mail
+  address — and it travelled verbatim into `assessment.json`, the OSCAL, the SARIF and
+  the sealed `input.json`. A bundle is meant to be handed to a **third party**: the tool
+  was putting personal data in it without anyone deciding to. `--redact`, already the
+  "for a third party" switch, now substitutes those subjects with the user's **stable
+  identifier**, in the inventory, in the sealed assessment and in the evidence line that
+  quotes them. The address is not dropped — an operator fixing an MFA needs to know who —
+  the **local report is unchanged**; only what leaves the perimeter is. Which attribute
+  names a person is **declared in the provider descriptor with its source**, never a
+  hard-coded list in the CLI.
 - **A collector no longer reads back a request it has just put a secret into.** CodeQL
   reported, at `high`, a secret key reaching a published report: a collector set its
   credential as a header, then rebuilt the call signature from that same request object

--- a/cmd/personal_data_test.go
+++ b/cmd/personal_data_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Un bundle de preuve est fait pour être remis à un TIERS — un auditeur, un client.
+// Le sujet d'un finding MFA était l'adresse e-mail de l'utilisateur, parce que
+// `iam_user.username` est mappé depuis `email` : chaque bundle scellé emportait donc
+// une donnée personnelle que l'outil y avait mise sans que personne ne le décide.
+//
+// On ne la supprime pas : un exploitant qui corrige un MFA doit savoir QUI. Seul le
+// bundle destiné à sortir du périmètre porte l'identifiant stable à sa place.
+
+const inventaireMFA = `{"format":"pepin-inventory/v9","provider":"scaleway","evaluated_at":"2026-09-10T00:00:00Z","resources":[
+ {"provider":"scaleway","type":"iam_user","id":"user-42","name":"jean.dupont@exemple.fr","region":"fr-par",
+  "attributes":{"user_id":"user-42","username":"jean.dupont@exemple.fr","mfa_enabled":false}}
+]}`
+
+func inventairePersonnel(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "inv.json")
+	if err := os.WriteFile(p, []byte(inventaireMFA), 0o600); err != nil {
+		t.Fatalf("écriture de la fixture : %v", err)
+	}
+	return p
+}
+
+// TestASharedBundleNamesNobody : rien de ce que le bundle emporte ne nomme la personne.
+// Le test cherche l'adresse dans TOUS les fichiers, pas dans les champs qu'on croit
+// concernés — c'est ainsi qu'on trouve celui qu'on avait oublié, et il y en avait un :
+// le message du finding, dans `evidence.observed`.
+func TestASharedBundleNamesNobody(t *testing.T) {
+	bin := buildPepin(t)
+	dir := filepath.Join(t.TempDir(), "bundle")
+	inv := inventairePersonnel(t)
+	runPepin(t, bin, nil, "scan", "scaleway", inv, "--seal", dir, "--redact")
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("bundle absent : %v", err)
+	}
+	var vus int
+	for _, e := range entries {
+		b, rerr := os.ReadFile(filepath.Join(dir, e.Name())) // #nosec G304 -- répertoire du test.
+		if rerr != nil {
+			t.Fatalf("lecture de %s : %v", e.Name(), rerr)
+		}
+		vus++
+		if strings.Contains(string(b), "jean.dupont@exemple.fr") {
+			t.Errorf("%s emporte l'adresse e-mail : un bundle remis à un tiers ne doit pas nommer une personne", e.Name())
+		}
+	}
+	if vus == 0 {
+		t.Fatal("bundle vide : la garde ne mesure rien")
+	}
+	// Et le finding reste ACTIONNABLE : l'identifiant stable désigne le même
+	// utilisateur. Effacer le sujet aurait rendu l'écart inexploitable.
+	b, _ := os.ReadFile(filepath.Join(dir, "assessment.json")) // #nosec G304
+	if !strings.Contains(string(b), "user-42") {
+		t.Error("l'identifiant stable ne remplace pas l'adresse : le finding devient inactionnable")
+	}
+}
+
+// LE CONTRE-EXEMPLE : sans `--redact`, le rapport local nomme la personne. C'est ce
+// qu'un exploitant a besoin de lire, et rien ne quitte sa machine.
+func TestTheLocalReportStillNamesThePerson(t *testing.T) {
+	bin := buildPepin(t)
+	stdout, _ := runPepin(t, bin, []string{"LANG=fr_FR.UTF-8"}, "scan", "scaleway", inventairePersonnel(t), "--format", "json")
+	if !strings.Contains(stdout, "jean.dupont@exemple.fr") {
+		t.Error("le rapport local ne nomme plus la personne : un exploitant ne saurait plus qui corriger")
+	}
+}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -257,7 +257,7 @@ var scanCmd = &cobra.Command{
 				// embarqué : un bundle remis à un tiers ne doit pas exfiltrer les secrets détectés.
 				// INCOMPATIBLE avec `verify --re-derive` (la détection ne rejoue pas sur du caviardé)
 				// → un bundle caviardé s'appuie sur la SIGNATURE cosign, pas sur la re-dérivation.
-				bundleInput = redactInventory(input)
+				bundleInput = redactInventory(input, personalOf(scanTargetProvider))
 			}
 			inputJSON, merr := json.MarshalIndent(bundleInput, "", "  ")
 			if merr != nil {
@@ -273,7 +273,18 @@ var scanCmd = &cobra.Command{
 				return cerr
 			}
 			extras.Config, extras.ConfigSummary = cextras.Config, cextras.ConfigSummary
-			cs, err := assess.WriteBundle(scanSeal, asmt, inputJSON, extras)
+			// L'assessment SCELLÉ suit l'inventaire caviardé : c'est lui qui part chez
+			// le tiers, et il porte les SUJETS. Caviarder l'inventaire seul aurait
+			// laissé l'adresse e-mail dans `assessment.json`, `assessment-oscal.json`
+			// et le SARIF — c'est-à-dire dans tout ce qu'un auditeur lit réellement.
+			//
+			// Le rapport LOCAL, lui, ne bouge pas : un exploitant qui corrige un MFA
+			// doit savoir qui, et rien ne sort de sa machine.
+			bundleAsmt := asmt
+			if scanRedact {
+				bundleAsmt = redactSubjects(asmt, input, personalOf(scanTargetProvider))
+			}
+			cs, err := assess.WriteBundle(scanSeal, bundleAsmt, inputJSON, extras)
 			if err != nil {
 				return err
 			}
@@ -442,7 +453,20 @@ var sensitiveAttrs = map[string]bool{
 // redactInventory retourne une COPIE de l'inventaire dont les valeurs des attributs sensibles
 // sont remplacées par une empreinte (le finding reste, la valeur brute disparaît). Ne mute pas
 // l'input évalué (la détection a déjà eu lieu en amont).
-func redactInventory(input any) any {
+// personalOf rend, par type normalisé, les attributs qui nomment une PERSONNE chez ce
+// fournisseur et l'identifiant stable qui les remplace. Lu au descripteur, jamais codé
+// ici : quel champ nomme une personne dépend du fournisseur.
+func personalOf(provider string) map[string]genprovider.DonneePersonnelle {
+	out := map[string]genprovider.DonneePersonnelle{}
+	for _, d := range genprovider.Descriptors()[provider].DonneesPersonnelles {
+		if d.Type != "" && d.IdentifiantStable != "" {
+			out[d.Type] = d
+		}
+	}
+	return out
+}
+
+func redactInventory(input any, personal map[string]genprovider.DonneePersonnelle) any {
 	m, ok := input.(map[string]any)
 	if !ok {
 		return input
@@ -450,6 +474,35 @@ func redactInventory(input any) any {
 	out := make(map[string]any, len(m))
 	for k, v := range m {
 		out[k] = v
+	}
+	// Une donnée PERSONNELLE ne se hache pas, elle se REMPLACE. Un exploitant qui
+	// corrige un MFA doit savoir QUI : effacer le sujet rendrait le finding inactionnable,
+	// et une empreinte ne se relie à personne. L'identifiant stable du même utilisateur
+	// dit la même chose sans nommer la personne.
+	//
+	// La substitution a lieu dans l'INVENTAIRE, pas seulement dans l'assessment, et c'est
+	// ce qui la rend correcte : `verify --re-derive` rejoue les règles sur cet input.json
+	// et doit retrouver EXACTEMENT les mêmes sujets. Caviarder d'un seul côté ferait
+	// mentir le bundle sur lui-même — précisément ce que l'ADR-0018 refuse.
+	remplacePersonnel := func(typ string, attrs map[string]any) map[string]any {
+		d, ok := personal[typ]
+		if !ok {
+			return attrs
+		}
+		stable, _ := attrs[d.IdentifiantStable].(string)
+		if stable == "" {
+			return attrs // pas d'identifiant stable observé : on ne fabrique rien (ADR-0014)
+		}
+		ac := make(map[string]any, len(attrs))
+		for k, v := range attrs {
+			ac[k] = v
+		}
+		for _, a := range d.Attributs {
+			if _, present := ac[a]; present {
+				ac[a] = stable
+			}
+		}
+		return ac
 	}
 	redactAttrs := func(attrs map[string]any) map[string]any {
 		ac := make(map[string]any, len(attrs))
@@ -468,7 +521,17 @@ func redactInventory(input any) any {
 	case []model.Resource: // source live/terraform (typée)
 		nr := make([]model.Resource, len(rs))
 		for i, r := range rs {
-			r.Attributes = redactAttrs(r.Attributes)
+			r.Attributes = redactAttrs(remplacePersonnel(r.Type, r.Attributes))
+			// Le NOM de la ressource porte souvent la même donnée que l'attribut
+			// personnel : le remplacer aussi, sans quoi l'adresse ressortirait par
+			// l'autre bout.
+			if d, ok := personal[r.Type]; ok {
+				if stable, _ := r.Attributes[d.IdentifiantStable].(string); stable != "" {
+					if r.Name != "" && r.Name != stable {
+						r.Name = stable
+					}
+				}
+			}
 			nr[i] = r
 		}
 		out["resources"] = nr
@@ -484,8 +547,17 @@ func redactInventory(input any) any {
 			for k, v := range rm {
 				rc[k] = v
 			}
+			typ, _ := rm["type"].(string)
 			if attrs, ok := rm["attributes"].(map[string]any); ok {
-				rc["attributes"] = redactAttrs(attrs)
+				sub := remplacePersonnel(typ, attrs)
+				rc["attributes"] = redactAttrs(sub)
+				if d, ok := personal[typ]; ok {
+					if stable, _ := sub[d.IdentifiantStable].(string); stable != "" {
+						if nom, _ := rm["name"].(string); nom != "" && nom != stable {
+							rc["name"] = stable
+						}
+					}
+				}
 			}
 			nr[i] = rc
 		}
@@ -1668,4 +1740,80 @@ func avertirRegionInconnue(w io.Writer, provider, region string, live bool) {
 			"  The scan continues — the catalogue may lag behind the provider — but a region that\n"+
 			"  does not exist makes every call unavailable, and the verdict INCONCLUSIVE.\n"),
 		region, provider, strings.Join(connues, ", "))
+}
+
+// redactSubjects remplace, dans une COPIE de l'assessment, les sujets qui nomment une
+// personne par l'identifiant stable du même utilisateur.
+//
+// La table de correspondance vient de l'inventaire ÉVALUÉ : c'est la seule source qui
+// relie une valeur personnelle à son identifiant stable, et elle évite d'avoir à
+// deviner à quoi ressemble une adresse. Ce qui n'y figure pas n'est pas touché — on ne
+// caviarde jamais au motif qu'une chaîne « ressemble » à une donnée personnelle.
+func redactSubjects(a assessment.Assessment, input any, personal map[string]genprovider.DonneePersonnelle) assessment.Assessment {
+	if len(personal) == 0 {
+		return a
+	}
+	remplace := map[string]string{}
+	forEachResource(input, func(typ, name string, attrs map[string]any) {
+		d, ok := personal[typ]
+		if !ok {
+			return
+		}
+		stable, _ := attrs[d.IdentifiantStable].(string)
+		if stable == "" {
+			return
+		}
+		for _, at := range d.Attributs {
+			if v, _ := attrs[at].(string); v != "" && v != stable {
+				remplace[v] = stable
+			}
+		}
+		if name != "" && name != stable {
+			remplace[name] = stable
+		}
+	})
+	if len(remplace) == 0 {
+		return a
+	}
+	out := a
+	out.Results = make([]assessment.Result, len(a.Results))
+	copy(out.Results, a.Results)
+	for i := range out.Results {
+		if s, ok := remplace[out.Results[i].Subject]; ok {
+			out.Results[i].Subject = s
+		}
+		// La PREUVE porte le message du finding, qui nomme la personne dans sa phrase :
+		// « Compte « … » sans authentification multifacteur ». Ne remplacer que le sujet
+		// laissait l'adresse dans la seule ligne qu'un auditeur lit vraiment.
+		for avant, apres := range remplace {
+			out.Results[i].Evidence.Observed = strings.ReplaceAll(out.Results[i].Evidence.Observed, avant, apres)
+		}
+	}
+	return out
+}
+
+// forEachResource parcourt les ressources d'un inventaire, quelle que soit sa forme
+// (typée pour une collecte, générique pour un export JSON relu).
+func forEachResource(input any, fn func(typ, name string, attrs map[string]any)) {
+	m, ok := input.(map[string]any)
+	if !ok {
+		return
+	}
+	switch rs := m["resources"].(type) {
+	case []model.Resource:
+		for _, r := range rs {
+			fn(r.Type, r.Name, r.Attributes)
+		}
+	case []any:
+		for _, r := range rs {
+			rm, ok := r.(map[string]any)
+			if !ok {
+				continue
+			}
+			typ, _ := rm["type"].(string)
+			name, _ := rm["name"].(string)
+			attrs, _ := rm["attributes"].(map[string]any)
+			fn(typ, name, attrs)
+		}
+	}
 }

--- a/internal/genprovider/genprovider.go
+++ b/internal/genprovider/genprovider.go
@@ -38,6 +38,19 @@ type Descriptor struct {
 	Description string `yaml:"description"`
 	Scope       string `yaml:"scope"`      // "cloud" (défaut) | "in-cluster" : une portée différente ne se compare pas en parité
 	RegionKey   string `yaml:"region_key"` // clé logique alimentée par --region (défaut "region" ; Exoscale: "zone")
+	// DonneesPersonnelles : par TYPE normalisé, les attributs qui identifient une
+	// PERSONNE, et l'attribut non personnel qui les remplace dans un bundle caviardé.
+	//
+	// Chez Scaleway comme chez Exoscale, `iam_user.username` est mappé depuis
+	// `email` : le sujet d'un finding MFA est donc une adresse, et elle voyage telle
+	// quelle dans l'assessment, le SARIF, l'OSCAL et le bundle scellé. Un bundle est
+	// fait pour être remis à un TIERS — un auditeur, un client —, et une adresse
+	// e-mail y est une donnée personnelle que l'outil a mise là sans que personne ne
+	// l'ait décidé.
+	//
+	// Déclaré ici plutôt que codé dans la CLI : quel champ nomme une personne dépend
+	// du fournisseur, et une liste en dur diverge au premier qui change de modèle.
+	DonneesPersonnelles []DonneePersonnelle `yaml:"donnees_personnelles"`
 	// Regions : le catalogue des régions CONNUES de ce fournisseur, celui-là même que
 	// les règles de souveraineté cataloguent (internal/commonrules/rules/lib.rego :
 	// `_eu_regions`, `_trusted_regions`, `_noneu_regions`). Il sert à prévenir tôt
@@ -107,6 +120,20 @@ type Permission struct {
 	Source string `yaml:"source"` // document officiel qui confirme (ou dont l'absence motive `a_verifier`)
 	Note   string `yaml:"note"`   // réserve ou précision, en français
 	NoteEn string `yaml:"note_en"`
+}
+
+// DonneePersonnelle : un type dont certains attributs nomment une personne, et
+// l'identifiant stable qui les remplace quand le bundle part chez un tiers.
+type DonneePersonnelle struct {
+	Type string `yaml:"type"`
+	// Attributs : ceux qui portent la donnée personnelle (ex. `username` = e-mail).
+	Attributs []string `yaml:"attributs"`
+	// IdentifiantStable : l'attribut non personnel qui les remplace. Il DOIT exister
+	// sur le type, sans quoi le caviardage effacerait le sujet au lieu de le
+	// remplacer, et un opérateur ne saurait plus QUI corriger.
+	IdentifiantStable string `yaml:"identifiant_stable"`
+	// Source : d'où l'on tient que ce champ nomme une personne.
+	Source string `yaml:"source"`
 }
 
 // Souverainete porte les FAITS de souveraineté du fournisseur (siège, contrôle

--- a/providers/exoscale.yaml
+++ b/providers/exoscale.yaml
@@ -15,6 +15,22 @@ region_key: zone
 # appartient au fournisseur, et une région ajoutée demain doit rester scannable.
 regions: [at-vie-1, at-vie-2, bg-sof-1, ch-dk-2, ch-gva-2, de-fra-1, de-muc-1, hr-zag-1]
 
+# Données PERSONNELLES : les attributs qui nomment une personne, et l'identifiant
+# stable qui les remplace dans un bundle caviardé (`--seal --redact`).
+#
+# `iam_user.username` est mappé depuis `email` : le sujet d'un finding MFA est donc une
+# adresse. Un bundle est fait pour être remis à un TIERS, et une adresse e-mail y est
+# une donnée personnelle que l'outil aurait mise là sans que personne ne le décide.
+#
+# On ne la SUPPRIME pas : un exploitant qui corrige un MFA doit savoir qui. Elle reste
+# dans le rapport local ; seul le bundle destiné à sortir du périmètre porte
+# l'identifiant stable à sa place.
+donnees_personnelles:
+  - type: iam_user
+    attributs: [username]
+    identifiant_stable: user_id
+    source: "API v2 IAM — l'utilisateur est identifié par son `email`, mappé en `username` (cf. collecte)"
+
 
 # Souveraineté du fournisseur (CLD-GVN-4) — faits ancrés, projetés en ressource
 # governance_provider. Siège en Suisse (hors UE) → écart GVN-4 attendu.

--- a/providers/scaleway.yaml
+++ b/providers/scaleway.yaml
@@ -14,6 +14,22 @@ description: "Scaleway — object storage, instances, IAM, security groups"
 # appartient au fournisseur, et une région ajoutée demain doit rester scannable.
 regions: [fr-par, nl-ams, pl-waw]
 
+# Données PERSONNELLES : les attributs qui nomment une personne, et l'identifiant
+# stable qui les remplace dans un bundle caviardé (`--seal --redact`).
+#
+# `iam_user.username` est mappé depuis `email` : le sujet d'un finding MFA est donc une
+# adresse. Un bundle est fait pour être remis à un TIERS, et une adresse e-mail y est
+# une donnée personnelle que l'outil aurait mise là sans que personne ne le décide.
+#
+# On ne la SUPPRIME pas : un exploitant qui corrige un MFA doit savoir qui. Elle reste
+# dans le rapport local ; seul le bundle destiné à sortir du périmètre porte
+# l'identifiant stable à sa place.
+donnees_personnelles:
+  - type: iam_user
+    attributs: [username]
+    identifiant_stable: user_id
+    source: "api/iam/v1alpha1 User — `email` mappé en `username` (cf. collecte)"
+
 
 # Souveraineté du fournisseur (CLD-GVN-4) — faits ancrés. Cloud français du
 # groupe Iliad (capital européen) ; qualification SecNumCloud en cours.


### PR DESCRIPTION
Closes #197.

## L'outil mettait une donnée personnelle dans l'artefact fait pour être partagé

`iam_user.username` est mappé depuis `email` chez Scaleway comme chez Exoscale. Le sujet
d'un finding MFA était donc une adresse, et elle voyageait telle quelle dans
`assessment.json`, l'OSCAL, le SARIF et l'`input.json` scellé.

Un bundle de preuve est *l'*artefact que ce produit existe pour produire, et il est fait
pour être remis à un **tiers**. Le destinataire héritait d'une base légale à laquelle il
n'avait pas pensé, parce qu'un scanner avait choisi pour lui.

## L'adresse n'est pas supprimée

Un exploitant qui corrige un MFA doit savoir **qui**, et le rapport local ne bouge pas :
rien ne quitte sa machine. `--redact` est déjà l'interrupteur « pour un tiers », et il
substitue désormais l'identifiant stable.

```
sans --redact   subject = jean.dupont@exemple.fr        (rapport local)
avec --redact   subject = user-42                       (bundle)
                evidence = « Compte « user-42 » sans MFA activée. »
```

## En trois endroits, parce que deux ne suffisaient pas

L'inventaire, l'assessment scellé, **et la ligne de preuve** — celle-ci *cite* le sujet à
l'intérieur de sa phrase. Je l'ai trouvée parce que le test cherche l'adresse dans **tous
les fichiers** du bundle, pas dans les champs que je croyais concernés. C'est la raison
pour laquelle il est écrit ainsi.

## Déclaré, pas codé en dur

Quel attribut nomme une personne vit dans le descripteur du fournisseur, avec sa source.
Une liste en dur dans la CLI serait fausse au premier fournisseur qui modélise ses
utilisateurs autrement — et ce n'est pas à la CLI de détenir cette connaissance.

## Ce qui ne change pas

`--redact` était déjà documenté comme **incompatible avec `verify --re-derive`**, un
bundle caviardé s'appuyant sur sa signature cosign. Cette frontière est inchangée.

Le contre-exemple a son propre test : sans `--redact`, le rapport nomme toujours la
personne.

`mise run prepush` vert.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)
