### PR TITLE
feat(outscale): a plan can judge load-balancer listeners

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -24,6 +24,18 @@ l'une ni l'autre appartient au `git log`.
 
 ### Ajouté
 
+- **Un plan Outscale juge les écouteurs d'un répartiteur de charge** (issue #203).
+  `loadbalancer_ssl_listeners` revenait `not-evaluated` sur la source Terraform alors que
+  le plan écrivait les écouteurs en clair — protocole et port. Un répartiteur exposé à
+  Internet qui n'écoute qu'en HTTP est désormais un `fail`, et celui en TCP 443 reste
+  inconcluant avec son sujet, comme en live. La **région** du type est projetée aussi, et
+  ce n'est pas un détail : le contrôle de souveraineté juge l'intersection sur tous les
+  types, si bien qu'ajouter un type sans région **retire** de la couverture au lieu d'en
+  ajouter — `governance_resource_region_in_eu` est passé de `pass` à `not-evaluated` au
+  premier essai. `access_log` n'est délibérément pas mappé : il vit sur une ressource
+  distincte que ce plan ne porte pas, donc `loadbalancer_logging_enabled` reste
+  honnêtement non évalué.
+
 - **Un plan Outscale juge les règles d'accès à l'API** (issue #203).
   `iam_apiaccessrule_no_public_cidr` revenait `not-evaluated` sur la source Terraform
   alors que le plan portait `ip_ranges` — argument **obligatoire** de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ belongs in `git log`.
 
 ### Added
 
+- **Outscale plans now judge load-balancer listeners** (issue #203).
+  `loadbalancer_ssl_listeners` came back `not-evaluated` on the Terraform source while the
+  plan wrote the listeners in clear — protocol and port. An internet-facing load balancer
+  listening only in HTTP is now a `fail`, and a TCP 443 one stays inconclusive with its
+  subject, as it does live. The type's **region** is projected too, and that is not a
+  detail: the sovereignty control judges the intersection across every type, so adding a
+  type without a region **removes** coverage instead of adding it —
+  `governance_resource_region_in_eu` dropped from `pass` to `not-evaluated` on the first
+  attempt. `access_log` is deliberately not mapped: it lives on a separate resource this
+  plan does not carry, so `loadbalancer_logging_enabled` honestly stays unevaluated.
+
 - **Outscale plans now judge API access rules** (issue #203).
   `iam_apiaccessrule_no_public_cidr` came back `not-evaluated` on the Terraform source
   while the plan carried `ip_ranges` — a **required** argument of

--- a/cmd/testdata/frozen/inventory.json
+++ b/cmd/testdata/frozen/inventory.json
@@ -2760,6 +2760,250 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 13,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "source": {
+                "file": "string",
+                "line": "number",
+                "module": "string"
+              },
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v13",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "creation_date",
+            "expiration_date",
+            "owner_application_id",
+            "owner_user",
+            "owner_user_id",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "description",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "state",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_interface",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud",
+            "secnumcloud_regions"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "provider_managed",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "user_type",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_interface": [
+            "nic_id",
+            "public_ip",
+            "security_group_ids",
+            "vm_id"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "description",
+            "inbound_default_policy",
+            "outbound_default_policy",
+            "security_group_id",
+            "tags"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "peer_security_group_ids",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
+        }
+      }
     }
   ]
 }

--- a/docs/concepts/terraform-vs-live.fr.md
+++ b/docs/concepts/terraform-vs-live.fr.md
@@ -280,8 +280,8 @@ couples, une source produit le type de ressource et son attribut décisif, et l'
 | `kubernetes_cluster_control_plane_highly_available` | outscale | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
 | `kubernetes_cluster_deletion_protection` | outscale | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
 | `kubernetes_cluster_not_publicly_accessible` | outscale | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
-| `loadbalancer_logging_enabled` | outscale | live | cette source ne produit aucune ressource de type « load_balancer » |
-| `loadbalancer_ssl_listeners` | outscale | live | cette source ne produit aucune ressource de type « load_balancer » |
+| `loadbalancer_logging_enabled` | outscale | live | attribut décisif « access_log » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| `loadbalancer_ssl_listeners` | outscale | live | attribut décisif « load_balancer_type » déclaré par le mapping mais ABSENT des plans de référence : soit la valeur n'existe qu'après `apply`, soit l'argument est optionnel et le HCL réel ne l'écrit pas — garde de capacité, le scan rend « not-evaluated » |
 | `network_peering_cross_organization` | outscale | live | cette source ne produit aucune ressource de type « network_peering » |
 | `network_securitygroup_default_restrict_traffic` | outscale | live | attribut décisif « security_group_name » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `objectstorage_bucket_default_encryption` | outscale | live | cette source ne produit aucune ressource de type « object_storage_bucket » |

--- a/docs/concepts/terraform-vs-live.md
+++ b/docs/concepts/terraform-vs-live.md
@@ -275,8 +275,8 @@ source produces the resource type and its deciding attribute, and the other does
 | `kubernetes_cluster_control_plane_highly_available` | outscale | live | this source produces no resource of type "kubernetes_cluster" |
 | `kubernetes_cluster_deletion_protection` | outscale | live | this source produces no resource of type "kubernetes_cluster" |
 | `kubernetes_cluster_not_publicly_accessible` | outscale | live | this source produces no resource of type "kubernetes_cluster" |
-| `loadbalancer_logging_enabled` | outscale | live | this source produces no resource of type "load_balancer" |
-| `loadbalancer_ssl_listeners` | outscale | live | this source produces no resource of type "load_balancer" |
+| `loadbalancer_logging_enabled` | outscale | live | deciding attribute "access_log" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| `loadbalancer_ssl_listeners` | outscale | live | deciding attribute "load_balancer_type" declared by the mapping but ABSENT from the reference plans: either the value exists only after `apply`, or the argument is optional and real-world HCL does not write it — a capability guard, so the scan returns "not-evaluated" |
 | `network_peering_cross_organization` | outscale | live | this source produces no resource of type "network_peering" |
 | `network_securitygroup_default_restrict_traffic` | outscale | live | deciding attribute "security_group_name" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `objectstorage_bucket_default_encryption` | outscale | live | this source produces no resource of type "object_storage_bucket" |

