### PR TITLE
fix(qualification): the Scaleway tenant refuses to run in the default project

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -53,6 +53,19 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Le tenant de qualification Scaleway refuse de tourner dans le projet par défaut**
+  (issue #240). Il applique des ressources délibérément exposées, et sa preuve de
+  destruction repose sur un delta avant/après pour ce qui ne porte pas d'étiquette — que
+  toute ressource **tierce** qui bouge pendant le run fausse, dans un sens ou dans
+  l'autre. Chez Scaleway, le projet par défaut porte l'ID de l'Organization, ne peut être
+  ni supprimé ni transféré, et c'est là que tout atterrit quand personne n'a choisi.
+  Mesuré le 2026-09-10 : il portait une VM d'un autre travail, lancée deux heures plus
+  tôt ; le run n'a pu avoir lieu qu'après vidage complet du compte, ce qui n'est pas une
+  procédure. Le crochet `identity` refuse désormais, en donnant les trois commandes qui
+  corrigent. Le projet est **vidé**, jamais recréé : un projet réutilisé garde son
+  historique de consommation, ne consomme qu'une fois le plafond de 25 projets, et n'a
+  besoin qu'une fois de son VPC (un projet créé depuis le 13 mai 2025 n'en reçoit plus).
+
 - **La règle absent/vide est désormais une porte, plus une habitude** (issue #227,
   seconde moitié). Une règle gouverne chaque attribut qu'une spec de fournisseur mappe —
   une clé **absente** de la source ne projette rien, une clé présente et **vide** projette

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ belongs in `git log`.
 
 ### Fixed
 
