### PR TITLE
feat(scaleway): collect a security group's default policy, with no new call

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -22,6 +22,19 @@ l'une ni l'autre appartient au `git log`.
 
 ## [Non publié]
 
+### Ajouté
+
+- **Scaleway live : la politique par défaut d'un groupe de sécurité est collectée**
+  (issue #195). `network_securitygroup_default_deny` — sévérité `high` — revenait
+  `not-evaluated` sur la source live alors que la même faute était trouvée sur le plan.
+  La lacune n'était pas une API manquante : le collecteur **paginait déjà**
+  `/instance/v1/zones/{zone}/security_groups` pour joindre les règles à leur groupe, et
+  cette réponse portait `inbound_default_policy` depuis toujours. Personne ne la
+  projetait. Le contrat a été vérifié contre l'API réelle le 2026-09-11 avant d'écrire
+  une ligne, et le contrôle conclut désormais sur les deux sources — confirmé par un run
+  de qualification sur un compte réel, GO avec sa destruction prouvée. Le format
+  d'inventaire passe en `v10` : un ajout pur, le nouveau type `security_group`.
+
 ### Corrigé
 
 - **La règle absent/vide est désormais une porte, plus une habitude** (issue #227,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ belongs in `git log`.
 
 ## [Unreleased]
 
+### Added
+
+- **Scaleway live: a security group's default policy is now collected** (issue #195).
+  `network_securitygroup_default_deny` — severity `high` — came back `not-evaluated` on
+  the live source while the same fault was found on the plan. The gap was not a missing
+  API: the collector **already paginates** `/instance/v1/zones/{zone}/security_groups`
+  to join rules to their group, and that response has carried
+  `inbound_default_policy` all along. Nobody projected it. The contract was verified
+  against the real API on 2026-09-11 before a line was written, and the control now
+  concludes on both sources — confirmed by a qualification run on a real account, GO with
+  its destruction proven. The inventory format moves to `v10`: a pure addition, the new
+  `security_group` type.
+
 ### Fixed
 
 - **The absent/empty rule is now a gate, not a habit** (issue #227, second half). One

--- a/cmd/testdata/frozen/inventory.json
+++ b/cmd/testdata/frozen/inventory.json
@@ -2033,6 +2033,246 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 10,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "source": {
+                "file": "string",
+                "line": "number",
+                "module": "string"
+              },
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v10",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "creation_date",
+            "expiration_date",
+            "owner_user",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "state",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_interface",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud",
+            "secnumcloud_regions"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "provider_managed",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_interface": [
+            "nic_id",
+            "public_ip",
+            "security_group_ids",
+            "vm_id"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "description",
+            "inbound_default_policy",
+            "outbound_default_policy",
+            "security_group_id",
+            "tags"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "peer_security_group_ids",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
+        }
+      }
     }
   ]
 }

--- a/docs/concepts/terraform-vs-live.fr.md
+++ b/docs/concepts/terraform-vs-live.fr.md
@@ -283,7 +283,6 @@ couples, une source produit le type de ressource et son attribut décisif, et l'
 | `loadbalancer_logging_enabled` | outscale | live | cette source ne produit aucune ressource de type « load_balancer » |
 | `loadbalancer_ssl_listeners` | outscale | live | cette source ne produit aucune ressource de type « load_balancer » |
 | `network_peering_cross_organization` | outscale | live | cette source ne produit aucune ressource de type « network_peering » |
-| `network_securitygroup_default_deny` | scaleway | terraform | cette source ne produit aucune ressource de type « security_group » |
 | `network_securitygroup_default_restrict_traffic` | outscale | live | attribut décisif « security_group_name » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `objectstorage_bucket_default_encryption` | outscale | live | cette source ne produit aucune ressource de type « object_storage_bucket » |
 | `objectstorage_bucket_default_encryption` | scaleway | live | attribut décisif « default_encryption_enabled » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |

--- a/docs/concepts/terraform-vs-live.md
+++ b/docs/concepts/terraform-vs-live.md
@@ -278,7 +278,6 @@ source produces the resource type and its deciding attribute, and the other does
 | `loadbalancer_logging_enabled` | outscale | live | this source produces no resource of type "load_balancer" |
 | `loadbalancer_ssl_listeners` | outscale | live | this source produces no resource of type "load_balancer" |
 | `network_peering_cross_organization` | outscale | live | this source produces no resource of type "network_peering" |
-| `network_securitygroup_default_deny` | scaleway | terraform | this source produces no resource of type "security_group" |
 | `network_securitygroup_default_restrict_traffic` | outscale | live | deciding attribute "security_group_name" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `objectstorage_bucket_default_encryption` | outscale | live | this source produces no resource of type "object_storage_bucket" |
 | `objectstorage_bucket_default_encryption` | scaleway | live | deciding attribute "default_encryption_enabled" not projected by this source: a capability guard, so the scan returns "not-evaluated" |

--- a/docs/controls/network_securitygroup_default_deny.fr.md
+++ b/docs/controls/network_securitygroup_default_deny.fr.md
@@ -52,22 +52,20 @@ déclaré, ou type absent de cette source ».
 |---|:-:|:-:|
 | exoscale | ✗ | ✗ |
 | outscale | ✗ | ✗ |
-| scaleway | ✅ | ✗ |
+| scaleway | ✅ | ✅ |
 | kubernetes | sans objet | ✗ |
 
 Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
 porte son motif :
 
-| Fournisseur | Source | Statut | Motif |
-|---|---|---|---|
-| scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « security_group » |
+_Aucune : toutes les cases déclarées sont pleinement observables._
 
 ## Ce que Pépin peut conclure
 
 | Statut | Ce que le statut affirme | Atteignable depuis |
 |---|---|---|
-| `fail` | un écart a été détecté sur une ressource réelle | scaleway / terraform |
-| `pass` | la donnée décisive a été collectée, et elle est conforme | scaleway / terraform |
+| `fail` | un écart a été détecté sur une ressource réelle | scaleway / terraform · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | scaleway / terraform · scaleway / live |
 | `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
 | `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
 
