### PR TITLE
fix(provider): a refused Outscale unit names the grant that collects it

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -561,6 +561,27 @@ l'une ni l'autre appartient au `git log`.
 
 ### Modifié
 
+- **Une unité Outscale refusée nomme désormais le droit qui l'aurait collectée, et la
+  documentation dit qu'un scan complet exige les clés du propriétaire du compte**
+  (issue #168). Mesuré le 2026-09-09 sur un tenant `eu-west-2` réel, avec un utilisateur
+  EIM ne portant que la politique de lecture publiée par Outscale (`api:Read*` sur `*`) :
+  toutes les unités OAPI sont revenues complètes, avec un inventaire identique à celui
+  du compte propriétaire — et **OOS comme OKS ont refusé cette identité**. OOS répond
+  `InvalidAccessKeyId — The AWS access key Id you provided does not exist in our
+  records`, c'est-à-dire qu'il ne connaît pas du tout les clés EIM ; OKS répond
+  `Forbidden: User type not allowed`, refusant l'identité par son type. Aucun des deux
+  n'est un droit manquant, donc aucune politique EIM ne les lève. Ces deux unités
+  portaient un droit **vide** au descripteur, et le relevé de capacités n'imprime
+  « droit requis » que si le descripteur le déclare : l'opérateur ne lisait que l'erreur
+  S3 brute et allait vérifier une clé parfaitement valide. Les deux droits sont
+  désormais déclarés, donc le relevé de capacités et chaque motif de `not-evaluated` les
+  nomment. La table des permissions distingue une ligne **documentée** d'une ligne
+  **mesurée** et date la seconde (`mesure:` au descripteur) ; la page du fournisseur dit
+  comment vivre avec les clés propriétaires — une clé dédiée avec une date
+  d'expiration, hors CI, et une dérogation datée sur `iam_no_root_access_key` plutôt que
+  le silence. Aucun identifiant n'entre en CI : la mesure est un geste de mainteneur,
+  lancé localement et consigné (ADR-0012).
+
 - **La porte de qualification disait GO alors qu'un faux vert connu subsistait.** Elle
   comparait un run à `expected.yaml` et concluait GO dès qu'ils coïncidaient — un bon
   **contrat de non-régression**, mais présenté comme une **porte de qualité de release**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -519,6 +519,25 @@ belongs in `git log`.
 
 ### Changed
 
+- **A refused Outscale unit now names the grant that would have collected it, and the
+  documentation says a complete scan needs the account owner's keys** (issue #168).
+  Measured on 2026-09-09 against a real `eu-west-2` tenant, with an EIM user carrying
+  nothing but the read-only policy Outscale publishes (`api:Read*` on `*`): every OAPI
+  unit came back complete, with an inventory identical to the account owner's — and
+  **OOS and OKS both refused that identity**. OOS answers `InvalidAccessKeyId — The AWS
+  access key Id you provided does not exist in our records`, meaning it does not know
+  EIM keys at all; OKS answers `Forbidden: User type not allowed`, refusing the identity
+  by its type. Neither is a missing grant, so no EIM policy lifts them. Those two units
+  carried an **empty** grant in the descriptor, and the capability report only prints
+  "required grant" when the descriptor declares one: the operator read the raw S3 error
+  and went to check a perfectly valid key. Both grants are now declared, so the
+  capability report and every `not-evaluated` reason name them. The permissions table
+  distinguishes a **documented** line from a **measured** one and dates the latter
+  (`mesure:` in the descriptor); the provider page states how to live with owner keys —
+  a dedicated key with an expiry, out of CI, and a dated exemption on
+  `iam_no_root_access_key` rather than silence. No credential enters CI: the measurement
+  is a maintainer gesture, run locally and recorded (ADR-0012).
+
 - **The qualification gate said GO while a known false green stood.** It compared a run
   to `expected.yaml` and concluded GO when they matched — a good **non-regression
   contract**, but presented as a **release quality gate**. A pinned defect reproduces

--- a/cmd/capability_grant_test.go
+++ b/cmd/capability_grant_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/pepin/internal/genprovider"
+	"github.com/stephrobert/pepin/internal/i18n"
+	"github.com/stephrobert/pepin/internal/model"
+)
+
+// Un refus nomme-t-il le droit qui, lui, aurait collecté ?
+//
+// Le défaut mesuré (issue #168). Sur Outscale, `object_storage_bucket` et
+// `kubernetes_cluster` portaient un `grant` VIDE au descripteur. Le relevé de
+// capacités n'imprime la ligne « droit requis » que si le descripteur la déclare,
+// et le motif d'un « non évalué » de même : l'opérateur ne lisait donc que la
+// réponse brute d'OOS —
+//
+//	The AWS access key Id you provided does not exist in our records
+//
+// — qui l'envoyait vérifier une clé parfaitement valide. Le fait mesuré est tout
+// autre : OOS ne connaît AUCUNE clé EIM, et seules les clés du propriétaire du
+// compte collectent cette unité. Un message qui envoie corriger la mauvaise chose
+// coûte plus cher qu'un message absent, parce qu'on le suit.
+//
+// Le test tire les droits du VRAI descripteur, jamais d'une table écrite ici :
+// c'est la chaîne descripteur → relevé qui est en cause, pas le rendu isolé.
+func TestARefusedUnitNamesTheGrantThatWouldHaveCollected(t *testing.T) {
+	ensureProvidersRegistered(t)
+	// La langue est un état de PAQUET : la laisser déplacée ferait dépendre les
+	// autres tests du binaire de l'ordre d'exécution.
+	defer i18n.Set(i18n.Current())
+	grants := genprovider.Grants("outscale")
+
+	coll := model.Collection{Units: []model.CollectionUnit{
+		{Unit: "compute_instance", Attempted: true, Complete: true},
+		{
+			Unit: "object_storage_bucket", Attempted: true, Complete: false,
+			Error:  model.OutcomePermissionDenied,
+			Detail: "HTTP 403 · ListBuckets · InvalidAccessKeyId: The AWS access key Id you provided does not exist in our records.",
+		},
+		{
+			Unit: "kubernetes_cluster", Attempted: true, Complete: false,
+			Error:  model.OutcomePermissionDenied,
+			Detail: `HTTP 403 · GET /api/v2/clusters/all · {"message":"Forbidden: User type not allowed."}`,
+		},
+	}}
+
+	// Les deux langues : un opérateur francophone doit lire la même action.
+	for _, l := range []i18n.Lang{i18n.FR, i18n.EN} {
+		i18n.Set(l)
+		var b bytes.Buffer
+		renderCapabilities(&b, coll, nil, grants, true)
+		out := b.String()
+
+		for _, cas := range []struct{ unit, droit string }{
+			{"object_storage_bucket", "account owner access key (OOS)"},
+			{"kubernetes_cluster", "account owner access key (OKS)"},
+		} {
+			if !strings.Contains(out, cas.droit) {
+				t.Errorf("[%s] %s refusé : le relevé ne nomme pas le droit qui aurait collecté (%q attendu).\n"+
+					"  L'opérateur ne lit alors que l'erreur brute de l'API, qui accuse sa clé.\n"+
+					"--- relevé ---\n%s", l, cas.unit, cas.droit, out)
+			}
+		}
+		// Le détail brut reste imprimé : la classe dit quoi faire, le détail dit à
+		// qui le demander. Le remplacer priverait l'utilisateur de la réponse réelle.
+		if !strings.Contains(out, "InvalidAccessKeyId") {
+			t.Errorf("[%s] le détail brut de l'API a disparu du relevé — le droit nommé le complète, il ne le remplace pas.\n--- relevé ---\n%s", l, out)
+		}
+	}
+}
+
+// Le contre-exemple : une unité refusée dont le descripteur ne déclare AUCUN droit
+// ne doit pas faire inventer de ligne. Un droit fabriqué ferait élargir des
+// privilèges au hasard, ce qui est le contraire du service rendu (ADR-0014).
+func TestAnUndeclaredGrantIsNeverInvented(t *testing.T) {
+	ensureProvidersRegistered(t)
+	defer i18n.Set(i18n.Current())
+	i18n.Set(i18n.FR)
+	coll := model.Collection{Units: []model.CollectionUnit{
+		{Unit: "type_inconnu_du_descripteur", Attempted: true, Complete: false,
+			Error: model.OutcomePermissionDenied, Detail: "HTTP 403"},
+	}}
+	var b bytes.Buffer
+	renderCapabilities(&b, coll, nil, genprovider.Grants("outscale"), true)
+	if strings.Contains(b.String(), "droit requis") {
+		t.Errorf("un droit a été nommé pour une unité que le descripteur ne déclare pas :\n%s", b.String())
+	}
+}

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -285,25 +285,53 @@ Ce qui reste vrai : Pépin ne peut pas vous dire ce qu'un identifiant *plus larg
 Il rend compte de la surface qu'on lui a donnée, et de l'absence de cette surface, jamais de ce
 qui s'étend au-delà.
 