+- **The Scaleway qualification tenant refuses to run in the default project** (issue
+  #240). It applies deliberately exposed resources, and its proof of destruction relies
+  on a before/after delta for what carries no tag — which a **third-party** resource
+  moving during the run falsifies, in either direction. At Scaleway the default project
+  carries the Organization's ID, cannot be deleted or transferred, and is where
+  everything lands when nobody chose. Measured on 2026-09-10: it held a VM from other
+  work, started two hours earlier; the run could only proceed after emptying the whole
+  account, which is not a procedure. The `identity` hook now refuses, and says which
+  three commands fix it. The project is **emptied**, never recreated: a reused project
+  keeps its consumption history, spends the 25-project quota once, and needs its VPC
+  created once (a project created since 13 May 2025 no longer receives a default one).
+
 - **The absent/empty rule is now a gate, not a habit** (issue #227, second half). One
   rule governs every attribute a provider spec maps — a key **absent** from the source
   projects nothing, a key present and **empty** projects the empty value — and

--- a/references/qualification/scaleway/README.fr.md
+++ b/references/qualification/scaleway/README.fr.md
@@ -17,6 +17,35 @@ live ne mesure : les ressources que seul un plan lit sont derrière
 scanne le plan complet en `--terraform`. `expected.yaml` épingle les deux sources
 séparément.
 
+## Prérequis : un projet dédié, jamais celui par défaut
+
+Cette stack applique des ressources **délibérément exposées** — SSH ouvert à tout
+Internet, buckets publics, politiques permissives — et sa preuve de destruction repose
+sur un delta avant/après pour ce qui ne porte pas d'étiquette. Une ressource **tierce**
+qui bouge pendant le run fausse ce delta, dans un sens ou dans l'autre.
+
+Chez Scaleway, les ressources vivent dans un **Projet** et n'en sortent pas, tandis que
+l'IAM et les quotas restent au niveau de l'**Organization**. Le projet est donc la seule
+frontière que ce tenant puisse utiliser — et le **projet par défaut n'en est pas une** :
+il porte l'ID de l'Organization, ne peut être ni supprimé ni transféré, et c'est là que
+tout atterrit quand personne n'a choisi.
+
+Mesuré le 2026-09-10 : le projet par défaut portait une VM `pavois-repro-…` lancée deux
+heures plus tôt, issue d'un autre travail. Le run n'a pu avoir lieu qu'après vidage
+complet du compte, ce qui n'est pas une procédure. D'où l'issue #240, et le refus que le
+crochet `identity` oppose désormais.
+
+```bash
+scw account project create name=pepin-qualification     description="Tenant de qualification Pepin — vide entre deux runs"
+scw config set default-project-id=<ID_DU_PROJET>
+export PEPIN_QUAL_SCW_PROJECT=<ID_DU_PROJET>
+```
+
+Le projet n'est **pas recréé** à chaque run : il est **vidé**. Un projet réutilisé garde
+son historique de consommation, ne consomme qu'une fois le plafond de 25 projets par
+organisation, et n'a besoin qu'une fois de son VPC (un projet créé depuis le
+13 mai 2025 n'en reçoit plus par défaut).
+
 ## Ce que la stack crée
 
 | Famille | Nombre | Ressource fautive → contrôle | Contre-exemple (doit rester muet) |

--- a/references/qualification/scaleway/README.md
+++ b/references/qualification/scaleway/README.md
@@ -16,6 +16,34 @@ measures, so the resources only a plan reads are behind `terraform_only_resource
 (default `true`): the runner applies with `false` and scans the full plan with
 `--terraform`. `expected.yaml` pins the two sources separately.
 
+## Prerequisite: a dedicated project, never the default one
+
+This stack applies **deliberately exposed** resources — SSH open to the whole internet,
+public buckets, permissive policies — and its proof of destruction relies on a
+before/after delta for what carries no tag. A **third-party** resource moving during the
+run falsifies that delta, in either direction.
+
+At Scaleway, resources live in a **Project** and never leave it, while IAM and quotas
+stay at the **Organization** level. The project is therefore the only boundary this
+tenant can use — and the **default project is not one**: it carries the Organization's
+ID, cannot be deleted or transferred, and is where everything lands when nobody chose.
+
+Measured on 2026-09-10: the default project held a `pavois-repro-…` VM started two hours
+earlier, from other work. The run could only proceed after emptying the whole account,
+which is not a procedure. Hence issue #240, and the refusal the `identity` hook now
+raises.
+
+```bash
+scw account project create name=pepin-qualification     description="Pepin qualification tenant — emptied between runs"
+scw config set default-project-id=<PROJECT_ID>
+export PEPIN_QUAL_SCW_PROJECT=<PROJECT_ID>
+```
+
+The project is **not recreated** on each run — it is **emptied**. A reused project keeps
+its consumption history, consumes the 25-project-per-organization quota only once, and
+needs its VPC created only once (a project created since 13 May 2025 no longer receives
+a default one).
+
 ## What the stack creates
 
 | Family | Count | Faulty resource → control | Counterexample (must stay silent) |

--- a/references/qualification/scaleway/hooks.py
+++ b/references/qualification/scaleway/hooks.py
@@ -169,6 +169,39 @@ def identity():
     if not project:
         sys.exit("la clé d'API n'a pas de projet par défaut : impossible d'établir le compte")
     p = api("GET", f"/account/v3/projects/{project}")
+    org = p.get("organization_id")
+    # LE PROJET PAR DÉFAUT N'EST PAS UN LIEU DE QUALIFICATION.
+    #
+    # Chez Scaleway, le projet par défaut porte l'ID de l'Organization : `project_id ==
+    # organization_id` le désigne sans ambiguïté. Il ne peut être ni supprimé ni
+    # transféré, et c'est là que vivent par défaut les ressources de tout le monde.
+    #
+    # Ce tenant applique délibérément SSH ouvert à tout Internet, des buckets publics et
+    # des politiques permissives. Deux raisons de refuser, et la seconde est la plus
+    # insidieuse :
+    #
+    #   1. une fenêtre d'exposition dans un projet où quelqu'un travaille ;
+    #   2. la preuve de destruction repose sur un delta avant/après pour ce qui ne
+    #      s'étiquette pas. Une ressource TIERCE qui apparaît ou disparaît pendant le run
+    #      fausse ce delta — dans un sens ou dans l'autre. Le run dirait alors « rien ne
+    #      survit » sans l'avoir établi, ou crierait sur ce qui ne lui appartient pas.
+    #
+    # Mesuré le 2026-09-10 : le projet par défaut portait une VM `pavois-repro-…` lancée
+    # deux heures plus tôt, d'un autre projet du mainteneur. Le run n'a pu avoir lieu
+    # qu'après vidage complet du compte, ce qui n'est pas une procédure (issue #240).
+    if project == org:
+        sys.exit(
+            "REFUS : la clé de qualification pointe le PROJET PAR DÉFAUT de "
+            f"l'organisation ({project}).\n"
+            "  Ce tenant crée délibérément des ressources exposées, et sa preuve de "
+            "destruction\n"
+            "  repose sur un delta avant/après que toute ressource tierce fausse.\n"
+            "  Créer un projet dédié, puis y pointer le projet par défaut de cette clé :\n"
+            "    scw account project create name=pepin-qualification \\\n"
+            "        description=\"Tenant de qualification Pepin — vide entre deux runs\"\n"
+            "    scw config set default-project-id=<ID_DU_PROJET>\n"
+            "  Puis poser PEPIN_QUAL_SCW_PROJECT sur ce même identifiant."
+        )
     bearer = "application" if key.get("application_id") else "user"
     return {
         "project_id": project,

--- a/references/qualification/scaleway/tenant.yaml
+++ b/references/qualification/scaleway/tenant.yaml
@@ -26,6 +26,31 @@ name_prefix: pepin-qual-
 # contrainte flottante (issue scaleway/terraform-provider-scaleway#4338).
 provider_version: "2.82.0"
 
+# UN PROJET DÉDIÉ, JAMAIS LE PROJET PAR DÉFAUT (issue #240).
+#
+# Chez Scaleway, les ressources vivent dans un PROJET et n'en sortent pas, tandis que
+# l'IAM et les quotas restent au niveau de l'Organization. Le projet est donc la seule
+# frontière que ce tenant puisse utiliser — et le projet PAR DÉFAUT n'en est pas une :
+# il porte l'ID de l'Organization, ne peut être ni supprimé ni transféré, et c'est là
+# que tout atterrit quand personne n'a choisi.
+#
+# Ce tenant crée délibérément SSH ouvert à tout Internet, des buckets publics et des
+# politiques permissives. Et sa preuve de destruction repose sur un delta avant/après
+# pour ce qui ne s'étiquette pas : une ressource TIERCE qui bouge pendant le run le
+# fausse. Le crochet `identity` refuse donc de démarrer sur le projet par défaut.
+#
+# Le projet n'est pas recréé à chaque run : il est VIDÉ. Un projet réutilisé garde son
+# historique de consommation, ne consomme qu'une fois le plafond de 25 projets par
+# organisation, et n'a besoin qu'une fois de son VPC (un projet créé depuis le
+# 13 mai 2025 n'en reçoit plus par défaut).
+projet_dedie:
+  exige: true
+  convention: "pepin-qualification"
+  prerequis: >
+    scw account project create name=pepin-qualification ;
+    scw config set default-project-id=<ID> ;
+    PEPIN_QUAL_SCW_PROJECT=<ID>
+
 # Outil requis par le chemin de SECOURS du nettoyage (jamais par la preuve, qui
 # passe par l'API) : le runner refuse de démarrer sans lui.
 required_tools: [scw]


### PR DESCRIPTION
Closes #240.

## What happened, measured

On 2026-09-10, before launching the three qualification runs, inspecting the account
found in the **default project** a VM `pavois-repro-20260910-1216` started **two hours
earlier and still running** — other work of the maintainer's.

The run could only proceed after **emptying the whole account**. That is not a procedure.

## Why the default project is the wrong place

This tenant applies **deliberately exposed** resources — SSH open to the whole internet,
public buckets, permissive policies. Two independent problems, and the second is the
insidious one:

1. an **exposure window** in a project where someone is working;
2. **the proof of destruction lies**. It relies on a tag-filtered listing *plus a
   before/after delta* for what carries no tag. A third-party resource appearing or
   disappearing during the run falsifies that delta — in either direction. The run would
   say *"nothing survived"* without having established it, or shout about something that
   is not its own.

At Scaleway, resources live in a **Project** and never leave it, while IAM and quotas
stay at the **Organization** level. The project is the only boundary this tenant can use
— and the default project is not one: it carries the Organization's ID, cannot be deleted
or transferred, and is where everything lands when nobody chose. `project_id ==
organization_id` names it without ambiguity.

## The refusal, and it is actionable

```
REFUS : la clé de qualification pointe le PROJET PAR DÉFAUT de l'organisation
(eea35431-…).
  Ce tenant crée délibérément des ressources exposées, et sa preuve de destruction
  repose sur un delta avant/après que toute ressource tierce fausse.
  Créer un projet dédié, puis y pointer le projet par défaut de cette clé :
    scw account project create name=pepin-qualification \
        description="Tenant de qualification Pepin — vide entre deux runs"
    scw config set default-project-id=<ID_DU_PROJET>
  Puis poser PEPIN_QUAL_SCW_PROJECT sur ce même identifiant.
```

## Emptied, not recreated — and that was a real trade-off

Deleting the project at the end would make **the deletion itself the proof of
destruction**: `scw account project delete` succeeds *only* if the project holds no
resource, which is an unfalsifiable proof needing no enumeration. It is strictly stronger
than the current listing, which must know 19 families and is only as good as that list.

It was weighed and **declined**, because reuse buys three things the stronger proof does
not pay for: the consumption history survives, the 25-project-per-organization quota is
spent once rather than per run, and the VPC is created once — a project created since
13 May 2025 no longer receives a default one.

## Consequence to know

**A Scaleway qualification run now refuses** until a dedicated project exists and the
key's default project points at it. That is the intended failure mode: the previous
behaviour was to run anyway, next to someone's work.

The refusal of leftovers from a *previous run* already existed (`snapshot_before`);
nothing was added there.

## Written where it will be met

`tenant.yaml` declares the requirement, and **both** tenant READMEs carry the prerequisite
with its three commands and the reason.

## Source

The repository's own training material — `cloud/scaleway/fondations/organisations-projets`
— validated in a live lab on 2026-07-18 and reconfirmed on 2026-09-08. It already said
*"le projet par défaut réservé à rien d'important"* and *"un projet par lab … tout
supprimer d'un coup"*. The guidance existed; the tenant did not follow it.

## Impact ADR

**ADR-0012** (no credential in CI; a live scan is a maintainer gesture whose result is
recorded) is what this strengthens: the gesture now has a defined place to happen.
**ADR-0020** (a declared origin is refused, not warned about) is the shape of the
refusal — it exits, it does not print a warning and continue. No ADR modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)