### PR TITLE
feat(scaleway): find a root-owned API key, with no new call

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -24,6 +24,22 @@ l'une ni l'autre appartient au `git log`.
 
 ### Ajouté
 
+- **Scaleway live : une clé d'API du propriétaire est désormais trouvée** (issue #195).
+  `iam_no_root_access_key` — sévérité `high` — ne savait conclure sur aucune source. La
+  donnée était dans la liste de clés que le collecteur **interroge déjà** : `user_id`, et
+  `application_id` pour une identité de service. La dérivation naïve que l'issue
+  esquissait — « une clé d'utilisateur est une clé root » — aurait signalé **la clé de
+  chaque membre**, un faux positif par personne. Le vrai marqueur est le `type` de
+  l'utilisateur, littéralement `owner`, vérifié contre l'API réelle le 2026-09-11 ;
+  `account_root_user_id`, porté par le même enregistrement, désigne autre chose et diffère
+  de l'id du propriétaire. La règle joint donc le propriétaire de la clé à l'utilisateur
+  de type `owner`, ce que son contrat disait déjà. Les deux champs d'appartenance sont
+  projetés ensemble : une clé appartient à un utilisateur **ou** à une application, et ne
+  projeter que le premier ferait taire le contrôle sur les clés d'application, dont
+  l'appartenance est pourtant parfaitement observée. Confirmé sur un compte réel — où il
+  trouve un écart véritable — et par un run de qualification, GO avec destruction prouvée.
+  Format d'inventaire `v11`, ajout pur.
+
 - **Scaleway live : la politique par défaut d'un groupe de sécurité est collectée**
   (issue #195). `network_securitygroup_default_deny` — sévérité `high` — revenait
   `not-evaluated` sur la source live alors que la même faute était trouvée sur le plan.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ belongs in `git log`.
 
 ### Added
 
+- **Scaleway live: a root-owned API key is now found** (issue #195).
+  `iam_no_root_access_key` — severity `high` — could not conclude on either source. The
+  data was in the API-key listing the collector **already calls**: `user_id`, and
+  `application_id` for a service identity. The naive derivation the issue sketched —
+  *"a user key is a root key"* — would have flagged **every member's own key**, one false
+  positive per person. The real marker is the user's `type`, literally `owner`, verified
+  against the live API on 2026-09-11; `account_root_user_id`, carried by the same record,
+  designates something else and differs from the owner's id. So the rule joins the key's
+  owner to the user of type `owner`, which is what its contract already said. Both
+  ownership fields are projected together: a key belongs to a user **or** to an
+  application, and projecting only the first would silence the control on application
+  keys whose ownership is perfectly observed. Confirmed on a real account — where it
+  finds a genuine deviation — and by a qualification run, GO with destruction proven.
+  Inventory format `v11`, a pure addition.
+
 - **Scaleway live: a security group's default policy is now collected** (issue #195).
   `network_securitygroup_default_deny` — severity `high` — came back `not-evaluated` on
   the live source while the same fault was found on the plan. The gap was not a missing

--- a/cmd/testdata/frozen/inventory.json
+++ b/cmd/testdata/frozen/inventory.json
@@ -2273,6 +2273,249 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 11,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "source": {
+                "file": "string",
+                "line": "number",
+                "module": "string"
+              },
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v11",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "creation_date",
+            "expiration_date",
+            "owner_application_id",
+            "owner_user",
+            "owner_user_id",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "state",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_interface",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud",
+            "secnumcloud_regions"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "provider_managed",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "user_type",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_interface": [
+            "nic_id",
+            "public_ip",
+            "security_group_ids",
+            "vm_id"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "description",
+            "inbound_default_policy",
+            "outbound_default_policy",
+            "security_group_id",
+            "tags"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "peer_security_group_ids",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
+        }
+      }
     }
   ]
 }

--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -96,7 +96,7 @@ Le tableau ci-dessous est rendu depuis cette table même, il n'en est pas la cop
 | `iam_account_mfa_enforced` | `api_access_policy` | `require_trusted_env` |
 | `iam_apiaccesspolicy_max_key_expiration` | `api_access_policy` | `max_access_key_expiration_seconds` |
 | `iam_apiaccessrule_no_public_cidr` | `api_access_rule` | `ip_ranges` |
-| `iam_no_root_access_key` | `access_key` | `root_owned` ou `scope` |
+| `iam_no_root_access_key` | `access_key` | `owner_application_id` ou `owner_user_id` ou `root_owned` ou `scope` |
 | `iam_policy_no_administrative_privileges` | `iam_policy` | `statements` |
 | `iam_policy_no_notaction_notresource` | `iam_policy` | `statements` |
 | `iam_policy_no_privilege_escalation` | `iam_policy` | `manages_iam` ou `statements` |

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -96,7 +96,7 @@ The table below is rendered from that very map — not transcribed from it:
 | `iam_account_mfa_enforced` | `api_access_policy` | `require_trusted_env` |
 | `iam_apiaccesspolicy_max_key_expiration` | `api_access_policy` | `max_access_key_expiration_seconds` |
 | `iam_apiaccessrule_no_public_cidr` | `api_access_rule` | `ip_ranges` |
-| `iam_no_root_access_key` | `access_key` | `root_owned` or `scope` |
+| `iam_no_root_access_key` | `access_key` | `owner_application_id` or `owner_user_id` or `root_owned` or `scope` |
 | `iam_policy_no_administrative_privileges` | `iam_policy` | `statements` |
 | `iam_policy_no_notaction_notresource` | `iam_policy` | `statements` |
 | `iam_policy_no_privilege_escalation` | `iam_policy` | `manages_iam` or `statements` |

--- a/docs/concepts/terraform-vs-live.fr.md
+++ b/docs/concepts/terraform-vs-live.fr.md
@@ -272,6 +272,7 @@ couples, une source produit le type de ressource et son attribut décisif, et l'
 | `iam_apiaccessrule_defined` | outscale | live | cette source ne produit aucune ressource de type « api_access_summary » |
 | `iam_apiaccessrule_no_public_cidr` | outscale | live | cette source ne produit aucune ressource de type « api_access_rule » |
 | `iam_no_root_access_key` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
+| `iam_no_root_access_key` | scaleway | live | attribut décisif « owner_application_id / owner_user_id / root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_policy_no_privilege_escalation` | scaleway | terraform | cette source ne produit aucune ressource de type « iam_policy » |
 | `iam_user_mfa_enabled` | exoscale | live | cette source ne produit aucune ressource de type « iam_user » |
 | `iam_user_mfa_enabled` | scaleway | live | cette source ne produit aucune ressource de type « iam_user » |

--- a/docs/concepts/terraform-vs-live.md
+++ b/docs/concepts/terraform-vs-live.md
@@ -267,6 +267,7 @@ source produces the resource type and its deciding attribute, and the other does
 | `iam_apiaccessrule_defined` | outscale | live | this source produces no resource of type "api_access_summary" |
 | `iam_apiaccessrule_no_public_cidr` | outscale | live | this source produces no resource of type "api_access_rule" |
 | `iam_no_root_access_key` | outscale | live | this source produces no resource of type "access_key" |
+| `iam_no_root_access_key` | scaleway | live | deciding attribute "owner_application_id / owner_user_id / root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_policy_no_privilege_escalation` | scaleway | terraform | this source produces no resource of type "iam_policy" |
 | `iam_user_mfa_enabled` | exoscale | live | this source produces no resource of type "iam_user" |
 | `iam_user_mfa_enabled` | scaleway | live | this source produces no resource of type "iam_user" |