@@ -99,6 +97,9 @@ tel quel, ou une note ancrée sur la documentation officielle. Voir
 ```bash
 # depuis un plan Terraform : aucune ressource n'est créée
 ./pepin scan scaleway --terraform plan.json --format assessment
+
+# depuis l'API du fournisseur : configuration effective
+./pepin scan scaleway --live --format assessment
 ```
 
 Dans la sortie `assessment`, chercher `"control": "network_securitygroup_default_deny"` : son `status` doit être

--- a/docs/controls/network_securitygroup_default_deny.md
+++ b/docs/controls/network_securitygroup_default_deny.md
@@ -51,22 +51,20 @@ source".
 |---|:-:|:-:|
 | exoscale | ✗ | ✗ |
 | outscale | ✗ | ✗ |
-| scaleway | ✅ | ✗ |
+| scaleway | ✅ | ✅ |
 | kubernetes | n/a | ✗ |
 
 Every cell that is not ✅ **while the control is declared for that provider** carries its
 reason:
 
-| Provider | Source | Status | Reason |
-|---|---|---|---|
-| scaleway | live | ✗ `unsupported` | this source produces no resource of type "security_group" |
+_None: every declared cell is fully observable._
 
 ## What Pépin can conclude
 
 | Status | What the status asserts | Reachable from |
 |---|---|---|
-| `fail` | a deviation was detected on a real resource | scaleway / terraform |
-| `pass` | the deciding data was collected, and it is compliant | scaleway / terraform |
+| `fail` | a deviation was detected on a real resource | scaleway / terraform · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | scaleway / terraform · scaleway / live |
 | `not-applicable` | the provider contract declares the control untestable, with its justification | — |
 | `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
 
@@ -98,6 +96,9 @@ is, or a note anchored on the official documentation. See
 ```bash
 # from a Terraform plan: nothing is provisioned
 ./pepin scan scaleway --terraform plan.json --format assessment
+
+# from the provider API: effective configuration
+./pepin scan scaleway --live --format assessment
 ```
 
 In the `assessment` output, look for `"control": "network_securitygroup_default_deny"`: its `status` must be `pass`.

--- a/docs/coverage.fr.md
+++ b/docs/coverage.fr.md
@@ -104,7 +104,7 @@ et le rapport le dit à chaque scan, contrôle par contrôle, avec le motif.
 | `network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports` | high | CLD-NET-1 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `network_securitygroup_allow_ingress_from_internet_to_tcp_port_22` | high | CLD-NET-1, CLD-IAM-6, CLD-NET-6 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389` | high | CLD-NET-1, CLD-IAM-6, CLD-NET-6 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `network_securitygroup_default_deny` | high | CLD-NET-2 | ✗ | ✗ | ✗ | ✗ | ✅ | ✗ |
+| `network_securitygroup_default_deny` | high | CLD-NET-2 | ✗ | ✗ | ✗ | ✗ | ✅ | ✅ |
 | `network_securitygroup_default_restrict_traffic` | high | CLD-NET-4 | ✗ | ✗ | ◐ | ✅ | ✗ | ✗ |
 | `network_securitygroup_unrestricted_egress` | medium | CLD-NET-4 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `network_subnet_no_public_ip_by_default` | medium | CLD-NET-3 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
@@ -180,7 +180,6 @@ ici : la matrice les montre déjà, et elles n'apprennent rien de plus.
 | `network_peering_cross_organization` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « network_peering » |
 | `network_securitygroup_allow_ingress_from_internet_to_all_ports` | exoscale | terraform | ∅ `not-applicable` | Une règle de security group Exoscale n'a pas de valeur « tous protocoles » : le schéma du provider (exoscale/exoscale 0.71.0, exoscale_security_group_rule.protocol) et l'API v2 (security-group-rule) n'acceptent que ah, esp, gre, icmp, icmpv6, ipip, tcp, udp. La conjonction any/any que ce contrôle mesure ne peut donc pas être déclarée, et les familles de ports (CLD-NET-1) couvrent le cas réel. |
 | `network_securitygroup_allow_ingress_from_internet_to_all_ports` | exoscale | live | ∅ `not-applicable` | Une règle de security group Exoscale n'a pas de valeur « tous protocoles » : le schéma du provider (exoscale/exoscale 0.71.0, exoscale_security_group_rule.protocol) et l'API v2 (security-group-rule) n'acceptent que ah, esp, gre, icmp, icmpv6, ipip, tcp, udp. La conjonction any/any que ce contrôle mesure ne peut donc pas être déclarée, et les familles de ports (CLD-NET-1) couvrent le cas réel. |
-| `network_securitygroup_default_deny` | scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « security_group » |
 | `network_securitygroup_default_restrict_traffic` | outscale | terraform | ◐ `partial` | attribut décisif « security_group_name » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `objectstorage_bucket_default_encryption` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « object_storage_bucket » |
 | `objectstorage_bucket_default_encryption` | scaleway | terraform | ◐ `partial` | attribut décisif « default_encryption_enabled » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
@@ -219,5 +218,5 @@ deux ne peut couvrir la portée de l'autre. Une seule source : la collecte live 
 | outscale | terraform | 17 | 4 | 4 | 33 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
-| scaleway | live | 17 | 3 | 2 | 36 |
+| scaleway | live | 18 | 3 | 2 | 35 |
 | kubernetes | live | 4 | 0 | 0 | 54 |

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -103,7 +103,7 @@ and the report says so on every scan, control by control, with the reason.
 | `network_securitygroup_allow_ingress_from_internet_to_high_risk_udp_ports` | high | CLD-NET-1 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `network_securitygroup_allow_ingress_from_internet_to_tcp_port_22` | high | CLD-NET-1, CLD-IAM-6, CLD-NET-6 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `network_securitygroup_allow_ingress_from_internet_to_tcp_port_3389` | high | CLD-NET-1, CLD-IAM-6, CLD-NET-6 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `network_securitygroup_default_deny` | high | CLD-NET-2 | ✗ | ✗ | ✗ | ✗ | ✅ | ✗ |
