### PR TITLE
feat(outscale): a plan can judge API access rules

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -24,6 +24,14 @@ l'une ni l'autre appartient au `git log`.
 
 ### Ajouté
 
+- **Un plan Outscale juge les règles d'accès à l'API** (issue #203).
+  `iam_apiaccessrule_no_public_cidr` revenait `not-evaluated` sur la source Terraform
+  alors que le plan portait `ip_ranges` — argument **obligatoire** de
+  `outscale_api_access_rule` quand aucun autre critère n'est donné, donc toujours écrit
+  dans le HCL. Pépin ne savait pas conclure sur un `0.0.0.0/0` écrit noir sur blanc.
+  Mesuré sur le plan réel du tenant de qualification et confirmé par un run
+  `--plan-only`, GO, sans rien créer.
+
 - **Un plan Outscale sait juger la protection contre la suppression** (issue #203).
   `compute_instance_deletion_protection` revenait `not-evaluated` sur la source Terraform
   alors que le plan portait la réponse : `outscale_vm.deletion_protection` est un

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ belongs in `git log`.
 
 ### Added
 
+- **Outscale plans now judge API access rules** (issue #203).
+  `iam_apiaccessrule_no_public_cidr` came back `not-evaluated` on the Terraform source
+  while the plan carried `ip_ranges` — a **required** argument of
+  `outscale_api_access_rule` when no other criterion is given, so always written in the
+  HCL. Pépin could not conclude about a `0.0.0.0/0` written in plain sight. Measured on
+  the qualification tenant's real plan and confirmed by a `--plan-only` run, GO, with
+  nothing created.
+
 - **Outscale plans can now judge deletion protection** (issue #203).
   `compute_instance_deletion_protection` came back `not-evaluated` on the Terraform
   source while the plan carried the answer: `outscale_vm.deletion_protection` is an

--- a/cmd/testdata/frozen/inventory.json
+++ b/cmd/testdata/frozen/inventory.json
@@ -2516,6 +2516,250 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 12,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "source": {
+                "file": "string",
+                "line": "number",
+                "module": "string"
+              },
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v12",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "creation_date",
+            "expiration_date",
+            "owner_application_id",
+            "owner_user",
+            "owner_user_id",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "description",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "state",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_interface",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud",
+            "secnumcloud_regions"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "provider_managed",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "user_type",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_interface": [
+            "nic_id",
+            "public_ip",
+            "security_group_ids",
+            "vm_id"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "description",
+            "inbound_default_policy",
+            "outbound_default_policy",
+            "security_group_id",
+            "tags"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "peer_security_group_ids",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
+        }
+      }
     }
   ]
 }

--- a/docs/concepts/terraform-vs-live.fr.md
+++ b/docs/concepts/terraform-vs-live.fr.md
@@ -270,7 +270,6 @@ couples, une source produit le type de ressource et son attribut décisif, et l'
 | `iam_account_mfa_enforced` | outscale | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccessrule_defined` | outscale | live | cette source ne produit aucune ressource de type « api_access_summary » |
-| `iam_apiaccessrule_no_public_cidr` | outscale | live | cette source ne produit aucune ressource de type « api_access_rule » |
 | `iam_no_root_access_key` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
 | `iam_no_root_access_key` | scaleway | live | attribut décisif « owner_application_id / owner_user_id / root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_policy_no_privilege_escalation` | scaleway | terraform | cette source ne produit aucune ressource de type « iam_policy » |

--- a/docs/concepts/terraform-vs-live.md
+++ b/docs/concepts/terraform-vs-live.md
@@ -265,7 +265,6 @@ source produces the resource type and its deciding attribute, and the other does
 | `iam_account_mfa_enforced` | outscale | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccessrule_defined` | outscale | live | this source produces no resource of type "api_access_summary" |
-| `iam_apiaccessrule_no_public_cidr` | outscale | live | this source produces no resource of type "api_access_rule" |
 | `iam_no_root_access_key` | outscale | live | this source produces no resource of type "access_key" |
 | `iam_no_root_access_key` | scaleway | live | deciding attribute "owner_application_id / owner_user_id / root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_policy_no_privilege_escalation` | scaleway | terraform | this source produces no resource of type "iam_policy" |