--- a/docs/controls/iam_no_root_access_key.fr.md
+++ b/docs/controls/iam_no_root_access_key.fr.md
@@ -15,7 +15,7 @@
 | Sévérité | `high` |
 | Exigence SCSL (index gelé) | `CLD-IAM-1` |
 | Type de ressource lu | `access_key` |
-| Attribut décisif | `root_owned` / `scope` |
+| Attribut décisif | `owner_application_id` / `owner_user_id` / `root_owned` / `scope` |
 | État | actif |
 | Déclaré pour | `outscale`, `scaleway` |
 | Preuves de remédiation | 0 / 2 |
@@ -52,7 +52,7 @@ déclaré, ou type absent de cette source ».
 |---|:-:|:-:|
 | exoscale | ✗ | ✗ |
 | outscale | ✗ | ✅ |
-| scaleway | ◐ | ◐ |
+| scaleway | ◐ | ✅ |
 | kubernetes | sans objet | ✗ |
 
 Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
@@ -61,17 +61,16 @@ porte son motif :
 | Fournisseur | Source | Statut | Motif |
 |---|---|---|---|
 | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « access_key » |
-| scaleway | terraform | ◐ `partial` | attribut décisif « root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
-| scaleway | live | ◐ `partial` | attribut décisif « root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| scaleway | terraform | ◐ `partial` | attribut décisif « owner_application_id / owner_user_id / root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 
 ## Ce que Pépin peut conclure
 
 | Statut | Ce que le statut affirme | Atteignable depuis |
 |---|---|---|
 | `fail` | un écart a été détecté sur une ressource réelle | outscale / live · scaleway / terraform · scaleway / live |
-| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live · scaleway / live |
 | `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
-| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | scaleway / terraform · scaleway / live |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | scaleway / terraform |
 
 Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
 contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
@@ -79,7 +78,7 @@ contient aucune ressource du type visé : « rien à voir » n'est pas « confor
 ## Comment enquêter
 
 - Type de ressource normalisé lu par la règle : `access_key`
-- Attribut dont la décision dépend : `root_owned` / `scope`
+- Attribut dont la décision dépend : `owner_application_id` / `owner_user_id` / `root_owned` / `scope`
 - Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
 - Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
 - La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.

--- a/docs/controls/iam_no_root_access_key.md
+++ b/docs/controls/iam_no_root_access_key.md
@@ -15,7 +15,7 @@
 | Severity | `high` |
 | SCSL requirement (frozen index) | `CLD-IAM-1` |
 | Resource type read | `access_key` |
-| Deciding attribute | `root_owned` / `scope` |
+| Deciding attribute | `owner_application_id` / `owner_user_id` / `root_owned` / `scope` |
 | State | active |
 | Declared for | `outscale`, `scaleway` |
 | Remediation proofs | 0 / 2 |
@@ -51,7 +51,7 @@ source".
 |---|:-:|:-:|
 | exoscale | ✗ | ✗ |
 | outscale | ✗ | ✅ |
-| scaleway | ◐ | ◐ |
+| scaleway | ◐ | ✅ |
 | kubernetes | n/a | ✗ |
 
 Every cell that is not ✅ **while the control is declared for that provider** carries its
@@ -60,17 +60,16 @@ reason:
 | Provider | Source | Status | Reason |
 |---|---|---|---|
 | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "access_key" |
-| scaleway | terraform | ◐ `partial` | deciding attribute "root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
-| scaleway | live | ◐ `partial` | deciding attribute "root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| scaleway | terraform | ◐ `partial` | deciding attribute "owner_application_id / owner_user_id / root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 
 ## What Pépin can conclude
 
 | Status | What the status asserts | Reachable from |
 |---|---|---|
 | `fail` | a deviation was detected on a real resource | outscale / live · scaleway / terraform · scaleway / live |
-| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live · scaleway / live |
 | `not-applicable` | the provider contract declares the control untestable, with its justification | — |
-| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | scaleway / terraform · scaleway / live |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | scaleway / terraform |
 
 An observable control still returns `not-evaluated` on an inventory that contains no
 resource of the targeted type: "nothing to look at" is not "compliant".
@@ -78,7 +77,7 @@ resource of the targeted type: "nothing to look at" is not "compliant".
 ## How to investigate
 
 - Normalized resource type the rule reads: `access_key`
-- Attribute the decision depends on: `root_owned` / `scope`
+- Attribute the decision depends on: `owner_application_id` / `owner_user_id` / `root_owned` / `scope`
 - Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
 - What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
 - The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.

--- a/docs/coverage.fr.md
+++ b/docs/coverage.fr.md
@@ -46,7 +46,7 @@ et le rapport le dit à chaque scan, contrôle par contrôle, avec le motif.
 | `chiffrement` | 7 | ✅ 1 · ◐ 0 · ∅ 3 · ✗ 3 | ✅ 2 · ◐ 0 · ∅ 3 · ✗ 2 | ✅ 2 · ◐ 1 · ∅ 1 · ✗ 3 |
 | `compute` | 9 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 5 | ✅ 7 · ◐ 0 · ∅ 0 · ✗ 2 | ✅ 2 · ◐ 0 · ∅ 0 · ✗ 7 |
 | `gouvernance` | 3 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 |
-| `iam` | 15 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 | ✅ 11 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 3 · ◐ 1 · ∅ 0 · ✗ 11 |
+| `iam` | 15 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 | ✅ 11 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 |
 | `journalisation` | 2 | ✅ 1 · ◐ 0 · ∅ 1 · ✗ 0 | ✅ 1 · ◐ 0 · ∅ 0 · ✗ 1 | ✅ 0 · ◐ 0 · ∅ 0 · ✗ 2 |
 | `reseau` | 15 | ✅ 8 · ◐ 0 · ∅ 1 · ✗ 6 | ✅ 11 · ◐ 0 · ∅ 0 · ✗ 4 | ✅ 9 · ◐ 1 · ∅ 0 · ✗ 5 |
 | `stockage` | 7 | ✅ 4 · ◐ 0 · ∅ 1 · ✗ 2 | ✅ 6 · ◐ 0 · ∅ 0 · ✗ 1 | ✅ 4 · ◐ 0 · ∅ 1 · ✗ 2 |
@@ -75,7 +75,7 @@ et le rapport le dit à chaque scan, contrôle par contrôle, avec le motif.
 | `iam_apiaccesspolicy_max_key_expiration` | medium | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccessrule_defined` | high | CLD-IAM-4 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccessrule_no_public_cidr` | high | CLD-IAM-4 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
-| `iam_no_root_access_key` | high | CLD-IAM-1 | ✗ | ✗ | ✗ | ✅ | ◐ | ◐ |
+| `iam_no_root_access_key` | high | CLD-IAM-1 | ✗ | ✗ | ✗ | ✅ | ◐ | ✅ |
 | `iam_policy_no_administrative_privileges` | critical | CLD-IAM-1 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
 | `iam_policy_no_notaction_notresource` | critical | CLD-IAM-1 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
 | `iam_policy_no_privilege_escalation` | high | CLD-IAM-12 | ✗ | ✗ | ✅ | ✅ | ✅ | ✗ |
@@ -153,8 +153,7 @@ ici : la matrice les montre déjà, et elles n'apprennent rien de plus.
 | `iam_apiaccessrule_defined` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_summary » |
 | `iam_apiaccessrule_no_public_cidr` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_rule » |
 | `iam_no_root_access_key` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « access_key » |
-| `iam_no_root_access_key` | scaleway | terraform | ◐ `partial` | attribut décisif « root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
-| `iam_no_root_access_key` | scaleway | live | ◐ `partial` | attribut décisif « root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| `iam_no_root_access_key` | scaleway | terraform | ◐ `partial` | attribut décisif « owner_application_id / owner_user_id / root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_policy_no_privilege_escalation` | scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « iam_policy » |
 | `iam_user_mfa_enabled` | exoscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « iam_user » |
 | `iam_user_mfa_enabled` | outscale | terraform | ∅ `not-applicable` | type de ressource « iam_user » absent de l'API outscale |