+| `network_securitygroup_default_deny` | high | CLD-NET-2 | ✗ | ✗ | ✗ | ✗ | ✅ | ✅ |
 | `network_securitygroup_default_restrict_traffic` | high | CLD-NET-4 | ✗ | ✗ | ◐ | ✅ | ✗ | ✗ |
 | `network_securitygroup_unrestricted_egress` | medium | CLD-NET-4 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `network_subnet_no_public_ip_by_default` | medium | CLD-NET-3 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
@@ -179,7 +179,6 @@ already shows them, and they add nothing.
 | `network_peering_cross_organization` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "network_peering" |
 | `network_securitygroup_allow_ingress_from_internet_to_all_ports` | exoscale | terraform | ∅ `not-applicable` | An Exoscale security group rule has no "all protocols" value: the provider schema (exoscale/exoscale 0.71.0, exoscale_security_group_rule.protocol) and the v2 API (security-group-rule) accept only ah, esp, gre, icmp, icmpv6, ipip, tcp, udp. The any/any conjunction this control measures cannot be expressed, and the port-family controls (CLD-NET-1) cover the real case. |
 | `network_securitygroup_allow_ingress_from_internet_to_all_ports` | exoscale | live | ∅ `not-applicable` | An Exoscale security group rule has no "all protocols" value: the provider schema (exoscale/exoscale 0.71.0, exoscale_security_group_rule.protocol) and the v2 API (security-group-rule) accept only ah, esp, gre, icmp, icmpv6, ipip, tcp, udp. The any/any conjunction this control measures cannot be expressed, and the port-family controls (CLD-NET-1) cover the real case. |
-| `network_securitygroup_default_deny` | scaleway | live | ✗ `unsupported` | this source produces no resource of type "security_group" |
 | `network_securitygroup_default_restrict_traffic` | outscale | terraform | ◐ `partial` | deciding attribute "security_group_name" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `objectstorage_bucket_default_encryption` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "object_storage_bucket" |
 | `objectstorage_bucket_default_encryption` | scaleway | terraform | ◐ `partial` | deciding attribute "default_encryption_enabled" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
@@ -218,5 +217,5 @@ the other's scope. One source only: live collection through a kubeconfig.
 | outscale | terraform | 17 | 4 | 4 | 33 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
-| scaleway | live | 17 | 3 | 2 | 36 |
+| scaleway | live | 18 | 3 | 2 | 35 |
 | kubernetes | live | 4 | 0 | 0 | 54 |

--- a/docs/detection-quality.fr.md
+++ b/docs/detection-quality.fr.md
@@ -16,7 +16,7 @@ pourcentage sans mesure derrière est un faux vert déplacé dans un tableau de
 bord, et il y est pire qu'ailleurs : personne ne relit un tableau de bord.
 
 Les chiffres sont donc laids, et c'est le point. « 58 contrôles » ne dit rien de
-la qualité d'une détection ; « 91 verdicts prouvés sur 457 » dit où en est le
+la qualité d'une détection ; « 94 verdicts prouvés sur 460 » dit où en est le
 produit, et rétrécit dans le bon sens à chaque scénario écrit.
 
 ## Les chiffres
@@ -24,10 +24,10 @@ produit, et rétrécit dans le bon sens à chaque scénario écrit.
 | Chiffre | Nombre |
 |---|---:|
 | Contrôles au référentiel | 58 |
-| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 181 |
-| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 30 |
-| Verdicts à prouver au total | 457 |
-| Verdicts prouvés | 91 |
+| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 182 |
+| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 31 |
+| Verdicts à prouver au total | 460 |
+| Verdicts prouvés | 94 |
 
 ## Couverture de véracité, par verdict
 
@@ -37,11 +37,11 @@ demanderait d'inventer une non-applicabilité.
 
 | Verdict | Ce qu'il met en scène | À prouver | Prouvés | % |
 |---|---|---:|---:|---:|
-| `fail` | une configuration vulnérable est détectée | 138 | 23 | 16 |
-| `pass` | une configuration réellement correcte est confirmée | 138 | 35 | 25 |
-| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 157 | 21 | 13 |
+| `fail` | une configuration vulnérable est détectée | 139 | 24 | 17 |
+| `pass` | une configuration réellement correcte est confirmée | 139 | 36 | 25 |
+| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 158 | 22 | 13 |
 | `not-applicable` | le contrat du fournisseur déclare le mécanisme inexistant | 24 | 12 | 50 |
-| **Total** | | **457** | **91** | **19** |
+| **Total** | | **460** | **94** | **20** |
 
 ## Validé en live
 
@@ -56,7 +56,7 @@ relevé authentifié, il montera tout seul.
 
 | Chiffre | Nombre |
 |---|---:|
-| Chemins dont la source est une collecte live | 102 |
+| Chemins dont la source est une collecte live | 103 |
 | Validé en live | **0 %** |
 
 ## Ce que les vrais plans de contrôle ont répondu

--- a/docs/detection-quality.md
+++ b/docs/detection-quality.md
@@ -16,7 +16,7 @@ with no measurement behind it is a false green moved into a dashboard, and it is
 worse there than anywhere else: nobody re-reads a dashboard.
 
 The figures are therefore ugly, and that is the point. "58 controls" says nothing
-about the quality of a detection; "91 verdicts proven out of 457" says where the
+about the quality of a detection; "94 verdicts proven out of 460" says where the
 product stands, and shrinks the right way with every scenario written.
 
 ## The figures
@@ -24,10 +24,10 @@ product stands, and shrinks the right way with every scenario written.
 | Figure | Count |
 |---|---:|
 | Controls in the reference | 58 |
-| Control x provider x source paths on which Pépin concludes | 181 |
-| Paths whose EVERY reachable verdict is proven end to end | 30 |
-| Verdicts to prove in total | 457 |
-| Verdicts proven | 91 |
+| Control x provider x source paths on which Pépin concludes | 182 |
+| Paths whose EVERY reachable verdict is proven end to end | 31 |
+| Verdicts to prove in total | 460 |
+| Verdicts proven | 94 |
 
 ## Veracity coverage, by verdict
 