--- a/docs/controls/iam_apiaccessrule_no_public_cidr.fr.md
+++ b/docs/controls/iam_apiaccessrule_no_public_cidr.fr.md
@@ -51,23 +51,21 @@ déclaré, ou type absent de cette source ».
 | Fournisseur | Plan Terraform | Collecte live |
 |---|:-:|:-:|
 | exoscale | ✗ | ✗ |
-| outscale | ✗ | ✅ |
+| outscale | ✅ | ✅ |
 | scaleway | ✗ | ✗ |
 | kubernetes | sans objet | ✗ |
 
 Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
 porte son motif :
 
-| Fournisseur | Source | Statut | Motif |
-|---|---|---|---|
-| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_rule » |
+_Aucune : toutes les cases déclarées sont pleinement observables._
 
 ## Ce que Pépin peut conclure
 
 | Statut | Ce que le statut affirme | Atteignable depuis |
 |---|---|---|
-| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
-| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / terraform · outscale / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / terraform · outscale / live |
 | `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
 | `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
 
@@ -97,6 +95,9 @@ tel quel, ou une note ancrée sur la documentation officielle. Voir
 ## Comment vérifier la correction
 
 ```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan outscale --terraform plan.json --format assessment
+
 # depuis l'API du fournisseur : configuration effective
 ./pepin scan outscale --live --format assessment
 ```

--- a/docs/controls/iam_apiaccessrule_no_public_cidr.md
+++ b/docs/controls/iam_apiaccessrule_no_public_cidr.md
@@ -50,23 +50,21 @@ source".
 | Provider | Terraform plan | Live collection |
 |---|:-:|:-:|
 | exoscale | ✗ | ✗ |
-| outscale | ✗ | ✅ |
+| outscale | ✅ | ✅ |
 | scaleway | ✗ | ✗ |
 | kubernetes | n/a | ✗ |
 
 Every cell that is not ✅ **while the control is declared for that provider** carries its
 reason:
 
-| Provider | Source | Status | Reason |
-|---|---|---|---|
-| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_rule" |
+_None: every declared cell is fully observable._
 
 ## What Pépin can conclude
 
 | Status | What the status asserts | Reachable from |
 |---|---|---|
-| `fail` | a deviation was detected on a real resource | outscale / live |
-| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `fail` | a deviation was detected on a real resource | outscale / terraform · outscale / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / terraform · outscale / live |
 | `not-applicable` | the provider contract declares the control untestable, with its justification | — |
 | `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
 
@@ -96,6 +94,9 @@ is, or a note anchored on the official documentation. See
 ## How to verify the fix
 
 ```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan outscale --terraform plan.json --format assessment
+
 # from the provider API: effective configuration
 ./pepin scan outscale --live --format assessment
 ```

--- a/docs/coverage.fr.md
+++ b/docs/coverage.fr.md
@@ -74,7 +74,7 @@ et le rapport le dit à chaque scan, contrôle par contrôle, avec le motif.
 | `iam_account_mfa_enforced` | high | CLD-IAM-3 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccesspolicy_max_key_expiration` | medium | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccessrule_defined` | high | CLD-IAM-4 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
-| `iam_apiaccessrule_no_public_cidr` | high | CLD-IAM-4 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
+| `iam_apiaccessrule_no_public_cidr` | high | CLD-IAM-4 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
 | `iam_no_root_access_key` | high | CLD-IAM-1 | ✗ | ✗ | ✗ | ✅ | ◐ | ✅ |
 | `iam_policy_no_administrative_privileges` | critical | CLD-IAM-1 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
 | `iam_policy_no_notaction_notresource` | critical | CLD-IAM-1 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
@@ -151,7 +151,6 @@ ici : la matrice les montre déjà, et elles n'apprennent rien de plus.
 | `iam_account_mfa_enforced` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccessrule_defined` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_summary » |