@@ -218,5 +217,5 @@ deux ne peut couvrir la portée de l'autre. Une seule source : la collecte live 
 | outscale | terraform | 17 | 4 | 4 | 33 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
-| scaleway | live | 18 | 3 | 2 | 35 |
+| scaleway | live | 19 | 2 | 2 | 35 |
 | kubernetes | live | 4 | 0 | 0 | 54 |

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -45,7 +45,7 @@ and the report says so on every scan, control by control, with the reason.
 | `chiffrement` | 7 | ✅ 1 · ◐ 0 · ∅ 3 · ✗ 3 | ✅ 2 · ◐ 0 · ∅ 3 · ✗ 2 | ✅ 2 · ◐ 1 · ∅ 1 · ✗ 3 |
 | `compute` | 9 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 5 | ✅ 7 · ◐ 0 · ∅ 0 · ✗ 2 | ✅ 2 · ◐ 0 · ∅ 0 · ✗ 7 |
 | `gouvernance` | 3 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 |
-| `iam` | 15 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 | ✅ 11 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 3 · ◐ 1 · ∅ 0 · ✗ 11 |
+| `iam` | 15 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 | ✅ 11 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 |
 | `journalisation` | 2 | ✅ 1 · ◐ 0 · ∅ 1 · ✗ 0 | ✅ 1 · ◐ 0 · ∅ 0 · ✗ 1 | ✅ 0 · ◐ 0 · ∅ 0 · ✗ 2 |
 | `reseau` | 15 | ✅ 8 · ◐ 0 · ∅ 1 · ✗ 6 | ✅ 11 · ◐ 0 · ∅ 0 · ✗ 4 | ✅ 9 · ◐ 1 · ∅ 0 · ✗ 5 |
 | `stockage` | 7 | ✅ 4 · ◐ 0 · ∅ 1 · ✗ 2 | ✅ 6 · ◐ 0 · ∅ 0 · ✗ 1 | ✅ 4 · ◐ 0 · ∅ 1 · ✗ 2 |
@@ -74,7 +74,7 @@ and the report says so on every scan, control by control, with the reason.
 | `iam_apiaccesspolicy_max_key_expiration` | medium | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccessrule_defined` | high | CLD-IAM-4 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccessrule_no_public_cidr` | high | CLD-IAM-4 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
-| `iam_no_root_access_key` | high | CLD-IAM-1 | ✗ | ✗ | ✗ | ✅ | ◐ | ◐ |
+| `iam_no_root_access_key` | high | CLD-IAM-1 | ✗ | ✗ | ✗ | ✅ | ◐ | ✅ |
 | `iam_policy_no_administrative_privileges` | critical | CLD-IAM-1 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
 | `iam_policy_no_notaction_notresource` | critical | CLD-IAM-1 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
 | `iam_policy_no_privilege_escalation` | high | CLD-IAM-12 | ✗ | ✗ | ✅ | ✅ | ✅ | ✗ |
@@ -152,8 +152,7 @@ already shows them, and they add nothing.
 | `iam_apiaccessrule_defined` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_summary" |
 | `iam_apiaccessrule_no_public_cidr` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_rule" |
 | `iam_no_root_access_key` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "access_key" |
-| `iam_no_root_access_key` | scaleway | terraform | ◐ `partial` | deciding attribute "root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
-| `iam_no_root_access_key` | scaleway | live | ◐ `partial` | deciding attribute "root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| `iam_no_root_access_key` | scaleway | terraform | ◐ `partial` | deciding attribute "owner_application_id / owner_user_id / root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_policy_no_privilege_escalation` | scaleway | live | ✗ `unsupported` | this source produces no resource of type "iam_policy" |
 | `iam_user_mfa_enabled` | exoscale | terraform | ✗ `unsupported` | this source produces no resource of type "iam_user" |
 | `iam_user_mfa_enabled` | outscale | terraform | ∅ `not-applicable` | resource type "iam_user" absent from the outscale API |
@@ -217,5 +216,5 @@ the other's scope. One source only: live collection through a kubeconfig.
 | outscale | terraform | 17 | 4 | 4 | 33 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
-| scaleway | live | 18 | 3 | 2 | 35 |
+| scaleway | live | 19 | 2 | 2 | 35 |
 | kubernetes | live | 4 | 0 | 0 | 54 |

--- a/docs/detection-quality.fr.md
+++ b/docs/detection-quality.fr.md
@@ -16,7 +16,7 @@ pourcentage sans mesure derrière est un faux vert déplacé dans un tableau de
 bord, et il y est pire qu'ailleurs : personne ne relit un tableau de bord.
 
 Les chiffres sont donc laids, et c'est le point. « 58 contrôles » ne dit rien de
-la qualité d'une détection ; « 94 verdicts prouvés sur 460 » dit où en est le
+la qualité d'une détection ; « 96 verdicts prouvés sur 462 » dit où en est le
 produit, et rétrécit dans le bon sens à chaque scénario écrit.
 
 ## Les chiffres
@@ -26,8 +26,8 @@ produit, et rétrécit dans le bon sens à chaque scénario écrit.
 | Contrôles au référentiel | 58 |
 | Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 182 |
 | Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 31 |
-| Verdicts à prouver au total | 460 |
-| Verdicts prouvés | 94 |
+| Verdicts à prouver au total | 462 |
+| Verdicts prouvés | 96 |
 
 ## Couverture de véracité, par verdict
 
@@ -37,11 +37,11 @@ demanderait d'inventer une non-applicabilité.
 
 | Verdict | Ce qu'il met en scène | À prouver | Prouvés | % |
 |---|---|---:|---:|---:|
-| `fail` | une configuration vulnérable est détectée | 139 | 24 | 17 |
-| `pass` | une configuration réellement correcte est confirmée | 139 | 36 | 25 |
+| `fail` | une configuration vulnérable est détectée | 140 | 25 | 17 |
+| `pass` | une configuration réellement correcte est confirmée | 140 | 37 | 26 |
 | `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 158 | 22 | 13 |
 | `not-applicable` | le contrat du fournisseur déclare le mécanisme inexistant | 24 | 12 | 50 |
