### PR TITLE
feat(release): the gate's verdict is publishable; its report stays local

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -66,6 +66,19 @@ l'une ni l'autre appartient au `git log`.
   jamais GO : un vert qui n'a rien mesuré est le défaut que ce produit reproche aux
   autres.
 
+  La porte écrit aussi `release-gate/SUMMARY.md` : le verdict **seul** — nom des
+  contrôles, leur verdict, la date, le commit —, destiné au **corps** de la GitHub
+  Release. Le rapport détaillé, lui, ne se publie délibérément pas : il porte les
+  chemins du mainteneur, les sorties brutes des outils et, à l'étape 3, les
+  identifiants de ressources d'un compte réel — et il ne pourrait de toute façon pas
+  entrer dans `checksums.txt`, puisqu'il est produit localement avant le tag quand les
+  sommes sont engendrées en CI (ADR-0016). Le corps d'une release n'est pas un artefact
+  — c'est le même registre que les notes qu'il prolonge, une affirmation humaine, non
+  signée —, donc le verdict n'y ajoute aucune promesse de confiance nouvelle. Et la
+  porte prouve que ce résumé est publiable : elle refuse de le déclarer tel s'il nomme
+  un chemin de cette machine, le dit à l'écran, et coiffe le fichier d'un
+  `NON PUBLIABLE`.
+
 - **Tenants de qualification Outscale et Exoscale** (issue #198). Outscale : 79 ressources
   Terraform, plus 6 buckets OOS et une politique EIM inline créés par le crochet `extra`
   du tenant, appliqués et détruits sur un compte réel — la machine à deux cartes, la clé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,17 @@ belongs in `git log`.
   **all** skipped is reported SKIPPED, never GO, because a green that measured nothing is
   the defect this product holds against others.
 
+  The gate also writes `release-gate/SUMMARY.md`: the verdict **alone** — check names,
+  their verdicts, the date, the commit — meant for the **body** of the GitHub Release.
+  The detailed report is deliberately not published: it carries the maintainer's paths,
+  raw tool output and, at stage 3, resource identifiers from a real account, and it
+  could not enter `checksums.txt` anyway, since it is produced locally before the tag
+  while the checksums are generated in CI (ADR-0016). A release body is not an artefact
+  — it is the same register as the notes it extends, a human claim, unsigned — so the
+  verdict adds no new trust promise there. And the gate proves the summary is safe to
+  publish: it refuses to call it publishable when it names a path on this machine, says
+  so on screen, and stamps the file `NON PUBLIABLE`.
+
 - **Qualification tenants for Outscale and Exoscale** (issue #198). Outscale: 79 Terraform
   resources plus 6 OOS buckets and an inline EIM policy created by the tenant's `extra`
   hook, applied and destroyed on a real account — the two-NIC machine, the root access

--- a/RELEASING.fr.md
+++ b/RELEASING.fr.md
@@ -146,6 +146,37 @@ l'outillage Python doit pouvoir couper une release.
    git push origin v0.1.0
    ```
 
+6. **Joindre le verdict au corps de la release**, une fois le workflow terminé :
+
+   ```bash
+   gh release view v0.1.0 --json body --jq .body > /tmp/notes.md
+   cat release-gate/SUMMARY.md >> /tmp/notes.md
+   gh release edit v0.1.0 --notes-file /tmp/notes.md
+   ```
+
+   `SUMMARY.md` est le verdict SEUL — nom des contrôles, leur verdict, la date et le
+   commit —, et la porte refuse de le déclarer publiable s'il nomme un chemin de cette
+   machine (un motif de `--skip` est écrit à la main : c'est par là qu'un chemin
+   entrerait). Elle le dit à l'écran et coiffe le fichier d'un `NON PUBLIABLE` pour que
+   personne ne le colle par mégarde.
+
+   **Le rapport détaillé, lui, ne se publie pas**, et pour deux raisons indépendantes
+   qui vont dans le même sens :
+
+   - il porte des chemins de la machine du mainteneur, les sorties brutes des outils
+     et, à l'étape 3, **les identifiants de ressources d'un compte réel** — c'est
+     précisément pourquoi `release-gate/` est ignoré par git ;
+   - il ne peut pas entrer dans `checksums.txt`, engendré en CI depuis ce que la CI
+     détient, alors que le rapport est produit **localement, avant le tag**. Un `.md`
+     joint à la release serait un artefact couvert par aucun chemin de vérification
+     documenté, ce que
+     [l'ADR-0016](./docs/adr/0016-chaine-dapprovisionnement-verifiable.md) interdit.
+
+   Le CORPS d'une release n'est pas un artefact : c'est le même registre que les notes
+   de version qu'il prolonge — une affirmation humaine, non signée, et que personne n'a
+   jamais présentée autrement. Le verdict n'y ajoute donc aucune promesse de confiance
+   nouvelle ; il dit ce qui a été mesuré, quand, et sur quel commit.
+
 Pousser le tag est ce qui publie. Cela ne s'annule pas discrètement : un tag se
 supprime des deux côtés, et une release qui a atteint le monde a été
 téléchargée.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -145,6 +145,36 @@ the Python tooling must still be able to cut a release.
    git push origin v0.1.0
    ```
 
+6. **Append the verdict to the release body**, once the workflow is done:
+
+   ```bash
+   gh release view v0.1.0 --json body --jq .body > /tmp/notes.md
+   cat release-gate/SUMMARY.md >> /tmp/notes.md
+   gh release edit v0.1.0 --notes-file /tmp/notes.md
+   ```
+
+   `SUMMARY.md` is the verdict ALONE — check names, their verdicts, the date and the
+   commit — and the gate refuses to call it publishable if it names a path on this
+   machine (a `--skip` reason is hand-written: that is where a path would get in). It
+   says so on screen and stamps the file `NON PUBLIABLE` so nobody pastes it by
+   accident.
+
+   **The detailed report is not published**, for two independent reasons pointing the
+   same way:
+
+   - it carries paths from the maintainer's machine, raw tool output and, at stage 3,
+     **resource identifiers from a real account** — which is exactly why
+     `release-gate/` is git-ignored;
+   - it cannot enter `checksums.txt`, generated in CI from what CI holds, while the
+     report is produced **locally, before the tag**. A `.md` attached to the release
+     would be an artefact covered by no documented verification path, which
+     [ADR-0016](./docs/adr/0016-chaine-dapprovisionnement-verifiable.md) forbids.
+
+   A release BODY is not an artefact: it is the same register as the release notes it
+   extends — a human claim, unsigned, and never presented as anything else. The verdict
+   therefore adds no new trust promise; it states what was measured, when, and on which
+   commit.
+
 Pushing the tag is what publishes. It cannot be undone quietly: a tag has to
 be deleted on both sides, and a release that reached the world has been
 downloaded.

--- a/tools/release/gate.py
+++ b/tools/release/gate.py
@@ -789,11 +789,13 @@ def ecris_rapport(version, etapes, final):
         (SORTIE / f"stage{e['stage']}.json").write_text(
             json.dumps(e, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
+    commit = subprocess.run(["git", "rev-parse", "--short", "HEAD"], cwd=ROOT,
+                            capture_output=True, text=True).stdout.strip()
     lignes = [
         f"# Porte de release — {version}",
         "",
         f"Lancée le {dt.datetime.now(dt.timezone.utc).isoformat(timespec='seconds')}, "
-        f"sur `{subprocess.run(['git', 'rev-parse', '--short', 'HEAD'], cwd=ROOT, capture_output=True, text=True).stdout.strip()}`.",
+        f"sur `{commit}`.",
         "",
         "| Étape | Verdict | Durée |",
         "|---|:-:|--:|",
@@ -818,7 +820,85 @@ def ecris_rapport(version, etapes, final):
     rouges = [str(e["stage"]) for e in etapes if e["verdict"] == NOGO]
     lignes.append(f"**{'GO' if final == GO else 'NO-GO: étape(s) ' + ', '.join(rouges)}**")
     (SORTIE / "REPORT.md").write_text("\n".join(lignes) + "\n", encoding="utf-8")
-    return SORTIE / "REPORT.md"
+
+    resume, fuites = resume_publiable(version, etapes, final, commit)
+    (SORTIE / "SUMMARY.md").write_text(resume, encoding="utf-8")
+    if fuites:
+        (SORTIE / "SUMMARY.md").write_text(
+            "<!-- NON PUBLIABLE — ce résumé nomme des chemins locaux :\n" +
+            "\n".join(fuites) + "\n-->\n" + resume, encoding="utf-8")
+    return SORTIE / "REPORT.md", fuites
+
+
+# ── Ce qui peut être PUBLIÉ, et ce qui ne le peut pas ──────────────────────────
+#
+# Le rapport complet ne se publie pas, et pour deux raisons indépendantes qui
+# convergent.
+#
+# LA PREMIÈRE EST UNE QUESTION DE DONNÉES. `release-gate/` est ignoré par git parce
+# que ses artefacts portent les identifiants de ressources d'un compte réel (étape 3),
+# des chemins de la machine du mainteneur, et les sorties brutes des outils. Rien de
+# tout cela n'a à partir chez un tiers, et le geste « joindre le rapport » est
+# exactement celui qui l'y enverrait sans que personne ne l'ait décidé.
+#
+# LA SECONDE EST UNE QUESTION DE CHAÎNE. L'ADR-0016 pose que TOUT artefact publié
+# figure dans `checksums.txt`, donc sous la signature — et le rapport ne peut pas y
+# entrer : il est produit LOCALEMENT, avant le tag, alors que `checksums.txt` est
+# engendré en CI depuis ce que la CI détient. Un `.md` joint à la release serait un
+# artefact couvert par aucun chemin de vérification documenté, et il passerait sous
+# `TestEveryPublishedArtefactIsChecksummed`, dont le motif ne reconnaît que
+# json/jsonl/txt/bundle. Une garde écrite parce que le SBOM avait glissé sous un
+# commentaire ne doit pas laisser glisser un rapport sous une extension.
+#
+# Ce qui se publie, c'est donc le VERDICT, dans le CORPS de la release — là où vivent
+# déjà les notes de version, qui sont une affirmation humaine non signée et que
+# personne n'a jamais présentée autrement. Le résumé n'ajoute aucune promesse de
+# confiance nouvelle : il dit ce qui a été mesuré, quand, et sur quel commit.
+#
+# Et il le prouve : `resume_publiable` REND les fuites qu'il détecte au lieu de les
+# taire. Un motif de saut est écrit à la main par le mainteneur — c'est précisément par
+# là qu'un chemin local entrerait.
+
+FUITE = re.compile(r"(/home/[^\s`\"']+|/Users/[^\s`\"']+|(?<![\w/])/(?:tmp|var|opt|srv)/[^\s`\"']+)")
+
+
+def fuites_locales(texte):
+    """Les fragments d'un texte destiné à la publication qui nomment cette machine."""
+    return sorted({m.group(0) for m in FUITE.finditer(texte)})
+
+
+def resume_publiable(version, etapes, final, commit):
+    """Le verdict, sans aucune preuve : nom des contrôles, verdicts, date, commit.
+
+    Rend le couple (markdown, fuites). Une fuite n'est pas corrigée en silence — la
+    corriger reviendrait à décider à la place du mainteneur ce qu'il voulait écrire.
+    """
+    lignes = [
+        f"### Porte de release — {version}",
+        "",
+        f"Verdict : **{'GO' if final == GO else 'NO-GO'}** · "
+        f"commit `{commit}` · {dt.datetime.now(dt.timezone.utc).strftime('%Y-%m-%d')}",
+        "",
+    ]
+    for e in etapes:
+        lignes.append(f"**Étape {e['stage']} — {e['title']} : {e['verdict'].upper()}**")
+        lignes.append("")
+        if e["verdict"] == SKIPPED and not e["checks"]:
+            lignes += [f"- — sautée : {e.get('skip_reason', '')}", ""]
+            continue
+        for c in e["checks"]:
+            ligne = f"- {SYMBOLE[c['verdict']]} {c['name']}"
+            # Un saut est la SEULE chose dont le motif se publie : c'est lui qui dit ce
+            # que la porte n'a pas mesuré, et le taire vaudrait un vert sans mesure.
+            if c["verdict"] == SKIPPED:
+                ligne += f" — sauté : {c['evidence']}"
+            lignes.append(ligne)
+        lignes.append("")
+    lignes.append("_Le rapport détaillé reste local : il porte des chemins de la machine "
+                  "qui a lancé la porte, et les identifiants de ressources du tenant de "
+                  "qualification._")
+    texte = "\n".join(lignes) + "\n"
+    return texte, fuites_locales(texte)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -909,6 +989,45 @@ def selftest():
     veut("une version postérieure passe", trop_ancienne("v0.3.0", "v0.2.0"), False)
     veut("une chaine qui n'est pas une version ne refuse rien",
          trop_ancienne("vX.Y.Z", "v0.2.0"), False)
+
+    # ── Le résumé PUBLIABLE ne publie jamais les preuves ───────────────────────
+    #
+    # La propriété qui décide : ce fichier part chez un tiers. Le rapport détaillé
+    # porte des chemins de la machine du mainteneur, les sorties brutes des outils et,
+    # à l'étape 3, les identifiants de ressources d'un compte réel. Le résumé ne doit
+    # rien en emporter — c'est un contrôle de FUITE, pas de mise en forme.
+    etapes_test = [{
+        "stage": 2, "title": "réseau", "verdict": NOGO, "duration_s": 3,
+        "checks": [
+            controle("un contrôle vert", GO, "/home/mainteneur/secret/chemin"),
+            controle("un contrôle rouge", NOGO, "identifiant-de-ressource-i-0123456789"),
+            controle("un contrôle sauté", SKIPPED, "outil(s) absent(s) : cosign"),
+        ],
+    }]
+    resume, fuites = resume_publiable("v1.2.3", etapes_test, NOGO, "abc1234")
+    veut("aucune preuve dans le résumé", "/home/mainteneur" in resume, False)
+    veut("aucun identifiant de ressource dans le résumé",
+         "i-0123456789" in resume, False)
+    veut("les noms de contrôle, eux, y sont", "un contrôle rouge" in resume, True)
+    veut("le motif d'un SAUT s'y publie", "outil(s) absent(s) : cosign" in resume, True)
+    veut("le verdict y est", "NO-GO" in resume, True)
+    veut("le commit y est", "abc1234" in resume, True)
+    veut("un résumé propre ne signale aucune fuite", fuites, [])
+
+    # Un motif de `--skip` est écrit à la main : c'est par là qu'un chemin local entre.
+    etape_sautee = [{"stage": 2, "title": "réseau", "verdict": SKIPPED, "duration_s": 0,
+                     "checks": [], "skip_reason": "cosign absent de /home/bob/.local/bin"}]
+    _, fuites = resume_publiable("v1.2.3", etape_sautee, GO, "abc1234")
+    veut("un chemin local dans un motif de saut est signalé",
+         fuites, ["/home/bob/.local/bin"])
+    veut("un chemin macOS aussi", fuites_locales("voir /Users/qui/dossier"), ["/Users/qui/dossier"])
+    veut("un chemin temporaire aussi", fuites_locales("dans /tmp/run-42"), ["/tmp/run-42"])
+    # Le contre-exemple : une porte qui crierait sur tout serait désarmée. Un chemin du
+    # DÉPÔT est relatif, et il n'a rien de local.
+    veut("un chemin du dépôt ne fuit rien",
+         fuites_locales("voir docs/install.md et .github/workflows/release.yml"), [])
+    veut("une URL ne fuit rien",
+         fuites_locales("https://github.com/stephrobert/pepin/releases"), [])
 
     # ── Les ancres, telles que GitHub les fabrique ─────────────────────────────
     veut("ancre accentuée", ancre_de("Ce que le scan à rôle réduit a mesuré"),
@@ -1012,9 +1131,16 @@ def cmd_run(args):
                           "duration_s": round(time.time() - t0, 1)})
 
     final = verdict_final(resultats)
-    chemin = ecris_rapport(version, resultats, final)
+    chemin, fuites = ecris_rapport(version, resultats, final)
     rouges = [str(e["stage"]) for e in resultats if e["verdict"] == NOGO]
-    print(f"\n{chemin.relative_to(ROOT)}")
+    print(f"\n{chemin.relative_to(ROOT)}  (détaillé, LOCAL)")
+    print(f"{(SORTIE / 'SUMMARY.md').relative_to(ROOT)}  (verdict seul, à joindre au corps de la release)")
+    if fuites:
+        print("  ATTENTION : le résumé nomme des chemins de cette machine, il n'est pas "
+              "publiable tel quel —")
+        for f in fuites:
+            print(f"    {f}")
+        print("  ils viennent d'un motif de --skip : le réécrire sans chemin local.")
     print("GO" if final == GO else f"NO-GO: étape(s) {', '.join(rouges)}")
     return 0 if final == GO else 1
 


### PR DESCRIPTION
Closes #178 — the last acceptance item, decided.

## The item, and why it could not be taken literally

#178 asked that `release-gate/REPORT.md` be **attached to the GitHub Release** as the
evidence that GO was said. Attaching *that file* is wrong twice over, and the two
reasons are independent:

- **It is not publishable data.** It carries the maintainer's paths, raw tool output
  and, at stage 3, **resource identifiers from a real account**. That is precisely why
  `release-gate/` is git-ignored — and "attach the report" is the one gesture that
  would send all of it to a third party without anyone deciding to.
- **It cannot enter the signed chain.** `checksums.txt` is generated in CI from what CI
  holds; the report is produced **locally, before the tag**. A `.md` attached to the
  release would be an artefact covered by no documented verification path, which
  **ADR-0016** forbids — and it would slip past
  `TestEveryPublishedArtefactIsChecksummed`, whose regex only matches
  `json|jsonl|txt|bundle`. A guard written because the SBOM slipped under a *comment*
  must not let a report slip under an *extension*.

## What is published instead

The **verdict**, in the release **body**. The gate now writes
`release-gate/SUMMARY.md`:

```
### Porte de release — v0.4.0

Verdict : **GO** · commit `de9851d` · 2026-09-10

**Étape 1 — hors ligne : le dépôt, et ce que sa documentation affirme : GO**

- ✔ release-check : tout ce qui doit être vrai avant un tag
- ✔ les versions épinglées valent au moins le minimum déclaré sûr
- ✔ tout lien relatif de la documentation résout
  …
```

Check names, verdicts, date, commit — **and the reason of every skip**, because a skip
is what says the gate did not measure something; hiding it would turn the summary into
a green without a measure. **No evidence body, ever.**

A release **body** is not an artefact. It is the same register as the notes it extends:
a human claim, unsigned, and never presented as anything else. Putting the verdict there
adds no new trust promise — which is exactly why it needs no ADR revision.

`RELEASING` gains **step 6** in both languages, with the three-command recipe
(`gh release view … | cat SUMMARY.md >> … | gh release edit --notes-file`) and the
reason the detailed report stays behind.

## The summary proves it is safe, rather than asserting it

A `--skip` reason is **hand-written by the maintainer** — that is exactly where a local
path gets in. So `resume_publiable` returns the leaks it finds instead of hiding them:
the gate says so on screen and stamps the file `NON PUBLIABLE` so nobody pastes it by
accident.

It does **not** silently rewrite the reason. Doing so would decide, on the maintainer's
behalf, what they meant to write — and a redaction nobody sees is how a leak becomes
invisible rather than absent.

```
release-gate/SUMMARY.md  (verdict seul, à joindre au corps de la release)
  ATTENTION : le résumé nomme des chemins de cette machine, il n'est pas publiable tel quel —
    /home/bob/.local/bin
  ils viennent d'un motif de --skip : le réécrire sans chemin local.
```

## Falsification

| Mutation | `gate:selftest` |
|---|---|
| the summary carries each check's `evidence` | **red** |
| the leak detector returns nothing | **red** |

And the counterexamples are in the selftest too, because a leak check that cries wolf
gets disarmed: a repo-relative path (`docs/install.md`) and a URL must **not** be
reported as leaks.

## Impact ADR

**ADR-0016** reviewed in full — **respected, not revised**. Its invariant ("every
published artefact figures in `checksums.txt`") stays intact because nothing new is
published as an artefact. Its rejected alternative *"signer chaque artefact
séparément"* is also respected: signing the report with a maintainer key would have
created a second verification path with a different identity, which that ADR turned
down for good reasons. **ADR-0012** is what makes the data half of the argument: the
stage-3 output holds a real tenant's identifiers, and nothing that holds them leaves
this machine. No new ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