-| `iam_apiaccessrule_no_public_cidr` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_rule » |
 | `iam_no_root_access_key` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « access_key » |
 | `iam_no_root_access_key` | scaleway | terraform | ◐ `partial` | attribut décisif « owner_application_id / owner_user_id / root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_policy_no_privilege_escalation` | scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « iam_policy » |
@@ -214,7 +213,7 @@ deux ne peut couvrir la portée de l'autre. Une seule source : la collecte live 
 |---|---|---:|---:|---:|---:|
 | exoscale | terraform | 19 | 2 | 6 | 31 |
 | exoscale | live | 24 | 1 | 6 | 27 |
-| outscale | terraform | 17 | 4 | 4 | 33 |
+| outscale | terraform | 18 | 4 | 4 | 32 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
 | scaleway | live | 19 | 2 | 2 | 35 |

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -73,7 +73,7 @@ and the report says so on every scan, control by control, with the reason.
 | `iam_account_mfa_enforced` | high | CLD-IAM-3 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccesspolicy_max_key_expiration` | medium | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccessrule_defined` | high | CLD-IAM-4 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
-| `iam_apiaccessrule_no_public_cidr` | high | CLD-IAM-4 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
+| `iam_apiaccessrule_no_public_cidr` | high | CLD-IAM-4 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
 | `iam_no_root_access_key` | high | CLD-IAM-1 | ✗ | ✗ | ✗ | ✅ | ◐ | ✅ |
 | `iam_policy_no_administrative_privileges` | critical | CLD-IAM-1 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
 | `iam_policy_no_notaction_notresource` | critical | CLD-IAM-1 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
@@ -150,7 +150,6 @@ already shows them, and they add nothing.
 | `iam_account_mfa_enforced` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccessrule_defined` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_summary" |
-| `iam_apiaccessrule_no_public_cidr` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_rule" |
 | `iam_no_root_access_key` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "access_key" |
 | `iam_no_root_access_key` | scaleway | terraform | ◐ `partial` | deciding attribute "owner_application_id / owner_user_id / root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_policy_no_privilege_escalation` | scaleway | live | ✗ `unsupported` | this source produces no resource of type "iam_policy" |
@@ -213,7 +212,7 @@ the other's scope. One source only: live collection through a kubeconfig.
 |---|---|---:|---:|---:|---:|
 | exoscale | terraform | 19 | 2 | 6 | 31 |
 | exoscale | live | 24 | 1 | 6 | 27 |
-| outscale | terraform | 17 | 4 | 4 | 33 |
+| outscale | terraform | 18 | 4 | 4 | 32 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
 | scaleway | live | 19 | 2 | 2 | 35 |

--- a/docs/detection-quality.fr.md
+++ b/docs/detection-quality.fr.md
@@ -16,7 +16,7 @@ pourcentage sans mesure derrière est un faux vert déplacé dans un tableau de
 bord, et il y est pire qu'ailleurs : personne ne relit un tableau de bord.
 
 Les chiffres sont donc laids, et c'est le point. « 58 contrôles » ne dit rien de
-la qualité d'une détection ; « 96 verdicts prouvés sur 462 » dit où en est le
+la qualité d'une détection ; « 96 verdicts prouvés sur 465 » dit où en est le
 produit, et rétrécit dans le bon sens à chaque scénario écrit.
 
 ## Les chiffres
@@ -24,9 +24,9 @@ produit, et rétrécit dans le bon sens à chaque scénario écrit.
 | Chiffre | Nombre |
 |---|---:|
 | Contrôles au référentiel | 58 |
-| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 182 |
+| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 183 |
 | Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 31 |
-| Verdicts à prouver au total | 462 |
+| Verdicts à prouver au total | 465 |
 | Verdicts prouvés | 96 |
 
 ## Couverture de véracité, par verdict
@@ -37,11 +37,11 @@ demanderait d'inventer une non-applicabilité.
 
 | Verdict | Ce qu'il met en scène | À prouver | Prouvés | % |
 |---|---|---:|---:|---:|
-| `fail` | une configuration vulnérable est détectée | 140 | 25 | 17 |
-| `pass` | une configuration réellement correcte est confirmée | 140 | 37 | 26 |
-| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 158 | 22 | 13 |
+| `fail` | une configuration vulnérable est détectée | 141 | 25 | 17 |
+| `pass` | une configuration réellement correcte est confirmée | 141 | 37 | 26 |
+| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 159 | 22 | 13 |
 | `not-applicable` | le contrat du fournisseur déclare le mécanisme inexistant | 24 | 12 | 50 |