-| **Total** | | **460** | **94** | **20** |
+| **Total** | | **462** | **96** | **20** |
 
 ## Validé en live
 
@@ -85,8 +85,8 @@ n'en ont pas encore sont comptés dans
 | Chiffre | Nombre |
 |---|---:|
 | Contrôles high/critical actifs | 43 |
-| Dont un chemin de détection est prouvé de bout en bout | 20 |
-| Dont un contre-exemple légitime est prouvé | 18 |
+| Dont un chemin de détection est prouvé de bout en bout | 21 |
+| Dont un contre-exemple légitime est prouvé | 19 |
 | Faux positifs mesurés sur les contre-témoins | 0 |
 
 Il n'y a pas de ligne « faux négatifs », et son absence est le chiffre le plus

--- a/docs/detection-quality.md
+++ b/docs/detection-quality.md
@@ -16,7 +16,7 @@ with no measurement behind it is a false green moved into a dashboard, and it is
 worse there than anywhere else: nobody re-reads a dashboard.
 
 The figures are therefore ugly, and that is the point. "58 controls" says nothing
-about the quality of a detection; "94 verdicts proven out of 460" says where the
+about the quality of a detection; "96 verdicts proven out of 462" says where the
 product stands, and shrinks the right way with every scenario written.
 
 ## The figures
@@ -26,8 +26,8 @@ product stands, and shrinks the right way with every scenario written.
 | Controls in the reference | 58 |
 | Control x provider x source paths on which Pépin concludes | 182 |
 | Paths whose EVERY reachable verdict is proven end to end | 31 |
-| Verdicts to prove in total | 460 |
-| Verdicts proven | 94 |
+| Verdicts to prove in total | 462 |
+| Verdicts proven | 96 |
 
 ## Veracity coverage, by verdict
 
@@ -37,11 +37,11 @@ inventing a non-applicability.
 
 | Verdict | What it stages | To prove | Proven | % |
 |---|---|---:|---:|---:|
-| `fail` | a vulnerable configuration is detected | 139 | 24 | 17 |
-| `pass` | a genuinely correct configuration is confirmed | 139 | 36 | 25 |
+| `fail` | a vulnerable configuration is detected | 140 | 25 | 17 |
+| `pass` | a genuinely correct configuration is confirmed | 140 | 37 | 26 |
 | `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 158 | 22 | 13 |
 | `not-applicable` | the provider's contract declares the mechanism non-existent | 24 | 12 | 50 |
-| **Total** | | **460** | **94** | **20** |
+| **Total** | | **462** | **96** | **20** |
 
 ## Validated live
 
@@ -84,8 +84,8 @@ in `internal/veracity/testdata/counterexamples-debt.txt`.
 | Figure | Count |
 |---|---:|
 | Active high/critical controls | 43 |
-| Of which a detection path is proven end to end | 20 |
-| Of which a legitimate counterexample is proven | 18 |
+| Of which a detection path is proven end to end | 21 |
+| Of which a legitimate counterexample is proven | 19 |
 | False positives measured on the counter-witnesses | 0 |
 
 There is no "false negatives" row, and its absence is the most honest figure on

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -58,7 +58,7 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v10",
+  "inventory_schema": "pepin-inventory/v11",
   "disclaimer": "Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -56,7 +56,7 @@ raises a version number and gets a CHANGELOG line.
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v10",
+  "inventory_schema": "pepin-inventory/v11",
   "disclaimer": "This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -98,6 +98,7 @@ pas.
 | `iam_apiaccessrule_defined` | outscale | live | cette source ne produit aucune ressource de type « api_access_summary » |
 | `iam_apiaccessrule_no_public_cidr` | outscale | live | cette source ne produit aucune ressource de type « api_access_rule » |
 | `iam_no_root_access_key` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
+| `iam_no_root_access_key` | scaleway | live | attribut décisif « owner_application_id / owner_user_id / root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_policy_no_privilege_escalation` | scaleway | terraform | cette source ne produit aucune ressource de type « iam_policy » |
 | `iam_user_mfa_enabled` | exoscale | live | cette source ne produit aucune ressource de type « iam_user » |
 | `iam_user_mfa_enabled` | scaleway | live | cette source ne produit aucune ressource de type « iam_user » |
@@ -153,7 +154,7 @@ Par fournisseur et par source, sur l'ensemble des contrôles du référentiel :
 | outscale | terraform | 17 | 4 | 4 | 33 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
-| scaleway | live | 18 | 3 | 2 | 35 |
+| scaleway | live | 19 | 2 | 2 | 35 |
 | kubernetes | live | 4 | 0 | 0 | 54 |
 <!-- /pepin:gen coverage-totals -->
 
@@ -209,7 +210,7 @@ Ce qui n'est pas encore prouvé est **compté**, pas masqué :
 |---|---:|
 | Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 182 |
 | Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 31 |
-| Verdicts à prouver au total | 460 |
+| Verdicts à prouver au total | 462 |
 | Verdicts restant à prouver | 366 |
 <!-- /pepin:gen veracity-debt -->
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -99,6 +99,7 @@ actually decide them. The reason given is the one that applies to the source tha
 | `iam_apiaccessrule_defined` | outscale | live | this source produces no resource of type "api_access_summary" |
 | `iam_apiaccessrule_no_public_cidr` | outscale | live | this source produces no resource of type "api_access_rule" |
 | `iam_no_root_access_key` | outscale | live | this source produces no resource of type "access_key" |
+| `iam_no_root_access_key` | scaleway | live | deciding attribute "owner_application_id / owner_user_id / root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_policy_no_privilege_escalation` | scaleway | terraform | this source produces no resource of type "iam_policy" |
 | `iam_user_mfa_enabled` | exoscale | live | this source produces no resource of type "iam_user" |
 | `iam_user_mfa_enabled` | scaleway | live | this source produces no resource of type "iam_user" |
@@ -153,7 +154,7 @@ Per provider and per source, over all controls in the reference:
 | outscale | terraform | 17 | 4 | 4 | 33 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
-| scaleway | live | 18 | 3 | 2 | 35 |
+| scaleway | live | 19 | 2 | 2 | 35 |
 | kubernetes | live | 4 | 0 | 0 | 54 |
 <!-- /pepin:gen coverage-totals -->
 
@@ -209,7 +210,7 @@ What is not yet proven is **counted**, not hidden:
 |---|---:|
 | Control x provider x source paths on which Pépin concludes | 182 |
 | Paths whose every reachable verdict is proven end to end | 31 |
