### PR TITLE
docs(roadmap): the roadmap derives its version instead of retyping it

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -20,6 +20,19 @@ leur utilisateur à expliquer à un auditeur un changement qu'il n'a pas fait,
 et c'est ici que cette explication commence. Un refactor qui ne change ni
 l'une ni l'autre appartient au `git log`.
 
+## [Non publié]
+
+### Corrigé
+
+- **La feuille de route annonçait une version que le projet avait dépassée.**
+  `ROADMAP.fr.md` disait encore « Où en est Pépin, v0.2.0 » deux releases plus tard.
+  Pour la plupart des projets ce serait un détail ; pour celui-ci, dont tout le propos
+  est qu'aucune affirmation ne vaut mieux que ce qui est mesuré, une page qui se trompe
+  sur sa propre version décrédibilise le reste. Le titre est désormais **dérivé** du
+  CHANGELOG — la même source que `TestTheInstallPagePinsTheLatestRelease`, parce que
+  deux sources de vérité pour une même question finissent par diverger — et une version
+  illisible laisse le titre sans numéro plutôt que d'en inventer un (ADR-0014).
+
 ## [0.4.0] - 2026-09-10
 
 ### Corrigé

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ second makes their user explain to an auditor a change they did not make, and
 this file is where that explanation starts. A refactor that changes neither
 belongs in `git log`.
 
+## [Unreleased]
+
+### Fixed
+
+- **The roadmap announced a version the project had left behind.** `ROADMAP.md` still
+  said *"Where Pépin stands, v0.2.0"* two releases later. For most projects that is a
+  detail; for one whose whole claim is that no assertion is worth more than what was
+  measured, a page wrong about its own version undermines the rest. The heading is now
+  **derived** from the CHANGELOG — the same source as
+  `TestTheInstallPagePinsTheLatestRelease`, because two sources of truth for one
+  question end up disagreeing — and a version that cannot be read leaves the heading
+  without a number rather than inventing one (ADR-0014).
+
 ## [0.4.0] - 2026-09-10
 
 ### Fixed

--- a/ROADMAP.fr.md
+++ b/ROADMAP.fr.md
@@ -14,7 +14,9 @@ en CI : les [limites connues](docs/known-limitations.fr.md) pour les angles mort
 la [matrice de couverture](docs/coverage.fr.md) pour ce qui est mesurable contrôle par
 contrôle. Cette page ne les recopie pas.
 
-## Où en est Pépin, v0.2.0
+<!-- pepin:gen roadmap-status-heading -->
+## Où en est Pépin, v0.4.0
+<!-- /pepin:gen roadmap-status-heading -->
 
 Quatre fournisseurs enregistrés : trois clouds souverains, plus un collecteur
 Kubernetes intra-cluster.
@@ -105,6 +107,13 @@ inventé la justification. Cette retenue est le sujet du projet, pas un effet de
 **OVHcloud** est le prochain cloud souverain de la liste. En ajouter un, c'est un
 descripteur et **zéro règle** : les règles sont communes, seule la source change. C'est
 exactement le parcours d'[ajouter un fournisseur](docs/contributing/adding-a-provider.fr.md).
+
+Il vient **après** que les trois fournisseurs actuels aient fermé leurs trous de
+couverture, et c'est une décision, pas un retard. Passer de trois fournisseurs
+imparfaits à quatre fournisseurs imparfaits ne rend le produit indispensable à
+personne ; trois fournisseurs très fiables, très bien qualifiés, utilisables en CI,
+avec la comparaison de campagnes et la remédiation, font d'OVHcloud un accélérateur de
+marché plutôt qu'une nouvelle source de dette.
 
 Rien n'est déclaré couvert avant que son contrat soit vérifié champ par champ contre le
 SDK ou la spécification d'API du fournisseur. Un fournisseur livré avec des champs non

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,9 @@ CI: [known limitations](docs/known-limitations.md) for the blind spots, and the
 [coverage matrix](docs/coverage.md) for what is measurable control by control. This
 page does not restate them.
 
-## Where Pépin stands, v0.2.0
+<!-- pepin:gen roadmap-status-heading -->
+## Where Pépin stands, v0.4.0
+<!-- /pepin:gen roadmap-status-heading -->
 
 Four registered providers: three sovereign clouds, plus an in-cluster Kubernetes
 collector.
@@ -103,6 +105,12 @@ justification for. That restraint is the point of the project, not an accident o
 **OVHcloud** is the next sovereign cloud on the list. Adding one is one descriptor and
 **zero rules** — the rules are common, only the source changes — which is what
 [adding a provider](docs/contributing/adding-a-provider.md) walks through.
+
+It comes **after** the three current providers have closed their coverage gaps, and
+that is a decision rather than a delay. Going from three imperfect providers to four
+imperfect providers makes the product indispensable to nobody; three providers that are
+highly reliable, well qualified, usable in CI, with campaign comparison and remediation,
+turn OVHcloud into a market accelerator instead of a new source of debt.
 
 Nothing is declared covered before its contract is verified field by field against the
 provider's own SDK or API specification. A provider that ships with unverified fields