@@ -37,11 +37,11 @@ inventing a non-applicability.
 
 | Verdict | What it stages | To prove | Proven | % |
 |---|---|---:|---:|---:|
-| `fail` | a vulnerable configuration is detected | 138 | 23 | 16 |
-| `pass` | a genuinely correct configuration is confirmed | 138 | 35 | 25 |
-| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 157 | 21 | 13 |
+| `fail` | a vulnerable configuration is detected | 139 | 24 | 17 |
+| `pass` | a genuinely correct configuration is confirmed | 139 | 36 | 25 |
+| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 158 | 22 | 13 |
 | `not-applicable` | the provider's contract declares the mechanism non-existent | 24 | 12 | 50 |
-| **Total** | | **457** | **91** | **19** |
+| **Total** | | **460** | **94** | **20** |
 
 ## Validated live
 
@@ -56,7 +56,7 @@ will rise on its own.
 
 | Figure | Count |
 |---|---:|
-| Paths whose source is a live collection | 102 |
+| Paths whose source is a live collection | 103 |
 | Validated live | **0 %** |
 
 ## What the real control planes answered

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -58,7 +58,7 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v9",
+  "inventory_schema": "pepin-inventory/v10",
   "disclaimer": "Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -56,7 +56,7 @@ raises a version number and gets a CHANGELOG line.
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v9",
+  "inventory_schema": "pepin-inventory/v10",
   "disclaimer": "This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -109,7 +109,6 @@ pas.
 | `loadbalancer_logging_enabled` | outscale | live | cette source ne produit aucune ressource de type « load_balancer » |
 | `loadbalancer_ssl_listeners` | outscale | live | cette source ne produit aucune ressource de type « load_balancer » |
 | `network_peering_cross_organization` | outscale | live | cette source ne produit aucune ressource de type « network_peering » |
-| `network_securitygroup_default_deny` | scaleway | terraform | cette source ne produit aucune ressource de type « security_group » |
 | `network_securitygroup_default_restrict_traffic` | outscale | live | attribut décisif « security_group_name » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `objectstorage_bucket_default_encryption` | outscale | live | cette source ne produit aucune ressource de type « object_storage_bucket » |
 | `objectstorage_bucket_default_encryption` | scaleway | live | attribut décisif « default_encryption_enabled » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
@@ -154,7 +153,7 @@ Par fournisseur et par source, sur l'ensemble des contrôles du référentiel :
 | outscale | terraform | 17 | 4 | 4 | 33 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
-| scaleway | live | 17 | 3 | 2 | 36 |
+| scaleway | live | 18 | 3 | 2 | 35 |
 | kubernetes | live | 4 | 0 | 0 | 54 |
 <!-- /pepin:gen coverage-totals -->
 
@@ -208,9 +207,9 @@ Ce qui n'est pas encore prouvé est **compté**, pas masqué :
 <!-- pepin:gen veracity-debt -->
 | Chiffre | Nombre |
 |---|---:|
-| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 181 |
-| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 30 |
-| Verdicts à prouver au total | 457 |
+| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 182 |
+| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 31 |
+| Verdicts à prouver au total | 460 |
 | Verdicts restant à prouver | 366 |
 <!-- /pepin:gen veracity-debt -->
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -110,7 +110,6 @@ actually decide them. The reason given is the one that applies to the source tha
 | `loadbalancer_logging_enabled` | outscale | live | this source produces no resource of type "load_balancer" |
 | `loadbalancer_ssl_listeners` | outscale | live | this source produces no resource of type "load_balancer" |
 | `network_peering_cross_organization` | outscale | live | this source produces no resource of type "network_peering" |
-| `network_securitygroup_default_deny` | scaleway | terraform | this source produces no resource of type "security_group" |
 | `network_securitygroup_default_restrict_traffic` | outscale | live | deciding attribute "security_group_name" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `objectstorage_bucket_default_encryption` | outscale | live | this source produces no resource of type "object_storage_bucket" |
 | `objectstorage_bucket_default_encryption` | scaleway | live | deciding attribute "default_encryption_enabled" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
@@ -154,7 +153,7 @@ Per provider and per source, over all controls in the reference:
 | outscale | terraform | 17 | 4 | 4 | 33 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
-| scaleway | live | 17 | 3 | 2 | 36 |
+| scaleway | live | 18 | 3 | 2 | 35 |
 | kubernetes | live | 4 | 0 | 0 | 54 |
 <!-- /pepin:gen coverage-totals -->
 
@@ -208,9 +207,9 @@ What is not yet proven is **counted**, not hidden:
 <!-- pepin:gen veracity-debt -->
 | Figure | Count |
 |---|---:|
-| Control x provider x source paths on which Pépin concludes | 181 |
-| Paths whose every reachable verdict is proven end to end | 30 |
-| Verdicts to prove in total | 457 |
+| Control x provider x source paths on which Pépin concludes | 182 |
+| Paths whose every reachable verdict is proven end to end | 31 |
+| Verdicts to prove in total | 460 |
 | Verdicts left to prove | 366 |
 <!-- /pepin:gen veracity-debt -->
 

--- a/docs/providers/scaleway.fr.md
+++ b/docs/providers/scaleway.fr.md
@@ -65,6 +65,7 @@ clé en lecture seule doit couvrir.
 | `access_key` | `GET /iam/v1alpha1/api-keys?organization_id={org}` | — |
 | `compute_instance` | `GET /instance/v1/zones/{zone}/servers` | — |
 | `iam_user` | `GET /iam/v1alpha1/users?organization_id={org}` | — |