-| Verdicts to prove in total | 460 |
+| Verdicts to prove in total | 462 |
 | Verdicts left to prove | 366 |
 <!-- /pepin:gen veracity-debt -->
 

--- a/docs/providers/scaleway.fr.md
+++ b/docs/providers/scaleway.fr.md
@@ -160,7 +160,7 @@ pepin scan scaleway --terraform plan.json
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
 | terraform | 17 | 8 | 2 | 31 |
-| live | 18 | 3 | 2 | 35 |
+| live | 19 | 2 | 2 | 35 |
 <!-- /pepin:gen provider-scaleway-coverage -->
 
 Contrôle par contrôle, avec le motif de chaque case qui n'est pas pleinement supportée, la
@@ -188,6 +188,7 @@ fournisseur.
 | `compute_instance_public_ip_with_open_securitygroup` | live | attribut décisif « nic_public_ips / public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `database_backup_enabled` | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `database_service_not_open_to_internet` | terraform | cette source ne produit aucune ressource de type « managed_database » |
+| `iam_no_root_access_key` | live | attribut décisif « owner_application_id / owner_user_id / root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_policy_no_privilege_escalation` | terraform | cette source ne produit aucune ressource de type « iam_policy » |
 | `iam_user_mfa_enabled` | live | cette source ne produit aucune ressource de type « iam_user » |
 | `objectstorage_bucket_default_encryption` | live | attribut décisif « default_encryption_enabled » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |

--- a/docs/providers/scaleway.md
+++ b/docs/providers/scaleway.md
@@ -157,7 +157,7 @@ pepin scan scaleway --terraform plan.json
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
 | terraform | 17 | 8 | 2 | 31 |
-| live | 18 | 3 | 2 | 35 |
+| live | 19 | 2 | 2 | 35 |
 <!-- /pepin:gen provider-scaleway-coverage -->
 
 Control by control, with the reason for every cell that is not fully supported, the source of
@@ -184,6 +184,7 @@ A `not-applicable` is a claim, so it carries its justification, taken from the p
 | `compute_instance_public_ip_with_open_securitygroup` | live | deciding attribute "nic_public_ips / public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `database_backup_enabled` | terraform | this source produces no resource of type "managed_database" |
 | `database_service_not_open_to_internet` | terraform | this source produces no resource of type "managed_database" |
+| `iam_no_root_access_key` | live | deciding attribute "owner_application_id / owner_user_id / root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_policy_no_privilege_escalation` | terraform | this source produces no resource of type "iam_policy" |
 | `iam_user_mfa_enabled` | live | this source produces no resource of type "iam_user" |
 | `objectstorage_bucket_default_encryption` | live | deciding attribute "default_encryption_enabled" not projected by this source: a capability guard, so the scan returns "not-evaluated" |

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -43,7 +43,7 @@ séparément :
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v10** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v11** |
 <!-- /pepin:gen surface-versions -->
 
 Un numéro monte à **tout** changement de forme, ajout compris : il signifie « la surface a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,7 +43,7 @@ independently:
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v10** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v11** |
 <!-- /pepin:gen surface-versions -->
 
 A version rises on **any** shape change, additions included: the number means "the surface has

--- a/docs/reference/inventory.fr.md
+++ b/docs/reference/inventory.fr.md
@@ -12,7 +12,7 @@ gelée, avec les mêmes égards que la surface CLI.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v10
+pepin-inventory/v11
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -149,7 +149,7 @@ code.
 <!-- pepin:gen inventory-types -->
 | Type de ressource lu | Attributs communs |
 |---|---|
-| `access_key` | `access_key_id` `creation_date` `expiration_date` `owner_user` `scope` `state` |
+| `access_key` | `access_key_id` `creation_date` `expiration_date` `owner_application_id` `owner_user` `owner_user_id` `scope` `state` |
 | `api_access_policy` | `id` `max_access_key_expiration_seconds` `require_trusted_env` |
 | `api_access_rule` | `api_access_rule_id` `ca_ids` `cns` `ip_ranges` |
 | `api_access_summary` | `id` `rule_count` |
@@ -160,7 +160,7 @@ code.
 | `governance_provider` | `capital_control` `eu_established` `extraterritorial_exposure` `jurisdiction` `secnumcloud` `secnumcloud_regions` |
 | `iam_policy` | `manages_iam` `owner_group` `owner_user` `policy_id` `policy_name` `scope` `statements` |
 | `iam_role` | `admin_privileges` `editable` `manages_iam` `max_session_ttl` `name` `policy_has_expiration` `provider_managed` `role_id` `source_ip_restricted` |
-| `iam_user` | `mfa_enabled` `user_id` `username` |
+| `iam_user` | `mfa_enabled` `user_id` `user_type` `username` |
 | `k8s_cluster_role_binding` | `name` `role_ref` `subjects` |
 | `k8s_crd` | `name` |
 | `k8s_namespace` | `labels` `name` |

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -12,7 +12,7 @@ with the same regard as the CLI surface.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v10
+pepin-inventory/v11
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -141,7 +141,7 @@ descriptors and from the Go collectors — never a hand-kept list beside the cod
 <!-- pepin:gen inventory-types -->
 | Resource type read | Common attributes |
 |---|---|
-| `access_key` | `access_key_id` `creation_date` `expiration_date` `owner_user` `scope` `state` |
+| `access_key` | `access_key_id` `creation_date` `expiration_date` `owner_application_id` `owner_user` `owner_user_id` `scope` `state` |
 | `api_access_policy` | `id` `max_access_key_expiration_seconds` `require_trusted_env` |
 | `api_access_rule` | `api_access_rule_id` `ca_ids` `cns` `ip_ranges` |
 | `api_access_summary` | `id` `rule_count` |
@@ -152,7 +152,7 @@ descriptors and from the Go collectors — never a hand-kept list beside the cod
 | `governance_provider` | `capital_control` `eu_established` `extraterritorial_exposure` `jurisdiction` `secnumcloud` `secnumcloud_regions` |
 | `iam_policy` | `manages_iam` `owner_group` `owner_user` `policy_id` `policy_name` `scope` `statements` |
 | `iam_role` | `admin_privileges` `editable` `manages_iam` `max_session_ttl` `name` `policy_has_expiration` `provider_managed` `role_id` `source_ip_restricted` |
-| `iam_user` | `mfa_enabled` `user_id` `username` |
+| `iam_user` | `mfa_enabled` `user_id` `user_type` `username` |
 | `k8s_cluster_role_binding` | `name` `role_ref` `subjects` |
 | `k8s_crd` | `name` |
 | `k8s_namespace` | `labels` `name` |

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -30,7 +30,7 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v10** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v11** |
 <!-- /pepin:gen surface-versions -->
 
 « Gelé » signifie qu'un test échoue quand la forme bouge sans que sa version ait suivi : les

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -30,7 +30,7 @@ See [Exit codes](exit-codes.md).
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v10** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v11** |
 <!-- /pepin:gen surface-versions -->
 
 "Frozen" means a test fails when the shape moves and its version has not: field paths and JSON