-| **Total** | | **462** | **96** | **20** |
+| **Total** | | **465** | **96** | **20** |
 
 ## Validé en live
 

--- a/docs/detection-quality.md
+++ b/docs/detection-quality.md
@@ -16,7 +16,7 @@ with no measurement behind it is a false green moved into a dashboard, and it is
 worse there than anywhere else: nobody re-reads a dashboard.
 
 The figures are therefore ugly, and that is the point. "58 controls" says nothing
-about the quality of a detection; "96 verdicts proven out of 462" says where the
+about the quality of a detection; "96 verdicts proven out of 465" says where the
 product stands, and shrinks the right way with every scenario written.
 
 ## The figures
@@ -24,9 +24,9 @@ product stands, and shrinks the right way with every scenario written.
 | Figure | Count |
 |---|---:|
 | Controls in the reference | 58 |
-| Control x provider x source paths on which Pépin concludes | 182 |
+| Control x provider x source paths on which Pépin concludes | 183 |
 | Paths whose EVERY reachable verdict is proven end to end | 31 |
-| Verdicts to prove in total | 462 |
+| Verdicts to prove in total | 465 |
 | Verdicts proven | 96 |
 
 ## Veracity coverage, by verdict
@@ -37,11 +37,11 @@ inventing a non-applicability.
 
 | Verdict | What it stages | To prove | Proven | % |
 |---|---|---:|---:|---:|
-| `fail` | a vulnerable configuration is detected | 140 | 25 | 17 |
-| `pass` | a genuinely correct configuration is confirmed | 140 | 37 | 26 |
-| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 158 | 22 | 13 |
+| `fail` | a vulnerable configuration is detected | 141 | 25 | 17 |
+| `pass` | a genuinely correct configuration is confirmed | 141 | 37 | 26 |
+| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 159 | 22 | 13 |
 | `not-applicable` | the provider's contract declares the mechanism non-existent | 24 | 12 | 50 |
-| **Total** | | **462** | **96** | **20** |
+| **Total** | | **465** | **96** | **20** |
 
 ## Validated live
 

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -58,7 +58,7 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v11",
+  "inventory_schema": "pepin-inventory/v12",
   "disclaimer": "Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -56,7 +56,7 @@ raises a version number and gets a CHANGELOG line.
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v11",
+  "inventory_schema": "pepin-inventory/v12",
   "disclaimer": "This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -96,7 +96,6 @@ pas.
 | `iam_account_mfa_enforced` | outscale | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccessrule_defined` | outscale | live | cette source ne produit aucune ressource de type « api_access_summary » |
-| `iam_apiaccessrule_no_public_cidr` | outscale | live | cette source ne produit aucune ressource de type « api_access_rule » |
 | `iam_no_root_access_key` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
 | `iam_no_root_access_key` | scaleway | live | attribut décisif « owner_application_id / owner_user_id / root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_policy_no_privilege_escalation` | scaleway | terraform | cette source ne produit aucune ressource de type « iam_policy » |
@@ -151,7 +150,7 @@ Par fournisseur et par source, sur l'ensemble des contrôles du référentiel :
 |---|---|---:|---:|---:|---:|
 | exoscale | terraform | 19 | 2 | 6 | 31 |
 | exoscale | live | 24 | 1 | 6 | 27 |
-| outscale | terraform | 17 | 4 | 4 | 33 |
+| outscale | terraform | 18 | 4 | 4 | 32 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
 | scaleway | live | 19 | 2 | 2 | 35 |
@@ -208,10 +207,10 @@ Ce qui n'est pas encore prouvé est **compté**, pas masqué :
 <!-- pepin:gen veracity-debt -->
 | Chiffre | Nombre |
 |---|---:|
-| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 182 |
+| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 183 |
 | Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 31 |