--- a/docs/controls/loadbalancer_logging_enabled.fr.md
+++ b/docs/controls/loadbalancer_logging_enabled.fr.md
@@ -50,7 +50,7 @@ déclaré, ou type absent de cette source ».
 | Fournisseur | Plan Terraform | Collecte live |
 |---|:-:|:-:|
 | exoscale | ∅ | ∅ |
-| outscale | ✗ | ✅ |
+| outscale | ◐ | ✅ |
 | scaleway | ✗ | ✗ |
 | kubernetes | sans objet | ✗ |
 
@@ -61,16 +61,16 @@ porte son motif :
 |---|---|---|---|
 | exoscale | terraform | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
 | exoscale | live | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
-| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « load_balancer » |
+| outscale | terraform | ◐ `partial` | attribut décisif « access_log » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 
 ## Ce que Pépin peut conclure
 
 | Statut | Ce que le statut affirme | Atteignable depuis |
 |---|---|---|
-| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / terraform · outscale / live |
 | `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
 | `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | exoscale / terraform · exoscale / live |
-| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | outscale / terraform |
 
 Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
 contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
@@ -98,6 +98,9 @@ tel quel, ou une note ancrée sur la documentation officielle. Voir
 ## Comment vérifier la correction
 
 ```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan outscale --terraform plan.json --format assessment
+
 # depuis l'API du fournisseur : configuration effective
 ./pepin scan outscale --live --format assessment
 ```
@@ -105,6 +108,10 @@ tel quel, ou une note ancrée sur la documentation officielle. Voir
 Dans la sortie `assessment`, chercher `"control": "loadbalancer_logging_enabled"` : son `status` doit être
 `pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
 correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+**Une des deux sources ne sait pas lever le verrou du « pass »** pour ce contrôle :
+le fournisseur cité y produit bien le type visé, mais le scan y rendra `not-evaluated`.
+Le tableau des motifs dit laquelle, et pourquoi.
 
 ## Voir aussi
 

--- a/docs/controls/loadbalancer_logging_enabled.md
+++ b/docs/controls/loadbalancer_logging_enabled.md
@@ -49,7 +49,7 @@ source".
 | Provider | Terraform plan | Live collection |
 |---|:-:|:-:|
 | exoscale | ∅ | ∅ |
-| outscale | ✗ | ✅ |
+| outscale | ◐ | ✅ |
 | scaleway | ✗ | ✗ |
 | kubernetes | n/a | ✗ |
 
@@ -60,16 +60,16 @@ reason:
 |---|---|---|---|
 | exoscale | terraform | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
 | exoscale | live | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
-| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "load_balancer" |
+| outscale | terraform | ◐ `partial` | deciding attribute "access_log" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 
 ## What Pépin can conclude
 
 | Status | What the status asserts | Reachable from |
 |---|---|---|
-| `fail` | a deviation was detected on a real resource | outscale / live |
+| `fail` | a deviation was detected on a real resource | outscale / terraform · outscale / live |
 | `pass` | the deciding data was collected, and it is compliant | outscale / live |
 | `not-applicable` | the provider contract declares the control untestable, with its justification | exoscale / terraform · exoscale / live |
-| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | outscale / terraform |
 
 An observable control still returns `not-evaluated` on an inventory that contains no
 resource of the targeted type: "nothing to look at" is not "compliant".
@@ -97,6 +97,9 @@ is, or a note anchored on the official documentation. See
 ## How to verify the fix
 
 ```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan outscale --terraform plan.json --format assessment
+
 # from the provider API: effective configuration
 ./pepin scan outscale --live --format assessment
 ```
@@ -104,6 +107,10 @@ is, or a note anchored on the official documentation. See
 In the `assessment` output, look for `"control": "loadbalancer_logging_enabled"`: its `status` must be `pass`.
 If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
 demonstrated: the reasons table above says why.
+
+**One of the two sources cannot lift the `pass` lock** for this control: the provider
+quoted does produce the targeted type there, but the scan will return `not-evaluated`.
+The reasons table says which one, and why.
 
 ## See also
 

--- a/docs/controls/loadbalancer_ssl_listeners.fr.md
+++ b/docs/controls/loadbalancer_ssl_listeners.fr.md
@@ -51,7 +51,7 @@ déclaré, ou type absent de cette source ».
 | Fournisseur | Plan Terraform | Collecte live |
 |---|:-:|:-:|
 | exoscale | ∅ | ∅ |
-| outscale | ✗ | ✅ |
+| outscale | ◐ | ✅ |
 | scaleway | ✗ | ✗ |
 | kubernetes | sans objet | ✗ |
 
@@ -62,16 +62,16 @@ porte son motif :
 |---|---|---|---|
 | exoscale | terraform | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
 | exoscale | live | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
-| outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « load_balancer » |
+| outscale | terraform | ◐ `partial` | attribut décisif « load_balancer_type » déclaré par le mapping mais ABSENT des plans de référence : soit la valeur n'existe qu'après `apply`, soit l'argument est optionnel et le HCL réel ne l'écrit pas — garde de capacité, le scan rend « not-evaluated » |
 
 ## Ce que Pépin peut conclure
 
 | Statut | Ce que le statut affirme | Atteignable depuis |
 |---|---|---|
-| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / terraform · outscale / live |
 | `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
 | `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | exoscale / terraform · exoscale / live |
-| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
+| `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | outscale / terraform |
 
 Un contrôle observable rend tout de même `not-evaluated` sur un inventaire qui ne
 contient aucune ressource du type visé : « rien à voir » n'est pas « conforme ».