--- a/internal/assess/assess.go
+++ b/internal/assess/assess.go
@@ -74,7 +74,9 @@ var requiredAttr = map[string]map[string][]string{
 	// `not-evaluated` une machine dont on avait parfaitement lu les cartes.
 	"compute_instance_public_ip_with_open_securitygroup": {"": {"public_ip", "nic_public_ips"}},
 	"compute_image_not_public":                           {"": {"public"}},
-	"iam_no_root_access_key":                             {"": {"root_owned", "scope"}},
+	// `owner_user_id` (Scaleway, #195) : la cle porte l'utilisateur auquel elle
+	// appartient, et la regle le joint a l'utilisateur de type `owner`.
+	"iam_no_root_access_key": {"": {"root_owned", "scope", "owner_user_id", "owner_application_id"}},
 	// Sans date de création, l'ÂGE d'une clé ne se déduit pas : une absence n'est pas
 	// une rotation récente. Le contrôle sort « non évalué » plutôt que conforme.
 	"iam_accesskey_rotated":                    {"": {"creation_date"}},

--- a/internal/commonrules/rules/iam_no_root_access_key.rego
+++ b/internal/commonrules/rules/iam_no_root_access_key.rego
@@ -30,6 +30,34 @@ _root_key(r) if {
 	not id in _eim_key_ids
 }
 
+# Ensemble des identifiants d'utilisateurs PROPRIÉTAIRES de l'organisation.
+#
+# Scaleway le dit littéralement : chaque utilisateur porte `type`, dont la valeur est
+# `owner` ou `member` (GET /iam/v1alpha1/users, vérifié contre l'API réelle le
+# 2026-09-11). C'est le seul marqueur fiable — `account_root_user_id`, porté par le même
+# enregistrement, désigne autre chose et diffère de l'id du propriétaire.
+_owner_user_ids contains id if {
+	some r in input.resources
+	r.type == "iam_user"
+	lower(object.get(r.attributes, "user_type", "")) == "owner"
+	id := object.get(r.attributes, "user_id", "")
+	id != ""
+}
+
+# root_owned dérivé (Scaleway) : la clé appartient à l'utilisateur PROPRIÉTAIRE.
+#
+# Ce que cette jointure évite. Une clé d'API Scaleway porte `user_id` (un humain) ou
+# `application_id` (une identité de service). S'arrêter à « c'est une clé
+# d'utilisateur » signalerait la clé de CHAQUE membre qui en a une : un faux positif par
+# personne, et dix de ces findings apprennent à ignorer l'outil. Ce que le contrôle vise,
+# c'est la clé qui contourne l'IAM parce qu'elle appartient au compte qui possède
+# l'organisation — pas celle d'un collègue.
+_root_key(r) if {
+	uid := object.get(r.attributes, "owner_user_id", "")
+	uid != ""
+	uid in _owner_user_ids
+}
+
 deny contains f if {
 	some r in input.resources
 	r.type == "access_key"

--- a/internal/commonrules/rules/iam_no_root_access_key_test.rego
+++ b/internal/commonrules/rules/iam_no_root_access_key_test.rego
@@ -48,3 +48,68 @@ test_osc_shared_key_not_root if {
 test_osc_eim_key_not_root if {
 	count({f | some f in deny; f.code == _sw_iam_code; f.subject == "eim-1"}) == 0 with input as _osc_keys
 }
+
+# ── La dérivation Scaleway : la clé du PROPRIÉTAIRE, pas celle d'un collègue ────
+#
+# Le piège que ces cas gardent. Une clé d'API Scaleway porte `user_id` (un humain) ou
+# `application_id` (une identité de service). S'arrêter à « c'est une clé
+# d'utilisateur » signalerait la clé de CHAQUE membre : un faux positif par personne,
+# et c'est ce qui fait désinstaller un outil. Le contrôle vise la clé qui contourne
+# l'IAM parce qu'elle appartient au compte propriétaire de l'organisation.
+
+_scw_user(id, type) := {
+	"type": "iam_user",
+	"id": id,
+	"name": id,
+	"attributes": {"user_id": id, "user_type": type},
+}
+
+_scw_key(id, owner) := {
+	"type": "access_key",
+	"id": id,
+	"name": id,
+	"attributes": {"access_key_id": id, "owner_user_id": owner},
+}
+
+test_scaleway_owner_key_is_root if {
+	count({f | some f in deny; f.code == _sw_iam_code}) == 1 with input as {"resources": [
+		_scw_user("u-owner", "owner"),
+		_scw_key("SCW1", "u-owner"),
+	]}
+}
+
+# LE CONTRE-EXEMPLE QUI COMPTE : un membre a sa propre clé, et ce n'est pas un écart.
+test_scaleway_member_key_is_not_root if {
+	count({f | some f in deny; f.code == _sw_iam_code}) == 0 with input as {"resources": [
+		_scw_user("u-owner", "owner"),
+		_scw_user("u-alice", "member"),
+		_scw_key("SCW2", "u-alice"),
+	]}
+}
+
+# Une clé d'APPLICATION ne porte aucun propriétaire humain : rien à signaler.
+test_scaleway_application_key_is_not_root if {
+	count({f | some f in deny; f.code == _sw_iam_code}) == 0 with input as {"resources": [
+		_scw_user("u-owner", "owner"),
+		{
+			"type": "access_key",
+			"id": "SCW3",
+			"name": "SCW3",
+			"attributes": {"access_key_id": "SCW3"},
+		},
+	]}
+}
+
+# Sans l'utilisateur, la jointure ne trouve rien : on ne conclut pas sur ce qu'on n'a
+# pas vu, plutôt que de supposer qu'une clé d'utilisateur est celle du propriétaire.
+test_scaleway_without_the_user_the_rule_stays_silent if {
+	count({f | some f in deny; f.code == _sw_iam_code}) == 0 with input as {"resources": [_scw_key("SCW4", "u-owner")]}
+}
+
+# La casse ne décide pas : `Owner` vaut `owner`.
+test_scaleway_owner_type_is_case_insensitive if {
+	count({f | some f in deny; f.code == _sw_iam_code}) == 1 with input as {"resources": [
+		_scw_user("u-owner", "Owner"),
+		_scw_key("SCW5", "u-owner"),
+	]}
+}

--- a/internal/model/schema.go
+++ b/internal/model/schema.go
@@ -151,7 +151,19 @@ import (
 //	fil : le collecteur paginait la même liste pour joindre les règles à leur
 //	groupe, sans jamais projeter le champ. Une lacune de couverture, pas une lacune
 //	d'API (issue #195). Contrat vérifié contre l'API réelle le 2026-09-11.
-const InventoryFormat = "pepin-inventory/v10"
+//
+// v11 : une `access_key` peut porter `owner_user_id` et `owner_application_id`, et un
+//
+//	`iam_user` son `user_type` (`owner` | `member`). Ajout PUR. Il est nécessaire parce
+//	que `iam_no_root_access_key` ne savait pas conclure en live chez Scaleway : la
+//	donnée était dans la liste de clés DÉJÀ interrogée, et personne ne la projetait.
+//	Les deux champs d'appartenance vont ensemble — une clé appartient à un
+//	utilisateur OU à une application, et ne projeter que le premier ferait taire le
+//	contrôle sur les clés d'application, dont l'appartenance est pourtant observée.
+//	`user_type` est le SEUL marqueur du propriétaire de l'organisation :
+//	`account_root_user_id`, porté par le même enregistrement, désigne autre chose
+//	(mesuré le 2026-09-11). Contrat vérifié contre l'API réelle.
+const InventoryFormat = "pepin-inventory/v11"
 
 // InventorySchemaVersion extrait le N du suffixe `/vN`. Comme pour le bundle, la
 // constante et le signal sur le fil sont la même chose : impossible de faire

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -2,12 +2,12 @@
   "controls": 58,
   "paths": 182,
   "paths_proven": 31,
-  "obligations": 460,
-  "proven": 94,
+  "obligations": 462,
+  "proven": 96,
   "verdicts": {
     "fail": {
-      "required": 139,
-      "proven": 24
+      "required": 140,
+      "proven": 25
     },
     "not-applicable": {
       "required": 24,
@@ -18,8 +18,8 @@
       "proven": 22
     },
     "pass": {
-      "required": 139,
-      "proven": 36
+      "required": 140,
+      "proven": 37
     }
   },
   "live_paths": 103,
@@ -995,9 +995,15 @@
         {
           "provider": "scaleway",
           "source": "live",
-          "status": "partial",
+          "status": "supported",
           "required": [
+            "fail",
+            "pass",
             "not-evaluated"
+          ],
+          "proven": [
+            "fail",
+            "pass"
           ]
         },
         {
@@ -1008,6 +1014,9 @@
             "not-evaluated"
           ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/root-access-key-scaleway-live.yaml"
       ],
       "rego_tests": [
         "internal/commonrules/rules/iam_no_root_access_key_test.rego"
@@ -2641,8 +2650,8 @@
   },
   "precision": {
     "controls": 43,
-    "detection_proven": 20,
-    "with_counterexample": 18,
+    "detection_proven": 21,
+    "with_counterexample": 19,
     "false_positives": 0,
     "counterwitnesses": 2
   }

--- a/internal/veracity/testdata/counterexamples-debt.txt
+++ b/internal/veracity/testdata/counterexamples-debt.txt
@@ -10,7 +10,7 @@
 # contre-exemple est une règle high/critical ajoutée sans sa preuve de
 # précision, et la CI la refuse.
 #
-# high/critical actifs : 43 · avec contre-exemple : 18 · restants : 25
+# high/critical actifs : 43 · avec contre-exemple : 19 · restants : 24
 
 blockstorage_snapshot_not_public
 blockstorage_volume_encryption
@@ -22,7 +22,6 @@ governance_resource_region_in_eu
 iam_account_mfa_enforced
 iam_apiaccessrule_defined
 iam_apiaccessrule_no_public_cidr
-iam_no_root_access_key
 iam_policy_no_privilege_escalation
 iam_role_key_lifetime_bounded
 iam_role_no_admin_privileges

--- a/internal/veracity/testdata/scenarios/root-access-key-scaleway-live.yaml
+++ b/internal/veracity/testdata/scenarios/root-access-key-scaleway-live.yaml
@@ -1,0 +1,69 @@
+# Cle d'API du PROPRIETAIRE de l'organisation, sur une collecte live Scaleway.
+#
+# Le chemin traverse le collecteur REEL : `/iam/v1alpha1/api-keys` et
+# `/iam/v1alpha1/users`, le mapping declaratif du descripteur (`user_id` ->
+# `owner_user_id`, `type` -> `user_type`), le verrou de capacite, la jointure de la
+# regle, puis l'assessment. C'est l'entree exigee par le contrat : les deux types sont
+# produits par la spec `collecte`, donc un scenario `live` ne peut pas passer par
+# `inventory:`.
+#
+# # Ce que ces cas gardent, et c'est le piege de ce controle
+#
+# Une cle d'API Scaleway porte `user_id` (un humain) ou `application_id` (une identite
+# de service). S'arreter a « c'est une cle d'utilisateur » signalerait la cle de CHAQUE
+# membre qui en a une : un faux positif par personne, et dix de ces findings apprennent
+# a ignorer l'outil. Ce que le controle vise, c'est la cle qui contourne l'IAM parce
+# qu'elle appartient au compte qui POSSEDE l'organisation.
+#
+# Le marqueur est `type: owner`, verifie contre l'API reelle le 2026-09-11. Ce n'est pas
+# `account_root_user_id`, porte par le meme enregistrement : il designe autre chose et
+# differe de l'id du proprietaire.
+control: iam_no_root_access_key
+provider: scaleway
+source: live
+
+scenarios:
+  - expect: fail
+    why: "la cle appartient a l'utilisateur de type owner : elle contourne l'IAM"
+    api:
+      /iam/v1alpha1/api-keys: |
+        {"api_keys": [{"access_key": "SCWOWNERKEY000000000",
+                       "user_id": "11111111-1111-1111-1111-111111111111",
+                       "expires_at": "2099-01-01T00:00:00Z"}],
+         "total_count": 1}
+      /iam/v1alpha1/users: |
+        {"users": [{"id": "11111111-1111-1111-1111-111111111111",
+                    "email": "proprietaire@exemple.fr",
+                    "type": "owner",
+                    "mfa": true}],
+         "total_count": 1}
+
+  - expect: pass
+    why: "LA MEME cle, le MEME utilisateur, mais membre et non proprietaire — la cle d'un collegue n'est pas un ecart"
+    api:
+      /iam/v1alpha1/api-keys: |
+        {"api_keys": [{"access_key": "SCWOWNERKEY000000000",
+                       "user_id": "11111111-1111-1111-1111-111111111111",
+                       "expires_at": "2099-01-01T00:00:00Z"}],
+         "total_count": 1}
+      /iam/v1alpha1/users: |
+        {"users": [{"id": "11111111-1111-1111-1111-111111111111",
+                    "email": "collegue@exemple.fr",
+                    "type": "member",
+                    "mfa": true}],
+         "total_count": 1}
+
+  - expect: pass
+    why: "une cle d'APPLICATION ne porte aucun proprietaire humain : c'est exactement la remediation que le controle demande"
+    api:
+      /iam/v1alpha1/api-keys: |
+        {"api_keys": [{"access_key": "SCWAPPKEY00000000000",
+                       "application_id": "22222222-2222-2222-2222-222222222222",
+                       "expires_at": "2099-01-01T00:00:00Z"}],
+         "total_count": 1}
+      /iam/v1alpha1/users: |
+        {"users": [{"id": "11111111-1111-1111-1111-111111111111",
+                    "email": "proprietaire@exemple.fr",
+                    "type": "owner",
+                    "mfa": true}],
+         "total_count": 1}

--- a/providers/scaleway.yaml
+++ b/providers/scaleway.yaml
@@ -115,6 +115,23 @@ collecte:
       map:
         access_key_id: access_key
         expiration_date: expires_at
+        # À QUI la clé appartient. Aucun appel supplémentaire : la liste des clés
+        # porte déjà `user_id` (et `application_id` pour une identité de service).
+        # Vérifié contre l'API réelle le 2026-09-11.
+        #
+        # Le champ ne dit PAS « root » à lui seul, et c'est le piège : une clé
+        # d'utilisateur est la clé d'un humain, pas celle du propriétaire de
+        # l'organisation. Signaler toutes les clés d'utilisateur ferait crier sur
+        # chaque membre qui a la sienne — un faux positif par personne. La règle
+        # joint donc cet identifiant à l'utilisateur de type `owner`.
+        owner_user_id: user_id
+        # L'autre moitié de l'appartenance, et elle est nécessaire. Une clé Scaleway
+        # appartient à un utilisateur OU à une application : sans ce champ, une clé
+        # d'application n'a aucun attribut d'appartenance, le verrou de capacité se
+        # ferme, et le contrôle ne conclut plus sur elle — alors qu'« appartient à une
+        # application » est précisément l'observation qui le rend muet à bon droit.
+        # C'est le motif de l'issue #227, un cran plus haut.
+        owner_application_id: application_id
       paging: { style: page, param: page, size_param: page_size, size: 100 }
   
     # Utilisateurs IAM → iam_user (alimente iam_user_mfa_enabled). Champ natif
@@ -127,6 +144,11 @@ collecte:
         user_id: id
         username: email
         mfa_enabled: mfa
+        # `owner` | `member` — c'est ce champ qui désigne le propriétaire de
+        # l'organisation, et il n'y en a pas d'autre. `account_root_user_id`, porté par
+        # le même enregistrement, désigne AUTRE CHOSE : mesuré le 2026-09-11, il diffère
+        # de l'id du propriétaire, et ce n'est pas lui que les clés référencent.
+        user_type: type
       paging: { style: page, param: page, size_param: page_size, size: 100 }
   
     # Groupes de sécurité → security_group. AUCUN APPEL SUPPLÉMENTAIRE : c'est la
@@ -469,7 +491,8 @@ contrat:
       mapping:
         access_key_id: AccessKey
         expiration_date: ExpiresAt (*time.Time)
-        root_owned: 'DÉRIVÉ : APIKey rattachée à un UserID (vs ApplicationID) — a_verifier'
+        owner_user_id: 'APIKey.UserID — l''utilisateur auquel la clé appartient (absent pour une clé d''application). VÉRIFIÉ contre l''API réelle le 2026-09-11.'
+        user_type: 'IAM User.Type — `owner` | `member`. C''est le SEUL marqueur du propriétaire de l''organisation : `account_root_user_id`, porté par le même enregistrement, désigne autre chose et diffère de l''id du propriétaire (mesuré). La règle joint owner_user_id à l''utilisateur de type owner ; s''arrêter à « clé d''utilisateur » signalerait la clé de chaque membre.'
     iam_user:
       etat: verifie
       source: api/iam/v1alpha1 User (GET /iam/v1alpha1/users)

--- a/references/qualification/scaleway/expected.yaml
+++ b/references/qualification/scaleway/expected.yaml
@@ -71,10 +71,18 @@ controls:
       silent: [scaleway_iam_api_key.expiring]
 
   iam_no_root_access_key:
-    # `root_owned` est DÉRIVÉ et non encore projeté (contrat a_verifier, issue #195) :
-    # le verrou de capacité tient sur les deux sources. Un pass ou un fail qui apparaîtrait ici
-    # sans changement du collecteur serait une régression.
-    live: not-evaluated
+    # #195 : la dérivation est projetée depuis la liste de clés DÉJÀ interrogée
+    # (`APIKey.user_id`) et le type de l'utilisateur (`IAM User.type` = owner|member),
+    # tous deux vérifiés contre l'API réelle le 2026-09-11. Aucun appel supplémentaire.
+    #
+    # Le tenant ne crée AUCUNE clé du propriétaire — on ne provisionne pas un écart qui
+    # consisterait à donner une clé au compte qui possède l'organisation. Les clés qu'il
+    # crée appartiennent à des applications, et elles doivent rester muettes : c'est le
+    # contre-exemple, et il vaut autant que l'écart. Le compte du mainteneur, lui, porte
+    # une vraie clé de propriétaire et le contrôle la trouve — mesuré, hors tenant.
+    live:
+      status: evaluated
+      reason: "aucune clé du propriétaire dans le tenant ; les écarts hors tenant ne sont pas gardés"
     terraform: not-evaluated
 
   iam_user_mfa_enabled:


### PR DESCRIPTION
Second control of #195, and the one where the issue's own sketch was **not good enough**.

## The gap, and the trap

`iam_no_root_access_key` — severity **high** — could not conclude on either source at
Scaleway. The data was in the API-key listing the collector **already calls**: `user_id`,
and `application_id` for a service identity.

The derivation the issue sketched — `user_id` vs `application_id` — is not enough, and
shipping it would have been **worse than the gap**. A user key is a *human's* key, not
the organisation owner's. Flagging every one of them means **one false positive per
member**, and ten of those teach people to ignore the tool.

The rule's own contract already said what it meant:

> `root_owned: true` : flag explicite posé par le collecteur (Scaleway : **APIKey.UserID
> == propriétaire de l'organisation**).

## What the API actually says

Verified against the **live API** on 2026-09-11, not inferred:

| Record | Field | Value |
|---|---|---|
| `GET /iam/v1alpha1/users` | `type` | **`owner`** \| `member` |
| same record | `account_root_user_id` | `92271422-…` |
| the owner user | `id` | `af34fa60-…` |
| `GET /iam/v1alpha1/api-keys` | `user_id` | `af34fa60-…` |

**`account_root_user_id` is not the owner's id**, and it is not what the keys reference.
`type: owner` is the only reliable marker. That measurement is what kept a plausible,
wrong derivation out.

## Both ownership fields, and why the second is not optional

Projecting only `user_id` left an **application** key with no ownership attribute at all
— the capability guard closed, and the control went silent on a key whose ownership is
*perfectly observed*, just in the other field. That is the pattern of **#227, one layer
up**, and it was caught here by a veracity scenario rather than in production.

## Gates

Five Rego cases, including the two that carry the weight:

- a **member's** key is not a deviation;
- an **application** key is exactly the remediation the control asks for.

Falsified before being kept: treating every user as owner, and dropping the join — each
turns the suite red.

A live veracity scenario with three cases: the owner's key fails, **the same key** on a
`member` passes, an application key passes.

## Measured

On a real account the control finds a **genuine deviation** — the owner's key, which
happens to be the one running the scan. Then a qualification run:

| | Result |
|---|---|
| non-regression contract | **GO** |
| release verdict | **GO** |
| destruction proven | 19 families, no delta, 0.0058 € |

## Impact ADR

**ADR-0003**: inventory format `v10` → `v11`, a pure addition, constant bumped **before**
regenerating the frozen surface, with the reason written. **ADR-0001** respected: one
common rule, gaining a provider-specific *derivation* alongside the two it already had —
no rule was added and none is provider-owned. **ADR-0006**: the control concludes because
the data now arrives. No ADR modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)