-| Verdicts à prouver au total | 462 |
-| Verdicts restant à prouver | 366 |
+| Verdicts à prouver au total | 465 |
+| Verdicts restant à prouver | 369 |
 <!-- /pepin:gen veracity-debt -->
 
 Le reste est listé chemin par chemin dans `internal/veracity/testdata/debt.txt`. Ce registre est

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -97,7 +97,6 @@ actually decide them. The reason given is the one that applies to the source tha
 | `iam_account_mfa_enforced` | outscale | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccessrule_defined` | outscale | live | this source produces no resource of type "api_access_summary" |
-| `iam_apiaccessrule_no_public_cidr` | outscale | live | this source produces no resource of type "api_access_rule" |
 | `iam_no_root_access_key` | outscale | live | this source produces no resource of type "access_key" |
 | `iam_no_root_access_key` | scaleway | live | deciding attribute "owner_application_id / owner_user_id / root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_policy_no_privilege_escalation` | scaleway | terraform | this source produces no resource of type "iam_policy" |
@@ -151,7 +150,7 @@ Per provider and per source, over all controls in the reference:
 |---|---|---:|---:|---:|---:|
 | exoscale | terraform | 19 | 2 | 6 | 31 |
 | exoscale | live | 24 | 1 | 6 | 27 |
-| outscale | terraform | 17 | 4 | 4 | 33 |
+| outscale | terraform | 18 | 4 | 4 | 32 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
 | scaleway | live | 19 | 2 | 2 | 35 |
@@ -208,10 +207,10 @@ What is not yet proven is **counted**, not hidden:
 <!-- pepin:gen veracity-debt -->
 | Figure | Count |
 |---|---:|
-| Control x provider x source paths on which Pépin concludes | 182 |
+| Control x provider x source paths on which Pépin concludes | 183 |
 | Paths whose every reachable verdict is proven end to end | 31 |
-| Verdicts to prove in total | 462 |
-| Verdicts left to prove | 366 |
+| Verdicts to prove in total | 465 |
+| Verdicts left to prove | 369 |
 <!-- /pepin:gen veracity-debt -->
 
 The remainder is listed path by path in `internal/veracity/testdata/debt.txt`. That ledger is a

--- a/docs/providers/outscale.fr.md
+++ b/docs/providers/outscale.fr.md
@@ -242,6 +242,7 @@ n'en montre aucune.
 <!-- pepin:gen provider-outscale-terraform -->
 | Ressource Terraform | Type normalisé | Bloc éclaté |
 |---|---|---|
+| `outscale_api_access_rule` | `api_access_rule` | — |
 | `outscale_image_launch_permission` | `compute_image` | — |
 | `outscale_net` | `network` | — |
 | `outscale_policy` | `iam_policy` | — |
@@ -266,7 +267,7 @@ rend un booléen. Les règles normalisent les deux
 <!-- pepin:gen provider-outscale-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 17 | 4 | 4 | 33 |
+| terraform | 18 | 4 | 4 | 32 |
 | live | 40 | 1 | 4 | 13 |
 <!-- /pepin:gen provider-outscale-coverage -->
 
@@ -298,7 +299,6 @@ source de vérité est la [matrice de couverture](../coverage.fr.md).
 | `iam_account_mfa_enforced` | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccesspolicy_max_key_expiration` | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccessrule_defined` | live | cette source ne produit aucune ressource de type « api_access_summary » |
-| `iam_apiaccessrule_no_public_cidr` | live | cette source ne produit aucune ressource de type « api_access_rule » |
 | `iam_no_root_access_key` | live | cette source ne produit aucune ressource de type « access_key » |
 | `kubernetes_cluster_auto_upgrade_enabled` | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
 | `kubernetes_cluster_control_plane_highly_available` | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |

--- a/docs/providers/outscale.md
+++ b/docs/providers/outscale.md
@@ -235,6 +235,7 @@ keys for an EIM user, that is the next thing to measure; `ReadAccessKeys` shows 
 <!-- pepin:gen provider-outscale-terraform -->
 | Terraform resource | Normalized type | Exploded block |
 |---|---|---|
+| `outscale_api_access_rule` | `api_access_rule` | — |
 | `outscale_image_launch_permission` | `compute_image` | — |
 | `outscale_net` | `network` | — |
 | `outscale_policy` | `iam_policy` | — |