+| `security_group` | `GET /instance/v1/zones/{zone}/security_groups` | — |
 | `security_group_rule` | `GET /instance/v1/zones/{zone}/security_groups` | liste parente d'une jointure (appelée en premier) |
 | `security_group_rule` | `GET /instance/v1/zones/{zone}/security_groups/{sg.id}/rules` | — |
 | `object_storage_bucket` | `https://s3.{region}.scw.cloud` | API S3 du stockage objet (collecteur Go) |
@@ -96,12 +97,14 @@ API de fournisseur.
 |---|---|:-:|---|
 | `access_key` | `IAMReadOnly (Organization scope)` | oui | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
 | `iam_user` | `IAMReadOnly (Organization scope)` | oui | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
+| `security_group` | `InstancesReadOnly (Project scope)` | oui | scaleway/docs-content — pages/iam/reference-content/permission-sets.md |
 | `security_group_rule` | `InstancesReadOnly (Project scope)` | oui | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
 | `compute_instance` | `InstancesReadOnly (Project scope)` | oui | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
 | `object_storage_bucket` | `ObjectStorageReadOnly (Project scope)` | non | scaleway/docs-content — pages/object-storage/reference-content/s3-iam-permissions-equivalence.mdx |
 
 **Réserves, dites plutôt que masquées.**
 
+- **`security_group`** — Le MÊME appel que `security_group_rule` : `ListSecurityGroups` sert de jointure parent pour les règles et porte, dans la même réponse, la politique par défaut du groupe. Aucun droit supplémentaire.
 - **`object_storage_bucket`** — Couvre ListBuckets, GetBucketAcl, GetBucketVersioning, GetBucketTagging et GetObjectLockConfiguration. GetBucketPolicy et GetBucketEncryption n'apparaissent dans AUCUN jeu de permissions en lecture seule de la table d'équivalence : le droit qui les accorde n'a pas pu être établi, et il n'est pas deviné. Les deux appels sont best effort — un 403 coûte de la couverture, jamais de la justesse.
 <!-- /pepin:gen provider-scaleway-permissions -->
 
@@ -157,7 +160,7 @@ pepin scan scaleway --terraform plan.json
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
 | terraform | 17 | 8 | 2 | 31 |
-| live | 17 | 3 | 2 | 36 |
+| live | 18 | 3 | 2 | 35 |
 <!-- /pepin:gen provider-scaleway-coverage -->
 
 Contrôle par contrôle, avec le motif de chaque case qui n'est pas pleinement supportée, la
@@ -187,7 +190,6 @@ fournisseur.
 | `database_service_not_open_to_internet` | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `iam_policy_no_privilege_escalation` | terraform | cette source ne produit aucune ressource de type « iam_policy » |
 | `iam_user_mfa_enabled` | live | cette source ne produit aucune ressource de type « iam_user » |
-| `network_securitygroup_default_deny` | terraform | cette source ne produit aucune ressource de type « security_group » |
 | `objectstorage_bucket_default_encryption` | live | attribut décisif « default_encryption_enabled » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `objectstorage_bucket_kms_encryption` | live | attribut décisif « sse_kms_enabled » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `objectstorage_bucket_versioning_enabled` | live | attribut décisif « versioning » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |

--- a/docs/providers/scaleway.md
+++ b/docs/providers/scaleway.md
@@ -65,6 +65,7 @@ key has to cover.
 | `access_key` | `GET /iam/v1alpha1/api-keys?organization_id={org}` | — |
 | `compute_instance` | `GET /instance/v1/zones/{zone}/servers` | — |
 | `iam_user` | `GET /iam/v1alpha1/users?organization_id={org}` | — |
+| `security_group` | `GET /instance/v1/zones/{zone}/security_groups` | — |
 | `security_group_rule` | `GET /instance/v1/zones/{zone}/security_groups` | parent listing of a join (called first) |
 | `security_group_rule` | `GET /instance/v1/zones/{zone}/security_groups/{sg.id}/rules` | — |
 | `object_storage_bucket` | `https://s3.{region}.scw.cloud` | object storage S3 API (Go collector) |
@@ -94,12 +95,14 @@ credentials and no automated check reaches a provider API.
 |---|---|:-:|---|
 | `access_key` | `IAMReadOnly (Organization scope)` | yes | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
 | `iam_user` | `IAMReadOnly (Organization scope)` | yes | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
+| `security_group` | `InstancesReadOnly (Project scope)` | yes | scaleway/docs-content — pages/iam/reference-content/permission-sets.md |
 | `security_group_rule` | `InstancesReadOnly (Project scope)` | yes | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
 | `compute_instance` | `InstancesReadOnly (Project scope)` | yes | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
 | `object_storage_bucket` | `ObjectStorageReadOnly (Project scope)` | no | scaleway/docs-content — pages/object-storage/reference-content/s3-iam-permissions-equivalence.mdx |
 
 **Reservations, stated rather than papered over.**
 
+- **`security_group`** — The SAME call as `security_group_rule`: `ListSecurityGroups` acts as the parent join for the rules and carries, in that same response, the group's default policy. No extra grant.
 - **`object_storage_bucket`** — Covers ListBuckets, GetBucketAcl, GetBucketVersioning, GetBucketTagging and GetObjectLockConfiguration. GetBucketPolicy and GetBucketEncryption appear in NO read-only permission set of the equivalence table: the right that grants them could not be established, and it is not guessed. Both calls are best-effort - a 403 costs coverage, never correctness.
 <!-- /pepin:gen provider-scaleway-permissions -->
 
@@ -154,7 +157,7 @@ pepin scan scaleway --terraform plan.json
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
 | terraform | 17 | 8 | 2 | 31 |
-| live | 17 | 3 | 2 | 36 |
+| live | 18 | 3 | 2 | 35 |
 <!-- /pepin:gen provider-scaleway-coverage -->
 
 Control by control, with the reason for every cell that is not fully supported, the source of
@@ -183,7 +186,6 @@ A `not-applicable` is a claim, so it carries its justification, taken from the p
 | `database_service_not_open_to_internet` | terraform | this source produces no resource of type "managed_database" |
 | `iam_policy_no_privilege_escalation` | terraform | this source produces no resource of type "iam_policy" |
 | `iam_user_mfa_enabled` | live | this source produces no resource of type "iam_user" |
