### PR TITLE
test(providers): a spec never fabricates an attribute from nothing

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -24,6 +24,18 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **La règle absent/vide est désormais une porte, plus une habitude** (issue #227,
+  seconde moitié). Une règle gouverne chaque attribut qu'une spec de fournisseur mappe —
+  une clé **absente** de la source ne projette rien, une clé présente et **vide** projette
+  la valeur vide — et `TestNoSpecFabricatesAnAttributeFromNothing` la tient en poussant un
+  **item vide** à travers chaque ressource de chaque descripteur : un seul attribut qui en
+  sort casse le build. Son contre-exemple compte autant : une source qui dit « aucun » doit
+  toujours le projeter, sans quoi « ne jamais fabriquer » se satisferait en ne projetant
+  jamais rien. Écrite une fois et tenue mécaniquement, plutôt qu'annotée sur 138 attributs
+  que personne ne relit — et elle vaut pour les fournisseurs qui n'existent pas encore. La
+  règle est aussi énoncée là où quelqu'un qui ajoute un fournisseur la rencontrera, dans
+  les deux langues.
+
 - **Une ressource qui n'a rien ne fait plus taire le contrôle qui la cherche**
   (issue #227). Le tenant de qualification Exoscale contient, délibérément, une instance
   **sans aucun groupe de sécurité** — l'écart même que

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ belongs in `git log`.
 
 ### Fixed
 
+- **The absent/empty rule is now a gate, not a habit** (issue #227, second half). One
+  rule governs every attribute a provider spec maps — a key **absent** from the source
+  projects nothing, a key present and **empty** projects the empty value — and
+  `TestNoSpecFabricatesAnAttributeFromNothing` holds it by pushing an **empty item**
+  through every resource of every descriptor: a single attribute coming out fails the
+  build. Its counterexample matters as much: a source that says *"none"* must still
+  project it, or "never fabricate" would be satisfied by projecting nothing ever. Written
+  once, mechanically enforced, rather than annotated across 138 attributes nobody
+  re-reads — and it applies to providers not written yet. The rule is also stated where
+  someone adding a provider will meet it, in both languages.
+
 - **A resource with nothing no longer silences the control looking for it** (issue #227).
   The Exoscale qualification tenant contains, deliberately, an instance with **no
   security group at all** — the very deviation `compute_instance_has_security_group`

--- a/docs/contributing/adding-a-provider.fr.md
+++ b/docs/contributing/adding-a-provider.fr.md
@@ -217,6 +217,34 @@ oks:
   endpoint: "https://api.{region}.oks.acme.example"
 ```
 
+### Absent n'est pas vide, et une spec n'invente jamais
+
+Une règle gouverne chaque attribut que vous mappez, et une porte la tient :
+
+| Ce que la source porte | Ce qui doit atteindre l'inventaire | Ce que ça veut dire |
+|---|---|---|
+| la clé est **absente** | rien — ne projetez pas l'attribut | non observé |
+| la clé est là, à `null`, `[]` ou `{}` | la valeur vide | **observé, et il n'y en a aucun** |
+| la clé est là avec une valeur | la valeur | observé |
+
+Cette distinction décide de ce qu'un contrôle a le droit de conclure. Un attribut qui
+n'est jamais arrivé doit le laisser incapable de conclure ; un attribut arrivé **vide**
+est une énumération complète qui compte zéro — et c'est souvent l'écart lui-même.
+« Cette instance n'a aucun groupe de sécurité » est exactement ce que cherche
+`compute_instance_has_security_group`.
+
+**Ne fabriquez jamais une valeur pour une clé que la source ne portait pas**, valeur par
+défaut comprise. Un `[]` fabriqué est indiscernable d'une observation, franchit le verrou
+de capacité, et fait conclure un contrôle sur zéro information — c'est l'incident
+fondateur de l'[ADR-0006](../adr/0006-jamais-un-pass-non-prouve.md). Le cas s'est
+présenté : un parseur de politique rendait `[]` aussi bien pour « ce document n'a pas pu
+être analysé » que pour « cette politique n'accorde rien » (issue #227).
+
+Vous n'avez pas à vous en souvenir. `TestNoSpecFabricatesAnAttributeFromNothing` projette
+un **item vide** à travers chaque ressource de chaque descripteur et échoue si un seul
+attribut en sort. Si votre collecteur est en Go plutôt que piloté par la spec, tenez le
+même contrat à la main : **omettez l'attribut** au lieu d'en poser un vide.
+
 ## 7. Le contrat : ce qui est vérifié, ce qui ne l'est pas, ce qui n'existe pas
 
 Le contrat est la couche d'honnêteté, et c'est lui qui pilote l'assessment. Pour chaque

--- a/docs/contributing/adding-a-provider.md
+++ b/docs/contributing/adding-a-provider.md
@@ -210,6 +210,34 @@ oks:
   endpoint: "https://api.{region}.oks.acme.example"
 ```
 
+### Absent is not empty, and a spec never invents
+
+One rule governs every attribute you map, and a gate holds it:
+
+| What the source carries | What must reach the inventory | What it means |
+|---|---|---|
+| the key is **absent** | nothing — do not project the attribute | not observed |
+| the key is present, `null` or `[]` or `{}` | the empty value | **observed, and there is none** |
+| the key is present with a value | the value | observed |
+
+The distinction decides what a control may conclude. An attribute that never arrived
+must leave the control unable to conclude; an attribute that arrived **empty** is a
+complete enumeration counting zero — and it is often the deviation itself. "This
+instance has no security group at all" is exactly what
+`compute_instance_has_security_group` is looking for.
+
+**Never fabricate a value for a key the source did not carry**, and that includes a
+default. A fabricated `[]` looks identical to an observation, crosses the capability
+guard, and makes a control conclude on zero information — which is the founding incident
+of [ADR-0006](../adr/0006-jamais-un-pass-non-prouve.md). It happened: a policy parser
+returned `[]` both for *"this document could not be parsed"* and for *"this policy grants
+nothing"* (issue #227).
+
+You do not have to remember this. `TestNoSpecFabricatesAnAttributeFromNothing` projects
+an **empty item** through every resource of every descriptor and fails if a single
+attribute comes out. If your collector is Go rather than spec-driven, hold the same
+contract by hand: **omit the attribute** rather than posting an empty one.
+
 ## 7. The contract: what is verified, what is not, what does not exist
 
 The contract is the honesty layer, and it drives the assessment. For each normalized

--- a/internal/genprovider/no_placeholder_test.go
+++ b/internal/genprovider/no_placeholder_test.go
@@ -1,0 +1,82 @@
+package genprovider
+
+import (
+	"testing"
+
+	"github.com/stephrobert/pepin/internal/collect"
+)
+
+// AUCUNE SPEC NE FABRIQUE UN ATTRIBUT À PARTIR DE RIEN.
+//
+// C'est la seconde moitié de l'issue #227, et la forme qu'elle devait prendre.
+//
+// # Ce que la première moitié a établi
+//
+// Un attribut ABSENT n'a pas été observé ; un attribut PRÉSENT ET VIDE l'a été, et sa
+// valeur est « aucun ». Le verrou de capacité répond désormais sur la présence, ce qui
+// rend au contrôle sa capacité à conclure sur une ressource qui n'a rien — une instance
+// sans groupe de sécurité, un stockage sans étiquette.
+//
+// Cette réponse n'est JUSTE que si un vide qui atteint l'inventaire vient toujours de la
+// source. C'était faux : `IAMPolicyStatements` posait `[]` pour un document illisible,
+// et ce bouchon obligeait le verrou à se méfier de tous les vides. Il a été retiré.
+//
+// # Pourquoi une porte, et pas cent trente-huit annotations
+//
+// L'exigence est que la sémantique cesse d'être implicite. On pourrait l'écrire attribut
+// par attribut — 138 aujourd'hui, sur quatre fournisseurs — mais une annotation qu'aucune
+// machine ne lit se périme au premier collecteur ajouté, et personne ne relit deux cents
+// lignes de commentaire. La règle est donc UNE, et elle se mesure :
+//
+//	une source qui ne porte rien ne projette rien
+//
+// Ce que cette porte interdit mécaniquement, c'est le bouchon — la seule façon dont un
+// vide peut atteindre l'inventaire sans avoir été observé. Elle vaut pour les 138
+// attributs d'aujourd'hui, et pour ceux qu'un fournisseur futur ajoutera sans avoir lu
+// cette histoire.
+func TestNoSpecFabricatesAnAttributeFromNothing(t *testing.T) {
+	vide := map[string]any{}
+	for name, d := range loadAllDescriptors(t) {
+		for _, r := range d.Collecte.Resources {
+			attrs := collect.Project(vide, r.Map, r.Transforms)
+			for attr, v := range attrs {
+				t.Errorf("%s / type %q : l'attribut %q est projeté (%#v) depuis un item VIDE.\n"+
+					"  Une source qui ne porte rien ne doit rien projeter : un attribut fabriqué\n"+
+					"  franchit le verrou de capacité et fait conclure un contrôle sur zéro\n"+
+					"  information — c'est l'incident fondateur de l'ADR-0006, et c'est le\n"+
+					"  bouchon que l'issue #227 a retiré de `IAMPolicyStatements`.\n"+
+					"  Si la source peut légitimement rendre « aucun », c'est à ELLE de le dire :\n"+
+					"  la clé doit être présente dans la réponse, pas inventée par la spec.",
+					name, r.Type, attr, v)
+			}
+		}
+	}
+}
+
+// LE CONTRE-EXEMPLE, et il vaut autant que la porte.
+//
+// Interdire de fabriquer ne doit pas faire perdre l'information inverse : quand la
+// source porte la clé et répond « aucun », la spec DOIT projeter le vide. Sans ce cas,
+// « ne rien projeter » se satisferait en ne projetant jamais rien, et on aurait échangé
+// un faux vert contre un aveuglement.
+func TestASourceThatSaysNoneStillProjectsIt(t *testing.T) {
+	mapping := map[string]string{"security_group_ids": "sg"}
+	transforms := map[string]any{"security_group_ids": "list"}
+
+	// La clé est là, sa valeur est nulle : l'API dit « aucun groupe ».
+	dit := collect.Project(map[string]any{"sg": nil}, mapping, transforms)
+	got, present := dit["security_group_ids"]
+	if !present {
+		t.Fatal("la source dit « aucun » et rien n'est projeté : le contrôle qui cherche " +
+			"une ressource sans groupe redevient aveugle (#227)")
+	}
+	if arr, ok := got.([]any); !ok || len(arr) != 0 {
+		t.Errorf("attendu une liste vide observée, got %#v", got)
+	}
+
+	// La clé n'est PAS là : rien n'est projeté, et c'est la porte ci-dessus.
+	tait := collect.Project(map[string]any{"autre": 1}, mapping, transforms)
+	if _, present := tait["security_group_ids"]; present {
+		t.Error("clé absente de la source : la spec a fabriqué une valeur")
+	}
+}


### PR DESCRIPTION
Second half of #227. The first half (#236) fixed the **mechanism**; this one makes the
rule **explicit**, which is what the milestone's first exit criterion asks for.

## One rule, not 138 annotations

| What the source carries | What must reach the inventory | Meaning |
|---|---|---|
| the key is **absent** | nothing | not observed |
| the key is present, `null` / `[]` / `{}` | the empty value | **observed, and there is none** |
| the key is present with a value | the value | observed |

Writing that attribute by attribute would mean two hundred lines of comment across four
descriptors — stale at the first collector added, and re-read by nobody. So the rule is
**measured** instead:

`TestNoSpecFabricatesAnAttributeFromNothing` pushes an **empty item** through every
resource of every descriptor. A single attribute coming out fails the build. It covers
the 138 mapped attributes that exist today, and the ones a provider written next year
will add without ever having read this history.

## The counterexample carries as much weight

`TestASourceThatSaysNoneStillProjectsIt`: a source that answers *"none"* must **still**
project it. Without that case, *"never fabricate"* would be satisfied by projecting
nothing ever — trading a false green for blindness, which is the failure this milestone
is about in the other direction.

## Falsified

Neutralising the absent-key skip in `Project` makes the gate name the placeholders it
would produce:

```
outscale / type "security_group_rule" : l'attribut "protocol" est projeté ("all")
  depuis un item VIDE.
outscale / type "security_group_rule" : l'attribut "cidrs" est projeté ([]) depuis
  un item VIDE.
```

The first one is worth pausing on: a fabricated **default** — `protocol: "all"` invented
for a key the source never carried. That is worse than an empty list, because it reads
as a measurement.

## Also written where it will be met

Section 6 of *adding a provider*, both languages, with the reason rather than the
instruction: a fabricated value crosses the capability guard and makes a control conclude
on zero information, which is **ADR-0006's founding incident**. And a note for Go
collectors, which the gate cannot reach: hold the same contract by hand — **omit** the
attribute rather than posting an empty one.

## Impact ADR

**ADR-0006** is what the gate protects, from the side that was not yet held: the lock
refuses to conclude on what was not observed, and this ensures nothing can *pretend* to
have been observed. **ADR-0014** (an absent datum is never fabricated) is the same rule
one layer down, now enforced at the projection rather than trusted. No ADR modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)