@@ -99,6 +99,9 @@ tel quel, ou une note ancrée sur la documentation officielle. Voir
 ## Comment vérifier la correction
 
 ```bash
+# depuis un plan Terraform : aucune ressource n'est créée
+./pepin scan outscale --terraform plan.json --format assessment
+
 # depuis l'API du fournisseur : configuration effective
 ./pepin scan outscale --live --format assessment
 ```
@@ -106,6 +109,10 @@ tel quel, ou une note ancrée sur la documentation officielle. Voir
 Dans la sortie `assessment`, chercher `"control": "loadbalancer_ssl_listeners"` : son `status` doit être
 `pass`. S'il reste `not-evaluated`, la donnée décisive n'a pas été collectée, et la
 correction n'est **pas** démontrée : le tableau des motifs ci-dessus dit pourquoi.
+
+**Une des deux sources ne sait pas lever le verrou du « pass »** pour ce contrôle :
+le fournisseur cité y produit bien le type visé, mais le scan y rendra `not-evaluated`.
+Le tableau des motifs dit laquelle, et pourquoi.
 
 ## Voir aussi
 

--- a/docs/controls/loadbalancer_ssl_listeners.md
+++ b/docs/controls/loadbalancer_ssl_listeners.md
@@ -50,7 +50,7 @@ source".
 | Provider | Terraform plan | Live collection |
 |---|:-:|:-:|
 | exoscale | ∅ | ∅ |
-| outscale | ✗ | ✅ |
+| outscale | ◐ | ✅ |
 | scaleway | ✗ | ✗ |
 | kubernetes | n/a | ✗ |
 
@@ -61,16 +61,16 @@ reason:
 |---|---|---|---|
 | exoscale | terraform | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
 | exoscale | live | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
-| outscale | terraform | ✗ `unsupported` | this source produces no resource of type "load_balancer" |
+| outscale | terraform | ◐ `partial` | deciding attribute "load_balancer_type" declared by the mapping but ABSENT from the reference plans: either the value exists only after `apply`, or the argument is optional and real-world HCL does not write it — a capability guard, so the scan returns "not-evaluated" |
 
 ## What Pépin can conclude
 
 | Status | What the status asserts | Reachable from |
 |---|---|---|
-| `fail` | a deviation was detected on a real resource | outscale / live |
+| `fail` | a deviation was detected on a real resource | outscale / terraform · outscale / live |
 | `pass` | the deciding data was collected, and it is compliant | outscale / live |
 | `not-applicable` | the provider contract declares the control untestable, with its justification | exoscale / terraform · exoscale / live |
-| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
+| `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | outscale / terraform |
 
 An observable control still returns `not-evaluated` on an inventory that contains no
 resource of the targeted type: "nothing to look at" is not "compliant".
@@ -98,6 +98,9 @@ is, or a note anchored on the official documentation. See
 ## How to verify the fix
 
 ```bash