-### Les permissions minimales sont documentées, pas mesurées
+### Les permissions minimales sont documentées ; mesurées chez un seul fournisseur
 
 Chaque page de fournisseur liste les appels d'API que fait un scan et les permissions de lecture
 qu'ils exigent. Ces listes sont **dérivées des descripteurs de collecte**, c'est-à-dire des
 endpoints que la spec déclare, et confrontées à la documentation IAM publique du fournisseur.
 Chaque page distingue les lignes confirmées par la documentation de celles qui restent non
-vérifiées.
+vérifiées, et **date** celles qu'un scan réel a mesurées.
 
-Deux moitiés, et elles ne sont pas dans le même état. La moitié **endpoints** est désormais
-mesurée : une session enregistrée prouve que le collecteur émet bien ce que le descripteur
-déclare, donc la liste n'est plus une affirmation sur du code que personne n'a regardé tourner
-([Tracer les appels réels](guides/tracing-api-calls.fr.md)). La moitié **droits** ne l'est pas,
-et ne peut pas l'être d'ici : confirmer que `InstancesReadOnly` et rien de plus suffit à
-`ListSecurityGroups` exige de lancer un scan avec un rôle délibérément réduit contre un tenant
-réel. Ce dépôt ne détient aucun identifiant cloud, par construction, et aucun contrôle
-automatisé n'atteint une API de fournisseur. Chez Outscale, l'essentiel des lignes est
-`a_verifier` pour une raison plus tranchée encore : les noms d'action y sont **inférés** de la
-syntaxe EIM documentée, et non recopiés d'un catalogue de permissions publié. Un droit inféré
-est une supposition, et c'est précisément ce qu'un CSPM ne doit pas vous demander d'accorder.
+Deux moitiés, et elles ne sont pas dans le même état. La moitié **endpoints** est mesurée : une
+session enregistrée prouve que le collecteur émet bien ce que le descripteur déclare, donc la
+liste n'est plus une affirmation sur du code que personne n'a regardé tourner
+([Tracer les appels réels](guides/tracing-api-calls.fr.md)).
+
+La moitié **droits** ne l'est que chez **Outscale**, où un scan mené le 2026-09-09 avec un
+utilisateur EIM ne portant que `api:Read*` a établi que cette politique suffit à toutes les
+unités OAPI, et qu'elle est refusée par OOS et par OKS
+([page Outscale](providers/outscale.fr.md#ce-que-le-scan-à-rôle-réduit-a-mesuré)). Ailleurs,
+elle ne l'est pas : confirmer que `InstancesReadOnly` et rien de plus suffit à
+`ListSecurityGroups` exige le même geste contre un tenant Scaleway, et il n'a pas été fait. Ces
+mesures ne sont **jamais automatisables** : aucun identifiant cloud n'entre dans ce dépôt ni
+dans sa CI, par construction ([ADR-0012](adr/0012-aucun-identifiant-en-ci.md)). Un relevé daté
+peut donc devenir périmé sans que rien ne rougisse — un droit se retire, un service change de
+modèle d'identité.
+
+Ce qui reste inféré même chez Outscale : les **noms d'action** détaillés, tirés de la syntaxe
+EIM documentée et non d'un catalogue de permissions publié. Ce qui a été mesuré, c'est
+`api:Read*` prise en bloc. Un droit inféré est une supposition, et c'est précisément ce qu'un
+CSPM ne doit pas vous demander d'accorder.
+
+### Un scan Outscale complet exige les clés du propriétaire du compte
+
+Mesuré le 2026-09-09 : OOS répond `InvalidAccessKeyId` à une clé EIM que l'OAPI vient pourtant
+d'accepter — il ne connaît pas du tout les clés EIM — et OKS répond
+`Forbidden: User type not allowed`, refusant l'identité par son type. Aucun de ces deux refus
+ne porte sur un droit, donc aucune politique EIM ne les lève.
+
+Le stockage objet et le Kubernetes managé ne sont donc atteignables qu'avec les clés du
+propriétaire du compte, que Pépin signale lui-même en `iam_no_root_access_key` (HIGH). Son seul
+mode de fonctionnement complet sur Outscale est l'un de ses propres constats. Un scan à rôle
+réduit n'est pas un faux vert — il consigne les deux unités incomplètes, nomme le droit qui les
+collecterait, et rend les contrôles concernés en `not-evaluated` — mais c'est un scan
+incomplet, et l'arbitrage revient à l'opérateur ; ce n'est pas à nous de le masquer. La page du
+fournisseur dit comment vivre avec :
+[un scan complet exige les clés du propriétaire du compte](providers/outscale.fr.md#un-scan-complet-exige-les-clés-du-propriétaire-du-compte).
+
+Qu'un droit plus étroit existe — des clés d'accès propres à OOS pour un utilisateur EIM —
+reste ouvert ; `ReadAccessKeys` n'en montre aucune.
 
 ### Les faits de souveraineté sont déclarés, pas vérifiés
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -282,24 +282,51 @@ produces a report that says what it could not see. See
 What remains true: Pépin cannot tell you what a *broader* credential would have found. It
 reports the surface it was given, and the absence of that surface, never what lies beyond it.
 
-### The minimum permissions are documented, not measured
+### The minimum permissions are documented; measured on one provider only
 
 Each provider page lists the API calls a scan makes and the read permissions they need. Those
 lists are **derived from the collection descriptors** — the endpoints the spec declares — and
 checked against the provider's public IAM documentation. Each page marks which lines are
-confirmed by documentation and which remain unverified.
+confirmed by documentation and which remain unverified, and **dates** the ones a real scan has
+measured.
 
-Two halves, and they are not in the same state. The **endpoints** half is now measured: a
-recorded session proves the collector really emits what the descriptor declares, so the list is
-no longer a claim about code nobody watched run
-([Tracing real API calls](guides/tracing-api-calls.md)). The **grants** half is not, and cannot
-be from here: confirming that `InstancesReadOnly` and nothing more suffices for
-`ListSecurityGroups` requires running a scan with a deliberately reduced role against a real
-tenant. This repository holds no cloud credentials, by design, and no automated check reaches a
-provider API. Most of Outscale's entries are `a_verifier` for a sharper reason still: the action
-names are **inferred** from the documented EIM syntax rather than read from a published
-permission set, and an inferred grant is a guess, which is precisely what a CSPM must not ask
-you to grant.
+Two halves, and they are not in the same state. The **endpoints** half is measured: a recorded
+session proves the collector really emits what the descriptor declares, so the list is no
+longer a claim about code nobody watched run
+([Tracing real API calls](guides/tracing-api-calls.md)).
+
+The **grants** half is measured on **Outscale** only, where a scan run on 2026-09-09 with an
+EIM user carrying nothing but `api:Read*` established that this policy suffices for every OAPI
+unit, and that OOS and OKS refuse it
+([Outscale page](providers/outscale.md#what-the-reduced-role-scan-measured)). Elsewhere it is
+not: confirming that `InstancesReadOnly` and nothing more suffices for `ListSecurityGroups`
+requires the same gesture against a Scaleway tenant, and it has not been made. These
+measurements can **never be automated**: no cloud credential enters this repository or its CI,
+by design ([ADR-0012](adr/0012-aucun-identifiant-en-ci.md)). A dated reading can therefore go
+stale with nothing turning red — a grant gets revoked, a service changes its identity model.
+
+What remains inferred even on Outscale: the detailed **action names**, taken from the documented
+EIM syntax rather than from a published permission set. What was measured is `api:Read*` taken
+as a whole, and an inferred grant is a guess, which is precisely what a CSPM must not ask you to
+grant.
+
+### A complete Outscale scan needs the account owner's keys
+
+Measured on 2026-09-09: OOS answers `InvalidAccessKeyId` to an EIM key the OAPI has just
+accepted — it does not know EIM keys at all — and OKS answers `Forbidden: User type not
+allowed`, refusing the identity by its type. Neither refusal is about a grant, so no EIM policy
+lifts them.
+
+Object storage and managed Kubernetes are therefore reachable only with the account owner's
+keys, which Pépin itself flags as `iam_no_root_access_key` (HIGH). Its only complete operating
+mode on Outscale is one of its own findings. A reduced-role scan is not a false green — it
+records both units as incomplete, names the grant that would collect them, and returns the
+affected controls as `not-evaluated` — but it is an incomplete one, and the trade-off is the
+operator's to make, not ours to hide. The provider page states how to live with it:
+[a complete scan needs the account owner's keys](providers/outscale.md#a-complete-scan-needs-the-account-owners-keys).
+
+Whether a narrower grant exists — OOS-specific access keys for an EIM user — is open;
+`ReadAccessKeys` shows none.
 
 ### Sovereignty facts are declared, not verified
 

--- a/docs/providers/outscale.fr.md
+++ b/docs/providers/outscale.fr.md
@@ -112,38 +112,41 @@ existe pour empêcher.
 Dérivé du descripteur du fournisseur, si bien que ce tableau et ce que rapporte le scan ne
 peuvent pas diverger : quand un appel est refusé, le relevé de capacités et le motif du
 `not-evaluated` nomment le droit listé ici. **Confirmé** signifie que le droit est énoncé dans
-la source officielle citée en regard, pas qu'un scan a été lancé avec un rôle délibérément
-réduit. Ce dépôt ne détient aucun identifiant cloud et aucun contrôle automatisé n'atteint une
-API de fournisseur.
+la source officielle citée en regard ; **quand une date suit**, il a de plus été mesuré ce
+jour-là par un scan réel mené avec un rôle délibérément réduit. Outscale est le seul
+fournisseur dans ce cas. Ces scans ne tournent pas en CI : ce sont des gestes de mainteneur,
+lancés localement, dont le résultat est consigné et daté dans le descripteur — aucun
+identifiant cloud n'entre dans ce dépôt
+([ADR-0012](../adr/0012-aucun-identifiant-en-ci.md)).
 
 <!-- pepin:gen provider-outscale-permissions -->
 | Unité de collecte | Droit minimal | Confirmé | Source |
 |---|---|:-:|---|
-| `security_group_rule` | `api:Read* (EIM) — ReadSecurityGroups` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `network_interface` | `api:Read* (EIM) — ReadVms` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `compute_instance` | `api:Read* (EIM) — ReadVms` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `access_key` | `api:Read* (EIM) — ReadAccounts, ReadAccessKeys` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `api_access_rule` | `api:Read* (EIM) — ReadApiAccessRules` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `api_access_summary` | `api:Read* (EIM) — ReadApiAccessRules` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `api_access_policy` | `api:Read* (EIM) — ReadApiAccessPolicy` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `blockstorage_volume` | `api:Read* (EIM) — ReadVolumes` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `blockstorage_snapshot` | `api:Read* (EIM) — ReadSnapshots` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `iam_policy` | `api:Read* (EIM) — ReadPolicies, ReadPolicyVersion` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `iam_policy_inline` | `api:Read* (EIM) — ReadUsers, ReadUserPolicies, ReadUserPolicy, ReadUserGroups, ReadUserGroupPolicies` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `network` | `api:Read* (EIM) — ReadNets` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `network_peering` | `api:Read* (EIM) — ReadNetPeerings` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `subnet` | `api:Read* (EIM) — ReadSubnets` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `load_balancer` | `api:Read* (EIM) — ReadLoadBalancers` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `compute_image` | `api:Read* (EIM) — ReadImages` | non | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `object_storage_bucket` | — | non | docs.outscale.com/en/userguide/EIM-Policy-Elements.html + EIM API reference |
-| `kubernetes_cluster` | — | non | docs.outscale.com/en/userguide/ (OKS + EIM) |
+| `security_group_rule` | `api:Read* (EIM) — ReadSecurityGroups` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `network_interface` | `api:Read* (EIM) — ReadVms` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `compute_instance` | `api:Read* (EIM) — ReadVms` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `access_key` | `api:Read* (EIM) — ReadAccounts, ReadAccessKeys` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `api_access_rule` | `api:Read* (EIM) — ReadApiAccessRules` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `api_access_summary` | `api:Read* (EIM) — ReadApiAccessRules` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `api_access_policy` | `api:Read* (EIM) — ReadApiAccessPolicy` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `blockstorage_volume` | `api:Read* (EIM) — ReadVolumes` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `blockstorage_snapshot` | `api:Read* (EIM) — ReadSnapshots` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `iam_policy` | `api:Read* (EIM) — ReadPolicies, ReadPolicyVersion` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `iam_policy_inline` | `api:Read* (EIM) — ReadUsers, ReadUserPolicies, ReadUserPolicy, ReadUserGroups, ReadUserGroupPolicies` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `network` | `api:Read* (EIM) — ReadNets` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `network_peering` | `api:Read* (EIM) — ReadNetPeerings` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `subnet` | `api:Read* (EIM) — ReadSubnets` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `load_balancer` | `api:Read* (EIM) — ReadLoadBalancers` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `compute_image` | `api:Read* (EIM) — ReadImages` | oui (mesuré le 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `object_storage_bucket` | `account owner access key (OOS) - not an EIM user key` | oui (mesuré le 2026-09-09) | issue #168 (measure) + docs.outscale.com/en/userguide/EIM-Policy-Elements.html |
+| `kubernetes_cluster` | `account owner access key (OKS) - not an EIM user key` | oui (mesuré le 2026-09-09) | issue #168 (measure) + docs.outscale.com/en/userguide/ (OKS + EIM) |
 
 **Réserves, dites plutôt que masquées.**
 
-- **`security_group_rule`, `compute_instance`, `access_key`, `api_access_rule`, `api_access_summary`, `api_access_policy`, `blockstorage_volume`, `blockstorage_snapshot`, `iam_policy`, `iam_policy_inline`, `network`, `network_peering`, `subnet`, `load_balancer`, `compute_image`** — La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue.
-- **`network_interface`** — Les cartes réseau sont lues DANS la réponse de ReadVms (Vm.Nics[]) : aucun appel ni droit supplémentaire. La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue.
-- **`object_storage_bucket`** — Aucun code de service de stockage objet n'apparaît dans les éléments de politique EIM. Avec les clés du propriétaire du compte, l'accès OOS vient avec le compte ; comment l'accorder à un utilisateur EIM n'est PAS vérifié. Par politique de bucket, les actions de lecture documentées sont s3:ListBucket, s3:HeadBucket, s3:GetBucketAcl, s3:GetBucketPolicy, s3:GetBucketTagging, s3:GetBucketVersioning, s3:GetEncryptionConfiguration, s3:GetBucketObjectLockConfiguration — sans action pour LISTER les buckets d'un compte, qui est pourtant le premier appel.
-- **`kubernetes_cluster`** — Le modèle de permission de GET /api/v2/clusters/all n'est PAS vérifié. Un appel refusé dégrade proprement : les contrôles Kubernetes reviennent « non évalués ».
+- **`security_group_rule`, `compute_instance`, `access_key`, `api_access_rule`, `api_access_summary`, `api_access_policy`, `blockstorage_volume`, `blockstorage_snapshot`, `iam_policy`, `iam_policy_inline`, `network`, `network_peering`, `subnet`, `load_balancer`, `compute_image`** — Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément.
+- **`network_interface`** — Les cartes réseau sont lues DANS la réponse de ReadVms (Vm.Nics[]) : aucun appel ni droit supplémentaire. Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément.
+- **`object_storage_bucket`** — MESURÉ le 2026-09-09 (issue #168) : une clé EIM portant `api:Read*` est refusée par OOS avec `InvalidAccessKeyId - The AWS access key Id you provided does not exist in our records`. OOS ne connaît donc pas du tout les clés EIM, et son message trompe : la clé existe, elle est inconnue de CE service. Seules les clés du propriétaire du compte collectent cette unité. Aucun code de service de stockage objet n'apparaît dans les éléments de politique EIM ; par politique de bucket, les actions de lecture documentées sont s3:ListBucket, s3:HeadBucket, s3:GetBucketAcl, s3:GetBucketPolicy, s3:GetBucketTagging, s3:GetBucketVersioning, s3:GetEncryptionConfiguration, s3:GetBucketObjectLockConfiguration — sans action pour LISTER les buckets d'un compte, qui est pourtant le premier appel. Qu'un droit plus étroit que les clés du compte existe reste ouvert.
+- **`kubernetes_cluster`** — MESURÉ le 2026-09-09 (issue #168) : une clé EIM portant `api:Read*` est refusée par OKS avec `403 - Forbidden: User type not allowed`. Le refus porte sur le TYPE d'identité, pas sur un droit manquant : aucune politique EIM ne le lève. Seules les clés du propriétaire du compte collectent cette unité. Un appel refusé dégrade proprement : les contrôles Kubernetes reviennent « non évalués », en nommant désormais le droit qui manque.
 <!-- /pepin:gen provider-outscale-permissions -->
 
 Le vocabulaire d'Outscale est une **politique EIM** : `Effect`, `Action` sous la forme
@@ -170,26 +173,61 @@ politique) et `EIM-Policy-Elements.html` (la syntaxe `service:MéthodeAPI` et le
 service `api`, `ec2`, `elasticloadbalancing`, `iam`, `directconnect`).
 
 L'action dont chaque unité de collecte a besoin est listée unité par unité dans le tableau
-ci-dessus. Ces noms d'actions sont **déduits de la syntaxe documentée `service:MéthodeAPI` et
-non recopiés d'un catalogue d'actions** : c'est pourquoi chaque ligne OAPI est marquée non
-confirmée, alors même que la politique `api:Read*` est, elle, vérifiée telle que publiée.
+ci-dessus. Ces noms d'actions restent **déduits de la syntaxe documentée `service:MéthodeAPI`
+et non recopiés d'un catalogue d'actions** : ce qui a été mesuré, c'est la politique
+`api:Read*` **prise en bloc**, pas chaque action prise isolément.
+
+### Ce que le scan à rôle réduit a mesuré
+
+Le 2026-09-09, sur un tenant `eu-west-2`, avec un utilisateur EIM ne portant que cette
+politique.
+
+- **Les unités OAPI sont revenues complètes**, avec un inventaire identique à celui du compte
+  propriétaire — jointures comprises (`ReadAccounts` → `ReadImages`, `ReadUsers` →
+  `ReadAccessKeys`, politiques en ligne). La politique de lecture publiée par Outscale suffit
+  donc à tout ce que Pépin appelle sur l'OAPI.
+- **OOS ne connaît pas les clés EIM.** `ListBuckets` répond `403 InvalidAccessKeyId — The AWS
+  access key Id you provided does not exist in our records`. Le message trompe : la clé existe,
+  elle est inconnue de *ce service*. Ce n'est donc pas un droit qui manque, et aucune politique
+  EIM ne l'accorde. Aucun code de service de stockage objet ne figure d'ailleurs dans les
+  éléments de politique EIM, et la référence complète de l'API EIM ne mentionne jamais OOS.
+- **OKS refuse l'utilisateur EIM par son type.** `GET /api/v2/clusters/all` répond
+  `403 Forbidden: User type not allowed`. Le refus porte sur le TYPE d'identité, pas sur un
+  droit : là non plus, aucune politique EIM ne le lève.
+
+Dans les deux cas le scan se dégrade proprement : l'unité est consignée incomplète, le relevé
+de capacités la nomme **avec le droit qui, lui, la collecte**, les contrôles concernés
+reviennent en `not-evaluated`, et le scan ne rend jamais `0`.
+
+### Un scan complet exige les clés du propriétaire du compte
+
+C'est la conséquence directe de ce qui précède, et elle est inconfortable : **Pépin signale
+lui-même ces clés** en `iam_no_root_access_key` (HIGH). Le seul mode de fonctionnement complet
+de l'outil sur Outscale est l'un de ses propres constats. Le taire serait pire que le fait.
+
+Comment vivre avec, sans faire semblant :
+
+- **Une clé dédiée au scan**, créée pour cela, avec une date d'expiration, révoquée dès que la
+  campagne est finie si le scan n'est pas récurrent. `ReadAccessKeys` rend sa date de création
+  comme sa date d'expiration, et `iam_accesskey_rotated` juge son âge : une clé propriétaire
+  qui traîne se verra.
+- **Hors CI, toujours.** La clé du propriétaire d'un compte est exactement ce qu'une chaîne
+  d'approvisionnement ne doit jamais porter. Un scan live est un geste de mainteneur ; ce que la
+  CI mesure, ce sont des plans Terraform et un émulateur
+  ([ADR-0012](../adr/0012-aucun-identifiant-en-ci.md)).
+- **Une dérogation datée plutôt que le silence.** `iam_no_root_access_key` sur cette clé se
+  couvre par une exemption explicite (`--policy`, avec `justification`, `expires_at`, `owner`,
+  `approved_by`). Le scan rend alors `4`, jamais `0` : le rapport continue de porter l'écart
+  ([ADR-0008](../adr/0008-derogation-nest-pas-conformite.md)).
+- **Restreindre l'accès à l'API par IP source** (`api_access_rule`), pour que cette clé ne
+  serve que depuis le poste qui scanne.
+
+Ce qui reste ouvert : **qu'un droit plus étroit existe**. Si Outscale expose des clés d'accès
+propres à OOS pour un utilisateur EIM, c'est la prochaine chose à mesurer ; `ReadAccessKeys`
+n'en montre aucune.
 
 **Ce qui n'a pas pu être vérifié, et qui compte.**
 
-- **Le stockage objet n'est pas gouverné par EIM.** Aucun code de service de stockage objet ne
-  figure dans les éléments de politique EIM, et la référence complète de l'API EIM ne mentionne
-  jamais OOS. Avec les clés du propriétaire du compte, l'accès à OOS vient avec le compte ;
-  comment l'accorder à un utilisateur EIM n'est **pas vérifié**. Par une bucket policy, les
-  actions de lecture documentées sont `s3:GetBucketAcl`, `s3:GetBucketPolicy`,
-  `s3:GetBucketTagging`, `s3:GetBucketVersioning`, `s3:GetEncryptionConfiguration`,
-  `s3:GetBucketObjectLockConfiguration`, `s3:ListBucket`, `s3:HeadBucket`, sans aucune action
-  pour *lister* les buckets d'un compte, qui est le premier appel que fait Pépin.
-- **OKS.** Le modèle de permission de `GET /api/v2/clusters/all` n'est **pas vérifié** ; la
-  documentation indique seulement qu'OKS est « partiellement compatible avec les utilisateurs
-  EIM », et les deux rôles OKS documentés portent sur les volumes et les snapshots, pas sur les
-  clusters. Un appel refusé se dégrade proprement : l'unité est consignée incomplète, le relevé
-  de capacités le dit, les contrôles Kubernetes reviennent en `not-evaluated` en la nommant, et
-  le scan rend `3`.
 - **Les clés du compte racine.** `ReadAccessKeys` sans nom d'utilisateur renvoie les clés de
   l'identité appelante : auditer les clés du compte racine exige donc des identifiants
   propriétaires du compte. C'est consigné dans le descripteur comme une limite d'API ; nous ne

--- a/docs/providers/outscale.md
+++ b/docs/providers/outscale.md
@@ -109,37 +109,40 @@ exists to prevent.
 Derived from the provider descriptor, so this table and what the scan reports cannot diverge:
 when a call is refused, the capability report and the `not-evaluated` reason name the very
 grant listed here. **Confirmed** means the grant is stated in the official source cited beside
-it — not that a scan was run with a deliberately reduced role. This repository holds no cloud
-credentials and no automated check reaches a provider API.
+it; **when a date follows**, it was also measured that day by a real scan run with a
+deliberately reduced role. Outscale is the only provider in that case. Those scans never run in
+CI: they are maintainer gestures, run locally, whose result is recorded and dated in the
+descriptor — no cloud credential enters this repository
+([ADR-0012](../adr/0012-aucun-identifiant-en-ci.md)).
 
 <!-- pepin:gen provider-outscale-permissions -->
 | Collection unit | Minimum grant | Confirmed | Source |
 |---|---|:-:|---|
-| `security_group_rule` | `api:Read* (EIM) — ReadSecurityGroups` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `network_interface` | `api:Read* (EIM) — ReadVms` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `compute_instance` | `api:Read* (EIM) — ReadVms` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `access_key` | `api:Read* (EIM) — ReadAccounts, ReadAccessKeys` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `api_access_rule` | `api:Read* (EIM) — ReadApiAccessRules` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `api_access_summary` | `api:Read* (EIM) — ReadApiAccessRules` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `api_access_policy` | `api:Read* (EIM) — ReadApiAccessPolicy` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `blockstorage_volume` | `api:Read* (EIM) — ReadVolumes` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `blockstorage_snapshot` | `api:Read* (EIM) — ReadSnapshots` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `iam_policy` | `api:Read* (EIM) — ReadPolicies, ReadPolicyVersion` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `iam_policy_inline` | `api:Read* (EIM) — ReadUsers, ReadUserPolicies, ReadUserPolicy, ReadUserGroups, ReadUserGroupPolicies` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `network` | `api:Read* (EIM) — ReadNets` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `network_peering` | `api:Read* (EIM) — ReadNetPeerings` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `subnet` | `api:Read* (EIM) — ReadSubnets` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `load_balancer` | `api:Read* (EIM) — ReadLoadBalancers` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `compute_image` | `api:Read* (EIM) — ReadImages` | no | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
-| `object_storage_bucket` | — | no | docs.outscale.com/en/userguide/EIM-Policy-Elements.html + EIM API reference |
-| `kubernetes_cluster` | — | no | docs.outscale.com/en/userguide/ (OKS + EIM) |
+| `security_group_rule` | `api:Read* (EIM) — ReadSecurityGroups` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `network_interface` | `api:Read* (EIM) — ReadVms` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `compute_instance` | `api:Read* (EIM) — ReadVms` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `access_key` | `api:Read* (EIM) — ReadAccounts, ReadAccessKeys` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `api_access_rule` | `api:Read* (EIM) — ReadApiAccessRules` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `api_access_summary` | `api:Read* (EIM) — ReadApiAccessRules` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `api_access_policy` | `api:Read* (EIM) — ReadApiAccessPolicy` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `blockstorage_volume` | `api:Read* (EIM) — ReadVolumes` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `blockstorage_snapshot` | `api:Read* (EIM) — ReadSnapshots` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `iam_policy` | `api:Read* (EIM) — ReadPolicies, ReadPolicyVersion` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `iam_policy_inline` | `api:Read* (EIM) — ReadUsers, ReadUserPolicies, ReadUserPolicy, ReadUserGroups, ReadUserGroupPolicies` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `network` | `api:Read* (EIM) — ReadNets` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `network_peering` | `api:Read* (EIM) — ReadNetPeerings` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `subnet` | `api:Read* (EIM) — ReadSubnets` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `load_balancer` | `api:Read* (EIM) — ReadLoadBalancers` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `compute_image` | `api:Read* (EIM) — ReadImages` | yes (measured 2026-09-09) | docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html |
+| `object_storage_bucket` | `account owner access key (OOS) - not an EIM user key` | yes (measured 2026-09-09) | issue #168 (measure) + docs.outscale.com/en/userguide/EIM-Policy-Elements.html |
+| `kubernetes_cluster` | `account owner access key (OKS) - not an EIM user key` | yes (measured 2026-09-09) | issue #168 (measure) + docs.outscale.com/en/userguide/ (OKS + EIM) |
 
 **Reservations, stated rather than papered over.**
 
-- **`security_group_rule`, `compute_instance`, `access_key`, `api_access_rule`, `api_access_summary`, `api_access_policy`, `blockstorage_volume`, `blockstorage_snapshot`, `iam_policy`, `iam_policy_inline`, `network`, `network_peering`, `subnet`, `load_balancer`, `compute_image`** — The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue.
-- **`network_interface`** — Network interfaces are read INSIDE the ReadVms response (Vm.Nics[]): no extra call, no extra grant. The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue.
-- **`object_storage_bucket`** — No object-storage service code appears in the EIM policy elements. With the account owner keys, OOS access comes with the account; how to grant it to an EIM user is NOT verified. Through a bucket policy the documented read actions are s3:ListBucket, s3:HeadBucket, s3:GetBucketAcl, s3:GetBucketPolicy, s3:GetBucketTagging, s3:GetBucketVersioning, s3:GetEncryptionConfiguration, s3:GetBucketObjectLockConfiguration - with no action for LISTING an account buckets, which is the first call made.
-- **`kubernetes_cluster`** — The permission model of GET /api/v2/clusters/all is NOT verified. A refused call degrades cleanly: the Kubernetes controls come back "not evaluated".
+- **`security_group_rule`, `compute_instance`, `access_key`, `api_access_rule`, `api_access_summary`, `api_access_policy`, `blockstorage_volume`, `blockstorage_snapshot`, `iam_policy`, `iam_policy_inline`, `network`, `network_peering`, `subnet`, `load_balancer`, `compute_image`** — Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own.
+- **`network_interface`** — Network interfaces are read INSIDE the ReadVms response (Vm.Nics[]): no extra call, no extra grant. Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own.
+- **`object_storage_bucket`** — MEASURED on 2026-09-09 (issue #168): an EIM key carrying `api:Read*` is refused by OOS with `InvalidAccessKeyId - The AWS access key Id you provided does not exist in our records`. OOS therefore does not know EIM keys at all, and its message misleads: the key exists, it is unknown to THAT service. Only the account owner keys collect this unit. No object-storage service code appears in the EIM policy elements; through a bucket policy the documented read actions are s3:ListBucket, s3:HeadBucket, s3:GetBucketAcl, s3:GetBucketPolicy, s3:GetBucketTagging, s3:GetBucketVersioning, s3:GetEncryptionConfiguration, s3:GetBucketObjectLockConfiguration - with no action for LISTING an account buckets, which is the first call made. Whether a grant narrower than the account keys exists remains open.
+- **`kubernetes_cluster`** — MEASURED on 2026-09-09 (issue #168): an EIM key carrying `api:Read*` is refused by OKS with `403 - Forbidden: User type not allowed`. The refusal is about the identity TYPE, not about a missing grant: no EIM policy lifts it. Only the account owner keys collect this unit. A refused call degrades cleanly: the Kubernetes controls come back "not evaluated", and now name the grant they lack.
 <!-- /pepin:gen provider-outscale-permissions -->
 
 Outscale's vocabulary is an **EIM policy**: `Effect`, `Action` as `<service>:<APIMethod>`, and
@@ -166,25 +169,59 @@ policy) and `EIM-Policy-Elements.html` (the `service:APIMethod` syntax and the s
 `api`, `ec2`, `elasticloadbalancing`, `iam`, `directconnect`).
 
 Which action each collection unit needs is listed per unit in the table above. Those action
-names are **inferred from the documented `service:APIMethod` syntax rather than copied from an
-action catalogue**, which is why every OAPI line is marked unconfirmed even though the
-`api:Read*` policy itself is verified as published.
+names remain **inferred from the documented `service:APIMethod` syntax rather than copied from
+an action catalogue**: what was measured is the `api:Read*` policy **taken as a whole**, not
+each action on its own.
+
+### What the reduced-role scan measured
+
+On 2026-09-09, against an `eu-west-2` tenant, with an EIM user carrying nothing but that
+policy.
+
+- **The OAPI units came back complete**, with an inventory identical to the account owner's —
+  joins included (`ReadAccounts` → `ReadImages`, `ReadUsers` → `ReadAccessKeys`, inline
+  policies). The read-only policy Outscale publishes is therefore enough for everything Pépin
+  calls on the OAPI.
+- **OOS does not know EIM keys.** `ListBuckets` answers `403 InvalidAccessKeyId — The AWS
+  access key Id you provided does not exist in our records`. The message misleads: the key
+  exists, it is unknown to *that service*. So it is not a missing grant, and no EIM policy
+  grants it. No object-storage service code appears in the EIM policy elements either, and the
+  full EIM API reference never mentions OOS.
+- **OKS refuses the EIM user by its type.** `GET /api/v2/clusters/all` answers
+  `403 Forbidden: User type not allowed`. The refusal is about the identity TYPE, not about a
+  grant: no EIM policy lifts that one either.
+
+In both cases the scan degrades cleanly: the unit is recorded as incomplete, the capability
+report names it **together with the grant that does collect it**, the affected controls come
+back `not-evaluated`, and the scan never exits `0`.
+
+### A complete scan needs the account owner's keys
+
+That follows directly from the above, and it is uncomfortable: **Pépin flags those keys
+itself**, as `iam_no_root_access_key` (HIGH). The tool's only complete operating mode on
+Outscale is one of its own findings. Saying nothing would be worse than the fact.
+
+How to live with it, without pretending:
+
+- **A key dedicated to the scan**, created for it, with an expiry date, revoked as soon as the
+  campaign is over if the scan is not recurring. `ReadAccessKeys` returns both its creation and
+  its expiry date, and `iam_accesskey_rotated` judges its age: an owner key left lying around
+  will show.
+- **Out of CI, always.** An account owner's key is exactly what a supply chain must never
+  carry. A live scan is a maintainer gesture; what CI measures is Terraform plans and an
+  emulator ([ADR-0012](../adr/0012-aucun-identifiant-en-ci.md)).
+- **A dated exemption rather than silence.** `iam_no_root_access_key` on that key is covered by
+  an explicit exemption (`--policy`, with `justification`, `expires_at`, `owner`,
+  `approved_by`). The scan then exits `4`, never `0`: the report keeps carrying the deviation
+  ([ADR-0008](../adr/0008-derogation-nest-pas-conformite.md)).
+- **Restrict API access by source IP** (`api_access_rule`), so that key only works from the
+  machine that scans.
+
+What remains open: **whether a narrower grant exists**. If Outscale exposes OOS-specific access
+keys for an EIM user, that is the next thing to measure; `ReadAccessKeys` shows none.
 
 **What could not be verified, and matters.**
 
-- **Object storage is not governed by EIM.** No object-storage service code appears in the EIM
-  policy elements, and the full EIM API reference never mentions OOS. With the account owner's
-  keys, OOS access comes with the account; how to grant it to an EIM user is **not verified**.
-  Through a bucket policy, the documented read actions are `s3:GetBucketAcl`,
-  `s3:GetBucketPolicy`, `s3:GetBucketTagging`, `s3:GetBucketVersioning`,
-  `s3:GetEncryptionConfiguration`, `s3:GetBucketObjectLockConfiguration`, `s3:ListBucket`,
-  `s3:HeadBucket` — with no action for *listing* the buckets of an account, which is the first
-  call Pépin makes.
-- **OKS.** The permission model of `GET /api/v2/clusters/all` is **not verified**; the
-  documentation states only that OKS is "partially compatible with EIM users", and the two
-  documented OKS roles concern volumes and snapshots, not clusters. A refused call degrades
-  cleanly: the unit is recorded as incomplete, the capability report says so, the Kubernetes
-  controls come back `not-evaluated` naming it, and the scan exits `3`.
 - **Root account keys.** `ReadAccessKeys` without a user name returns the keys of the calling
   identity, so auditing the root account's keys requires account-owner credentials. This is
   recorded in the descriptor as an API limitation; we did not find it stated in the official

--- a/internal/docgen/providers.go
+++ b/internal/docgen/providers.go
@@ -284,10 +284,13 @@ func boolLabel(t providerStrings, v *bool) string {
 // information, pas une lacune honteuse : elle dit exactement où s'arrête ce que
 // le projet peut prouver.
 //
-// Aucune de ces lignes n'est confirmée par un scan réel à rôle réduit : ce dépôt
-// ne détient aucun identifiant cloud et aucun contrôle automatisé n'atteint une
-// API de fournisseur. Ce que « confirmé » engage, c'est la documentation
-// officielle citée en regard.
+// « Confirmé » engage la documentation officielle citée en regard — et, quand une
+// DATE le suit, un scan réel mené avec un rôle délibérément réduit ce jour-là. Les
+// deux ne disent pas la même chose : un document dit ce que le fournisseur écrit,
+// une mesure dit ce qu'il répond, et c'est la seconde qui a montré qu'une clé EIM
+// portant la politique de lecture publiée par Outscale était refusée par OOS et par
+// OKS. Aucun de ces scans n'a lieu en CI : ce sont des gestes de mainteneur, lancés
+// localement, consignés et datés dans le descripteur (ADR-0012).
 func providerPermissionsTable(t providerStrings, l i18n.Lang, d genprovider.Descriptor) string {
 	perms := d.Permissions
 	if len(perms) == 0 {
@@ -304,6 +307,12 @@ func providerPermissionsTable(t providerStrings, l i18n.Lang, d genprovider.Desc
 		mark := t.no
 		if p.Etat == "verifie" {
 			mark = t.yes
+			// Une ligne MESURÉE se distingue d'une ligne documentée : les fondre
+			// dans un même « oui » perdrait ce qui décide de la confiance qu'on
+			// peut y mettre. La date est ce qui permettra de la juger périmée.
+			if d := p.Mesure.Date; d != "" {
+				mark = fmt.Sprintf(t.yesMeasured, d)
+			}
 		}
 		grant := p.Grant
 		if grant == "" {
@@ -337,6 +346,7 @@ type providerStrings struct {
 	colExploded, colSource, colControl, colJustification       string
 	colOnlyVia, colReason                                      string
 	colUnit, colGrant, colConfirmed, reservations              string
+	yesMeasured                                                string
 	fieldDescription, fieldScope, fieldRegionKey, fieldAuth    string
 	fieldJurisdiction, fieldEUEstablished, fieldCapital        string
 	fieldSecNumCloud, fieldExtraterritorial, fieldSources      string
@@ -368,6 +378,7 @@ func providerText(lang string) providerStrings {
 			noteManagedK8s: "API du Kubernetes managé (collecteur Go)",
 			baseURL:        "URL de base :",
 			unset:          "—", yes: "oui", no: "non", none: "_Aucun._",
+			yesMeasured:  "oui (mesuré le %s)",
 			noDescriptor: "_Descripteur absent du dépôt : cette page ne peut rien affirmer sur ce fournisseur._",
 		}
 	}
@@ -392,6 +403,7 @@ func providerText(lang string) providerStrings {
 		noteManagedK8s: "managed Kubernetes API (Go collector)",
 		baseURL:        "Base URL:",
 		unset:          "—", yes: "yes", no: "no", none: "_None._",
+		yesMeasured:  "yes (measured %s)",
 		noDescriptor: "_Descriptor missing from the repository: this page can assert nothing about this provider._",
 	}
 }

--- a/internal/genprovider/genprovider.go
+++ b/internal/genprovider/genprovider.go
@@ -110,16 +110,45 @@ type Descriptor struct {
 // devine les droits qu'il réclame pousse à en donner trop.
 //
 // D'où `Etat`, sur le modèle du contrat d'API : `verifie` engage la source citée,
-// `a_verifier` dit explicitement que le droit n'a pas pu être établi. Aucune de
-// ces lignes n'est confirmée par un scan réel à rôle réduit — le dépôt ne détient
-// aucun identifiant cloud —, et la documentation générée le dit à chaque page.
+// `a_verifier` dit explicitement que le droit n'a pas pu être établi.
+//
+// `Mesure` dit COMMENT il a été établi. Une ligne confirmée par un document et une
+// ligne confirmée par un scan réel à rôle réduit n'engagent pas la même chose : la
+// première dit ce que le fournisseur ÉCRIT, la seconde ce qu'il RÉPOND. Les fondre
+// dans un seul « oui » perdrait la distinction qui décide, pour qui doit accorder
+// ces droits, s'il peut s'y fier.
 type Permission struct {
-	Unit   string `yaml:"unit"`   // unité de collecte (type de ressource normalisé, ou chaîne d'appels nommée)
-	Grant  string `yaml:"grant"`  // le droit, dans le vocabulaire natif du fournisseur
-	Etat   string `yaml:"etat"`   // verifie | a_verifier
-	Source string `yaml:"source"` // document officiel qui confirme (ou dont l'absence motive `a_verifier`)
-	Note   string `yaml:"note"`   // réserve ou précision, en français
-	NoteEn string `yaml:"note_en"`
+	Unit   string           `yaml:"unit"`   // unité de collecte (type de ressource normalisé, ou chaîne d'appels nommée)
+	Grant  string           `yaml:"grant"`  // le droit, dans le vocabulaire natif du fournisseur
+	Etat   string           `yaml:"etat"`   // verifie | a_verifier
+	Source string           `yaml:"source"` // document officiel qui confirme (ou dont l'absence motive `a_verifier`)
+	Note   string           `yaml:"note"`   // réserve ou précision, en français
+	NoteEn string           `yaml:"note_en"`
+	Mesure MesurePermission `yaml:"mesure"` // le scan réel qui a tranché, s'il y en a eu un
+}
+
+// Les deux verdicts d'un rôle réduit, et c'est tout le vocabulaire.
+const (
+	// RoleReduitSuffisant : la politique de moindre privilège a collecté l'unité.
+	RoleReduitSuffisant = "suffisant"
+	// RoleReduitRefuse : elle a été refusée. L'unité exige davantage, et `Grant` doit
+	// alors NOMMER ce davantage — sans quoi l'opérateur ne lit qu'une erreur brute de
+	// l'API, qui l'envoie corriger une clé qui n'a rien à se reprocher.
+	RoleReduitRefuse = "refuse"
+)
+
+// MesurePermission consigne le scan réel qui a tranché sur un droit : quand, où, et
+// ce que le rôle RÉDUIT a rendu.
+//
+// L'ADR-0012 interdit tout identifiant en CI et fait du scan live un geste de
+// mainteneur « dont le résultat est consigné et daté ». Ce type est ce consignement :
+// la date permet de juger un relevé périmé, la région dit sur quel plan de contrôle
+// il a porté, et `RoleReduit` porte le seul fait qui intéresse un lecteur — la
+// politique de moindre privilège a-t-elle suffi.
+type MesurePermission struct {
+	Date       string `yaml:"date"`        // AAAA-MM-JJ, jour du scan
+	Region     string `yaml:"region"`      // région du tenant mesuré
+	RoleReduit string `yaml:"role_reduit"` // suffisant | refuse
 }
 
 // DonneePersonnelle : un type dont certains attributs nomment une personne, et

--- a/internal/genprovider/permissions_test.go
+++ b/internal/genprovider/permissions_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 // La porte des DROITS MINIMAUX : chaque unité de collecte qu'un descripteur sait
@@ -16,8 +17,11 @@ import (
 //
 // La porte n'exige PAS que le droit soit vérifié. Elle exige qu'il soit DÉCLARÉ
 // et que son état soit dit. `a_verifier` est une réponse parfaitement recevable —
-// c'est même la seule honnête tant qu'aucun scan à rôle réduit n'a eu lieu, et ce
-// dépôt n'en fait aucun. Ce qui est refusé, c'est le silence.
+// c'est la seule honnête tant qu'aucun scan à rôle réduit n'a porté sur l'unité.
+// Ce qui est refusé, c'est le silence.
+//
+// Quand un tel scan a bien eu lieu, il se CONSIGNE (`mesure:`), et les deux portes
+// du bas disent ce que ce consignement engage.
 
 // collectionUnitsOf énumère les unités de collecte qu'un descripteur produit :
 // les types de la spec `collecte`, plus les collecteurs Go que le descripteur
@@ -176,6 +180,70 @@ func TestGrantsAndSourcesCarryNoProse(t *testing.T) {
 					t.Errorf("%s / %s : le champ %s porte de la prose accentuée (%q) ; les identifiants restent neutres, la prose va dans `note`/`note_en`",
 						name, p.Unit, f.label, f.value)
 				}
+			}
+		}
+	}
+}
+
+// TestAMeasuredPermissionIsDatedAndSituated : un scan à rôle réduit ne vaut que
+// daté et situé.
+//
+// Sans date, rien ne permet de juger le relevé périmé — et un droit se retire, un
+// service change de modèle d'identité. Sans région, on ne sait pas sur quel plan
+// de contrôle il a porté, alors qu'un même fournisseur n'expose pas les mêmes
+// services partout (OKS n'existe pas en cloudgouv). Une mesure vague se lirait
+// comme une preuve tout en n'en étant pas une, ce qui est pire que son absence.
+func TestAMeasuredPermissionIsDatedAndSituated(t *testing.T) {
+	for name, d := range loadAllDescriptors(t) {
+		for _, p := range d.Permissions {
+			m := p.Mesure
+			if m == (MesurePermission{}) {
+				continue // aucun scan à rôle réduit n'a porté sur cette unité
+			}
+			if _, err := time.Parse("2006-01-02", m.Date); err != nil {
+				t.Errorf("%s / %s : mesure sans date lisible (%q) — un relevé qu'on ne peut pas juger périmé n'est pas un relevé",
+					name, p.Unit, m.Date)
+			}
+			if strings.TrimSpace(m.Region) == "" {
+				t.Errorf("%s / %s : mesure sans région — un droit se mesure sur un plan de contrôle, pas dans l'absolu",
+					name, p.Unit)
+			}
+			switch m.RoleReduit {
+			case RoleReduitSuffisant, RoleReduitRefuse:
+			default:
+				t.Errorf("%s / %s : role_reduit %q inconnu (%s | %s)",
+					name, p.Unit, m.RoleReduit, RoleReduitSuffisant, RoleReduitRefuse)
+			}
+		}
+	}
+}
+
+// TestAMeasuredRefusalNamesTheGrantThatWorks : le défaut fondateur de l'issue #168,
+// tenu par un test.
+//
+// `object_storage_bucket` et `kubernetes_cluster` portaient un `grant` VIDE. Le
+// relevé de capacités n'imprime la ligne « droit requis » que si le descripteur la
+// déclare, et le motif d'un « non évalué » de même : l'opérateur ne lisait donc que
+// l'erreur brute d'OOS — « The AWS access key Id you provided does not exist in our
+// records » — qui l'envoyait vérifier une clé parfaitement valide, alors que le fait
+// mesuré est qu'OOS ne connaît AUCUNE clé EIM.
+//
+// Un refus mesuré sans droit nommé est donc pire qu'un refus non mesuré : on sait ce
+// qu'il faut, et on ne le dit pas. La réserve est exigée dans la foulée, parce que
+// c'est elle qui porte ce que le fournisseur a réellement répondu.
+func TestAMeasuredRefusalNamesTheGrantThatWorks(t *testing.T) {
+	for name, d := range loadAllDescriptors(t) {
+		for _, p := range d.Permissions {
+			if p.Mesure.RoleReduit != RoleReduitRefuse {
+				continue
+			}
+			if strings.TrimSpace(p.Grant) == "" {
+				t.Errorf("%s / %s : rôle réduit mesuré REFUSÉ sans nommer le droit qui, lui, collecte — le relevé de capacités et le motif du « non évalué » resteront muets sous l'erreur brute de l'API",
+					name, p.Unit)
+			}
+			if strings.TrimSpace(p.Note) == "" || strings.TrimSpace(p.NoteEn) == "" {
+				t.Errorf("%s / %s : refus mesuré sans réserve écrite — dire CE QUE le fournisseur a répondu, pas seulement qu'il a dit non",
+					name, p.Unit)
 			}
 		}
 	}

--- a/providers/outscale.yaml
+++ b/providers/outscale.yaml
@@ -65,124 +65,213 @@ oks:
 # DÉRIVÉE de la même donnée. Deux listes tenues en parallèle divergent, et celle
 # qui diverge est toujours celle qu'on lit.
 #
-# `etat: verifie` engage : la permission est confirmée dans la source citée, un
-# document officiel du fournisseur. `a_verifier` dit l'inverse, explicitement.
-# AUCUNE de ces lignes n'a été confirmée par un scan réel avec un rôle réduit :
-# ce dépôt ne détient aucun identifiant cloud, par construction.
+# `etat: verifie` engage : le droit est ÉTABLI. `a_verifier` dit l'inverse,
+# explicitement. Le bloc `mesure` dit COMMENT il l'a été — un document dit ce que le
+# fournisseur ÉCRIT, un scan à rôle réduit dit ce qu'il RÉPOND, et les deux ne valent
+# pas la même chose pour qui doit décider quels droits accorder.
 #
-# La politique EIM en lecture seule publiée par Outscale — `api:Read*` sur `*` —
-# couvre TOUS les appels OAPI ci-dessous. Les actions sont énumérées pour dire
-# lesquelles chaque unité exige, mais leur nom exact est INFÉRÉ de la syntaxe
-# documentée `<service>:<APIMethod>`, pas recopié d'un catalogue d'actions.
+# Outscale est le seul fournisseur dont les droits sont MESURÉS : le 2026-09-09, sur
+# un tenant eu-west-2, avec un utilisateur EIM ne portant QUE la politique de lecture
+# publiée par Outscale (`api:Read*` sur `*`). Geste de mainteneur, lancé localement,
+# consigné et daté ici — aucun identifiant n'entre en CI (ADR-0012).
+#
+# Ce que ce scan a rendu, et c'est la raison d'être de l'issue #168 :
+#
+#   - les unités OAPI sont revenues COMPLÈTES, inventaire identique à celui du compte
+#     propriétaire. La politique `api:Read*` suffit, PRISE EN BLOC : les noms d'action
+#     détaillés restent INFÉRÉS de la syntaxe documentée `<service>:<APIMethod>`, et
+#     aucun d'eux n'a été éprouvé isolément ;
+#   - OOS et OKS l'ont REFUSÉE, et pas faute d'un droit : OOS ne connaît pas les clés
+#     EIM, OKS refuse l'utilisateur EIM par son TYPE. Un scan Outscale complet exige
+#     donc les clés du propriétaire du compte — que le référentiel signale lui-même en
+#     `iam_no_root_access_key`. Comment vivre avec est dit sur la page du fournisseur ;
+#     ce descripteur ne dit que ce qui a été mesuré.
+#
+# `grant` NOMME ce qu'il faut détenir, y compris quand la réponse est « les clés du
+# compte » : c'est cette chaîne que le relevé de capacités imprime sous un refus, et
+# que le motif d'un « non évalué » cite. La laisser vide, comme elle l'était pour OOS
+# et OKS, laissait l'opérateur devant une erreur brute qui accuse sa clé.
 permissions:
   - unit: security_group_rule
     grant: "api:Read* (EIM) — ReadSecurityGroups"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: network_interface
     grant: "api:Read* (EIM) — ReadVms"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "Les cartes réseau sont lues DANS la réponse de ReadVms (Vm.Nics[]) : aucun appel ni droit supplémentaire. La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "Network interfaces are read INSIDE the ReadVms response (Vm.Nics[]): no extra call, no extra grant. The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Les cartes réseau sont lues DANS la réponse de ReadVms (Vm.Nics[]) : aucun appel ni droit supplémentaire. Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Network interfaces are read INSIDE the ReadVms response (Vm.Nics[]): no extra call, no extra grant. Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: compute_instance
     grant: "api:Read* (EIM) — ReadVms"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: access_key
     grant: "api:Read* (EIM) — ReadAccounts, ReadAccessKeys"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: api_access_rule
     grant: "api:Read* (EIM) — ReadApiAccessRules"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: api_access_summary
     grant: "api:Read* (EIM) — ReadApiAccessRules"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: api_access_policy
     grant: "api:Read* (EIM) — ReadApiAccessPolicy"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: blockstorage_volume
     grant: "api:Read* (EIM) — ReadVolumes"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: blockstorage_snapshot
     grant: "api:Read* (EIM) — ReadSnapshots"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: iam_policy
     grant: "api:Read* (EIM) — ReadPolicies, ReadPolicyVersion"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: iam_policy_inline
     grant: "api:Read* (EIM) — ReadUsers, ReadUserPolicies, ReadUserPolicy, ReadUserGroups, ReadUserGroupPolicies"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: network
     grant: "api:Read* (EIM) — ReadNets"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: network_peering
     grant: "api:Read* (EIM) — ReadNetPeerings"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: subnet
     grant: "api:Read* (EIM) — ReadSubnets"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: load_balancer
     grant: "api:Read* (EIM) — ReadLoadBalancers"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: compute_image
     grant: "api:Read* (EIM) — ReadImages"
-    etat: a_verifier
+    etat: verifie
     source: "docs.outscale.com/en/userguide/Managing-Access-for-Cloud-Automation.html + EIM-Policy-Elements.html"
-    note: "La politique `api:Read*` est vérifiée telle quelle dans la documentation ; le nom d'action détaillé, lui, est inféré de la syntaxe et non recopié d'un catalogue."
-    note_en: "The `api:Read*` policy itself is verified as published; the detailed action name is inferred from the documented syntax rather than copied from an action catalogue."
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: suffisant
+    note: "Scan réel du 2026-09-09 sur un tenant eu-west-2, avec un utilisateur EIM ne portant que cette politique : l'unité est revenue COMPLÈTE, inventaire identique à celui du compte propriétaire (issue #168). Ce qui a été mesuré, c'est `api:Read*` PRISE EN BLOC : le nom d'action détaillé reste inféré de la syntaxe documentée, pas recopié d'un catalogue, et il n'a pas été éprouvé isolément."
+    note_en: "Real scan on 2026-09-09 against an eu-west-2 tenant, with an EIM user carrying nothing but this policy: the unit came back COMPLETE, with an inventory identical to the account owner's (issue #168). What was measured is `api:Read*` TAKEN AS A WHOLE: the detailed action name is still inferred from the documented syntax rather than copied from an action catalogue, and it was not exercised on its own."
   - unit: object_storage_bucket
-    grant: ""
-    etat: a_verifier
-    source: "docs.outscale.com/en/userguide/EIM-Policy-Elements.html + EIM API reference"
-    note: "Aucun code de service de stockage objet n'apparaît dans les éléments de politique EIM. Avec les clés du propriétaire du compte, l'accès OOS vient avec le compte ; comment l'accorder à un utilisateur EIM n'est PAS vérifié. Par politique de bucket, les actions de lecture documentées sont s3:ListBucket, s3:HeadBucket, s3:GetBucketAcl, s3:GetBucketPolicy, s3:GetBucketTagging, s3:GetBucketVersioning, s3:GetEncryptionConfiguration, s3:GetBucketObjectLockConfiguration — sans action pour LISTER les buckets d'un compte, qui est pourtant le premier appel."
-    note_en: "No object-storage service code appears in the EIM policy elements. With the account owner keys, OOS access comes with the account; how to grant it to an EIM user is NOT verified. Through a bucket policy the documented read actions are s3:ListBucket, s3:HeadBucket, s3:GetBucketAcl, s3:GetBucketPolicy, s3:GetBucketTagging, s3:GetBucketVersioning, s3:GetEncryptionConfiguration, s3:GetBucketObjectLockConfiguration - with no action for LISTING an account buckets, which is the first call made."
+    grant: "account owner access key (OOS) - not an EIM user key"
+    etat: verifie
+    source: "issue #168 (measure) + docs.outscale.com/en/userguide/EIM-Policy-Elements.html"
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: refuse
+    note: "MESURÉ le 2026-09-09 (issue #168) : une clé EIM portant `api:Read*` est refusée par OOS avec `InvalidAccessKeyId - The AWS access key Id you provided does not exist in our records`. OOS ne connaît donc pas du tout les clés EIM, et son message trompe : la clé existe, elle est inconnue de CE service. Seules les clés du propriétaire du compte collectent cette unité. Aucun code de service de stockage objet n'apparaît dans les éléments de politique EIM ; par politique de bucket, les actions de lecture documentées sont s3:ListBucket, s3:HeadBucket, s3:GetBucketAcl, s3:GetBucketPolicy, s3:GetBucketTagging, s3:GetBucketVersioning, s3:GetEncryptionConfiguration, s3:GetBucketObjectLockConfiguration — sans action pour LISTER les buckets d'un compte, qui est pourtant le premier appel. Qu'un droit plus étroit que les clés du compte existe reste ouvert."
+    note_en: "MEASURED on 2026-09-09 (issue #168): an EIM key carrying `api:Read*` is refused by OOS with `InvalidAccessKeyId - The AWS access key Id you provided does not exist in our records`. OOS therefore does not know EIM keys at all, and its message misleads: the key exists, it is unknown to THAT service. Only the account owner keys collect this unit. No object-storage service code appears in the EIM policy elements; through a bucket policy the documented read actions are s3:ListBucket, s3:HeadBucket, s3:GetBucketAcl, s3:GetBucketPolicy, s3:GetBucketTagging, s3:GetBucketVersioning, s3:GetEncryptionConfiguration, s3:GetBucketObjectLockConfiguration - with no action for LISTING an account buckets, which is the first call made. Whether a grant narrower than the account keys exists remains open."
   - unit: kubernetes_cluster
-    grant: ""
-    etat: a_verifier
-    source: "docs.outscale.com/en/userguide/ (OKS + EIM)"
-    note: "Le modèle de permission de GET /api/v2/clusters/all n'est PAS vérifié. Un appel refusé dégrade proprement : les contrôles Kubernetes reviennent « non évalués »."
-    note_en: "The permission model of GET /api/v2/clusters/all is NOT verified. A refused call degrades cleanly: the Kubernetes controls come back \"not evaluated\"."
+    grant: "account owner access key (OKS) - not an EIM user key"
+    etat: verifie
+    source: "issue #168 (measure) + docs.outscale.com/en/userguide/ (OKS + EIM)"
+    mesure:
+      date: "2026-09-09"
+      region: eu-west-2
+      role_reduit: refuse
+    note: "MESURÉ le 2026-09-09 (issue #168) : une clé EIM portant `api:Read*` est refusée par OKS avec `403 - Forbidden: User type not allowed`. Le refus porte sur le TYPE d'identité, pas sur un droit manquant : aucune politique EIM ne le lève. Seules les clés du propriétaire du compte collectent cette unité. Un appel refusé dégrade proprement : les contrôles Kubernetes reviennent « non évalués », en nommant désormais le droit qui manque."
+    note_en: "MEASURED on 2026-09-09 (issue #168): an EIM key carrying `api:Read*` is refused by OKS with `403 - Forbidden: User type not allowed`. The refusal is about the identity TYPE, not about a missing grant: no EIM policy lifts it. Only the account owner keys collect this unit. A refused call degrades cleanly: the Kubernetes controls come back \"not evaluated\", and now name the grant they lack."
 
 collecte:
   # Collecte live Outscale PILOTÉE PAR YAML (moteur internal/collect, SigV4).


### PR DESCRIPTION
Closes #168.

## The defect

`object_storage_bucket` and `kubernetes_cluster` carried an **empty** `grant` in
`providers/outscale.yaml`. Both the capability report and `IncompleteReason` print
"required grant" **only when the descriptor declares one**, so an operator whose scan
hit OOS read exactly this, and nothing else:

```
✗ object_storage_bucket — insufficient privilege on the scanning account
  HTTP 403 · ListBuckets · InvalidAccessKeyId: The AWS access key Id you provided
  does not exist in our records.
```

That message sends them to check a key that is perfectly valid. The measured fact is
different in kind: **OOS does not know EIM keys at all**. A message that sends someone
to fix the wrong thing costs more than an absent one, because it gets followed.

## What was measured, and what it establishes

2026-09-09, real `eu-west-2` tenant, EIM user carrying nothing but the read-only policy
Outscale publishes (`api:Read*` on `*`):

| | Result |
|---|---|
| the OAPI units | ✓ complete, inventory identical to the account owner's — joins included |
| `object_storage_bucket` | ✗ `403 InvalidAccessKeyId — … does not exist in our records` |
| `kubernetes_cluster` | ✗ `403 Forbidden: User type not allowed` |

Neither refusal is about a **grant**: OOS ignores EIM keys, OKS refuses the identity by
its **type**. No EIM policy lifts either. So a complete Outscale scan needs the account
owner's keys — which Pépin flags itself, as `iam_no_root_access_key` (HIGH). The tool's
only complete operating mode on this cloud is one of its own findings, and nothing said
so.

## The change

- **Descriptor.** The 16 OAPI units become `etat: verifie`; the two refused units get the
  grant that *does* collect them (`account owner access key (OOS/OKS) - not an EIM user
  key`), so the capability report and every `not-evaluated` reason now name it.
- **`Permission.Mesure`** — a dated block (`date`, `region`, `role_reduit: suffisant |
  refuse`). A line confirmed by a **document** and a line confirmed by a **scan** do not
  engage the same thing; the permissions table now says which, and dates the second
  (`yes (measured 2026-09-09)`).
- **Docs, both languages.** The provider page gains *what the reduced-role scan measured*
  and *a complete scan needs the account owner's keys* — a dedicated key with an expiry,
  out of CI, a dated exemption (exit `4`, never `0`) rather than silence, API access
  restricted by source IP. `known-limitations` retitles "documented, **not measured**" to
  "measured on one provider only", and gains the Outscale entry. Three sentences that had
  become false ("no scan was run with a deliberately reduced role", "every OAPI line is
  marked unconfirmed", the Go doc comments saying the same) are corrected rather than
  left standing.

What is **not** claimed: that a narrower grant does not exist. If Outscale exposes
OOS-specific access keys for an EIM user, that is the next thing to measure;
`ReadAccessKeys` shows none. And a dated reading can go stale with nothing turning red —
that limitation is written down, not gated, because no gate here can hold a credential.

## Gates

Four, each **falsified before being kept**:

- `TestAMeasuredPermissionIsDatedAndSituated` — a measurement without a readable date or
  a region is not a measurement.
- `TestAMeasuredRefusalNamesTheGrantThatWorks` — **the founding defect**: a measured
  refusal that does not name the grant that works is worse than an unmeasured one.
- `TestARefusedUnitNamesTheGrantThatWouldHaveCollected` — end to end, from the **real**
  descriptor through `renderCapabilities`, in both languages, and asserting the raw API
  detail still prints (the grant completes it, never replaces it).
- `TestAnUndeclaredGrantIsNeverInvented` — the counterexample: an unknown unit gets no
  fabricated grant (ADR-0014).

`mise run prepush` green.

## Impact ADR

**ADR-0012** (no credential in CI) reviewed in full — **applied, not amended**. It
authorises exactly this: "un scan live est un geste de mainteneur, lancé localement, dont
le résultat est **consigné et daté**". `Permission.Mesure` is that recording. Its
consequence "ce qui n'est pas mesuré est déclaré comme tel — les permissions minimales en
`a_verifier`" stays true: Scaleway and Exoscale lines are untouched.

ADR-0014 (never fabricate an absent datum) and ADR-0008 (an exemption is not compliance)
are cited by the new documentation, not modified. No new ADR: no decision was reopened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