@@ -259,7 +260,7 @@ API returns a boolean. The rules normalize both
 <!-- pepin:gen provider-outscale-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 17 | 4 | 4 | 33 |
+| terraform | 18 | 4 | 4 | 32 |
 | live | 40 | 1 | 4 | 13 |
 <!-- /pepin:gen provider-outscale-coverage -->
 
@@ -291,7 +292,6 @@ truth is the [coverage matrix](../coverage.md).
 | `iam_account_mfa_enforced` | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccesspolicy_max_key_expiration` | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccessrule_defined` | live | this source produces no resource of type "api_access_summary" |
-| `iam_apiaccessrule_no_public_cidr` | live | this source produces no resource of type "api_access_rule" |
 | `iam_no_root_access_key` | live | this source produces no resource of type "access_key" |
 | `kubernetes_cluster_auto_upgrade_enabled` | live | this source produces no resource of type "kubernetes_cluster" |
 | `kubernetes_cluster_control_plane_highly_available` | live | this source produces no resource of type "kubernetes_cluster" |

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -43,7 +43,7 @@ séparément :
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v11** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v12** |
 <!-- /pepin:gen surface-versions -->
 
 Un numéro monte à **tout** changement de forme, ajout compris : il signifie « la surface a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,7 +43,7 @@ independently:
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v11** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v12** |
 <!-- /pepin:gen surface-versions -->
 
 A version rises on **any** shape change, additions included: the number means "the surface has

--- a/docs/reference/inventory.fr.md
+++ b/docs/reference/inventory.fr.md
@@ -12,7 +12,7 @@ gelée, avec les mêmes égards que la surface CLI.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v11
+pepin-inventory/v12
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -151,7 +151,7 @@ code.
 |---|---|
 | `access_key` | `access_key_id` `creation_date` `expiration_date` `owner_application_id` `owner_user` `owner_user_id` `scope` `state` |
 | `api_access_policy` | `id` `max_access_key_expiration_seconds` `require_trusted_env` |
-| `api_access_rule` | `api_access_rule_id` `ca_ids` `cns` `ip_ranges` |
+| `api_access_rule` | `api_access_rule_id` `ca_ids` `cns` `description` `ip_ranges` |
 | `api_access_summary` | `id` `rule_count` |
 | `blockstorage_snapshot` | `creation_date` `global_permission` `snapshot_id` `state` `volume_id` |
 | `blockstorage_volume` | `encrypted` `state` `tags` `volume_id` |

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -12,7 +12,7 @@ with the same regard as the CLI surface.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v11
+pepin-inventory/v12
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -143,7 +143,7 @@ descriptors and from the Go collectors — never a hand-kept list beside the cod
 |---|---|
 | `access_key` | `access_key_id` `creation_date` `expiration_date` `owner_application_id` `owner_user` `owner_user_id` `scope` `state` |
 | `api_access_policy` | `id` `max_access_key_expiration_seconds` `require_trusted_env` |
-| `api_access_rule` | `api_access_rule_id` `ca_ids` `cns` `ip_ranges` |
+| `api_access_rule` | `api_access_rule_id` `ca_ids` `cns` `description` `ip_ranges` |
 | `api_access_summary` | `id` `rule_count` |
 | `blockstorage_snapshot` | `creation_date` `global_permission` `snapshot_id` `state` `volume_id` |
 | `blockstorage_volume` | `encrypted` `state` `tags` `volume_id` |

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -30,7 +30,7 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v11** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v12** |
 <!-- /pepin:gen surface-versions -->
 
 « Gelé » signifie qu'un test échoue quand la forme bouge sans que sa version ait suivi : les

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -30,7 +30,7 @@ See [Exit codes](exit-codes.md).
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v11** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v12** |
 <!-- /pepin:gen surface-versions -->
 
 "Frozen" means a test fails when the shape moves and its version has not: field paths and JSON