-| `network_securitygroup_default_deny` | terraform | this source produces no resource of type "security_group" |
 | `objectstorage_bucket_default_encryption` | live | deciding attribute "default_encryption_enabled" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `objectstorage_bucket_kms_encryption` | live | deciding attribute "sse_kms_enabled" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `objectstorage_bucket_versioning_enabled` | live | deciding attribute "versioning" not projected by this source: a capability guard, so the scan returns "not-evaluated" |

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -43,7 +43,7 @@ séparément :
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v9** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v10** |
 <!-- /pepin:gen surface-versions -->
 
 Un numéro monte à **tout** changement de forme, ajout compris : il signifie « la surface a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,7 +43,7 @@ independently:
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v9** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v10** |
 <!-- /pepin:gen surface-versions -->
 
 A version rises on **any** shape change, additions included: the number means "the surface has

--- a/docs/reference/inventory.fr.md
+++ b/docs/reference/inventory.fr.md
@@ -12,7 +12,7 @@ gelée, avec les mêmes égards que la surface CLI.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v9
+pepin-inventory/v10
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -172,7 +172,7 @@ code.
 | `network_interface` | `nic_id` `public_ip` `security_group_ids` `vm_id` |
 | `network_peering` | `accepter_account` `peering_id` `source_account` `state` |
 | `object_storage_bucket` | `acl` `acl_grants` `default_encryption_enabled` `kms_key_id` `name` `object_lock_enabled` `policy_public` `public_via_acl` `sse_kms_enabled` `tags` `versioning` |
-| `security_group` | `inbound_default_policy` `security_group_id` |
+| `security_group` | `description` `inbound_default_policy` `outbound_default_policy` `security_group_id` `tags` |
 | `security_group_rule` | `action` `cidrs` `description` `direction` `peer_security_group_ids` `port_from` `port_to` `protocol` `security_group_id` `security_group_name` |
 | `subnet` | `map_public_ip_on_launch` `network_id` `state` `subnet_id` `tags` |
 <!-- /pepin:gen inventory-types -->

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -12,7 +12,7 @@ with the same regard as the CLI surface.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v9
+pepin-inventory/v10
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -164,7 +164,7 @@ descriptors and from the Go collectors — never a hand-kept list beside the cod
 | `network_interface` | `nic_id` `public_ip` `security_group_ids` `vm_id` |
 | `network_peering` | `accepter_account` `peering_id` `source_account` `state` |
 | `object_storage_bucket` | `acl` `acl_grants` `default_encryption_enabled` `kms_key_id` `name` `object_lock_enabled` `policy_public` `public_via_acl` `sse_kms_enabled` `tags` `versioning` |
-| `security_group` | `inbound_default_policy` `security_group_id` |
+| `security_group` | `description` `inbound_default_policy` `outbound_default_policy` `security_group_id` `tags` |
 | `security_group_rule` | `action` `cidrs` `description` `direction` `peer_security_group_ids` `port_from` `port_to` `protocol` `security_group_id` `security_group_name` |
 | `subnet` | `map_public_ip_on_launch` `network_id` `state` `subnet_id` `tags` |
 <!-- /pepin:gen inventory-types -->

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -30,7 +30,7 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v9** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v10** |
 <!-- /pepin:gen surface-versions -->
 
 « Gelé » signifie qu'un test échoue quand la forme bouge sans que sa version ait suivi : les

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -30,7 +30,7 @@ See [Exit codes](exit-codes.md).
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v9** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v10** |
 <!-- /pepin:gen surface-versions -->
 
 "Frozen" means a test fails when the shape moves and its version has not: field paths and JSON

