### PR TITLE
fix(collect): a live scan writes the region it scanned, whatever the provider calls it

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -82,6 +82,20 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **La collecte live Exoscale écrit la zone qu'elle a scannée** (issue #210).
+  `governance_resource_region_in_eu` rendait `not-evaluated` sur **toute** organisation
+  Exoscale : aucune ressource ne portait de région, donc le contrôle ne pouvait jamais
+  conclure sur la localisation de quoi que ce soit. Le collecteur connaissait pourtant la
+  zone depuis toujours — c'est le `--region` qu'on lui donne et l'hôte auquel il parle —
+  mais le moteur lisait la variable `region` là où Exoscale déclare `zone`
+  (`region_key`), si bien que chaque ressource sortait avec une région **vide**. La
+  région suit désormais la clé déclarée, pour tous les fournisseurs. Poser la zone
+  **scannée** n'affirme rien qu'on n'ait observé : l'API Exoscale est zone-scopée par son
+  hôte, donc un scan de `de-fra-1` ne rend que des ressources de `de-fra-1` — c'est la
+  zone dont l'API a répondu, pas une valeur déduite. Confirmé par un run de qualification
+  sur un compte réel, GO, le contrôle rendant désormais `pass` sur les instances, les
+  volumes, les instantanés et les clusters.
+
 - **Le tenant de qualification Scaleway refuse de tourner dans le projet par défaut**
   (issue #240). Il applique des ressources délibérément exposées, et sa preuve de
   destruction repose sur un delta avant/après pour ce qui ne porte pas d'étiquette — que

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,18 @@ belongs in `git log`.
 
 ### Fixed
 
+- **Exoscale live now writes the zone it scanned** (issue #210).
+  `governance_resource_region_in_eu` returned `not-evaluated` on **every** Exoscale
+  organisation: no resource carried a region, so the control could never conclude about
+  where anything lived. The collector knew the zone all along — it is the `--region` it
+  was given and the host it talks to — but the engine read the variable `region` where
+  Exoscale declares `zone` (`region_key`), so every resource came out with an **empty**
+  region. The region now follows the declared key, for every provider. Writing the
+  **scanned** zone asserts nothing unobserved: Exoscale's API is zone-scoped by its host,
+  so a scan of `de-fra-1` returns only `de-fra-1` resources — it is the zone whose API
+  answered, not a value inferred. Confirmed by a qualification run on a real account,
+  GO, with the control now `pass` over instances, volumes, snapshots and clusters.
+
 - **The Scaleway qualification tenant refuses to run in the default project** (issue
   #240). It applies deliberately exposed resources, and its proof of destruction relies
   on a before/after delta for what carries no tag — which a **third-party** resource

--- a/internal/collect/engine.go
+++ b/internal/collect/engine.go
@@ -87,9 +87,33 @@ type ResourceSpec struct {
 
 // Spec est la configuration de collecte d'un provider.
 type Spec struct {
-	Provider  string         `yaml:"provider"`
-	BaseURL   string         `yaml:"base_url"`
+	Provider string `yaml:"provider"`
+	BaseURL  string `yaml:"base_url"`
+	// RegionKey : la variable que `--region` alimente chez ce fournisseur. Vide vaut
+	// « region ».
+	//
+	// Elle existe parce que tous les clouds ne nomment pas leur périmètre de la même
+	// façon : Exoscale scanne une ZONE, et chez lui une zone EST sa région. Le nom
+	// logique était déjà déclaré au descripteur (`region_key`) et servait à substituer
+	// `{zone}` dans les chemins ; ce qui manquait, c'est que la RÉGION POSÉE SUR CHAQUE
+	// RESSOURCE en vienne aussi.
+	//
+	// Sans elle, `mapItems` lisait `vars["region"]` — jamais alimentée chez Exoscale —
+	// et toute ressource sortait avec une région VIDE. Le contrôle de souveraineté, qui
+	// exige la région sur chaque type localisé, ne pouvait donc jamais conclure en live
+	// alors que le collecteur connaissait la zone : c'est celle qu'on lui a donnée, et
+	// c'est l'hôte auquel il parle (issue #210).
+	RegionKey string         `yaml:"region_key"`
 	Resources []ResourceSpec `yaml:"resources"`
+}
+
+// regionOf rend la région à poser sur les ressources de cette spec : la valeur de la
+// clé que le fournisseur déclare, `region` par défaut.
+func (s Spec) regionOf(vars map[string]string) string {
+	if s.RegionKey != "" {
+		return vars[s.RegionKey]
+	}
+	return vars["region"]
 }
 
 // Collect exécute toute la spec et retourne l'inventaire normalisé AVEC son état
@@ -166,7 +190,7 @@ func collectResource(ctx context.Context, hc *http.Client, spec Spec, auth Auth,
 		}
 		AttestConst(&prov, r.Const, constRef)
 		id, _ := attrs[r.ID].(string)
-		return []model.Resource{{Provider: spec.Provider, Type: r.Type, ID: id, Name: id, Region: vars["region"], Attributes: attrs, Provenance: prov}}, nil
+		return []model.Resource{{Provider: spec.Provider, Type: r.Type, ID: id, Name: id, Region: spec.regionOf(vars), Attributes: attrs, Provenance: prov}}, nil
 	}
 	return mapItems(spec, r, items, vars, src), nil
 }
@@ -339,7 +363,7 @@ func tokenFromDoc(doc any, path string) string {
 // transforms). La région de collecte (vars["region"]) est propagée sur chaque
 // ressource pour les contrôles de localisation (souveraineté, CLD-GVN-3).
 func mapItems(spec Spec, r ResourceSpec, items []any, vars map[string]string, src Source) []model.Resource {
-	region := vars["region"]
+	region := spec.regionOf(vars)
 	out := make([]model.Resource, 0, len(items))
 	for _, it := range items {
 		attrs, prov := ProjectAttested(it, r.Map, r.Transforms, src)

--- a/internal/genprovider/genprovider.go
+++ b/internal/genprovider/genprovider.go
@@ -303,6 +303,11 @@ func (g GenericProvider) Collect(ctx context.Context, cfg provider.Config) (mode
 		}
 	}
 	spec := g.desc.Collecte
+	// La clé que `--region` alimente chez ce fournisseur, pour que la région POSÉE sur
+	// chaque ressource vienne de la même variable que les chemins substitués. Elle est
+	// déclarée au descripteur (`region_key`), pas devinée : chez Exoscale c'est `zone`,
+	// et une ressource sortait sans région parce que le moteur lisait `region` (#210).
+	spec.RegionKey = g.desc.RegionKey
 	spec.Provider = g.desc.Name
 	eimCfg := collectkit.EIM{}
 	if g.desc.EIM.InlinePolicies {

--- a/references/qualification/exoscale/expected.yaml
+++ b/references/qualification/exoscale/expected.yaml
@@ -292,11 +292,16 @@ controls:
     # seul constructible. `swiss` n'est que sur le plan (`terraform_only_resources`) :
     # en live, le scan lit de-fra-1 (UE), elle y serait invisible, et l'organisation
     # n'a droit qu'à quatre instances.
-    # DETTE DE COLLECTE NOMMÉE (ADR-0010) : en live, la collecte Exoscale ne projette
-    # `region` sur aucun type (instances, volumes, snapshots, clusters) — la zone
-    # scannée n'est pas reportée sur les ressources —, et la garde de capacité rend
-    # not-evaluated. Le jour où le collecteur le fait, cette ligne devient `pass`.
-    live: not-evaluated
+    # DETTE PAYÉE (#210) : la collecte live reporte désormais la zone scannée sur
+    # chaque ressource. Le collecteur la connaissait depuis toujours — c'est le
+    # `--region` qu'on lui donne, et l'hôte auquel il parle — mais le moteur lisait la
+    # variable `region` là où Exoscale déclare `zone` (`region_key`), si bien que toute
+    # ressource sortait avec une région VIDE.
+    #
+    # Poser la zone SCANNÉE n'affirme rien qu'on n'ait observé : l'API Exoscale est
+    # zone-scopée par son hôte, donc un scan de de-fra-1 ne rend que des ressources de
+    # de-fra-1. C'est la zone dont l'API a répondu, pas une valeur déduite.
+    live: pass
     terraform:
       fail: [pepin-qual-vm-swiss]
       silent: [pepin-qual-vm-hardened]


### PR DESCRIPTION
Closes #210.

## The defect

`governance_resource_region_in_eu` returned `not-evaluated` on **every** Exoscale
organisation. No resource carried a region, so the control could never conclude about
where anything lived — on a product whose entire subject is **sovereign cloud**.

## It was a name

The collector knew the zone all along: it is the `--region` it was given, and the host it
talks to. But `mapItems` read `vars["region"]`, while Exoscale declares:

```yaml
region_key: zone
```

So the variable `--region` fills was `zone`, `region` was never set, and every resource
came out with an **empty** region. Not a missing API, not a missing field — a name.

The spec now carries its region key, filled from the descriptor, and the region posted on
each resource follows it. Default unchanged: absent means `region`, which Outscale,
Scaleway and Kubernetes already use.

## Writing the scanned zone asserts nothing unobserved

Worth being explicit about, because a sovereignty control is the **worst possible place**
to invent a location. Exoscale's API is zone-scoped **by its host**: a scan of `de-fra-1`
reaches `api-de-fra-1.exoscale.com` and returns only `de-fra-1` resources. The value
posted is the zone whose API *answered*, not one deduced from a name.

## Measured

| | Before | After |
|---|---|---|
| resources on the maintainer's org | `region=(vide)` | `region=ch-gva-2` |
| control, empty org | `not-evaluated` | `not-evaluated` (no located type — correct) |
| control, qualification tenant | `not-evaluated` | **`pass`** over snapshots, volumes, instances and clusters |

The qualification run answers **GO** on both contracts, destruction proven — 15 collection
families, no before/after delta.

The **named collection debt** in the Exoscale expectation (ADR-0010) is paid: the pin
moves from `not-evaluated` to `pass`, with the reason written beside it.

## Impact ADR

**ADR-0010** (a counted debt, never a green matrix): this pays one and says so, rather
than quietly deleting the line. **ADR-0014**: the region is *observed* — the zone whose
API answered — not derived from a resource name. **ADR-0006**: an organisation holding no
located type still returns `not-evaluated`, which is the correct answer and stays. No ADR
modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)