--- a/internal/model/schema.go
+++ b/internal/model/schema.go
@@ -163,7 +163,15 @@ import (
 //	`user_type` est le SEUL marqueur du propriétaire de l'organisation :
 //	`account_root_user_id`, porté par le même enregistrement, désigne autre chose
 //	(mesuré le 2026-09-11). Contrat vérifié contre l'API réelle.
-const InventoryFormat = "pepin-inventory/v11"
+//
+// v12 : un plan Terraform Outscale produit le type `api_access_rule`, porteur de
+//
+//	`ip_ranges`, `ca_ids`, `cns` et `description`, et une `compute_instance` y porte
+//	`deletion_protection`. Ajout PUR. Il est nécessaire parce que le plan portait ces
+//	réponses en clair — `ip_ranges` est un argument OBLIGATOIRE quand aucun autre
+//	critère n'est donné — pendant que Pépin rendait « non évalué » sur un
+//	`0.0.0.0/0` écrit noir sur blanc (issue #203).
+const InventoryFormat = "pepin-inventory/v12"
 
 // InventorySchemaVersion extrait le N du suffixe `/vN`. Comme pour le bundle, la
 // constante et le signal sur le fil sont la même chose : impossible de faire

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -1,12 +1,12 @@
 {
   "controls": 58,
-  "paths": 182,
+  "paths": 183,
   "paths_proven": 31,
-  "obligations": 462,
+  "obligations": 465,
   "proven": 96,
   "verdicts": {
     "fail": {
-      "required": 140,
+      "required": 141,
       "proven": 25
     },
     "not-applicable": {
@@ -14,11 +14,11 @@
       "proven": 12
     },
     "not-evaluated": {
-      "required": 158,
+      "required": 159,
       "proven": 22
     },
     "pass": {
-      "required": 140,
+      "required": 141,
       "proven": 37
     }
   },
@@ -968,6 +968,16 @@
         {
           "provider": "outscale",
           "source": "live",
+          "status": "supported",
+          "required": [
+            "fail",
+            "pass",
+            "not-evaluated"
+          ]
+        },
+        {
+          "provider": "outscale",
+          "source": "terraform",
           "status": "supported",
           "required": [
             "fail",

--- a/internal/veracity/testdata/debt.txt
+++ b/internal/veracity/testdata/debt.txt
@@ -8,7 +8,7 @@
 # Une ligne qui disparaît est une dette payée. Une ligne qui apparaît sans
 # scénario est un contrôle ajouté sans sa preuve, et la CI la refuse.
 #
-# chemins : 181 · entierement prouves : 30 · obligations : 457 · restantes : 366
+# chemins : 183 · entierement prouves : 31 · obligations : 465 · restantes : 369
 
 blockstorage_snapshot_not_public exoscale live not-applicable
 blockstorage_snapshot_not_public outscale live fail,pass,not-evaluated
@@ -63,6 +63,7 @@ iam_account_mfa_enforced outscale live fail,pass,not-evaluated
 iam_apiaccesspolicy_max_key_expiration outscale live fail,pass,not-evaluated
 iam_apiaccessrule_defined outscale live fail,pass,not-evaluated
 iam_apiaccessrule_no_public_cidr outscale live fail,pass,not-evaluated
+iam_apiaccessrule_no_public_cidr outscale terraform fail,pass,not-evaluated
 iam_no_root_access_key outscale live fail,pass,not-evaluated
 iam_no_root_access_key scaleway live not-evaluated
 iam_no_root_access_key scaleway terraform not-evaluated

--- a/providers/outscale.yaml
+++ b/providers/outscale.yaml
@@ -738,6 +738,28 @@ mapping_terraform:
         image_id: image_id
         public: permission_additions.0.global_permission
 
+    # Règles d'accès à l'API. Un plan les porte en clair — `ip_ranges` est un argument
+    # OBLIGATOIRE de outscale_api_access_rule quand aucun autre critère n'est donné —,
+    # et Pépin disait pourtant « je ne peux pas conclure » sur un `0.0.0.0/0` écrit noir
+    # sur blanc dans le HCL (issue #203).
+    #
+    # L'identifiant n'existe pas au stade du plan : le sujet est l'adresse Terraform
+    # (ADR-0022), comme pour les autres types de ce mapping.
+    - tf_type: outscale_api_access_rule
+      type: api_access_rule
+      id: api_access_rule_id
+      map:
+        ip_ranges: ip_ranges
+        ca_ids: ca_ids
+        cns: cns
+        description: description
+      transforms:
+        # `list` est idempotent : il garde une liste et enveloppe un scalaire. Un plan
+        # peut porter l'une ou l'autre forme selon l'écriture du HCL.
+        ip_ranges: list
+        ca_ids: list
+        cns: list
+
 # Contrat d'API (ancrage §2) + applicabilité SCSL (non_applicable) — lu par `pepin scsl`.
 contrat:
   types:

--- a/references/qualification/outscale/expected.yaml
+++ b/references/qualification/outscale/expected.yaml
@@ -114,8 +114,16 @@ controls:
     live:
       fail: ["${output.api_rule_public_id}"]
       silent: ["${output.api_rule_private_id}"]
-    # `outscale_api_access_rule` n'est pas mappé sur le plan (#203).
-    terraform: not-evaluated
+    # #203 : `outscale_api_access_rule` est mappé. `ip_ranges` est un argument
+    # OBLIGATOIRE quand aucun autre critère n'est donné, donc toujours écrit en clair
+    # dans le HCL — Pépin disait pourtant « je ne peux pas conclure » sur un
+    # `0.0.0.0/0` noir sur blanc.
+    #
+    # Sujets = adresses Terraform, l'identifiant n'existant pas au stade du plan
+    # (ADR-0022).
+    terraform:
+      fail: [outscale_api_access_rule.public]
+      silent: [outscale_api_access_rule.private]
 
   # ── Groupes de sécurité ───────────────────────────────────────────────────────
   # Sujet live = identifiant du groupe ; sujet Terraform = adresse du groupe (les


### PR DESCRIPTION
Second control of #203.

## The gap

`iam_apiaccessrule_no_public_cidr` came back `not-evaluated` on the Terraform source
while the plan carried `ip_ranges` — a **required** argument of
`outscale_api_access_rule` when no other criterion is given, so **always** written in the
HCL. Pépin could not conclude about a `0.0.0.0/0` written in plain sight.

## Measured

```
iam_apiaccessrule_no_public_cidr   fail     outscale_api_access_rule.public
```

Then a **`--plan-only`** qualification run: **GO** on both contracts, nothing created,
nothing billed.

`iam_apiaccessrule_defined` stays `not-evaluated`, and rightly: it reads the
account-level `api_access_summary`, which a plan has no equivalent of.

Inventory format `v12`, a pure addition.

## What this PR deliberately does not do

The same plan carries `outscale_access_key` **three times**: one with an
`expiration_date`, one **without**, and one with **no `user_name`**. Those are exactly
the deviations `iam_accesskey_expiration_set` and `iam_no_root_access_key` look for — and
in both cases **the fault is expressed by an absence**. The HCL simply does not write the
optional argument.

Mapping that today would break two rules this repository has just established:

- `collect.Project` does not project a key absent from the source, and
  `TestNoSpecFabricatesAnAttributeFromNothing` (#237) now holds it **mechanically**.
  Deriving a value from an absence is precisely what it forbids.
- **The absence does not always carry that meaning.** An attribute can be missing from a
  plan because its value exists only after `apply` — true of every identifier. Treating
  both alike would produce a CRITICAL on the most common configuration there is, which is
  the defect `TestProjectDistinguishesAbsentFromEmptyCollection` exists to stop.

So the question is **filed with what it must establish** — [#243](https://github.com/stephrobert/pepin/issues/243) — rather than answered in a hurry.

It is the **third time today** the same pattern appeared, on three unrelated controls
(#227 on live collection, `deletion_protection` on a plan, and these two). That is what
makes it a design question and not a mapping line.

## Impact ADR

**ADR-0014** is the reason this PR stops where it does: an absent datum is not
fabricated, even when its absence is meaningful, until there is a way to *declare* that
meaning rather than infer it. **ADR-0022**: subjects on a plan are Terraform addresses,
the identifier not existing yet. **ADR-0012**: this strengthens the source that
provisions nothing. No ADR modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)