--- a/internal/model/schema.go
+++ b/internal/model/schema.go
@@ -141,7 +141,17 @@ import (
 //	cluster apportait deux écarts IAM que personne ne pouvait faire disparaître. Le
 //	fait est déclaré par le descripteur, avec sa source ; aucune règle ne connaît de
 //	convention de nommage.
-const InventoryFormat = "pepin-inventory/v9"
+//
+// v10 : la collecte live Scaleway produit le type `security_group`, porteur de
+//
+//	`inbound_default_policy` et `outbound_default_policy` (accept|drop), de sa
+//	description et de ses étiquettes. Ajout PUR : aucun type existant ne change.
+//	Il est nécessaire parce que `network_securitygroup_default_deny` — sévérité
+//	`high` — revenait « non évalué » en live alors que sa donnée était DÉJÀ sur le
+//	fil : le collecteur paginait la même liste pour joindre les règles à leur
+//	groupe, sans jamais projeter le champ. Une lacune de couverture, pas une lacune
+//	d'API (issue #195). Contrat vérifié contre l'API réelle le 2026-09-11.
+const InventoryFormat = "pepin-inventory/v10"
 
 // InventorySchemaVersion extrait le N du suffixe `/vN`. Comme pour le bundle, la
 // constante et le signal sur le fil sont la même chose : impossible de faire

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -1,28 +1,28 @@
 {
   "controls": 58,
-  "paths": 181,
-  "paths_proven": 30,
-  "obligations": 457,
-  "proven": 91,
+  "paths": 182,
+  "paths_proven": 31,
+  "obligations": 460,
+  "proven": 94,
   "verdicts": {
     "fail": {
-      "required": 138,
-      "proven": 23
+      "required": 139,
+      "proven": 24
     },
     "not-applicable": {
       "required": 24,
       "proven": 12
     },
     "not-evaluated": {
-      "required": 157,
-      "proven": 21
+      "required": 158,
+      "proven": 22
     },
     "pass": {
-      "required": 138,
-      "proven": 35
+      "required": 139,
+      "proven": 36
     }
   },
-  "live_paths": 102,
+  "live_paths": 103,
   "live_validated": 0,
   "counterwitnesses": 2,
   "tenants": 6,
@@ -2170,6 +2170,21 @@
       "paths": [
         {
           "provider": "scaleway",
+          "source": "live",
+          "status": "supported",
+          "required": [
+            "fail",
+            "pass",
+            "not-evaluated"
+          ],
+          "proven": [
+            "fail",
+            "pass",
+            "not-evaluated"
+          ]
+        },
+        {
+          "provider": "scaleway",
           "source": "terraform",
           "status": "supported",
           "required": [
@@ -2184,6 +2199,7 @@
         }
       ],
       "scenarios": [
+        "internal/veracity/testdata/scenarios/sg-default-deny-scaleway-live.yaml",
         "internal/veracity/testdata/scenarios/sg-default-deny-scaleway-terraform.yaml"
       ],
       "rego_tests": [

--- a/internal/veracity/testdata/scenarios/sg-default-deny-scaleway-live.yaml
+++ b/internal/veracity/testdata/scenarios/sg-default-deny-scaleway-live.yaml
@@ -1,0 +1,65 @@
+# Politique par defaut d'un groupe de securite Scaleway, sur une collecte LIVE.
+#
+# Le chemin traverse le collecteur REEL : la liste
+# `/instance/v1/zones/{zone}/security_groups` que le collecteur parcourait DEJA pour
+# joindre les regles a leur groupe, le mapping declaratif du descripteur
+# (`inbound_default_policy`), le verrou de capacite, la regle, puis l'assessment.
+# C'est l'entree exigee par le contrat : le type `security_group` est produit par la
+# spec `collecte`, donc un scenario `live` ne peut pas passer par `inventory:`.
+#
+# # Ce que ce scenario prouve, et qui n'existait pas
+#
+# Ce controle revenait `not-evaluated` en live alors que sa donnee etait deja sur le
+# fil : la reponse portait `inbound_default_policy`, et personne ne la projetait. Une
+# lacune de couverture n'est pas une lacune d'API (issue #195).
+#
+# # Pourquoi le contre-exemple garde le MEME groupe
+#
+# Seule la politique par defaut change entre les deux cas. Retirer le groupe, ou ses
+# regles, prouverait autre chose : que la regle se tait quand il n'y a rien a juger.
+# Ce qu'il faut prouver ici, c'est qu'elle discrimine sur le champ qu'elle lit.
+control: network_securitygroup_default_deny
+provider: scaleway
+source: live
+
+scenarios:
+  - expect: fail
+    why: "politique entrante par defaut a accept : tout ce que les regles n'interdisent pas passe"
+    api:
+      /instance/v1/zones/fr-par-1/security_groups: |
+        {"security_groups": [{"id": "11111111-2222-3333-4444-555555555555",
+                              "name": "web",
+                              "inbound_default_policy": "accept",
+                              "outbound_default_policy": "accept",
+                              "description": "",
+                              "tags": []}],
+         "total_count": 1}
+      /instance/v1/zones/fr-par-1/security_groups/11111111-2222-3333-4444-555555555555/rules: |
+        {"rules": [], "total_count": 0}
+
+  - expect: pass
+    why: "le MEME groupe, les MEMES regles, mais la politique par defaut a drop"
+    api:
+      /instance/v1/zones/fr-par-1/security_groups: |
+        {"security_groups": [{"id": "11111111-2222-3333-4444-555555555555",
+                              "name": "web",
+                              "inbound_default_policy": "drop",
+                              "outbound_default_policy": "accept",
+                              "description": "",
+                              "tags": []}],
+         "total_count": 1}
+      /instance/v1/zones/fr-par-1/security_groups/11111111-2222-3333-4444-555555555555/rules: |
+        {"rules": [], "total_count": 0}
+
+  - expect: not-evaluated
+    why: "la reponse ne porte pas le champ : on ne conclut pas sur ce qu'on n'a pas vu"
+    api:
+      /instance/v1/zones/fr-par-1/security_groups: |
+        {"security_groups": [{"id": "11111111-2222-3333-4444-555555555555",
+                              "name": "web",
+                              "outbound_default_policy": "accept",
+                              "description": "",
+                              "tags": []}],
+         "total_count": 1}
+      /instance/v1/zones/fr-par-1/security_groups/11111111-2222-3333-4444-555555555555/rules: |
+        {"rules": [], "total_count": 0}

--- a/providers/scaleway.yaml
+++ b/providers/scaleway.yaml
@@ -79,6 +79,12 @@ permissions:
     grant: "IAMReadOnly (Organization scope)"
     etat: verifie
     source: "scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx"
+  - unit: security_group
+    grant: "InstancesReadOnly (Project scope)"
+    etat: verifie
+    source: "scaleway/docs-content — pages/iam/reference-content/permission-sets.md"
+    note: "Le MÊME appel que `security_group_rule` : `ListSecurityGroups` sert de jointure parent pour les règles et porte, dans la même réponse, la politique par défaut du groupe. Aucun droit supplémentaire."
+    note_en: "The SAME call as `security_group_rule`: `ListSecurityGroups` acts as the parent join for the rules and carries, in that same response, the group's default policy. No extra grant."
   - unit: security_group_rule
     grant: "InstancesReadOnly (Project scope)"
     etat: verifie
@@ -123,6 +129,37 @@ collecte:
         mfa_enabled: mfa
       paging: { style: page, param: page, size_param: page_size, size: 100 }
   
+    # Groupes de sécurité → security_group. AUCUN APPEL SUPPLÉMENTAIRE : c'est la
+    # MÊME liste que le `for_each` ci-dessous parcourt déjà pour joindre les règles à
+    # leur groupe. La réponse portait `inbound_default_policy` depuis toujours, et
+    # personne ne la projetait — `network_securitygroup_default_deny` (sévérité `high`)
+    # revenait donc « non évalué » en live alors que sa donnée était sur le fil.
+    #
+    # Contrat vérifié contre l'API RÉELLE le 2026-09-11
+    # (GET /instance/v1/zones/fr-par-1/security_groups) : la réponse porte
+    # inbound_default_policy et outbound_default_policy (accept|drop), tags, stateful,
+    # description, project_default, organization_default.
+    #
+    # `tags` est projeté pour ce qu'il EST, pas pour ce qu'on en fera : un groupe sans
+    # étiquette est une observation, et c'est `governance_resource_required_tags` qui
+    # décide. Le projeter ici ne fabrique rien — la clé vient de la réponse.
+    - type: security_group
+      path: /instance/v1/zones/{zone}/security_groups
+      items: security_groups
+      id: security_group_id
+      paging: { style: page, param: page, size_param: per_page, size: 100 }
+      map:
+        # `id:` ci-dessus nomme un ATTRIBUT PROJETÉ, pas un chemin de la source : sans
+        # cette ligne, la ressource n'a pas d'identifiant et le finding nomme un groupe
+        # vide — « Security group «  » ». Mesuré sur le compte réel avant correction.
+        security_group_id: id
+        inbound_default_policy: inbound_default_policy   # accept|drop
+        outbound_default_policy: outbound_default_policy # accept|drop
+        description: description
+        tags: tags
+      transforms:
+        tags: list
+
     # Règles de security group → security_group_rule. Jointure parent→enfant :
     # lister les SG (api/instance/v1 ListSecurityGroups) puis les règles de chacun
     # (ListSecurityGroupRules). Champs ancrés sur api/instance/v1 SecurityGroupRule.

--- a/references/qualification/scaleway/expected.yaml
+++ b/references/qualification/scaleway/expected.yaml
@@ -142,8 +142,16 @@ controls:
       silent: [scaleway_instance_security_group.hardened]
 
   network_securitygroup_default_deny:
-    # InboundDefaultPolicy n'est pas encore projetée par la collecte live (#195).
-    live: not-evaluated
+    # #195 : la collecte live projette désormais `inbound_default_policy`. AUCUN appel
+    # nouveau — le collecteur paginait déjà `ListSecurityGroups` pour joindre les règles
+    # à leur groupe, et la réponse portait le champ depuis toujours. Contrat vérifié
+    # contre l'API réelle le 2026-09-11.
+    #
+    # Le sujet live est l'UUID du groupe ; le sujet du plan est son nom, l'identifiant
+    # n'existant pas encore au stade du plan (ADR-0022).
+    live:
+      fail: ["${output.sg_default_accept_id}"]
+      silent: ["${output.sg_hardened_id}", "${output.sg_ssh_open_id}"]
     terraform:
       fail: [pepin-qual-sg-default-accept]
       silent: [pepin-qual-sg-hardened, pepin-qual-sg-ssh-open]

--- a/references/qualification/scaleway/network.tf
+++ b/references/qualification/scaleway/network.tf
@@ -130,8 +130,9 @@ resource "scaleway_instance_security_group" "egress_any" {
 }
 
 # ÉCART network_securitygroup_default_deny (high) : politique entrante par défaut
-# « accept » — observable sur le PLAN seulement (la collecte live ne projette pas
-# encore InboundDefaultPolicy, cf. providers/scaleway.yaml, contrat security_group).
+# « accept » — observable sur les DEUX sources depuis #195. La collecte live projette
+# désormais `inbound_default_policy`, lu dans la réponse de ListSecurityGroups que le
+# collecteur paginait déjà pour joindre les règles à leur groupe.
 resource "scaleway_instance_security_group" "default_accept" {
   name                    = "pepin-qual-sg-default-accept"
   description             = "Politique entrante par defaut accept"


### PR DESCRIPTION
First control of #195, and the pattern that issue is about.

## The gap was not a missing API

`network_securitygroup_default_deny` — severity **high** — came back `not-evaluated` on
the live source while the same fault was found on the plan. But the collector **already
paginates**:

```
GET /instance/v1/zones/{zone}/security_groups
```

to join rules to their group, and that response has carried `inbound_default_policy` all
along. **Nobody projected it.** A coverage gap, not an API gap.

## Verified before written

The contract was checked against the **real API** on 2026-09-11, not inferred from the
Terraform schema:

```
creation_date, description, enable_default_security, id, inbound_default_policy,
modification_date, name, organization, organization_default,
outbound_default_policy, project, project_default, servers, state, stateful,
tags, zone
```

## A defect of my own, caught by running it

Found by scanning a real account rather than by reading the diff: `id:` in a collection
spec names a **projected attribute**, not a path in the source item. The first version
produced

```
Security group «  » : politique entrante par défaut « accept »
```

— a **true** finding naming nothing, which is nearly useless to whoever has to fix it.
The identifier is now projected.

## Measured end to end

On a real Scaleway account, the control now concludes on both sources, and the
qualification run answers:

| | Result |
|---|---|
| non-regression contract | **GO** |
| release verdict | **GO** |
| destruction proven | 19 collection families, no before/after delta |
| cost | 0.0065 € |

And on the maintainer's own account the control found a **genuine deviation**: the
project's default security group runs `inbound_default_policy: accept`.

## Details

- **Veracity scenario on the LIVE path** — canned responses served to the *real*
  collector, as the contract requires for a type the `collecte` spec produces. Three
  cases: `accept` fails, the **same** group with `drop` passes, and a response without
  the field concludes nothing.
- `outbound_default_policy`, `description` and `tags` come in the same response and are
  projected **for what they are**, not for what a rule will do with them. They fabricate
  nothing — the keys come from the answer, which is the rule #237 just made a gate.
- **Inventory format `v9` → `v10`**: a pure addition, the new `security_group` type, with
  its justification in `schema.go`.
- **Minimum grant declared**: the same `InstancesReadOnly` as the rules, since it is the
  same call.

## Impact ADR

**ADR-0003** (the normalized inventory is a frozen, versioned contract): respected — the
constant is bumped **before** regenerating the frozen surface, with the reason written.
**ADR-0006**: the control moves from `not-evaluated` to a conclusion because the data now
*arrives*, not because the lock was loosened. No ADR modified.

## Next in #195

`root_owned` on the API-key listing — also no new call. Verified this session that the
listing carries `user_id` and `application_id`, which is the derivation the issue names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)