--- a/internal/docgen/blocks.go
+++ b/internal/docgen/blocks.go
@@ -470,6 +470,7 @@ func buildBlocks(root, lang string, m Matrix, c captures, rem []RemediationCover
 		"scan-control-encryption":   Fence("text", controlBlock(t, c.vulnerable.Stdout, "CLD-CHF-2")),
 		"scan-control-objectstore":  Fence("text", controlBlock(t, c.vulnerable.Stdout, "CLD-STO-1")),
 		"provider-list":             Fence("text", c.providers.Stdout),
+		"roadmap-status-heading":    roadmapStatusHeading(t, root),
 		"fixture-empty-inventory":   Fence("json", emptyInventory),
 		"fixture-tagless-inventory": Fence("json", taglessInventory),
 		"fixture-partial-inventory": Fence("json", partialInventory),
@@ -1105,4 +1106,42 @@ func mustIndent(v any) string {
 		return "{}"
 	}
 	return string(b)
+}
+
+// roadmapStatusHeading rend le titre « Où en est Pépin » avec la version COURANTE.
+//
+// Le défaut qu'il ferme. La feuille de route annonçait « v0.2.0 » alors que la v0.4.0
+// était publiée. Pour n'importe quel projet ce serait mineur ; pour celui-ci, dont tout
+// le propos est qu'aucune affirmation ne vaut mieux que ce qui est mesuré, une page qui
+// se trompe sur sa propre version est exactement le genre de détail qui décrédibilise
+// le reste. Et un numéro retapé à la main se périme à chaque release, par construction.
+//
+// La source est le CHANGELOG, pas un tag git : un clone de CI peut n'avoir aucun tag,
+// alors que le CHANGELOG est dans l'arbre. C'est déjà la source de
+// `TestTheInstallPagePinsTheLatestRelease`, et deux sources de vérité pour la même
+// question finiraient par diverger.
+func roadmapStatusHeading(t blockStrings, root string) string {
+	v := derniereVersionDuChangelog(root)
+	if v == "" {
+		// Une version illisible ne se fabrique pas (ADR-0014) : le titre reste sans
+		// numéro plutôt que d'en inventer un.
+		return "## " + t.roadmapStatus
+	}
+	return "## " + t.roadmapStatus + ", v" + v
+}
+
+// versionChangelog : la première section `## [X.Y.Z]` du CHANGELOG anglais, celle que
+// la release publie. `## [Unreleased]` ne correspond pas au motif, donc s'ignore seul.
+var versionChangelog = regexp.MustCompile(`(?m)^## \[(\d+\.\d+\.\d+)\]`)
+
+func derniereVersionDuChangelog(root string) string {
+	// #nosec G304 -- nom de fichier constant, sous la racine du dépôt que le générateur reçoit.
+	raw, err := os.ReadFile(filepath.Join(root, "CHANGELOG.md"))
+	if err != nil {
+		return ""
+	}
+	if m := versionChangelog.FindSubmatch(raw); m != nil {
+		return string(m[1])
+	}
+	return ""
 }

--- a/internal/docgen/strings.go
+++ b/internal/docgen/strings.go
@@ -20,6 +20,7 @@ type blockStrings struct {
 	orWord, none, totalWord, figControls, figDeclared string
 	noTypeWord                                        string
 	noDeviationFor, noResultFor, quotedPlaceholder    string
+	roadmapStatus                                     string
 }
 
 func blockText(lang string) blockStrings {
@@ -43,6 +44,7 @@ func blockText(lang string) blockStrings {
 			veracityObligations: "Verdicts à prouver au total",
 			veracityRemaining:   "Verdicts restant à prouver",
 			veracityUnavailable: "_Contrat de véracité indisponible : le calcul des obligations a échoué._",
+			roadmapStatus:       "Où en est Pépin",
 			exitExempted:        "Tout écart critical/high est couvert par une dérogation valide",
 			exitExpired:         "La même dérogation, échue : elle ne s'applique plus",
 			colAttributes:       "Attributs communs",
@@ -76,6 +78,7 @@ func blockText(lang string) blockStrings {
 		veracityObligations: "Verdicts to prove in total",
 		veracityRemaining:   "Verdicts left to prove",
 		veracityUnavailable: "_Veracity contract unavailable: the obligation computation failed._",
+		roadmapStatus:       "Where Pépin stands",
 		exitExempted:        "Every critical/high deviation is covered by a valid exemption",
 		exitExpired:         "The same exemption, lapsed: it no longer applies",
 		colAttributes:       "Common attributes",


### PR DESCRIPTION
`ROADMAP.md` still said *"Where Pépin stands, **v0.2.0**"* — two releases later.

For most projects that is a detail. For one whose entire claim is that **no assertion is
worth more than what was measured**, a page wrong about its own version undermines
everything else printed on it. And a number typed by hand goes stale at every release,
by construction.

## The change

The heading becomes a generated block, computed from the first `## [X.Y.Z]` section of
`CHANGELOG.md`:

```
<!-- pepin:gen roadmap-status-heading -->
## Où en est Pépin, v0.4.0
<!-- /pepin:gen roadmap-status-heading -->
```

**The CHANGELOG rather than a git tag**: a CI clone may carry no tag, while the CHANGELOG
is in the tree. It is already the source of `TestTheInstallPagePinsTheLatestRelease`, and
two sources of truth for one question end up disagreeing.

**A version that cannot be read leaves the heading without a number** rather than
inventing one — ADR-0014, applied to the generator itself.

## Falsified

Rewriting the heading to `v0.1.0` and running `mise run gen-docs` restores `v0.4.0`.
`TestGeneratedDocsAreUpToDate` then fails the build if the committed page ever drifts
from what the code computes — so this cannot go stale again without CI saying so.

## Also

Both roadmaps now state **where OVHcloud sits**: after the three current providers have
closed their coverage gaps. Three imperfect providers becoming four imperfect providers
makes the product indispensable to nobody; three highly reliable, well-qualified ones,
usable in CI with campaign comparison and remediation, turn OVHcloud into a market
accelerator rather than a new source of debt.

## Impact ADR

**ADR-0014** is what decides the failure mode: an unreadable version produces a heading
without a number, never a fabricated one. No ADR modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)