+# from a Terraform plan: nothing is provisioned
+./pepin scan outscale --terraform plan.json --format assessment
+
 # from the provider API: effective configuration
 ./pepin scan outscale --live --format assessment
 ```
@@ -105,6 +108,10 @@ is, or a note anchored on the official documentation. See
 In the `assessment` output, look for `"control": "loadbalancer_ssl_listeners"`: its `status` must be `pass`.
 If it stays `not-evaluated`, the deciding data was not collected and the fix is **not**
 demonstrated: the reasons table above says why.
+
+**One of the two sources cannot lift the `pass` lock** for this control: the provider
+quoted does produce the targeted type there, but the scan will return `not-evaluated`.
+The reasons table says which one, and why.
 
 ## See also
 

--- a/docs/coverage.fr.md
+++ b/docs/coverage.fr.md
@@ -94,8 +94,8 @@ et le rapport le dit à chaque scan, contrôle par contrôle, avec le motif.
 | `kubernetes_cluster_deletion_protection` | medium | CLD-K8S-3 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `kubernetes_cluster_not_publicly_accessible` | critical | CLD-K8S-1 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `loadbalancer_http_redirect_to_https` | medium | CLD-CHF-1 | ∅ | ∅ | ∅ | ∅ | ✗ | ✗ |
-| `loadbalancer_logging_enabled` | medium | CLD-LOG-1 | ∅ | ∅ | ✗ | ✅ | ✗ | ✗ |
-| `loadbalancer_ssl_listeners` | high | CLD-CHF-1 | ∅ | ∅ | ✗ | ✅ | ✗ | ✗ |
+| `loadbalancer_logging_enabled` | medium | CLD-LOG-1 | ∅ | ∅ | ◐ | ✅ | ✗ | ✗ |
+| `loadbalancer_ssl_listeners` | high | CLD-CHF-1 | ∅ | ∅ | ◐ | ✅ | ✗ | ✗ |
 | `network_documented` | low | CLD-NET-5 | ✅ | ✅ | ✅ | ✅ | ◐ | ✗ |
 | `network_flow_matrix_documented` | medium | CLD-NET-5 | ✅ | ✅ | ✗ | ✗ | ✗ | ✗ |
 | `network_peering_cross_organization` | high | CLD-NET-7 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
@@ -169,10 +169,10 @@ ici : la matrice les montre déjà, et elles n'apprennent rien de plus.
 | `loadbalancer_http_redirect_to_https` | outscale | live | ∅ `not-applicable` | Le LBU Outscale ne peut pas rediriger : `ListenerRule.Action` est documenté « always forward » au contrat OAPI (aucune action de redirection), et aucun attribut de redirection n'existe sur `Listener`. Le mécanisme est inexistant → contrôle non applicable (CHF-1). |
 | `loadbalancer_logging_enabled` | exoscale | terraform | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
 | `loadbalancer_logging_enabled` | exoscale | live | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
-| `loadbalancer_logging_enabled` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « load_balancer » |
+| `loadbalancer_logging_enabled` | outscale | terraform | ◐ `partial` | attribut décisif « access_log » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `loadbalancer_ssl_listeners` | exoscale | terraform | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
 | `loadbalancer_ssl_listeners` | exoscale | live | ∅ `not-applicable` | type de ressource « load_balancer » absent de l'API exoscale |
-| `loadbalancer_ssl_listeners` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « load_balancer » |
+| `loadbalancer_ssl_listeners` | outscale | terraform | ◐ `partial` | attribut décisif « load_balancer_type » déclaré par le mapping mais ABSENT des plans de référence : soit la valeur n'existe qu'après `apply`, soit l'argument est optionnel et le HCL réel ne l'écrit pas — garde de capacité, le scan rend « not-evaluated » |
 | `network_documented` | scaleway | terraform | ◐ `partial` | contrat du fournisseur : le type « network » n'est pas déclaré `verifie` (état : a_verifier) |
 | `network_documented` | scaleway | live | ✗ `unsupported` | cette source ne produit aucune ressource de type « network » |
 | `network_peering_cross_organization` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « network_peering » |
@@ -213,7 +213,7 @@ deux ne peut couvrir la portée de l'autre. Une seule source : la collecte live 
 |---|---|---:|---:|---:|---:|
 | exoscale | terraform | 19 | 2 | 6 | 31 |
 | exoscale | live | 24 | 1 | 6 | 27 |
-| outscale | terraform | 18 | 4 | 4 | 32 |
+| outscale | terraform | 18 | 6 | 4 | 30 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
 | scaleway | live | 19 | 2 | 2 | 35 |

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -93,8 +93,8 @@ and the report says so on every scan, control by control, with the reason.
 | `kubernetes_cluster_deletion_protection` | medium | CLD-K8S-3 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `kubernetes_cluster_not_publicly_accessible` | critical | CLD-K8S-1 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `loadbalancer_http_redirect_to_https` | medium | CLD-CHF-1 | ∅ | ∅ | ∅ | ∅ | ✗ | ✗ |
-| `loadbalancer_logging_enabled` | medium | CLD-LOG-1 | ∅ | ∅ | ✗ | ✅ | ✗ | ✗ |
-| `loadbalancer_ssl_listeners` | high | CLD-CHF-1 | ∅ | ∅ | ✗ | ✅ | ✗ | ✗ |
+| `loadbalancer_logging_enabled` | medium | CLD-LOG-1 | ∅ | ∅ | ◐ | ✅ | ✗ | ✗ |
+| `loadbalancer_ssl_listeners` | high | CLD-CHF-1 | ∅ | ∅ | ◐ | ✅ | ✗ | ✗ |
 | `network_documented` | low | CLD-NET-5 | ✅ | ✅ | ✅ | ✅ | ◐ | ✗ |
 | `network_flow_matrix_documented` | medium | CLD-NET-5 | ✅ | ✅ | ✗ | ✗ | ✗ | ✗ |
 | `network_peering_cross_organization` | high | CLD-NET-7 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
@@ -168,10 +168,10 @@ already shows them, and they add nothing.
 | `loadbalancer_http_redirect_to_https` | outscale | live | ∅ `not-applicable` | The Outscale LBU cannot redirect: `ListenerRule.Action` is documented as "always forward" in the OAPI contract (no redirect action), and no redirect attribute exists on `Listener`. The mechanism does not exist, so the control is not applicable (CHF-1). |
 | `loadbalancer_logging_enabled` | exoscale | terraform | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
 | `loadbalancer_logging_enabled` | exoscale | live | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
-| `loadbalancer_logging_enabled` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "load_balancer" |
+| `loadbalancer_logging_enabled` | outscale | terraform | ◐ `partial` | deciding attribute "access_log" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `loadbalancer_ssl_listeners` | exoscale | terraform | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
 | `loadbalancer_ssl_listeners` | exoscale | live | ∅ `not-applicable` | resource type "load_balancer" absent from the exoscale API |
-| `loadbalancer_ssl_listeners` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "load_balancer" |
+| `loadbalancer_ssl_listeners` | outscale | terraform | ◐ `partial` | deciding attribute "load_balancer_type" declared by the mapping but ABSENT from the reference plans: either the value exists only after `apply`, or the argument is optional and real-world HCL does not write it — a capability guard, so the scan returns "not-evaluated" |
 | `network_documented` | scaleway | terraform | ◐ `partial` | provider contract: type "network" is not declared `verifie` (state: a_verifier) |
 | `network_documented` | scaleway | live | ✗ `unsupported` | this source produces no resource of type "network" |
 | `network_peering_cross_organization` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "network_peering" |
@@ -212,7 +212,7 @@ the other's scope. One source only: live collection through a kubeconfig.
 |---|---|---:|---:|---:|---:|
 | exoscale | terraform | 19 | 2 | 6 | 31 |
 | exoscale | live | 24 | 1 | 6 | 27 |
-| outscale | terraform | 18 | 4 | 4 | 32 |
+| outscale | terraform | 18 | 6 | 4 | 30 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
 | scaleway | live | 19 | 2 | 2 | 35 |

--- a/docs/detection-quality.fr.md
+++ b/docs/detection-quality.fr.md
@@ -16,7 +16,7 @@ pourcentage sans mesure derrière est un faux vert déplacé dans un tableau de
 bord, et il y est pire qu'ailleurs : personne ne relit un tableau de bord.
 
 Les chiffres sont donc laids, et c'est le point. « 58 contrôles » ne dit rien de
-la qualité d'une détection ; « 96 verdicts prouvés sur 465 » dit où en est le
+la qualité d'une détection ; « 98 verdicts prouvés sur 467 » dit où en est le
 produit, et rétrécit dans le bon sens à chaque scénario écrit.
 
 ## Les chiffres
@@ -24,10 +24,10 @@ produit, et rétrécit dans le bon sens à chaque scénario écrit.
 | Chiffre | Nombre |
 |---|---:|
 | Contrôles au référentiel | 58 |
-| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 183 |
-| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 31 |
-| Verdicts à prouver au total | 465 |
-| Verdicts prouvés | 96 |
+| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 185 |
+| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 33 |
+| Verdicts à prouver au total | 467 |
+| Verdicts prouvés | 98 |
 
 ## Couverture de véracité, par verdict
 
@@ -39,9 +39,9 @@ demanderait d'inventer une non-applicabilité.
 |---|---|---:|---:|---:|
 | `fail` | une configuration vulnérable est détectée | 141 | 25 | 17 |
 | `pass` | une configuration réellement correcte est confirmée | 141 | 37 | 26 |
-| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 159 | 22 | 13 |
+| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 161 | 24 | 14 |
 | `not-applicable` | le contrat du fournisseur déclare le mécanisme inexistant | 24 | 12 | 50 |
-| **Total** | | **465** | **96** | **20** |
+| **Total** | | **467** | **98** | **20** |
 
 ## Validé en live
 

--- a/docs/detection-quality.md
+++ b/docs/detection-quality.md
@@ -16,7 +16,7 @@ with no measurement behind it is a false green moved into a dashboard, and it is
 worse there than anywhere else: nobody re-reads a dashboard.
 
 The figures are therefore ugly, and that is the point. "58 controls" says nothing
-about the quality of a detection; "96 verdicts proven out of 465" says where the
+about the quality of a detection; "98 verdicts proven out of 467" says where the
 product stands, and shrinks the right way with every scenario written.
 
 ## The figures
@@ -24,10 +24,10 @@ product stands, and shrinks the right way with every scenario written.
 | Figure | Count |
 |---|---:|
 | Controls in the reference | 58 |
-| Control x provider x source paths on which Pépin concludes | 183 |
-| Paths whose EVERY reachable verdict is proven end to end | 31 |
-| Verdicts to prove in total | 465 |
-| Verdicts proven | 96 |
+| Control x provider x source paths on which Pépin concludes | 185 |
+| Paths whose EVERY reachable verdict is proven end to end | 33 |
+| Verdicts to prove in total | 467 |
+| Verdicts proven | 98 |
 
 ## Veracity coverage, by verdict
 
@@ -39,9 +39,9 @@ inventing a non-applicability.
 |---|---|---:|---:|---:|
 | `fail` | a vulnerable configuration is detected | 141 | 25 | 17 |
 | `pass` | a genuinely correct configuration is confirmed | 141 | 37 | 26 |
-| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 159 | 22 | 13 |
+| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 161 | 24 | 14 |
 | `not-applicable` | the provider's contract declares the mechanism non-existent | 24 | 12 | 50 |
-| **Total** | | **465** | **96** | **20** |
+| **Total** | | **467** | **98** | **20** |
 
 ## Validated live
 

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -58,7 +58,7 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v12",
+  "inventory_schema": "pepin-inventory/v13",
   "disclaimer": "Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -56,7 +56,7 @@ raises a version number and gets a CHANGELOG line.
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v12",
+  "inventory_schema": "pepin-inventory/v13",
   "disclaimer": "This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -106,8 +106,8 @@ pas.
 | `kubernetes_cluster_control_plane_highly_available` | outscale | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
 | `kubernetes_cluster_deletion_protection` | outscale | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
 | `kubernetes_cluster_not_publicly_accessible` | outscale | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
-| `loadbalancer_logging_enabled` | outscale | live | cette source ne produit aucune ressource de type « load_balancer » |
-| `loadbalancer_ssl_listeners` | outscale | live | cette source ne produit aucune ressource de type « load_balancer » |
+| `loadbalancer_logging_enabled` | outscale | live | attribut décisif « access_log » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| `loadbalancer_ssl_listeners` | outscale | live | attribut décisif « load_balancer_type » déclaré par le mapping mais ABSENT des plans de référence : soit la valeur n'existe qu'après `apply`, soit l'argument est optionnel et le HCL réel ne l'écrit pas — garde de capacité, le scan rend « not-evaluated » |
 | `network_peering_cross_organization` | outscale | live | cette source ne produit aucune ressource de type « network_peering » |
 | `network_securitygroup_default_restrict_traffic` | outscale | live | attribut décisif « security_group_name » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `objectstorage_bucket_default_encryption` | outscale | live | cette source ne produit aucune ressource de type « object_storage_bucket » |
@@ -150,7 +150,7 @@ Par fournisseur et par source, sur l'ensemble des contrôles du référentiel :
 |---|---|---:|---:|---:|---:|
 | exoscale | terraform | 19 | 2 | 6 | 31 |
 | exoscale | live | 24 | 1 | 6 | 27 |
-| outscale | terraform | 18 | 4 | 4 | 32 |
+| outscale | terraform | 18 | 6 | 4 | 30 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
 | scaleway | live | 19 | 2 | 2 | 35 |
@@ -207,9 +207,9 @@ Ce qui n'est pas encore prouvé est **compté**, pas masqué :
 <!-- pepin:gen veracity-debt -->
 | Chiffre | Nombre |
 |---|---:|
-| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 183 |
-| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 31 |
-| Verdicts à prouver au total | 465 |
+| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 185 |
+| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 33 |
+| Verdicts à prouver au total | 467 |
 | Verdicts restant à prouver | 369 |
 <!-- /pepin:gen veracity-debt -->
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -107,8 +107,8 @@ actually decide them. The reason given is the one that applies to the source tha
 | `kubernetes_cluster_control_plane_highly_available` | outscale | live | this source produces no resource of type "kubernetes_cluster" |
 | `kubernetes_cluster_deletion_protection` | outscale | live | this source produces no resource of type "kubernetes_cluster" |
 | `kubernetes_cluster_not_publicly_accessible` | outscale | live | this source produces no resource of type "kubernetes_cluster" |
-| `loadbalancer_logging_enabled` | outscale | live | this source produces no resource of type "load_balancer" |
-| `loadbalancer_ssl_listeners` | outscale | live | this source produces no resource of type "load_balancer" |
+| `loadbalancer_logging_enabled` | outscale | live | deciding attribute "access_log" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| `loadbalancer_ssl_listeners` | outscale | live | deciding attribute "load_balancer_type" declared by the mapping but ABSENT from the reference plans: either the value exists only after `apply`, or the argument is optional and real-world HCL does not write it — a capability guard, so the scan returns "not-evaluated" |
 | `network_peering_cross_organization` | outscale | live | this source produces no resource of type "network_peering" |
 | `network_securitygroup_default_restrict_traffic` | outscale | live | deciding attribute "security_group_name" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `objectstorage_bucket_default_encryption` | outscale | live | this source produces no resource of type "object_storage_bucket" |
@@ -150,7 +150,7 @@ Per provider and per source, over all controls in the reference:
 |---|---|---:|---:|---:|---:|
 | exoscale | terraform | 19 | 2 | 6 | 31 |
 | exoscale | live | 24 | 1 | 6 | 27 |
-| outscale | terraform | 18 | 4 | 4 | 32 |
+| outscale | terraform | 18 | 6 | 4 | 30 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
 | scaleway | live | 19 | 2 | 2 | 35 |
@@ -207,9 +207,9 @@ What is not yet proven is **counted**, not hidden:
 <!-- pepin:gen veracity-debt -->
 | Figure | Count |
 |---|---:|
-| Control x provider x source paths on which Pépin concludes | 183 |
-| Paths whose every reachable verdict is proven end to end | 31 |
-| Verdicts to prove in total | 465 |
+| Control x provider x source paths on which Pépin concludes | 185 |
+| Paths whose every reachable verdict is proven end to end | 33 |
+| Verdicts to prove in total | 467 |
 | Verdicts left to prove | 369 |
 <!-- /pepin:gen veracity-debt -->
 

--- a/docs/providers/outscale.fr.md
+++ b/docs/providers/outscale.fr.md
@@ -244,6 +244,7 @@ n'en montre aucune.
 |---|---|---|
 | `outscale_api_access_rule` | `api_access_rule` | — |
 | `outscale_image_launch_permission` | `compute_image` | — |
+| `outscale_load_balancer` | `load_balancer` | — |
 | `outscale_net` | `network` | — |
 | `outscale_policy` | `iam_policy` | — |
 | `outscale_security_group_rule` | `security_group_rule` | — |
@@ -267,7 +268,7 @@ rend un booléen. Les règles normalisent les deux
 <!-- pepin:gen provider-outscale-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 18 | 4 | 4 | 32 |
+| terraform | 18 | 6 | 4 | 30 |
 | live | 40 | 1 | 4 | 13 |
 <!-- /pepin:gen provider-outscale-coverage -->
 
@@ -304,8 +305,8 @@ source de vérité est la [matrice de couverture](../coverage.fr.md).
 | `kubernetes_cluster_control_plane_highly_available` | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
 | `kubernetes_cluster_deletion_protection` | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
 | `kubernetes_cluster_not_publicly_accessible` | live | cette source ne produit aucune ressource de type « kubernetes_cluster » |
-| `loadbalancer_logging_enabled` | live | cette source ne produit aucune ressource de type « load_balancer » |
-| `loadbalancer_ssl_listeners` | live | cette source ne produit aucune ressource de type « load_balancer » |
+| `loadbalancer_logging_enabled` | live | attribut décisif « access_log » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
+| `loadbalancer_ssl_listeners` | live | attribut décisif « load_balancer_type » déclaré par le mapping mais ABSENT des plans de référence : soit la valeur n'existe qu'après `apply`, soit l'argument est optionnel et le HCL réel ne l'écrit pas — garde de capacité, le scan rend « not-evaluated » |
 | `network_peering_cross_organization` | live | cette source ne produit aucune ressource de type « network_peering » |
 | `network_securitygroup_default_restrict_traffic` | live | attribut décisif « security_group_name » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `objectstorage_bucket_default_encryption` | live | cette source ne produit aucune ressource de type « object_storage_bucket » |

--- a/docs/providers/outscale.md
+++ b/docs/providers/outscale.md
@@ -237,6 +237,7 @@ keys for an EIM user, that is the next thing to measure; `ReadAccessKeys` shows 
 |---|---|---|
 | `outscale_api_access_rule` | `api_access_rule` | — |
 | `outscale_image_launch_permission` | `compute_image` | — |
+| `outscale_load_balancer` | `load_balancer` | — |
 | `outscale_net` | `network` | — |
 | `outscale_policy` | `iam_policy` | — |
 | `outscale_security_group_rule` | `security_group_rule` | — |
@@ -260,7 +261,7 @@ API returns a boolean. The rules normalize both
 <!-- pepin:gen provider-outscale-coverage -->
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
-| terraform | 18 | 4 | 4 | 32 |
+| terraform | 18 | 6 | 4 | 30 |
 | live | 40 | 1 | 4 | 13 |
 <!-- /pepin:gen provider-outscale-coverage -->
 
@@ -297,8 +298,8 @@ truth is the [coverage matrix](../coverage.md).
 | `kubernetes_cluster_control_plane_highly_available` | live | this source produces no resource of type "kubernetes_cluster" |
 | `kubernetes_cluster_deletion_protection` | live | this source produces no resource of type "kubernetes_cluster" |
 | `kubernetes_cluster_not_publicly_accessible` | live | this source produces no resource of type "kubernetes_cluster" |
-| `loadbalancer_logging_enabled` | live | this source produces no resource of type "load_balancer" |
-| `loadbalancer_ssl_listeners` | live | this source produces no resource of type "load_balancer" |
+| `loadbalancer_logging_enabled` | live | deciding attribute "access_log" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
+| `loadbalancer_ssl_listeners` | live | deciding attribute "load_balancer_type" declared by the mapping but ABSENT from the reference plans: either the value exists only after `apply`, or the argument is optional and real-world HCL does not write it — a capability guard, so the scan returns "not-evaluated" |
 | `network_peering_cross_organization` | live | this source produces no resource of type "network_peering" |
 | `network_securitygroup_default_restrict_traffic` | live | deciding attribute "security_group_name" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `objectstorage_bucket_default_encryption` | live | this source produces no resource of type "object_storage_bucket" |

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -43,7 +43,7 @@ séparément :
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v12** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v13** |
 <!-- /pepin:gen surface-versions -->
 
 Un numéro monte à **tout** changement de forme, ajout compris : il signifie « la surface a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,7 +43,7 @@ independently:
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v12** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v13** |
 <!-- /pepin:gen surface-versions -->
 
 A version rises on **any** shape change, additions included: the number means "the surface has

--- a/docs/reference/inventory.fr.md
+++ b/docs/reference/inventory.fr.md
@@ -12,7 +12,7 @@ gelée, avec les mêmes égards que la surface CLI.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v12
+pepin-inventory/v13
 ```
 <!-- /pepin:gen inventory-format -->
 

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -12,7 +12,7 @@ with the same regard as the CLI surface.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v12
+pepin-inventory/v13
 ```
 <!-- /pepin:gen inventory-format -->
 

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -30,7 +30,7 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v12** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v13** |
 <!-- /pepin:gen surface-versions -->
 
 « Gelé » signifie qu'un test échoue quand la forme bouge sans que sa version ait suivi : les

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -30,7 +30,7 @@ See [Exit codes](exit-codes.md).
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v12** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v13** |
 <!-- /pepin:gen surface-versions -->
 
 "Frozen" means a test fails when the shape moves and its version has not: field paths and JSON

--- a/internal/model/schema.go
+++ b/internal/model/schema.go
@@ -171,7 +171,18 @@ import (
 //	réponses en clair — `ip_ranges` est un argument OBLIGATOIRE quand aucun autre
 //	critère n'est donné — pendant que Pépin rendait « non évalué » sur un
 //	`0.0.0.0/0` écrit noir sur blanc (issue #203).
-const InventoryFormat = "pepin-inventory/v12"
+//
+// v13 : un plan Terraform Outscale produit le type `load_balancer`, porteur de ses
+//
+//	écouteurs, de son type d'exposition et de sa région dérivée. Ajout PUR. Le plan
+//	écrivait ces écouteurs en clair — protocole et port — pendant que Pépin rendait
+//	« non évalué » sur un répartiteur exposé à Internet qui n'écoute qu'en HTTP
+//	(issue #203). La RÉGION du type est projetée elle aussi, et ce n'est pas un
+//	détail : le contrôle de souveraineté juge l'intersection sur tous les types, si
+//	bien qu'ajouter un type sans région RETIRE de la couverture au lieu d'en ajouter
+//	— mesuré au premier essai, `governance_resource_region_in_eu` passant de `pass` à
+//	« non évalué ».
+const InventoryFormat = "pepin-inventory/v13"
 
 // InventorySchemaVersion extrait le N du suffixe `/vN`. Comme pour le bundle, la
 // constante et le signal sur le fil sont la même chose : impossible de faire

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -1,9 +1,9 @@
 {
   "controls": 58,
-  "paths": 183,
-  "paths_proven": 31,
-  "obligations": 465,
-  "proven": 96,
+  "paths": 185,
+  "paths_proven": 33,
+  "obligations": 467,
+  "proven": 98,
   "verdicts": {
     "fail": {
       "required": 141,
@@ -14,8 +14,8 @@
       "proven": 12
     },
     "not-evaluated": {
-      "required": 159,
-      "proven": 22
+      "required": 161,
+      "proven": 24
     },
     "pass": {
       "required": 141,
@@ -1610,11 +1610,23 @@
             "pass",
             "not-evaluated"
           ]
+        },
+        {
+          "provider": "outscale",
+          "source": "terraform",
+          "status": "partial",
+          "required": [
+            "not-evaluated"
+          ],
+          "proven": [
+            "not-evaluated"
+          ]
         }
       ],
       "tenants": [
         "exoscale/eu-data-bootstrap",
-        "exoscale/zone-demo"
+        "exoscale/zone-demo",
+        "outscale/ztiac-two-tier"
       ],
       "rego_tests": [
         "internal/commonrules/rules/oks_lbu_governance_test.rego"
@@ -1650,11 +1662,23 @@
             "pass",
             "not-evaluated"
           ]
+        },
+        {
+          "provider": "outscale",
+          "source": "terraform",
+          "status": "partial",
+          "required": [
+            "not-evaluated"
+          ],
+          "proven": [
+            "not-evaluated"
+          ]
         }
       ],
       "tenants": [
         "exoscale/eu-data-bootstrap",
-        "exoscale/zone-demo"
+        "exoscale/zone-demo",
+        "outscale/ztiac-two-tier"
       ],
       "rego_tests": [
         "internal/commonrules/rules/oks_lbu_governance_test.rego"

--- a/internal/veracity/testdata/debt.txt
+++ b/internal/veracity/testdata/debt.txt
@@ -8,7 +8,7 @@
 # Une ligne qui disparaît est une dette payée. Une ligne qui apparaît sans
 # scénario est un contrôle ajouté sans sa preuve, et la CI la refuse.
 #
-# chemins : 183 · entierement prouves : 31 · obligations : 465 · restantes : 369
+# chemins : 185 · entierement prouves : 33 · obligations : 467 · restantes : 369
 
 blockstorage_snapshot_not_public exoscale live not-applicable
 blockstorage_snapshot_not_public outscale live fail,pass,not-evaluated

--- a/providers/outscale.yaml
+++ b/providers/outscale.yaml
@@ -745,6 +745,36 @@ mapping_terraform:
     #
     # L'identifiant n'existe pas au stade du plan : le sujet est l'adresse Terraform
     # (ADR-0022), comme pour les autres types de ce mapping.
+    # Répartiteurs de charge. Le plan porte les écouteurs en clair, avec leur protocole
+    # et leur port : un LBU exposé à Internet qui n'écoute qu'en HTTP est écrit noir sur
+    # blanc dans le HCL, et Pépin rendait pourtant « non évalué » (issue #203).
+    #
+    # PAS de `snake_keys` ici, contrairement à la collecte live : Terraform écrit déjà
+    # ses clés en snake_case. Le transform est destiné aux réponses OAPI, en PascalCase.
+    #
+    # `access_log` n'est PAS mappé : il vit sur `outscale_load_balancer_attributes`, une
+    # ressource distincte que ce plan ne porte pas. `loadbalancer_logging_enabled` reste
+    # donc « non évalué » sur cette source, et c'est honnête — la donnée n'y est pas.
+    - tf_type: outscale_load_balancer
+      type: load_balancer
+      id: load_balancer_name
+      # La région, DÉRIVÉE de la sous-région comme pour les VM. Sans elle, ajouter ce
+      # type RETIRAIT de la couverture au lieu d'en ajouter : le contrôle de
+      # souveraineté juge l'intersection sur tous les types, et un type sans région
+      # l'empêche de conclure sur les autres. Mesuré : `governance_resource_region_in_eu`
+      # est passé de `pass` à `not-evaluated` au premier essai.
+      region: subregion_names.0
+      map:
+        load_balancer_name: load_balancer_name
+        load_balancer_type: load_balancer_type   # internet-facing | internal
+        listeners: listeners
+        tags: tags
+      transforms:
+        listeners: list
+        # Le transform de la région se déclare sous le CHEMIN du champ source, comme
+        # pour `outscale_vm` : la région n'est pas un attribut de `map`.
+        subregion_names.0: region_of_zone
+
     - tf_type: outscale_api_access_rule
       type: api_access_rule
       id: api_access_rule_id

--- a/references/qualification/outscale/expected.yaml
+++ b/references/qualification/outscale/expected.yaml
@@ -320,8 +320,15 @@ controls:
     live:
       fail: ["${output.lb_http_name}"]
       inconclusive: ["${output.lb_tcp443_name}"]
-    # `outscale_load_balancer` n'est pas mappé sur le plan (#203).
-    terraform: not-evaluated
+    # #203 : `outscale_load_balancer` est mappé. Le plan porte les écouteurs en clair,
+    # avec leur protocole et leur port — un LBU exposé à Internet qui n'écoute qu'en
+    # HTTP est écrit noir sur blanc dans le HCL.
+    #
+    # Le sujet est le NOM du répartiteur sur les deux sources : c'est son identifiant
+    # chez Outscale, et il est connu dès le plan.
+    terraform:
+      fail: [pepin-qual-lb-http]
+      inconclusive: [pepin-qual-lb-tcp443]
 
   loadbalancer_logging_enabled:
     live:


### PR DESCRIPTION
Third control of #203.

## The gap

`loadbalancer_ssl_listeners` came back `not-evaluated` on the Terraform source while the
plan wrote the listeners in clear — protocol and port, one entry per listener. An
**internet-facing load balancer listening only in HTTP** is written black on white in the
HCL, and Pépin could not tell.

## Measured

```
loadbalancer_ssl_listeners   fail            pepin-qual-lb-http
loadbalancer_ssl_listeners   not-evaluated   pepin-qual-lb-tcp443
```

The second is the rule refusing to decide whether TLS terminates on a TCP 443 listener —
inconclusive **with its subject**, exactly as it behaves live. A `--plan-only`
qualification run answers **GO**, nothing created, nothing billed.

## The region of the type is projected too, and that is the part worth reading

The first attempt mapped the listeners and **not** the region. The qualification answered
NO-GO on a control I had not touched:

```
governance_resource_region_in_eu : attendu pass, obtenu not-evaluated
                                   — régression de couverture
