### PR TITLE
fix(assess): an unreadable policy is not an empty one, and an empty list is an observation

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -24,6 +24,28 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Une ressource qui n'a rien ne fait plus taire le contrôle qui la cherche**
+  (issue #227). Le tenant de qualification Exoscale contient, délibérément, une instance
+  **sans aucun groupe de sécurité** — l'écart même que
+  `compute_instance_has_security_group` existe pour attraper. Le scan rendait
+  `not-evaluated` : l'inventaire scellé portait bien `security_group_ids: []`, mais une
+  liste vide observée comptait comme *non collectée*, et l'intersection par type retirait
+  alors l'attribut de toutes les instances. La ressource fautive aveuglait son propre
+  contrôle, et ses voisines avec elle.
+
+  Le correctif n'est **pas** d'apprendre au verrou de capacité à tolérer les vides : cela
+  aurait rouvert l'incident fondateur de l'ADR-0006, puisque `IAMPolicyStatements` rendait
+  `[]` aussi bien pour « ce document n'a pas pu être analysé » que pour « cette politique
+  n'accorde rien ». **Le bouchon est retiré à la source** : le parseur ne rend plus rien
+  quand il n'a pas su lire, les collecteurs omettent alors l'attribut au lieu d'en poser
+  un vide, et c'est seulement là que le verrou répond sur la **présence**. Une liste vide
+  observée est une énumération complète qui compte zéro ; `nil` n'établit toujours rien.
+
+  Mesuré : un verdict bouge — `compute_instance_has_security_group` en live Exoscale, de
+  `not-evaluated` à `pass`, et ce `pass` est prouvé : les quatre instances portent leur
+  attribut, et la seule vide est privée (#212). Confirmé de bout en bout par deux runs de
+  qualification réels, Exoscale et Outscale, tous deux GO.
+
 - **La feuille de route annonçait une version que le projet avait dépassée.**
   `ROADMAP.fr.md` disait encore « Où en est Pépin, v0.2.0 » deux releases plus tard.
   Pour la plupart des projets ce serait un détail ; pour celui-ci, dont tout le propos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@ belongs in `git log`.
 
 ### Fixed
 
+- **A resource with nothing no longer silences the control looking for it** (issue #227).
+  The Exoscale qualification tenant contains, deliberately, an instance with **no
+  security group at all** — the very deviation `compute_instance_has_security_group`
+  exists to catch. The scan answered `not-evaluated`: the sealed inventory carried
+  `security_group_ids: []`, but an observed empty list counted as *not collected*, and
+  the per-type intersection then removed the attribute from every instance. The faulty
+  resource blinded its own control, and its neighbours with it.
+
+  The fix is **not** teaching the capability lock to tolerate empty values — that would
+  have re-opened ADR-0006's founding incident, because `IAMPolicyStatements` returned
+  `[]` both for *"this document could not be parsed"* and for *"this policy grants
+  nothing"*. **The placeholder is removed at the source**: the parser now returns nothing
+  when it could not read, the collectors omit the attribute rather than posting an empty
+  one, and only then does the lock answer on **presence**. An observed empty list is a
+  complete enumeration that counts zero; `nil` still establishes nothing.
+
+  Measured: one verdict moves — `compute_instance_has_security_group` on Exoscale live,
+  `not-evaluated` → `pass`, and that `pass` is proven: all four instances carry the
+  attribute, and the only empty one is private (#212). Confirmed end to end by two real
+  qualification runs, Exoscale and Outscale, both GO.
+
 - **The roadmap announced a version the project had left behind.** `ROADMAP.md` still
   said *"Where Pépin stands, v0.2.0"* two releases later. For most projects that is a
   detail; for one whose whole claim is that no assertion is worth more than what was

--- a/cmd/collected_test.go
+++ b/cmd/collected_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import "testing"
+
+// Une valeur VIDE qui est arrivée est-elle une observation ?
+//
+// Le défaut mesuré (issue #227), sur le tenant de qualification Exoscale. Le tenant
+// contient, délibérément, une instance SANS aucun groupe de sécurité — l'écart même que
+// `compute_instance_has_security_group` existe pour attraper. Le scan a rendu
+// `not-evaluated`, en disant :
+//
+//	attribute "security_group_ids" not collected on the resources of type
+//	"compute_instance" (capability guard)
+//
+// L'inventaire scellé de ce run portait pourtant `security_group_ids: []` sur cette
+// instance. `collected` comptait une liste vide pour non collectée ; l'intersection
+// retirait alors l'attribut de TOUT le type, et le contrôle perdait sa capacité à
+// conclure. La ressource fautive faisait taire le contrôle qui la visait — le motif
+// que cette vague a corrigé quatre fois dans les règles, une cinquième fois ici.
+//
+// Pourquoi cette réponse n'était pas gratuite. Elle défendait un vrai risque :
+// `IAMPolicyStatements` posait `[]` aussi bien pour « ce document n'a pas pu être
+// analysé » que pour « cette politique n'accorde rien ». Compter ce `[]` comme une
+// collecte aurait rouvert l'incident fondateur de l'ADR-0006 — une policy `Action:*`
+// échappant à tous les contrôles `iam_policy_*`. Le bouchon a donc été retiré à la
+// SOURCE : le parseur rend `nil` quand il n'a pas su lire, et les collecteurs OMETTENT
+// alors l'attribut. Apprendre au verrou à tolérer un bouchon aurait été la mauvaise
+// direction ; le supprimer est la bonne.
+//
+// La frontière que ce test grave : la PRÉSENCE décide, pas le remplissage. Une liste
+// vide énumère complètement, et compte zéro.
+func TestAnObservedEmptyValueIsCollected(t *testing.T) {
+	cas := []struct {
+		nom    string
+		valeur any
+		veut   bool
+		motif  string
+	}{
+		{"une liste pleine", []any{"sg-1"}, true, ""},
+		{
+			"une liste VIDE", []any{}, true,
+			"« aucun groupe de sécurité » est une information, et c'est celle que le contrôle cherche",
+		},
+		{
+			"une table VIDE", map[string]any{}, true,
+			"« aucune étiquette » est une observation, pas une lacune de collecte",
+		},
+		{"une table pleine", map[string]any{"env": "prod"}, true, ""},
+		{"une chaîne vide", "", true, "la source a répondu, et sa réponse est vide"},
+		{"un faux booléen", false, true, "`false` est une valeur, pas une absence"},
+		{"un zéro", float64(0), true, "`0` est une valeur, pas une absence"},
+		{
+			"nil", nil, false,
+			"un scalaire nul n'énumère rien : il ne permet pas de distinguer absent d'inconnu",
+		},
+	}
+	for _, c := range cas {
+		if got := collected(c.valeur); got != c.veut {
+			t.Errorf("%s : collected(%#v) = %v, attendu %v.\n  %s",
+				c.nom, c.valeur, got, c.veut, c.motif)
+		}
+	}
+}
+
+// Le bout de chaîne qui compte vraiment : l'INTERSECTION par type.
+//
+// `collected` seul ne dit rien de ce qu'un contrôle pourra conclure. C'est
+// `attrsByTypeOf` qui décide, et c'est là que la ressource fautive faisait le dégât :
+// une seule liste vide suffisait à retirer l'attribut de tout le type, donc à faire
+// taire le contrôle sur les ressources VOISINES autant que sur elle.
+func TestOneEmptyValueNoLongerBlindsItsWholeType(t *testing.T) {
+	res := func(typ, id string, attrs map[string]any) map[string]any {
+		return map[string]any{"type": typ, "id": id, "name": id, "attributes": attrs}
+	}
+	// Le tenant Exoscale, dans sa forme mesurée : deux instances avec un groupe, une
+	// sans — celle qui est fautive.
+	inv := map[string]any{"resources": []any{
+		res("compute_instance", "avec-1", map[string]any{"security_group_ids": []any{"sg-1"}}),
+		res("compute_instance", "avec-2", map[string]any{"security_group_ids": []any{"sg-2"}}),
+		res("compute_instance", "sans", map[string]any{"security_group_ids": []any{}}),
+	}}
+	if !attrsByTypeOf(inv)["compute_instance"]["security_group_ids"] {
+		t.Error("une instance SANS groupe retire encore l'attribut de tout son type — " +
+			"le contrôle qui la vise ne peut plus conclure (#227)")
+	}
+
+	// LE CONTRE-EXEMPLE, et il vaut autant : un attribut réellement ABSENT d'une
+	// ressource doit toujours fermer la porte. Sans lui, ce correctif ouvrirait la voie
+	// à un `pass` que rien n'établit — le seul défaut que l'ADR-0006 interdit.
+	partiel := map[string]any{"resources": []any{
+		res("compute_instance", "porte", map[string]any{"deletion_protection": true}),
+		res("compute_instance", "porte-pas", map[string]any{}),
+	}}
+	if attrsByTypeOf(partiel)["compute_instance"]["deletion_protection"] {
+		t.Error("un attribut absent d'une ressource compte comme collecté pour le type — " +
+			"c'est l'union que l'intersection existe pour empêcher")
+	}
+
+	// Et un `nil` explicite ne vaut pas mieux qu'une absence : il ne dit pas ce que la
+	// valeur est.
+	nul := map[string]any{"resources": []any{
+		res("compute_instance", "a", map[string]any{"encrypted": true}),
+		res("compute_instance", "b", map[string]any{"encrypted": nil}),
+	}}
+	if attrsByTypeOf(nul)["compute_instance"]["encrypted"] {
+		t.Error("un `nil` compte comme collecté : un scalaire nul n'établit rien")
+	}
+}

--- a/cmd/fuzz_test.go
+++ b/cmd/fuzz_test.go
@@ -14,8 +14,27 @@ import (
 // attrsByTypeOf alimente le verrou de capacité, celui qui autorise ou non un
 // « pass ». Une panique y ferait tomber le scan sur une entrée choisie par
 // l'audité ; une lecture trop permissive lui ferait affirmer une conformité
-// jamais mesurée. Les deux sont couverts ici : pas de panique, et un attribut
-// n'est jamais compté comme collecté si sa valeur est une collection vide.
+// jamais mesurée.
+//
+// L'INVARIANT A CHANGÉ AVEC L'ISSUE #227, et la raison mérite d'être écrite parce
+// qu'elle explique pourquoi un test de fuzzing peut devenir faux.
+//
+// Il disait : une collection VIDE n'est jamais collectée. C'était un garde-fou par
+// PROCURATION. Ce qu'il protégeait réellement, c'est qu'un document de politique
+// illisible ne fasse pas conclure : `IAMPolicyStatements` rendait `[]` aussi bien pour
+// « ce document n'a pas pu être analysé » que pour « cette politique n'accorde rien »,
+// et le verrou se défendait en se méfiant de tous les vides. Le prix était lourd : une
+// instance SANS aucun groupe de sécurité — l'écart même qu'un contrôle cherche — faisait
+// taire ce contrôle, sur elle et sur ses voisines.
+//
+// Le bouchon a été retiré à la source : le parseur rend désormais `nil` quand il n'a pas
+// su lire, et les collecteurs OMETTENT alors l'attribut. Le verrou peut donc répondre sur
+// la PRÉSENCE, et ce test garde les deux propriétés qui tiennent vraiment :
+//
+//	nil n'est jamais collecté                      — un scalaire nul n'établit rien
+//	un attribut absent d'UNE ressource du type      — c'est l'intersection, et c'est elle
+//	n'est jamais collecté pour ce type                qui empêche l'union de faire conclure
+//	                                                  sur une ressource jamais observée
 func FuzzInventoryWalk(f *testing.F) {
 	for _, p := range []string{
 		"../examples/scaleway/inventory.json",
@@ -31,6 +50,13 @@ func FuzzInventoryWalk(f *testing.F) {
 	f.Add([]byte(`{"resources":[{"type":"bucket","attributes":null}]}`))
 	f.Add([]byte(`{"resources":[{"type":"bucket","attributes":"boom"}]}`))
 	f.Add([]byte(`{"resources":[{"type":123,"attributes":{"acl":[]}}]}`))
+	// #227 : une liste vide OBSERVÉE, et une ressource voisine qui porte la même clé.
+	f.Add([]byte(`{"resources":[{"type":"vm","attributes":{"sg":[]}},{"type":"vm","attributes":{"sg":["a"]}}]}`))
+	// Une valeur NULLE explicite : elle ne dit pas ce que la valeur est, seulement
+	// qu'il n'y en a pas — absent et inconnu s'y confondent, donc elle n'établit rien.
+	f.Add([]byte(`{"resources":[{"type":"vm","attributes":{"sg":null}}]}`))
+	// Et le contre-exemple : la clé manque à une ressource du même type.
+	f.Add([]byte(`{"resources":[{"type":"vm","attributes":{"sg":[]}},{"type":"vm","attributes":{}}]}`))
 	f.Add([]byte(`[]`))
 	f.Add([]byte(`null`))
 	f.Add([]byte(`"chaine"`))
@@ -45,10 +71,6 @@ func FuzzInventoryWalk(f *testing.F) {
 		_ = resourceTypesOf(input)
 		attrs := attrsByTypeOf(input)
 
-		// Le verrou de capacité repose sur une propriété précise : une valeur
-		// vide n'est PAS une collecte. C'est ce qui empêche `statements: []`,
-		// toujours posé par le collecteur IAM, de faire conclure « conforme »
-		// sur zéro information. On la vérifie ici sur des entrées arbitraires.
 		m, ok := input.(map[string]any)
 		if !ok {
 			return
@@ -57,6 +79,8 @@ func FuzzInventoryWalk(f *testing.F) {
 		if !ok {
 			return
 		}
+		// Les ressources par type, telles que l'entrée les donne.
+		parType := map[string][]map[string]any{}
 		for _, it := range rs {
 			rm, ok := it.(map[string]any)
 			if !ok {
@@ -66,23 +90,47 @@ func FuzzInventoryWalk(f *testing.F) {
 			if !ok || typ == "" {
 				continue
 			}
+			// Une ressource porteuse de PROVENANCE sort du test : un attribut absent des
+			// `attributes` mais attesté a été CHERCHÉ, et le verrou le compte à ce titre
+			// (ADR-0007). Le mesurer ici demanderait de réimplémenter cette règle, donc
+			// de tester le test.
+			if _, atteste := rm["provenance"]; atteste {
+				continue
+			}
+			if _, atteste := m["provenance"]; atteste {
+				return
+			}
 			am, ok := rm["attributes"].(map[string]any)
 			if !ok {
 				continue
 			}
-			for k, v := range am {
-				switch vv := v.(type) {
-				case []any:
-					if len(vv) == 0 && attrs[typ][k] {
-						t.Fatalf("attribut %q de type %q compté comme collecté alors qu'il est une liste vide", k, typ)
-					}
-				case map[string]any:
-					if len(vv) == 0 && attrs[typ][k] {
-						t.Fatalf("attribut %q de type %q compté comme collecté alors qu'il est un objet vide", k, typ)
-					}
-				case nil:
-					if attrs[typ][k] {
+			parType[typ] = append(parType[typ], am)
+		}
+
+		for typ, ressources := range parType {
+			for _, am := range ressources {
+				for k, v := range am {
+					// `nil` n'établit rien : un scalaire nul ne dit pas ce que la valeur
+					// est, seulement qu'il n'y en a pas — absent et inconnu s'y confondent.
+					if v == nil && attrs[typ][k] {
 						t.Fatalf("attribut %q de type %q compté comme collecté alors qu'il est nul", k, typ)
+					}
+				}
+			}
+			// L'INTERSECTION : un attribut qu'une seule ressource du type ne porte pas
+			// n'est pas collecté POUR CE TYPE. C'est ce qui empêche une ressource
+			// porteuse d'ouvrir la porte du `pass` à ses voisines jamais observées.
+			for _, am := range ressources {
+				for k := range am {
+					manquant := false
+					for _, autre := range ressources {
+						if _, present := autre[k]; !present {
+							manquant = true
+							break
+						}
+					}
+					if manquant && attrs[typ][k] {
+						t.Fatalf("attribut %q de type %q compté comme collecté alors qu'une ressource de ce type ne le porte pas — c'est l'union, pas l'intersection", k, typ)
 					}
 				}
 			}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -885,15 +885,39 @@ func resourceTypesOf(input any) map[string]bool {
 // `false`, `0` et `""` sont en revanche des informations parfaitement valides
 // (`encrypted: false` est justement ce qu'un contrôle cherche) : seules les
 // collections vides et les valeurs absentes comptent comme non collectées.
+// collected répond à UNE question : cette donnée est-elle arrivée ?
+//
+// La réponse se lit sur la PRÉSENCE, jamais sur le remplissage. Une liste vide qui est
+// arrivée est une énumération complète qui compte zéro — « cette instance n'a aucun
+// groupe de sécurité » est une information, et c'est même exactement celle que
+// `compute_instance_has_security_group` cherche.
+//
+// Le défaut que ce choix corrige (issue #227). `[]` comptait pour non collecté ;
+// l'intersection retirait alors l'attribut de TOUT le type, et le contrôle rendait
+// `not-evaluated`. Autrement dit la ressource fautive — la seule dont la liste est
+// vide — faisait taire le contrôle qui la visait. Mesuré sur le tenant de
+// qualification Exoscale : une instance sans aucun groupe, et pas un mot.
+//
+// Pourquoi c'est SÛR, et c'est la question qui décidait. Le risque serait qu'un
+// collecteur émette `[]` en BOUCHON, là où il n'a rien lu : on transformerait alors un
+// `not-evaluated` honnête en `pass` que rien n'établit — le seul défaut que l'ADR-0006
+// interdit. Ce risque est déjà écarté à la source : `collect.Project` ne projette PAS
+// une clé absente de la réponse, et ne fabrique une collection vide que si la clé est
+// là (`TestProjectDistinguishesAbsentFromEmptyCollection`, motivé par le faux positif
+// CRITICAL qu'un `[]` fabriqué produisait sur un plan Terraform). Un vide qui atteint
+// l'inventaire vient donc toujours de la source.
+//
+// `nil` reste non collecté, et la frontière est là. Une collection vide énumère ; un
+// scalaire nul n'énumère rien — il dit « pas de valeur », ce qui ne permet pas de
+// décider si la propriété est absente ou inconnue. En rester à la présence pour les
+// collections et à la valeur pour les scalaires est la ligne la plus étroite qui
+// rende la capacité perdue.
 func collected(v any) bool {
-	switch t := v.(type) {
+	switch v.(type) {
 	case nil:
 		return false
-	case []any:
-		return len(t) > 0
-	case map[string]any:
-		return len(t) > 0
 	default:
+		// Y COMPRIS `[]any{}` et `map[string]any{}` : présents, donc observés.
 		return true
 	}
 }

--- a/internal/collect/engine.go
+++ b/internal/collect/engine.go
@@ -654,18 +654,37 @@ func splitRange(s string) (int64, int64, bool) {
 // format de statements (ex. Outscale EIM).
 // IAMPolicyStatements expose le parseur pour les collecteurs Go qui doivent normaliser
 // un document de politique hors du moteur YAML (ex. policies EIM inline, chaîne à 3 niveaux).
+//
+// REND `nil` QUAND IL N'A PAS SU LIRE, et une liste vide quand il a lu ZÉRO statement.
+// Les deux cas se confondaient en `[]`, et c'est le défaut fondateur de l'issue #227 :
+// un document illisible ressemblait trait pour trait à une politique qui n'accorde
+// rien. Le verrou de capacité s'en défendait en traitant TOUTE liste vide comme non
+// collectée — au prix d'un contrôle rendu muet sur une liste vide légitimement
+// observée, par exemple une instance sans aucun groupe de sécurité.
+//
+// L'appelant DOIT omettre l'attribut quand ce parseur rend `nil`, jamais le poser à
+// nil : c'est le contrat de `Project`, où une clé absente de la source n'est pas
+// projetée. Un attribut posé à une liste nil franchirait la garde de capacité.
 func IAMPolicyStatements(v any) []any { return iamPolicyStatements(v) }
 
 func iamPolicyStatements(v any) []any {
 	doc, ok := v.(string)
 	if !ok || doc == "" {
-		return []any{}
+		return nil // rien à lire
 	}
 	var parsed struct {
 		Statement json.RawMessage `json:"Statement"`
 	}
+	// Un document qui ne s'analyse pas, ou dont la grammaire IAM n'a pas son
+	// `Statement` obligatoire, n'a pas été LU : ce n'est pas une politique vide.
 	if json.Unmarshal([]byte(doc), &parsed) != nil || len(parsed.Statement) == 0 {
-		return []any{}
+		return nil
+	}
+	// `"Statement": null` n'est ni un tableau ni un objet : la grammaire IAM ne l'admet
+	// pas, donc le document n'a pas été lu. Sans ce cas, il se décodait en tranche nil
+	// puis ressortait en `[]` — le bouchon, par une autre porte.
+	if string(parsed.Statement) == "null" {
+		return nil
 	}
 	// La grammaire des policies IAM admet Statement comme TABLEAU ou comme OBJET unique : sans gérer le
 	// second cas, json.Unmarshal échouait et renvoyait [] -> toutes les règles iam_policy
@@ -674,7 +693,7 @@ func iamPolicyStatements(v any) []any {
 	if json.Unmarshal(parsed.Statement, &stmts) != nil {
 		var one map[string]any
 		if json.Unmarshal(parsed.Statement, &one) != nil {
-			return []any{}
+			return nil // ni tableau ni objet : illisible
 		}
 		stmts = []map[string]any{one}
 	}
@@ -899,7 +918,14 @@ func applyTransform(v any, spec any) any {
 			_, to := splitPortRange(v)
 			return to
 		case "iampolicy":
-			return iamPolicyStatements(v)
+			st := iamPolicyStatements(v)
+			if st == nil {
+				// Un nil d'INTERFACE, pas une slice nil typée : c'est ce que
+				// `Project` teste pour ne pas projeter la clé. Rendre `st`
+				// directement poserait un `[]any(nil)` que `v == nil` ne voit pas.
+				return nil
+			}
+			return st
 		case "list":
 			if arr, ok := v.([]any); ok {
 				return arr // idempotent : déjà une liste

--- a/internal/collect/unreadable_policy_test.go
+++ b/internal/collect/unreadable_policy_test.go
@@ -1,0 +1,85 @@
+package collect
+
+import "testing"
+
+// Un document de politique ILLISIBLE n'est pas une politique à zéro statement.
+//
+// Le défaut fondateur de l'issue #227, à sa racine. `iamPolicyStatements` rendait `[]`
+// dans les deux cas, et un `[]` est indiscernable d'une observation. Le verrou de
+// capacité s'en défendait en traitant TOUTE liste vide comme non collectée — ce qui
+// protégeait bien l'incident fondateur de l'ADR-0006 (une policy `Action:*` échappant
+// à tous les contrôles `iam_policy_*`), mais au prix d'un contrôle rendu muet sur une
+// liste vide légitimement observée, ailleurs, sur un tout autre type de ressource.
+//
+// Le bouchon disparaît donc à la SOURCE. Une fois qu'un vide qui atteint l'inventaire
+// vient TOUJOURS de la source, le verrou peut répondre sur la présence.
+func TestAnUnreadablePolicyIsNotAnEmptyOne(t *testing.T) {
+	illisibles := []struct{ nom, doc string }{
+		{"chaîne vide", ""},
+		{"JSON invalide", "{ceci n'est pas du JSON"},
+		{"JSON valide sans Statement", `{"Version":"2012-10-17"}`},
+		{"Statement ni tableau ni objet", `{"Statement":"Allow *"}`},
+		{"Statement nul", `{"Statement":null}`},
+	}
+	for _, c := range illisibles {
+		if got := IAMPolicyStatements(c.doc); got != nil {
+			t.Errorf("%s : rendu %#v, attendu nil.\n"+
+				"  Un document qu'on n'a pas su lire doit se déclarer non lu, sinon il\n"+
+				"  ressemble à une politique qui n'accorde rien — et le contrôle conclut\n"+
+				"  « conforme » sur zéro information (ADR-0006).", c.nom, got)
+		}
+	}
+
+	// Une valeur qui n'est même pas une chaîne : rien à lire non plus.
+	if got := IAMPolicyStatements(42); got != nil {
+		t.Errorf("valeur non textuelle : rendu %#v, attendu nil", got)
+	}
+
+	// LE CONTRE-EXEMPLE : un document qui S'ANALYSE et porte zéro statement est une
+	// observation, et doit se distinguer de l'illisible. Sans lui, ce correctif serait
+	// juste un « rendre nil partout », qui perdrait l'information inverse.
+	vide := IAMPolicyStatements(`{"Statement":[]}`)
+	if vide == nil {
+		t.Error("`{\"Statement\":[]}` rend nil : une politique analysée qui n'accorde rien " +
+			"est une OBSERVATION, pas un échec de lecture")
+	}
+	if len(vide) != 0 {
+		t.Errorf("`{\"Statement\":[]}` rend %d statement(s), attendu 0", len(vide))
+	}
+
+	// Et le cas nominal ne bouge pas.
+	plein := IAMPolicyStatements(`{"Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]}`)
+	if len(plein) != 1 {
+		t.Fatalf("document nominal : %d statement(s), attendu 1", len(plein))
+	}
+	st, ok := plein[0].(map[string]any)
+	if !ok || st["effect"] != "Allow" {
+		t.Errorf("statement mal normalisé : %#v", plein[0])
+	}
+}
+
+// Le contrat que l'appelant doit tenir : un document illisible ne projette PAS la clé.
+//
+// C'est la moitié qui décide. Poser `statements` à une liste nil franchirait la garde
+// de capacité aussi sûrement qu'un `[]`, et le parseur aurait été corrigé pour rien.
+func TestAnUnreadablePolicyProjectsNoAttributeAtAll(t *testing.T) {
+	mapping := map[string]string{"statements": "Body"}
+	transforms := map[string]any{"statements": "iampolicy"}
+
+	illisible := Project(map[string]any{"Body": "{pas du JSON"}, mapping, transforms)
+	if _, present := illisible["statements"]; present {
+		t.Errorf("document illisible : la clé est projetée (%#v) — la garde de capacité "+
+			"s'ouvrira sur du vide", illisible["statements"])
+	}
+
+	// Analysé et vide : la clé EST projetée, parce que « cette politique n'accorde
+	// rien » est une information que les règles doivent pouvoir juger.
+	vide := Project(map[string]any{"Body": `{"Statement":[]}`}, mapping, transforms)
+	got, present := vide["statements"]
+	if !present {
+		t.Fatal("politique analysée et vide : la clé doit être projetée")
+	}
+	if arr, ok := got.([]any); !ok || len(arr) != 0 {
+		t.Errorf("attendu une liste vide, got %#v", got)
+	}
+}

--- a/internal/eimpolicy/eimpolicy.go
+++ b/internal/eimpolicy/eimpolicy.go
@@ -77,18 +77,26 @@ func CollectInlinePolicies(ctx context.Context, hc *http.Client, provider, baseU
 				return nil, fmt.Errorf("ReadUserPolicy(%s/%s) : %w", user, name, err)
 			}
 			id := user + "/" + name
+			attrs := map[string]any{
+				"policy_name": name,
+				"policy_id":   id,
+				"owner_user":  user,
+				"scope":       "inline",
+			}
+			// Un document ILLISIBLE ne pose pas l'attribut (#227). Le poser à une liste
+			// vide le rendrait indiscernable d'une politique qui n'accorde rien, et
+			// c'est ce bouchon qui obligeait le verrou de capacité à se méfier de
+			// toutes les listes vides, y compris celles qu'un collecteur a vraiment
+			// observées. Une clé absente ferme la garde ; une clé vide la franchit.
+			if st := collect.IAMPolicyStatements(doc.PolicyDocument); st != nil {
+				attrs["statements"] = st
+			}
 			out = append(out, model.Resource{
-				Provider: provider,
-				Type:     "iam_policy",
-				ID:       id,
-				Name:     name,
-				Attributes: map[string]any{
-					"policy_name": name,
-					"policy_id":   id,
-					"owner_user":  user,
-					"scope":       "inline",
-					"statements":  collect.IAMPolicyStatements(doc.PolicyDocument),
-				},
+				Provider:   provider,
+				Type:       "iam_policy",
+				ID:         id,
+				Name:       name,
+				Attributes: attrs,
 				Provenance: inlineProvenance(baseURL+"/ReadUserPolicy", "PolicyDocument", "owner_user"),
 			})
 		}
@@ -114,18 +122,21 @@ func collectGroupPolicies(ctx context.Context, hc *http.Client, provider, baseUR
 		}
 		for _, pol := range policies {
 			id := "group/" + g + "/" + pol.Name
+			attrs := map[string]any{
+				"policy_name": pol.Name,
+				"policy_id":   id,
+				"owner_group": g,
+				"scope":       "inline_group",
+			}
+			if st := collect.IAMPolicyStatements(pol.Body); st != nil {
+				attrs["statements"] = st
+			}
 			out = append(out, model.Resource{
-				Provider: provider,
-				Type:     "iam_policy",
-				ID:       id,
-				Name:     pol.Name,
-				Attributes: map[string]any{
-					"policy_name": pol.Name,
-					"policy_id":   id,
-					"owner_group": g,
-					"scope":       "inline_group",
-					"statements":  collect.IAMPolicyStatements(pol.Body),
-				},
+				Provider:   provider,
+				Type:       "iam_policy",
+				ID:         id,
+				Name:       pol.Name,
+				Attributes: attrs,
 				Provenance: inlineProvenance(baseURL+"/ReadUserGroupPolicies", "Policies.Body", "owner_group"),
 			})
 		}

--- a/references/qualification/exoscale/expected.yaml
+++ b/references/qualification/exoscale/expected.yaml
@@ -154,11 +154,13 @@ controls:
     # C'est la direction sûre (ADR-0006), donc non bloquant — mais c'est une capacité
     # perdue, et #227 doit la rendre.
     live:
-      status: not-evaluated
-      known_defect:
-        issue: 227
-        class: coverage_gap
-        note: "une liste vide OBSERVÉE est comptée comme non collectée ; l'instance sans groupe retire l'attribut de tout son type"
+      # #227 CORRIGÉE : une liste vide OBSERVÉE compte désormais comme collectée, parce
+      # que le bouchon qui obligeait à s'en méfier a été retiré à la source (un document
+      # de politique illisible se déclare non lu, au lieu de rendre `[]`). Le contrôle
+      # retrouve donc sa capacité à conclure — et il conclut `pass` : les quatre
+      # instances portent leur attribut, et la seule à liste vide est PRIVÉE, donc hors
+      # de portée de la règle depuis #212. Rien à signaler, mesuré, plus supposé.
+      status: pass
     terraform: pass
 
   compute_instance_no_secrets_in_user_data:


### PR DESCRIPTION
Closes #227 — the **P0 of Wave 5**.

## The defect

The Exoscale qualification tenant contains, deliberately, an instance with **no security
group at all** — the very deviation `compute_instance_has_security_group` exists to
catch. The scan answered `not-evaluated`.

The sealed inventory of that run carried the data:

| instance | `security_group_ids` | `public_interface` |
|---|---|---|
| `c7f886e9-…` | `[]` | `false` |
| three others | `["sg-…"]` | `true` |

But an **observed empty list counted as not collected**, and the per-type intersection
then removed the attribute from every instance. The faulty resource blinded its own
control, and its neighbours with it.

## Why the obvious fix was wrong, and the fuzz corpus said so

Making `[]` count as collected re-opens **ADR-0006's founding incident**:
`IAMPolicyStatements` returned `[]` both for *"this document could not be parsed"* and
for *"this policy grants nothing"*. An inline `Action:*` policy would have escaped every
`iam_policy_*` control. `FuzzInventoryWalk` caught it on the first attempt, and
`internal/assess/assess.go` said so outright:

> `statements` est TOUJOURS posé par le collecteur, au besoin à `[]` … le verrou ne vaut
> que parce que `attrsByTypeOf` ne compte plus une collection vide comme collectée.

The behaviour was **load-bearing**, not an oversight.

## The fix: remove the placeholder at the source

An empty value is *sometimes* an observation and *sometimes* a placeholder — and which
one depends on the attribute, not its shape. Teaching the lock to tolerate placeholders
is the wrong direction.

1. `iamPolicyStatements` returns **nil when it could not read** — not a string, invalid
   JSON, no `Statement`, `Statement` neither array nor object, `Statement: null` — and an
   empty slice **only** when a parsed document holds zero statements.
2. The `iampolicy` transform returns an **interface** nil, which is what `Project` tests
   to skip the key. A typed nil slice would have been projected right past the guard.
3. The two Go collectors in `internal/eimpolicy` **omit** the attribute instead of
   posting an empty one. A key absent closes the guard; a key present and empty crosses
   it.
4. **Only then** does `collected()` answer on **presence**. An observed empty list is a
   complete enumeration that counts zero. `nil` still establishes nothing: a null scalar
   does not separate *absent* from *unknown*.

## The fuzz invariant is replaced, not deleted

It asserted *"an empty collection is never collected"* — a **proxy** for the placeholder.
It now asserts the two properties that actually hold:

- `nil` is never collected;
- an attribute missing from **one** resource of a type is never collected for that type —
  the intersection, which is what stops a bearing resource from opening a `pass` for
  neighbours nobody observed.

Three seeds added for the cases the issue names. Falsified: swapping the intersection for
a union turns it red, and so does making `nil` collected.

## Measured, twice, in that order

**Offline first**, re-scanning the three runs' sealed inventories and plans with both
binaries: **exactly one verdict moves**. `compute_instance_has_security_group` on
Exoscale live, `not-evaluated` → `pass` — and that `pass` is proven: all four instances
carry the attribute, the only empty one is private, and #212 keeps the rule rightly
silent on it.

**Then on real accounts**, because a correction is reconciled by a measurement and not by
a prediction:

| Run | Non-regression | Release | Destruction proven |
|---|---|---|---|
| exoscale | **GO** | **GO** | 15 families, no delta |
| outscale | **GO** | **GO** | 20 families, no delta |

Outscale is the one that matters here: its tenant carries the EIM policies whose parser
changed, including `Action:*`.

The `known_defect` pinned in the Exoscale expectation is lifted — which the runner gates
on its own, since a fixed defect left pinned makes it say NO-GO.

## Impact ADR

**ADR-0006** (never an unproven pass) is what the whole change is arranged around: the
capability lock keeps refusing to conclude on what was not observed, and it now stops
refusing to conclude on what *was*. **ADR-0014** (an absent datum is never fabricated)
is what the parser now honours — it declares "not read" instead of fabricating "empty".
**ADR-0007** (provenance attests a field was sought) is untouched and still supplies the
fallback. No ADR modified, none reopened.

## What remains of #227

The issue also asks for the absent/empty semantics to be **declared per attribute in the
provider contracts**. That is the second half, and it is a contract change with a
measurement per provider — filed as its own follow-up rather than smuggled into this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)