### PR TITLE
fix(qualification): reconcile the three expectations with the first real runs

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -616,6 +616,32 @@ l'une ni l'autre appartient au `git log`.
 
 ### Modifié
 
+- **Cinq verdicts bougent sur un tenant inchangé, et chacun est mesuré** (issue #229).
+  Les trois tenants de qualification ont été appliqués, scannés, scellés, détruits et
+  **prouvés détruits** sur des comptes Scaleway, Outscale et Exoscale réels le
+  2026-09-10 — 15, 19 et 20 familles de collecte listées, aucune ressource du tenant
+  survivante, aucun delta avant/après, pour 0,072 EUR au total. Ce qui suit change ce
+  qu'un rapport dit d'une infrastructure que vous n'avez pas touchée :
+  - `compute_instance_has_security_group` ne signale plus une instance **privée** : un
+    groupe de sécurité ne s'attache pas à une instance sans interface publique, donc la
+    remédiation ne pouvait jamais aboutir (#212). En live Exoscale, le contrôle rend
+    désormais `not-evaluated` plutôt que `pass`, parce qu'une liste vide observée est
+    comptée comme non collectée — lacune de couverture, épinglée et nommée #227.
+  - `governance_resource_required_tags` ne signale plus un bucket SOS Exoscale : SOS
+    accepte `PutBucketTagging` et ne persiste rien, donc un tel bucket n'a jamais
+    d'étiquette quoi qu'on fasse (#208). Le contrôle dit qu'il ne peut pas conclure au
+    lieu de crier.
+  - `database_service_not_open_to_internet` nomme **la base**, et non l'adresse de la
+    règle d'ACL qui l'expose (#193). Une base, un sujet.
+  - `objectstorage_bucket_default_encryption` sur un plan Terraform n'est plus **absent**
+    de l'assessment : il apparaît en `not-evaluated`, en nommant l'attribut que le plan
+    ne porte pas. Un contrôle qui disparaît se lit comme un contrôle sans rien à dire.
+  - `governance_resource_region_in_eu` conclut `pass` sur un plan Outscale, là où il
+    renonçait : la région est désormais **dérivée de la zone que le plan porte**
+    (`placement_subregion_name` → `region`, #194). Vérifié avant d'être épinglé — un
+    `not-evaluated` qui devient `pass` a la forme exacte d'un faux vert, et celui-ci
+    repose sur une valeur observée avec sa formule, pas sur une fabrication.
+
 - **Une unité Outscale refusée nomme désormais le droit qui l'aurait collectée, et la
   documentation dit qu'un scan complet exige les clés du propriétaire du compte**
   (issue #168). Mesuré le 2026-09-09 sur un tenant `eu-west-2` réel, avec un utilisateur

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -569,6 +569,31 @@ belongs in `git log`.
 
 ### Changed
 
+- **Five verdicts move on an unchanged tenant, and each one is measured** (issue #229).
+  The three qualification tenants were applied, scanned, sealed, destroyed and **proven
+  destroyed** on real Scaleway, Outscale and Exoscale accounts on 2026-09-10 — 15, 19 and
+  20 collection families listed, no tenant resource left, no before/after delta, for a
+  total of 0.072 EUR. What follows changes what a report says about infrastructure you
+  did not touch:
+  - `compute_instance_has_security_group` no longer flags a **private** instance: a
+    security group does not attach to an instance with no public interface, so the
+    remediation could never be carried out (#212). On Exoscale live the control now
+    answers `not-evaluated` rather than `pass`, because an observed empty list is
+    counted as not collected — a coverage gap, pinned and named as #227.
+  - `governance_resource_required_tags` no longer flags an Exoscale SOS bucket: SOS
+    accepts `PutBucketTagging` and persists nothing, so such a bucket never carries a
+    tag whatever you do (#208). The control says it cannot conclude instead of shouting.
+  - `database_service_not_open_to_internet` names **the database**, not the address of
+    the ACL rule that exposes it (#193). One database, one subject.
+  - `objectstorage_bucket_default_encryption` on a Terraform plan is no longer **absent**
+    from the assessment: it appears as `not-evaluated`, naming the attribute the plan
+    does not carry. A control that vanishes reads like a control with nothing to say.
+  - `governance_resource_region_in_eu` concludes `pass` on an Outscale plan, where it
+    used to give up: the region is now **derived from the zone the plan carries**
+    (`placement_subregion_name` → `region`, #194). Verified before being pinned — a
+    `not-evaluated` turning into a `pass` has the exact shape of a false green, and this
+    one rests on an observed value with its formula, not on a fabrication.
+
 - **A refused Outscale unit now names the grant that would have collected it, and the
   documentation says a complete scan needs the account owner's keys** (issue #168).
   Measured on 2026-09-09 against a real `eu-west-2` tenant, with an EIM user carrying

--- a/references/qualification/exoscale/expected.yaml
+++ b/references/qualification/exoscale/expected.yaml
@@ -135,14 +135,30 @@ controls:
     terraform: not-evaluated
 
   compute_instance_has_security_group:
-    # MESURÉ, FAUX POSITIF : `untagged` est privée (`private = true`, public-ip-assignment
-    # none) ; l'API ignore les groupes déclarés et rend `security-groups: []` — un
-    # groupe ne s'attache pas à une instance sans interface publique. La règle en fait
-    # un écart, avec une remédiation inexécutable. Issue #212 ; sa
-    # correction fera rougir cette porte sciemment.
+    # RÉCONCILIÉ le 2026-09-10 par le premier run réel — et cette attente avait annoncé
+    # par écrit les deux mouvements avant qu'ils arrivent.
+    #
+    # 1. #212 est CORRIGÉE : `untagged` est privée (`public-ip-assignment: none`, donc
+    #    `public_interface: false`), et un groupe ne s'attache pas à une instance sans
+    #    interface publique. Ce n'est plus un écart, et sa remédiation était
+    #    inexécutable — le genre de finding qui fait désactiver un outil.
+    #
+    # 2. Le contrôle ne rend pourtant pas `pass` mais `not-evaluated`, et c'est #227.
+    #    L'inventaire scellé de ce run porte bien `security_group_ids: []` sur cette
+    #    instance, mais `collected()` compte une liste VIDE comme non collectée ;
+    #    l'intersection retire alors l'attribut de tout le type. La ressource fautive
+    #    fait taire le contrôle qui la vise — le motif de cette vague, un cran plus bas
+    #    que les règles.
+    #
+    # `coverage_gap` : le scan dit « je n'ai pas pu conclure », jamais « conforme ».
+    # C'est la direction sûre (ADR-0006), donc non bloquant — mais c'est une capacité
+    # perdue, et #227 doit la rendre.
     live:
-      fail: ["${output.vm_untagged_id}"]
-      silent: ["${output.vm_exposed_id}", "${output.vm_hardened_id}"]
+      status: not-evaluated
+      known_defect:
+        issue: 227
+        class: coverage_gap
+        note: "une liste vide OBSERVÉE est comptée comme non collectée ; l'instance sans groupe retire l'attribut de tout son type"
     terraform: pass
 
   compute_instance_no_secrets_in_user_data:
@@ -252,17 +268,19 @@ controls:
 
   # ── Gouvernance ───────────────────────────────────────────────────────────────
   governance_resource_required_tags:
-    # Les trois buckets SOS sont fautifs PAR CONSTRUCTION : SOS accepte
-    # PutBucketTagging et ne persiste rien (NoSuchTagSet juste après, mesuré par SigV4
-    # et par la CLI aws). Un bucket SOS n'a jamais d'étiquette, quoi qu'on fasse ;
-    # épinglé tel que mesuré, faux positif non remédiable — issue #208.
-    # Et FAUX VERT sur `untagged` : la collecte live ne projette pas `labels` sur les
-    # instances (ni volumes, ni clusters), la règle les saute en silence, seuls les
-    # buckets sont jugés — issue #211 ; sa correction ajoutera
-    # `${output.vm_untagged_id}` au `fail` et fera rougir cette porte.
+    # RÉCONCILIÉ le 2026-09-10 par le premier run réel. #208 est CORRIGÉE : SOS accepte
+    # PutBucketTagging et ne persiste RIEN (NoSuchTagSet juste après, mesuré par SigV4
+    # et par la CLI aws), donc le descripteur déclare `s3.tags_persisted: false` et un
+    # bucket SOS n'est plus tenu pour un bucket sans étiquette. Crier dessus était un
+    # faux positif non remédiable.
+    #
+    # Le contrôle rend donc `not-evaluated` sur cette source, avec son motif : « la
+    # collecte de la donnée requise n'est pas confirmée pour ce fournisseur (contrat
+    # non vérifié) ». Ce n'est pas un défaut mais une LIMITE déclarée : la source
+    # n'expose pas la donnée, et le scan le dit au lieu de conclure (ADR-0006,
+    # ADR-0015).
     live:
-      fail: ["${output.bucket_public}", "${output.bucket_unversioned}", "${output.bucket_hardened}"]
-      silent: ["${output.vm_hardened_id}", "${output.vm_secrets_id}", "${output.volume_unsnapshotted_id}", pepin-qual-sks-weak]
+      status: not-evaluated
     terraform:
       fail: [pepin-qual-vm-untagged]
       silent: [pepin-qual-vm-hardened, pepin-qual-vm-secrets]

--- a/references/qualification/outscale/expected.yaml
+++ b/references/qualification/outscale/expected.yaml
@@ -325,8 +325,20 @@ controls:
 
   governance_resource_region_in_eu:
     live: pass
-    # Le mapping Terraform ne projette pas la région (#203 ; #194 pour Scaleway).
-    terraform: not-evaluated
+    # RÉCONCILIÉ le 2026-09-10 : #194 est CORRIGÉE et vaut aussi pour Outscale. Le
+    # mapping projette désormais la région, DÉRIVÉE de la zone que le plan porte
+    # (`placement_subregion_name: eu-west-2a` → `eu-west-2`, transform `region_of_zone`).
+    #
+    # Le passage de `not-evaluated` à `pass` a la forme exacte d'un faux vert, et c'est
+    # à ce titre qu'il a été vérifié AVANT d'être épinglé : la région n'est pas
+    # fabriquée, elle est dérivée d'une valeur observée dans le plan, avec sa formule
+    # (ADR-0014). L'assessment le dit lui-même — « no deviation detected on the
+    # resources of type "compute_instance", whose deciding data was observed on every
+    # one of them », sur les 8 VM du tenant.
+    #
+    # La porte avait raison de crier : avant cette ligne, rien dans le dépôt
+    # n'expliquait le changement. C'est précisément ce qu'un pin doit porter.
+    terraform: pass
 
   governance_provider_sovereignty:
     live: pass

--- a/references/qualification/scaleway/expected.yaml
+++ b/references/qualification/scaleway/expected.yaml
@@ -230,18 +230,31 @@ controls:
       # #192 CORRIGÉE (#206) : le contrôle est désormais déclaré pour Scaleway, et la
       # matrice ne dit plus ✗ là où l'outil mesure. Les six écarts étaient JUSTES —
       # seule la déclaration était fausse —, donc ce pin de statut ne bouge pas.
-    terraform: absent
+    # RÉCONCILIÉ le 2026-09-10 : sur le PLAN, le contrôle n'est plus absent, il rend
+    # `not-evaluated` en nommant sa raison — « attribut `default_encryption_enabled`
+    # non collecté sur les ressources de type `object_storage_bucket` ». C'est le bon
+    # comportement et non une régression : un plan Terraform ne porte pas de bloc SSE
+    # pour un bucket qui n'en déclare aucun, donc il n'y a rien à observer. Une règle
+    # qui ne peut pas conclure le DIT, au lieu de disparaître du rapport (ADR-0015) —
+    # et disparaître était le pire des deux, parce qu'un contrôle absent se lit comme
+    # un contrôle sans écart.
+    terraform: not-evaluated
 
   # ── Bases managées (PLAN SEULEMENT : aucune collecte live RDB, et rien n'est
   #    provisionné qu'aucun scan live ne verrait — cf. variables.tf) ────────────
   database_service_not_open_to_internet:
     live: not-evaluated
     terraform:
-      # `_parent.instance_id` n'est pas comblé par les références du plan (ADR-0022,
-      # chemins simples seulement, issue #193) : le sujet est l'adresse de la
-      # ressource ACL, indexée parce que les bases n'existent que sur le plan (count).
-      fail: ["scaleway_rdb_acl.exposed[0]"]
-      silent: ["scaleway_rdb_acl.hardened[0]"]
+      # RÉCONCILIÉ le 2026-09-10 : #193 est CORRIGÉE. Le mapper réécrit désormais une
+      # adresse injectée vers l'IDENTITÉ que la cible porte dans l'inventaire, si bien
+      # que le sujet n'est plus `scaleway_rdb_acl.exposed[0]` — l'adresse d'une règle
+      # d'ACL — mais la base elle-même. Une base, un sujet : l'opérateur lit le nom de
+      # ce qu'il doit corriger, pas la coordonnée d'une ressource intermédiaire.
+      #
+      # Mesuré : `ip_filter=terraform-plan:scaleway_rdb_acl (derived) observed=2/2`,
+      # « ACL allowing a public CIDR (0.0.0.0/0) ».
+      fail: [pepin-qual-rdb-exposed]
+      silent: [pepin-qual-rdb-hardened]
 
   database_encryption_at_rest_enabled:
     live: not-evaluated


### PR DESCRIPTION
Closes #229.

## The measurement

The three qualification tenants were **applied, scanned, sealed, destroyed and proven
destroyed** on real Scaleway, Outscale and Exoscale accounts on 2026-09-10, against
`main` @ d9679a2.

| Provider | Families listed | Tenant resources left | Before/after delta | Duration | Cost |
|---|---:|---:|---:|---:|---:|
| exoscale | 15 | 0 | none | 117 s | 0.0036 € |
| scaleway | 19 | 0 | none | 245 s | 0.0034 € |
| outscale | 20 | 0 | none | 406 s | 0.0652 € |

`expected.yaml` had not moved since #217, while **five PRs since then moved a verdict on
an unchanged tenant**. These runs measured what those moves actually did.

## The five verdicts, and what each traces to

| Provider | Source | Movement | Traces to |
|---|---|---|---|
| exoscale | live | `compute_instance_has_security_group` → `not-evaluated` | #212 fixed, **+ #227** |
| exoscale | live | `governance_resource_required_tags` → `not-evaluated` | #208 fixed |
| scaleway | tf | `database_service_not_open_to_internet`: subject is now **the database** | #193 fixed |
| scaleway | tf | `objectstorage_bucket_default_encryption`: `absent` → `not-evaluated` | ADR-0015 |
| outscale | tf | `governance_resource_region_in_eu` → **`pass`** | #194 fixed |

**Two of these five expectations had already written, in their own comment, what their
fix would do to this gate.** They were right — and that is exactly why one writes it
down.

## The one that had to be established before anything was written

`governance_resource_region_in_eu` turning `not-evaluated` into `pass` has the **exact
shape of a false green**, and #217 makes that class blocking without waiver. It is not
one:

- the plan carries `placement_subregion_name: "eu-west-2a"` on all 8 VMs;
- `region_of_zone` (#194) derives `eu-west-2` from it;
- the assessment says so itself — *"no deviation detected on the resources of type
  `compute_instance`, whose deciding data was observed on every one of them"*.

An observed value with its formula, which is what ADR-0014 allows. The pin predated #194,
and the runner was right to shout: nothing in the repository explained the change. **Now
the pin does** — that is what a pin is for.

## The one that is a real gap, named as such

#227: the Exoscale instance with **no security group** carries `security_group_ids: []`
in the sealed inventory, but `collected()` counts an observed empty list as not
collected, and the intersection then removes the attribute from the whole type. The
faulty resource silences the control aimed at it.

Pinned `known_defect: {class: coverage_gap, issue: 227}` — the scan answers *"I could not
conclude"*, never *"compliant"*. The safe direction (ADR-0006), so it does not block a
release; but it names the capability that has to come back.

```
· [live] compute_instance_has_security_group : DÉFAUT CONNU (coverage_gap,
  n'empêche pas la release) — une liste vide OBSERVÉE est comptée comme non
  collectée … — issue #227
```

## Result

```
exoscale  [live] GO  [terraform] GO   verdict : GO
scaleway  [live] GO  [terraform] GO   verdict : GO
outscale  [live] GO  [terraform] GO   verdict : GO
```

Non-regression contract **and** release verdict, on all three.

## CHANGELOG

One line per moved verdict, both languages. The CHANGELOG header promises exactly this:
a verdict that changes on an unchanged tenant is what its reader will have to explain to
an auditor — a change they did not make.

## Impact ADR

**ADR-0014** (an absent datum is never fabricated) is what settled the Outscale region:
derived from an observed value, with its formula, so it is an observation.
**ADR-0006** and **ADR-0015** are why two controls answering `not-evaluated` is the right
outcome rather than a regression — a rule that cannot conclude says so, instead of
vanishing from the report or claiming compliance. No ADR modified, none reopened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)