```

The sovereignty control judges the **intersection across every resource type**. A new type
carrying no region therefore removes the control's ability to conclude **about the types
that do**. Adding coverage had removed coverage. The plan carries `subregion_names`, so
the region derives as it does for a VM, and the control concludes again.

**This is a general trap for the rest of #203**, and it has its own issue now:
[#245](https://github.com/stephrobert/pepin/issues/245). Every type added to this mapping
must carry a region — and some cannot, which is exactly where the next block of #203
stops.

## What is deliberately not here

- **`access_log`**: it lives on `outscale_load_balancer_attributes`, a separate resource
  this plan does not carry. `loadbalancer_logging_enabled` honestly stays unevaluated.
- **`outscale_snapshot` + `outscale_snapshot_attributes`**: written, measured, and
  **reverted**. The reference resolution works — ADR-0022 resolves the declared
  `snapshot_id → outscale_snapshot.public`, and `blockstorage_snapshot_not_public`
  correctly `fail`s on a snapshot declared public. But a snapshot carries no subregion in
  a plan, so mapping it costs `governance_resource_region_in_eu`. Trading one `high`
  control for another is not progress, and the qualification gate rightly refuses the
  regression. Filed as #245 rather than forced.
- **`outscale_net_peering`**: this plan carries only its tags; the account ids the control
  compares are not written for a same-account peering. Nothing to map.
- No `snake_keys` transform, unlike the live collection: Terraform already writes
  snake_case. That transform exists for PascalCase OAPI responses.

Inventory format `v13`, a pure addition.

## Impact ADR

**ADR-0003**: constant bumped before regenerating the frozen surface, with the reason.
**ADR-0015**: the inconclusive verdict keeps its subject. **ADR-0014**: `access_log` is
not fabricated from a resource the plan does not carry. No ADR modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)