### PR TITLE
feat(scaleway): read the organisation's API-key expiry policy

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -24,6 +24,19 @@ l'une ni l'autre appartient au `git log`.
 
 ### Ajouté
 
+- **Scaleway : la politique d'expiration des clés d'API de l'organisation est lue**
+  (issue #196). `iam_apiaccesspolicy_max_key_expiration` n'était actif que pour Outscale.
+  Scaleway a l'équivalent, au niveau de l'**organisation**, et l'impose — le tenant de
+  qualification l'a découvert en se faisant refuser : « organization security settings
+  require an expiration date for API keys ». Le refus était la mesure.
+  `GET /iam/v1alpha1/organizations/{id}/security-settings` porte
+  `max_api_key_expiration_duration`, vérifié contre l'API réelle le 2026-09-11. Le contrôle
+  est désormais actif pour Scaleway et conclut `pass` sur une organisation imposant
+  365 jours. C'est un contrôle **préventif** : lister les clés dit ce qui est vrai
+  aujourd'hui, ce réglage dit ce que l'organisation refusera demain — la distinction que
+  SecNumCloud 9.5 et CIS 5.4 font tous deux. Une règle, inchangée, sur une donnée
+  normalisée (ADR-0001).
+
 - **Un plan Outscale juge les écouteurs d'un répartiteur de charge** (issue #203).
   `loadbalancer_ssl_listeners` revenait `not-evaluated` sur la source Terraform alors que
   le plan écrivait les écouteurs en clair — protocole et port. Un répartiteur exposé à

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ belongs in `git log`.
 
 ### Added
 
+- **Scaleway: the organisation's API-key expiry policy is read** (issue #196).
+  `iam_apiaccesspolicy_max_key_expiration` was active for Outscale only. Scaleway has the
+  equivalent, at **organisation** level, and enforces it — the qualification tenant found
+  it by being refused: *"organization security settings require an expiration date for API
+  keys"*. The refusal was the measurement. `GET /iam/v1alpha1/organizations/{id}/security-settings`
+  carries `max_api_key_expiration_duration`, verified against the live API on 2026-09-11.
+  The control is now active for Scaleway and concludes `pass` on an organisation enforcing
+  365 days. This is a **preventive** control: listing keys says what is true today, this
+  setting says what the organisation will refuse tomorrow — the distinction SecNumCloud 9.5
+  and CIS 5.4 both draw. One rule, unchanged, on normalised data (ADR-0001).
+
 - **Outscale plans now judge load-balancer listeners** (issue #203).
   `loadbalancer_ssl_listeners` came back `not-evaluated` on the Terraform source while the
   plan wrote the listeners in clear — protocol and port. An internet-facing load balancer

--- a/ROADMAP.fr.md
+++ b/ROADMAP.fr.md
@@ -76,8 +76,8 @@ déployable** : un module Terraform autonome et conforme sous `references/remedi
 | exoscale | 26 / 26 |
 | kubernetes | 0 / 4 |
 | outscale | 0 / 41 |
-| scaleway | 0 / 26 |
-| **Total** | **26 / 97** |
+| scaleway | 0 / 27 |
+| **Total** | **26 / 98** |
 <!-- /pepin:gen remediation-coverage -->
 
 `mise run check-remediation` est volontairement débranché de `mise run validate` : une

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,8 +74,8 @@ compliant Terraform module under `references/remediation/`.
 | exoscale | 26 / 26 |
 | kubernetes | 0 / 4 |
 | outscale | 0 / 41 |
-| scaleway | 0 / 26 |
-| **Total** | **26 / 97** |
+| scaleway | 0 / 27 |
+| **Total** | **26 / 98** |
 <!-- /pepin:gen remediation-coverage -->
 
 `mise run check-remediation` is deliberately not wired into `mise run validate`: a gate

--- a/docs/concepts/assessment-model.fr.md
+++ b/docs/concepts/assessment-model.fr.md
@@ -393,7 +393,7 @@ voici les motifs distincts observés :
 |---|---:|---|
 | attribut « … » non collecté sur les ressources de type « … » (garde de capacité) | 5 | `compute_instance_has_security_group` |
 | attributs décisifs non collectés : « … » sur les ressources de type « … », « … » sur les ressources de type « … », « … » sur les ressources de type « … » (garde de capacité) | 1 | `governance_resource_region_in_eu` |
-| aucune ressource de type « … » dans l'inventaire évalué | 3 | `iam_accesskey_expiration_set` |
+| aucune ressource de type « … » dans l'inventaire évalué | 4 | `iam_accesskey_expiration_set` |
 | collecte de la donnée nécessaire non confirmée pour ce fournisseur (contrat non « … ») | 1 | `network_documented` |
 <!-- /pepin:gen not-evaluated-reasons -->
 
@@ -541,7 +541,7 @@ fois (`exempted` n'apparaît qu'avec un fichier de dérogations) :
 | `pass` | 6 |
 | `fail` | 10 |
 | `not-applicable` | 2 |
-| `not-evaluated` | 10 |
+| `not-evaluated` | 11 |
 <!-- /pepin:gen assessment-counts -->
 
 ## Le lien avec le code de sortie `3`

--- a/docs/concepts/assessment-model.md
+++ b/docs/concepts/assessment-model.md
@@ -391,7 +391,7 @@ reasons observed:
 | attribute "…" not collected on the resources of type "…" (capability guard) | 5 | `compute_instance_has_security_group` |
 | collection of the required data is not confirmed for this provider (contract not "…") | 1 | `network_documented` |
 | deciding attributes not collected: "…" on the resources of type "…", "…" on the resources of type "…", "…" on the resources of type "…" (capability guard) | 1 | `governance_resource_region_in_eu` |
-| no resource of type "…" in the assessed inventory | 3 | `iam_accesskey_expiration_set` |
+| no resource of type "…" in the assessed inventory | 4 | `iam_accesskey_expiration_set` |
 <!-- /pepin:gen not-evaluated-reasons -->
 
 ### `not-evaluated` is never a compliance
@@ -537,7 +537,7 @@ Scanning the deliberately misconfigured plan of the
 | `pass` | 6 |
 | `fail` | 10 |
 | `not-applicable` | 2 |
-| `not-evaluated` | 10 |
+| `not-evaluated` | 11 |
 <!-- /pepin:gen assessment-counts -->
 
 ## The link with exit code `3`

--- a/docs/concepts/terraform-vs-live.fr.md
+++ b/docs/concepts/terraform-vs-live.fr.md
@@ -269,6 +269,7 @@ couples, une source produit le type de ressource et son attribut décisif, et l'
 | `iam_accesskey_rotated` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
 | `iam_account_mfa_enforced` | outscale | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | live | cette source ne produit aucune ressource de type « api_access_policy » |
+| `iam_apiaccesspolicy_max_key_expiration` | scaleway | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccessrule_defined` | outscale | live | cette source ne produit aucune ressource de type « api_access_summary » |
 | `iam_no_root_access_key` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
 | `iam_no_root_access_key` | scaleway | live | attribut décisif « owner_application_id / owner_user_id / root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |

--- a/docs/concepts/terraform-vs-live.md
+++ b/docs/concepts/terraform-vs-live.md
@@ -264,6 +264,7 @@ source produces the resource type and its deciding attribute, and the other does
 | `iam_accesskey_rotated` | outscale | live | this source produces no resource of type "access_key" |
 | `iam_account_mfa_enforced` | outscale | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | live | this source produces no resource of type "api_access_policy" |
+| `iam_apiaccesspolicy_max_key_expiration` | scaleway | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccessrule_defined` | outscale | live | this source produces no resource of type "api_access_summary" |
 | `iam_no_root_access_key` | outscale | live | this source produces no resource of type "access_key" |
 | `iam_no_root_access_key` | scaleway | live | deciding attribute "owner_application_id / owner_user_id / root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |

--- a/docs/controls/iam_apiaccesspolicy_max_key_expiration.fr.md
+++ b/docs/controls/iam_apiaccesspolicy_max_key_expiration.fr.md
@@ -17,8 +17,8 @@
 | Type de ressource lu | `api_access_policy` |
 | Attribut décisif | `max_access_key_expiration_seconds` |
 | État | actif |
-| Déclaré pour | `outscale` |
-| Preuves de remédiation | 0 / 1 |
+| Déclaré pour | `outscale`, `scaleway` |
+| Preuves de remédiation | 0 / 2 |
 
 ## Le risque
 
@@ -51,7 +51,7 @@ déclaré, ou type absent de cette source ».
 |---|:-:|:-:|
 | exoscale | ✗ | ✗ |
 | outscale | ✗ | ✅ |
-| scaleway | ✗ | ✗ |
+| scaleway | ✗ | ✅ |
 | kubernetes | sans objet | ✗ |
 
 Chaque case qui n'est pas ✅, **alors que le contrôle est déclaré pour ce fournisseur**,
@@ -60,13 +60,14 @@ porte son motif :
 | Fournisseur | Source | Statut | Motif |
 |---|---|---|---|
 | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_policy » |
+| scaleway | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_policy » |
 
 ## Ce que Pépin peut conclure
 
 | Statut | Ce que le statut affirme | Atteignable depuis |
 |---|---|---|
-| `fail` | un écart a été détecté sur une ressource réelle | outscale / live |
-| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live |
+| `fail` | un écart a été détecté sur une ressource réelle | outscale / live · scaleway / live |
+| `pass` | la donnée décisive a été collectée, et elle est conforme | outscale / live · scaleway / live |
 | `not-applicable` | le contrat du fournisseur déclare le contrôle non testable, avec sa justification | aucun |
 | `not-evaluated` | le contrôle est implémenté, mais la donnée dont il dépend n'a pas été confirmée | aucun |
 
@@ -78,7 +79,7 @@ contient aucune ressource du type visé : « rien à voir » n'est pas « confor
 - Type de ressource normalisé lu par la règle : `api_access_policy`
 - Attribut dont la décision dépend : `max_access_key_expiration_seconds`
 - Sans cet attribut sur une ressource du type visé, le scan rend `not-evaluated` et non `pass` (`internal/assess`, table `requiredAttr`).
-- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- Ce que chaque source projette se lit dans le descripteur : [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
 - La règle qui émet ce code vit dans [`internal/commonrules/rules/`](../../internal/commonrules/rules) : elle est **commune** à tous les fournisseurs, seule la source change.
 
 ## Comment corriger
@@ -88,6 +89,7 @@ Configurer une expiration maximale des clés d'accès (ex. 90 jours).
 | Fournisseur | Montage déployable |
 |---|---|
 | outscale | _aucune preuve déposée à ce jour_ |
+| scaleway | _aucune preuve déposée à ce jour_ |
 
 Une preuve de remédiation est un module Terraform autonome, **conforme**, qui se déploie
 tel quel, ou une note ancrée sur la documentation officielle. Voir

--- a/docs/controls/iam_apiaccesspolicy_max_key_expiration.md
+++ b/docs/controls/iam_apiaccesspolicy_max_key_expiration.md
@@ -17,8 +17,8 @@
 | Resource type read | `api_access_policy` |
 | Deciding attribute | `max_access_key_expiration_seconds` |
 | State | active |
-| Declared for | `outscale` |
-| Remediation proofs | 0 / 1 |
+| Declared for | `outscale`, `scaleway` |
+| Remediation proofs | 0 / 2 |
 
 ## The risk
 
@@ -50,7 +50,7 @@ source".
 |---|:-:|:-:|
 | exoscale | ✗ | ✗ |
 | outscale | ✗ | ✅ |
-| scaleway | ✗ | ✗ |
+| scaleway | ✗ | ✅ |
 | kubernetes | n/a | ✗ |
 
 Every cell that is not ✅ **while the control is declared for that provider** carries its
@@ -59,13 +59,14 @@ reason:
 | Provider | Source | Status | Reason |
 |---|---|---|---|
 | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_policy" |
+| scaleway | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_policy" |
 
 ## What Pépin can conclude
 
 | Status | What the status asserts | Reachable from |
 |---|---|---|
-| `fail` | a deviation was detected on a real resource | outscale / live |
-| `pass` | the deciding data was collected, and it is compliant | outscale / live |
+| `fail` | a deviation was detected on a real resource | outscale / live · scaleway / live |
+| `pass` | the deciding data was collected, and it is compliant | outscale / live · scaleway / live |
 | `not-applicable` | the provider contract declares the control untestable, with its justification | — |
 | `not-evaluated` | the control is implemented, but the data it depends on was not confirmed | — |
 
@@ -77,7 +78,7 @@ resource of the targeted type: "nothing to look at" is not "compliant".
 - Normalized resource type the rule reads: `api_access_policy`
 - Attribute the decision depends on: `max_access_key_expiration_seconds`
 - Without that attribute on a resource of the targeted type, the scan returns `not-evaluated` rather than `pass` (`internal/assess`, `requiredAttr` table).
-- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml)
+- What each source projects is readable in the descriptor: [`providers/outscale.yaml`](../../providers/outscale.yaml) · [`providers/scaleway.yaml`](../../providers/scaleway.yaml)
 - The rule that emits this code lives in [`internal/commonrules/rules/`](../../internal/commonrules/rules): it is **common** to every provider, only the source changes.
 
 ## How to remediate
@@ -87,6 +88,7 @@ Configure a maximum access key expiry (90 days, for instance).
 | Provider | Deployable setup |
 |---|---|
 | outscale | _no proof filed yet_ |
+| scaleway | _no proof filed yet_ |
 
 A remediation proof is a self-contained, **compliant** Terraform module that deploys as
 is, or a note anchored on the official documentation. See

--- a/docs/controls/index.fr.md
+++ b/docs/controls/index.fr.md
@@ -23,7 +23,7 @@ vue d'ensemble par fournisseur et par source, voir la [matrice de couverture](..
 | `high` | 33 |
 | `medium` | 13 |
 | `low` | 2 |
-| Preuves de remédiation déployables | 26 / 97 |
+| Preuves de remédiation déployables | 26 / 98 |
 
 ## Comment lire ce catalogue
 
@@ -45,7 +45,7 @@ vue d'ensemble par fournisseur et par source, voir la [matrice de couverture](..
 | [`iam_accesskey_expiration_set`](iam_accesskey_expiration_set.fr.md) Clé d'accès sans expiration ni rotation | critical | `CLD-IAM-2` | `outscale`, `scaleway` | 0 / 2 |
 | [`iam_accesskey_rotated`](iam_accesskey_rotated.fr.md) Clé d'accès jamais renouvelée | high | `CLD-IAM-2` | `outscale` | 0 / 1 |
 | [`iam_account_mfa_enforced`](iam_account_mfa_enforced.fr.md) MFA non imposée au niveau du compte | high | `CLD-IAM-3` | `outscale` | 0 / 1 |
-| [`iam_apiaccesspolicy_max_key_expiration`](iam_apiaccesspolicy_max_key_expiration.fr.md) Politique d'accès API sans expiration maximale des clés | medium | `CLD-IAM-2` | `outscale` | 0 / 1 |
+| [`iam_apiaccesspolicy_max_key_expiration`](iam_apiaccesspolicy_max_key_expiration.fr.md) Politique d'accès API sans expiration maximale des clés | medium | `CLD-IAM-2` | `outscale`, `scaleway` | 0 / 2 |
 | [`iam_apiaccessrule_defined`](iam_apiaccessrule_defined.fr.md) Aucune règle d'accès API définie | high | `CLD-IAM-4` | `outscale` | 0 / 1 |
 | [`iam_apiaccessrule_no_public_cidr`](iam_apiaccessrule_no_public_cidr.fr.md) Règle d'accès API ouverte à un CIDR public | high | `CLD-IAM-4` | `outscale` | 0 / 1 |
 | [`iam_no_root_access_key`](iam_no_root_access_key.fr.md) Clé d'accès rattachée au compte root | high | `CLD-IAM-1` | `outscale`, `scaleway` | 0 / 2 |

--- a/docs/controls/index.md
+++ b/docs/controls/index.md
@@ -23,7 +23,7 @@ overview per provider and per source, see the [coverage matrix](../coverage.md).
 | `high` | 33 |
 | `medium` | 13 |
 | `low` | 2 |
-| Deployable remediation proofs | 26 / 97 |
+| Deployable remediation proofs | 26 / 98 |
 
 ## How to read this catalogue
 
@@ -45,7 +45,7 @@ overview per provider and per source, see the [coverage matrix](../coverage.md).
 | [`iam_accesskey_expiration_set`](iam_accesskey_expiration_set.md) Access key without expiry or rotation | critical | `CLD-IAM-2` | `outscale`, `scaleway` | 0 / 2 |
 | [`iam_accesskey_rotated`](iam_accesskey_rotated.md) Access key never renewed | high | `CLD-IAM-2` | `outscale` | 0 / 1 |
 | [`iam_account_mfa_enforced`](iam_account_mfa_enforced.md) MFA not enforced at the account level | high | `CLD-IAM-3` | `outscale` | 0 / 1 |
-| [`iam_apiaccesspolicy_max_key_expiration`](iam_apiaccesspolicy_max_key_expiration.md) API access policy without a maximum key expiry | medium | `CLD-IAM-2` | `outscale` | 0 / 1 |
+| [`iam_apiaccesspolicy_max_key_expiration`](iam_apiaccesspolicy_max_key_expiration.md) API access policy without a maximum key expiry | medium | `CLD-IAM-2` | `outscale`, `scaleway` | 0 / 2 |
 | [`iam_apiaccessrule_defined`](iam_apiaccessrule_defined.md) No API access rule defined | high | `CLD-IAM-4` | `outscale` | 0 / 1 |
 | [`iam_apiaccessrule_no_public_cidr`](iam_apiaccessrule_no_public_cidr.md) API access rule open to a public CIDR | high | `CLD-IAM-4` | `outscale` | 0 / 1 |
 | [`iam_no_root_access_key`](iam_no_root_access_key.md) Access key attached to the root account | high | `CLD-IAM-1` | `outscale`, `scaleway` | 0 / 2 |

--- a/docs/coverage.fr.md
+++ b/docs/coverage.fr.md
@@ -46,7 +46,7 @@ et le rapport le dit à chaque scan, contrôle par contrôle, avec le motif.
 | `chiffrement` | 7 | ✅ 1 · ◐ 0 · ∅ 3 · ✗ 3 | ✅ 2 · ◐ 0 · ∅ 3 · ✗ 2 | ✅ 2 · ◐ 1 · ∅ 1 · ✗ 3 |
 | `compute` | 9 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 5 | ✅ 7 · ◐ 0 · ∅ 0 · ✗ 2 | ✅ 2 · ◐ 0 · ∅ 0 · ✗ 7 |
 | `gouvernance` | 3 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 |
-| `iam` | 15 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 | ✅ 11 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 |
+| `iam` | 15 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 | ✅ 11 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 5 · ◐ 0 · ∅ 0 · ✗ 10 |
 | `journalisation` | 2 | ✅ 1 · ◐ 0 · ∅ 1 · ✗ 0 | ✅ 1 · ◐ 0 · ∅ 0 · ✗ 1 | ✅ 0 · ◐ 0 · ∅ 0 · ✗ 2 |
 | `reseau` | 15 | ✅ 8 · ◐ 0 · ∅ 1 · ✗ 6 | ✅ 11 · ◐ 0 · ∅ 0 · ✗ 4 | ✅ 9 · ◐ 1 · ∅ 0 · ✗ 5 |
 | `stockage` | 7 | ✅ 4 · ◐ 0 · ∅ 1 · ✗ 2 | ✅ 6 · ◐ 0 · ∅ 0 · ✗ 1 | ✅ 4 · ◐ 0 · ∅ 1 · ✗ 2 |
@@ -72,7 +72,7 @@ et le rapport le dit à chaque scan, contrôle par contrôle, avec le motif.
 | `iam_accesskey_expiration_set` | critical | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✅ | ✅ |
 | `iam_accesskey_rotated` | high | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_account_mfa_enforced` | high | CLD-IAM-3 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
-| `iam_apiaccesspolicy_max_key_expiration` | medium | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
+| `iam_apiaccesspolicy_max_key_expiration` | medium | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✅ |
 | `iam_apiaccessrule_defined` | high | CLD-IAM-4 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccessrule_no_public_cidr` | high | CLD-IAM-4 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
 | `iam_no_root_access_key` | high | CLD-IAM-1 | ✗ | ✗ | ✗ | ✅ | ◐ | ✅ |
@@ -150,6 +150,7 @@ ici : la matrice les montre déjà, et elles n'apprennent rien de plus.
 | `iam_accesskey_rotated` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « access_key » |
 | `iam_account_mfa_enforced` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_policy » |
+| `iam_apiaccesspolicy_max_key_expiration` | scaleway | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccessrule_defined` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « api_access_summary » |
 | `iam_no_root_access_key` | outscale | terraform | ✗ `unsupported` | cette source ne produit aucune ressource de type « access_key » |
 | `iam_no_root_access_key` | scaleway | terraform | ◐ `partial` | attribut décisif « owner_application_id / owner_user_id / root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
@@ -216,5 +217,5 @@ deux ne peut couvrir la portée de l'autre. Une seule source : la collecte live 
 | outscale | terraform | 18 | 6 | 4 | 30 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
-| scaleway | live | 19 | 2 | 2 | 35 |
+| scaleway | live | 20 | 2 | 2 | 34 |
 | kubernetes | live | 4 | 0 | 0 | 54 |

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -45,7 +45,7 @@ and the report says so on every scan, control by control, with the reason.
 | `chiffrement` | 7 | ✅ 1 · ◐ 0 · ∅ 3 · ✗ 3 | ✅ 2 · ◐ 0 · ∅ 3 · ✗ 2 | ✅ 2 · ◐ 1 · ∅ 1 · ✗ 3 |
 | `compute` | 9 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 5 | ✅ 7 · ◐ 0 · ∅ 0 · ✗ 2 | ✅ 2 · ◐ 0 · ∅ 0 · ✗ 7 |
 | `gouvernance` | 3 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 | ✅ 2 · ◐ 1 · ∅ 0 · ✗ 0 |
-| `iam` | 15 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 | ✅ 11 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 |
+| `iam` | 15 | ✅ 4 · ◐ 0 · ∅ 0 · ✗ 11 | ✅ 11 · ◐ 0 · ∅ 1 · ✗ 3 | ✅ 5 · ◐ 0 · ∅ 0 · ✗ 10 |
 | `journalisation` | 2 | ✅ 1 · ◐ 0 · ∅ 1 · ✗ 0 | ✅ 1 · ◐ 0 · ∅ 0 · ✗ 1 | ✅ 0 · ◐ 0 · ∅ 0 · ✗ 2 |
 | `reseau` | 15 | ✅ 8 · ◐ 0 · ∅ 1 · ✗ 6 | ✅ 11 · ◐ 0 · ∅ 0 · ✗ 4 | ✅ 9 · ◐ 1 · ∅ 0 · ✗ 5 |
 | `stockage` | 7 | ✅ 4 · ◐ 0 · ∅ 1 · ✗ 2 | ✅ 6 · ◐ 0 · ∅ 0 · ✗ 1 | ✅ 4 · ◐ 0 · ∅ 1 · ✗ 2 |
@@ -71,7 +71,7 @@ and the report says so on every scan, control by control, with the reason.
 | `iam_accesskey_expiration_set` | critical | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✅ | ✅ |
 | `iam_accesskey_rotated` | high | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_account_mfa_enforced` | high | CLD-IAM-3 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
-| `iam_apiaccesspolicy_max_key_expiration` | medium | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
+| `iam_apiaccesspolicy_max_key_expiration` | medium | CLD-IAM-2 | ✗ | ✗ | ✗ | ✅ | ✗ | ✅ |
 | `iam_apiaccessrule_defined` | high | CLD-IAM-4 | ✗ | ✗ | ✗ | ✅ | ✗ | ✗ |
 | `iam_apiaccessrule_no_public_cidr` | high | CLD-IAM-4 | ✗ | ✗ | ✅ | ✅ | ✗ | ✗ |
 | `iam_no_root_access_key` | high | CLD-IAM-1 | ✗ | ✗ | ✗ | ✅ | ◐ | ✅ |
@@ -149,6 +149,7 @@ already shows them, and they add nothing.
 | `iam_accesskey_rotated` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "access_key" |
 | `iam_account_mfa_enforced` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_policy" |
+| `iam_apiaccesspolicy_max_key_expiration` | scaleway | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccessrule_defined` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "api_access_summary" |
 | `iam_no_root_access_key` | outscale | terraform | ✗ `unsupported` | this source produces no resource of type "access_key" |
 | `iam_no_root_access_key` | scaleway | terraform | ◐ `partial` | deciding attribute "owner_application_id / owner_user_id / root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
@@ -215,5 +216,5 @@ the other's scope. One source only: live collection through a kubeconfig.
 | outscale | terraform | 18 | 6 | 4 | 30 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
-| scaleway | live | 19 | 2 | 2 | 35 |
+| scaleway | live | 20 | 2 | 2 | 34 |
 | kubernetes | live | 4 | 0 | 0 | 54 |

--- a/docs/detection-quality.fr.md
+++ b/docs/detection-quality.fr.md
@@ -16,7 +16,7 @@ pourcentage sans mesure derrière est un faux vert déplacé dans un tableau de
 bord, et il y est pire qu'ailleurs : personne ne relit un tableau de bord.
 
 Les chiffres sont donc laids, et c'est le point. « 58 contrôles » ne dit rien de
-la qualité d'une détection ; « 98 verdicts prouvés sur 467 » dit où en est le
+la qualité d'une détection ; « 101 verdicts prouvés sur 470 » dit où en est le
 produit, et rétrécit dans le bon sens à chaque scénario écrit.
 
 ## Les chiffres
@@ -24,10 +24,10 @@ produit, et rétrécit dans le bon sens à chaque scénario écrit.
 | Chiffre | Nombre |
 |---|---:|
 | Contrôles au référentiel | 58 |
-| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 185 |
-| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 33 |
-| Verdicts à prouver au total | 467 |
-| Verdicts prouvés | 98 |
+| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 186 |
+| Chemins dont TOUS les verdicts atteignables sont prouvés de bout en bout | 34 |
+| Verdicts à prouver au total | 470 |
+| Verdicts prouvés | 101 |
 
 ## Couverture de véracité, par verdict
 
@@ -37,11 +37,11 @@ demanderait d'inventer une non-applicabilité.
 
 | Verdict | Ce qu'il met en scène | À prouver | Prouvés | % |
 |---|---|---:|---:|---:|
-| `fail` | une configuration vulnérable est détectée | 141 | 25 | 17 |
-| `pass` | une configuration réellement correcte est confirmée | 141 | 37 | 26 |
-| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 161 | 24 | 14 |
+| `fail` | une configuration vulnérable est détectée | 142 | 26 | 18 |
+| `pass` | une configuration réellement correcte est confirmée | 142 | 38 | 26 |
+| `not-evaluated` | l'attribut décisif manque, et le scan refuse de conclure | 162 | 25 | 15 |
 | `not-applicable` | le contrat du fournisseur déclare le mécanisme inexistant | 24 | 12 | 50 |
-| **Total** | | **467** | **98** | **20** |
+| **Total** | | **470** | **101** | **21** |
 
 ## Validé en live
 
@@ -56,7 +56,7 @@ relevé authentifié, il montera tout seul.
 
 | Chiffre | Nombre |
 |---|---:|
-| Chemins dont la source est une collecte live | 103 |
+| Chemins dont la source est une collecte live | 104 |
 | Validé en live | **0 %** |
 
 ## Ce que les vrais plans de contrôle ont répondu

--- a/docs/detection-quality.md
+++ b/docs/detection-quality.md
@@ -16,7 +16,7 @@ with no measurement behind it is a false green moved into a dashboard, and it is
 worse there than anywhere else: nobody re-reads a dashboard.
 
 The figures are therefore ugly, and that is the point. "58 controls" says nothing
-about the quality of a detection; "98 verdicts proven out of 467" says where the
+about the quality of a detection; "101 verdicts proven out of 470" says where the
 product stands, and shrinks the right way with every scenario written.
 
 ## The figures
@@ -24,10 +24,10 @@ product stands, and shrinks the right way with every scenario written.
 | Figure | Count |
 |---|---:|
 | Controls in the reference | 58 |
-| Control x provider x source paths on which Pépin concludes | 185 |
-| Paths whose EVERY reachable verdict is proven end to end | 33 |
-| Verdicts to prove in total | 467 |
-| Verdicts proven | 98 |
+| Control x provider x source paths on which Pépin concludes | 186 |
+| Paths whose EVERY reachable verdict is proven end to end | 34 |
+| Verdicts to prove in total | 470 |
+| Verdicts proven | 101 |
 
 ## Veracity coverage, by verdict
 
@@ -37,11 +37,11 @@ inventing a non-applicability.
 
 | Verdict | What it stages | To prove | Proven | % |
 |---|---|---:|---:|---:|
-| `fail` | a vulnerable configuration is detected | 141 | 25 | 17 |
-| `pass` | a genuinely correct configuration is confirmed | 141 | 37 | 26 |
-| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 161 | 24 | 14 |
+| `fail` | a vulnerable configuration is detected | 142 | 26 | 18 |
+| `pass` | a genuinely correct configuration is confirmed | 142 | 38 | 26 |
+| `not-evaluated` | the deciding attribute is missing, and the scan refuses to conclude | 162 | 25 | 15 |
 | `not-applicable` | the provider's contract declares the mechanism non-existent | 24 | 12 | 50 |
-| **Total** | | **467** | **98** | **20** |
+| **Total** | | **470** | **101** | **21** |
 
 ## Validated live
 
@@ -56,7 +56,7 @@ will rise on its own.
 
 | Figure | Count |
 |---|---:|
-| Paths whose source is a live collection | 103 |
+| Paths whose source is a live collection | 104 |
 | Validated live | **0 %** |
 
 ## What the real control planes answered

--- a/docs/getting-started/understanding-a-scan.fr.md
+++ b/docs/getting-started/understanding-a-scan.fr.md
@@ -388,7 +388,7 @@ marqueurs ; tout le reste est le document capturé.)*
 | `pass` | 6 |
 | `fail` | 10 |
 | `not-applicable` | 2 |
-| `not-evaluated` | 10 |
+| `not-evaluated` | 11 |
 <!-- /pepin:gen assessment-counts -->
 
 Un unique scan sans compte cloud produit les quatre. Le cinquième statut, `exempted`, relève

--- a/docs/getting-started/understanding-a-scan.md
+++ b/docs/getting-started/understanding-a-scan.md
@@ -386,7 +386,7 @@ everything else is the captured document.)*
 | `pass` | 6 |
 | `fail` | 10 |
 | `not-applicable` | 2 |
-| `not-evaluated` | 10 |
+| `not-evaluated` | 11 |
 <!-- /pepin:gen assessment-counts -->
 
 A single account-free scan produces all four. The fifth status, `exempted`, is a decision

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -79,7 +79,7 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
   "summary": {
     "fail": 10,
     "not-applicable": 2,
-    "not-evaluated": 10,
+    "not-evaluated": 11,
     "pass": 6
   },
   "artifacts": [

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -77,7 +77,7 @@ raises a version number and gets a CHANGELOG line.
   "summary": {
     "fail": 10,
     "not-applicable": 2,
-    "not-evaluated": 10,
+    "not-evaluated": 11,
     "pass": 6
   },
   "artifacts": [

--- a/docs/guides/remediation.fr.md
+++ b/docs/guides/remediation.fr.md
@@ -209,8 +209,8 @@ couples (contrôle, fournisseur) que le référentiel déclare réellement :
 | exoscale | 26 / 26 |
 | kubernetes | 0 / 4 |
 | outscale | 0 / 41 |
-| scaleway | 0 / 26 |
-| **Total** | **26 / 97** |
+| scaleway | 0 / 27 |
+| **Total** | **26 / 98** |
 <!-- /pepin:gen remediation-coverage -->
 
 Ce tableau compte des **preuves déployables**, pas des remédiations. La remédiation

--- a/docs/guides/remediation.md
+++ b/docs/guides/remediation.md
@@ -205,8 +205,8 @@ provider) pairs the reference actually declares:
 | exoscale | 26 / 26 |
 | kubernetes | 0 / 4 |
 | outscale | 0 / 41 |
-| scaleway | 0 / 26 |
-| **Total** | **26 / 97** |
+| scaleway | 0 / 27 |
+| **Total** | **26 / 98** |
 <!-- /pepin:gen remediation-coverage -->
 
 Read that table for what it is: it counts **deployable proofs**, not remediations. The

--- a/docs/known-limitations.fr.md
+++ b/docs/known-limitations.fr.md
@@ -95,6 +95,7 @@ pas.
 | `iam_accesskey_rotated` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
 | `iam_account_mfa_enforced` | outscale | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | live | cette source ne produit aucune ressource de type « api_access_policy » |
+| `iam_apiaccesspolicy_max_key_expiration` | scaleway | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_apiaccessrule_defined` | outscale | live | cette source ne produit aucune ressource de type « api_access_summary » |
 | `iam_no_root_access_key` | outscale | live | cette source ne produit aucune ressource de type « access_key » |
 | `iam_no_root_access_key` | scaleway | live | attribut décisif « owner_application_id / owner_user_id / root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
@@ -153,7 +154,7 @@ Par fournisseur et par source, sur l'ensemble des contrôles du référentiel :
 | outscale | terraform | 18 | 6 | 4 | 30 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
-| scaleway | live | 19 | 2 | 2 | 35 |
+| scaleway | live | 20 | 2 | 2 | 34 |
 | kubernetes | live | 4 | 0 | 0 | 54 |
 <!-- /pepin:gen coverage-totals -->
 
@@ -173,8 +174,8 @@ note documentée. À ce jour :
 | exoscale | 26 / 26 |
 | kubernetes | 0 / 4 |
 | outscale | 0 / 41 |
-| scaleway | 0 / 26 |
-| **Total** | **26 / 97** |
+| scaleway | 0 / 27 |
+| **Total** | **26 / 98** |
 <!-- /pepin:gen remediation-coverage -->
 
 Ce contrôle n'est **délibérément pas** branché sur `mise run validate` : tous fournisseurs
@@ -207,9 +208,9 @@ Ce qui n'est pas encore prouvé est **compté**, pas masqué :
 <!-- pepin:gen veracity-debt -->
 | Chiffre | Nombre |
 |---|---:|
-| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 185 |
-| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 33 |
-| Verdicts à prouver au total | 467 |
+| Chemins contrôle × fournisseur × source sur lesquels Pépin conclut | 186 |
+| Chemins dont tous les verdicts atteignables sont prouvés de bout en bout | 34 |
+| Verdicts à prouver au total | 470 |
 | Verdicts restant à prouver | 369 |
 <!-- /pepin:gen veracity-debt -->
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -96,6 +96,7 @@ actually decide them. The reason given is the one that applies to the source tha
 | `iam_accesskey_rotated` | outscale | live | this source produces no resource of type "access_key" |
 | `iam_account_mfa_enforced` | outscale | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccesspolicy_max_key_expiration` | outscale | live | this source produces no resource of type "api_access_policy" |
+| `iam_apiaccesspolicy_max_key_expiration` | scaleway | live | this source produces no resource of type "api_access_policy" |
 | `iam_apiaccessrule_defined` | outscale | live | this source produces no resource of type "api_access_summary" |
 | `iam_no_root_access_key` | outscale | live | this source produces no resource of type "access_key" |
 | `iam_no_root_access_key` | scaleway | live | deciding attribute "owner_application_id / owner_user_id / root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
@@ -153,7 +154,7 @@ Per provider and per source, over all controls in the reference:
 | outscale | terraform | 18 | 6 | 4 | 30 |
 | outscale | live | 40 | 1 | 4 | 13 |
 | scaleway | terraform | 17 | 8 | 2 | 31 |
-| scaleway | live | 19 | 2 | 2 | 35 |
+| scaleway | live | 20 | 2 | 2 | 34 |
 | kubernetes | live | 4 | 0 | 0 | 54 |
 <!-- /pepin:gen coverage-totals -->
 
@@ -173,8 +174,8 @@ documented note. Today:
 | exoscale | 26 / 26 |
 | kubernetes | 0 / 4 |
 | outscale | 0 / 41 |
-| scaleway | 0 / 26 |
-| **Total** | **26 / 97** |
+| scaleway | 0 / 27 |
+| **Total** | **26 / 98** |
 <!-- /pepin:gen remediation-coverage -->
 
 This is deliberately **not** wired into `mise run validate`: over all providers the count is
@@ -207,9 +208,9 @@ What is not yet proven is **counted**, not hidden:
 <!-- pepin:gen veracity-debt -->
 | Figure | Count |
 |---|---:|
-| Control x provider x source paths on which Pépin concludes | 185 |
-| Paths whose every reachable verdict is proven end to end | 33 |
-| Verdicts to prove in total | 467 |
+| Control x provider x source paths on which Pépin concludes | 186 |
+| Paths whose every reachable verdict is proven end to end | 34 |
+| Verdicts to prove in total | 470 |
 | Verdicts left to prove | 369 |
 <!-- /pepin:gen veracity-debt -->
 

--- a/docs/providers/scaleway.fr.md
+++ b/docs/providers/scaleway.fr.md
@@ -63,6 +63,7 @@ clé en lecture seule doit couvrir.
 | Type normalisé | Appel | Note |
 |---|---|---|
 | `access_key` | `GET /iam/v1alpha1/api-keys?organization_id={org}` | — |
+| `api_access_policy` | `GET /iam/v1alpha1/organizations/{org}/security-settings` | — |
 | `compute_instance` | `GET /instance/v1/zones/{zone}/servers` | — |
 | `iam_user` | `GET /iam/v1alpha1/users?organization_id={org}` | — |
 | `security_group` | `GET /instance/v1/zones/{zone}/security_groups` | — |
@@ -97,6 +98,7 @@ API de fournisseur.
 |---|---|:-:|---|
 | `access_key` | `IAMReadOnly (Organization scope)` | oui | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
 | `iam_user` | `IAMReadOnly (Organization scope)` | oui | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
+| `api_access_policy` | `IAMReadOnly (Organization scope)` | oui | scaleway/docs-content — pages/iam/reference-content/permission-sets.md |
 | `security_group` | `InstancesReadOnly (Project scope)` | oui | scaleway/docs-content — pages/iam/reference-content/permission-sets.md |
 | `security_group_rule` | `InstancesReadOnly (Project scope)` | oui | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
 | `compute_instance` | `InstancesReadOnly (Project scope)` | oui | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
@@ -104,6 +106,7 @@ API de fournisseur.
 
 **Réserves, dites plutôt que masquées.**
 
+- **`api_access_policy`** — Les réglages de sécurité sont au niveau de l'ORGANISATION : la portée du jeu de permissions doit l'être aussi, contrairement aux unités d'infrastructure qui se portent sur un projet.
 - **`security_group`** — Le MÊME appel que `security_group_rule` : `ListSecurityGroups` sert de jointure parent pour les règles et porte, dans la même réponse, la politique par défaut du groupe. Aucun droit supplémentaire.
 - **`object_storage_bucket`** — Couvre ListBuckets, GetBucketAcl, GetBucketVersioning, GetBucketTagging et GetObjectLockConfiguration. GetBucketPolicy et GetBucketEncryption n'apparaissent dans AUCUN jeu de permissions en lecture seule de la table d'équivalence : le droit qui les accorde n'a pas pu être établi, et il n'est pas deviné. Les deux appels sont best effort — un 403 coûte de la couverture, jamais de la justesse.
 <!-- /pepin:gen provider-scaleway-permissions -->
@@ -160,7 +163,7 @@ pepin scan scaleway --terraform plan.json
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
 | terraform | 17 | 8 | 2 | 31 |
-| live | 19 | 2 | 2 | 35 |
+| live | 20 | 2 | 2 | 34 |
 <!-- /pepin:gen provider-scaleway-coverage -->
 
 Contrôle par contrôle, avec le motif de chaque case qui n'est pas pleinement supportée, la
@@ -188,6 +191,7 @@ fournisseur.
 | `compute_instance_public_ip_with_open_securitygroup` | live | attribut décisif « nic_public_ips / public_ip » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `database_backup_enabled` | terraform | cette source ne produit aucune ressource de type « managed_database » |
 | `database_service_not_open_to_internet` | terraform | cette source ne produit aucune ressource de type « managed_database » |
+| `iam_apiaccesspolicy_max_key_expiration` | live | cette source ne produit aucune ressource de type « api_access_policy » |
 | `iam_no_root_access_key` | live | attribut décisif « owner_application_id / owner_user_id / root_owned / scope » non projeté par cette source : garde de capacité, le scan rend « not-evaluated » |
 | `iam_policy_no_privilege_escalation` | terraform | cette source ne produit aucune ressource de type « iam_policy » |
 | `iam_user_mfa_enabled` | live | cette source ne produit aucune ressource de type « iam_user » |

--- a/docs/providers/scaleway.md
+++ b/docs/providers/scaleway.md
@@ -63,6 +63,7 @@ key has to cover.
 | Normalized type | Call | Note |
 |---|---|---|
 | `access_key` | `GET /iam/v1alpha1/api-keys?organization_id={org}` | — |
+| `api_access_policy` | `GET /iam/v1alpha1/organizations/{org}/security-settings` | — |
 | `compute_instance` | `GET /instance/v1/zones/{zone}/servers` | — |
 | `iam_user` | `GET /iam/v1alpha1/users?organization_id={org}` | — |
 | `security_group` | `GET /instance/v1/zones/{zone}/security_groups` | — |
@@ -95,6 +96,7 @@ credentials and no automated check reaches a provider API.
 |---|---|:-:|---|
 | `access_key` | `IAMReadOnly (Organization scope)` | yes | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
 | `iam_user` | `IAMReadOnly (Organization scope)` | yes | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
+| `api_access_policy` | `IAMReadOnly (Organization scope)` | yes | scaleway/docs-content — pages/iam/reference-content/permission-sets.md |
 | `security_group` | `InstancesReadOnly (Project scope)` | yes | scaleway/docs-content — pages/iam/reference-content/permission-sets.md |
 | `security_group_rule` | `InstancesReadOnly (Project scope)` | yes | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
 | `compute_instance` | `InstancesReadOnly (Project scope)` | yes | scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx |
@@ -102,6 +104,7 @@ credentials and no automated check reaches a provider API.
 
 **Reservations, stated rather than papered over.**
 
+- **`api_access_policy`** — Security settings live at the ORGANISATION level, so the permission set's scope must be too — unlike the infrastructure units, which are project-scoped.
 - **`security_group`** — The SAME call as `security_group_rule`: `ListSecurityGroups` acts as the parent join for the rules and carries, in that same response, the group's default policy. No extra grant.
 - **`object_storage_bucket`** — Covers ListBuckets, GetBucketAcl, GetBucketVersioning, GetBucketTagging and GetObjectLockConfiguration. GetBucketPolicy and GetBucketEncryption appear in NO read-only permission set of the equivalence table: the right that grants them could not be established, and it is not guessed. Both calls are best-effort - a 403 costs coverage, never correctness.
 <!-- /pepin:gen provider-scaleway-permissions -->
@@ -157,7 +160,7 @@ pepin scan scaleway --terraform plan.json
 | Source | ✅ `supported` | ◐ `partial` | ∅ `not-applicable` | ✗ `unsupported` |
 |---|---:|---:|---:|---:|
 | terraform | 17 | 8 | 2 | 31 |
-| live | 19 | 2 | 2 | 35 |
+| live | 20 | 2 | 2 | 34 |
 <!-- /pepin:gen provider-scaleway-coverage -->
 
 Control by control, with the reason for every cell that is not fully supported, the source of
@@ -184,6 +187,7 @@ A `not-applicable` is a claim, so it carries its justification, taken from the p
 | `compute_instance_public_ip_with_open_securitygroup` | live | deciding attribute "nic_public_ips / public_ip" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `database_backup_enabled` | terraform | this source produces no resource of type "managed_database" |
 | `database_service_not_open_to_internet` | terraform | this source produces no resource of type "managed_database" |
+| `iam_apiaccesspolicy_max_key_expiration` | live | this source produces no resource of type "api_access_policy" |
 | `iam_no_root_access_key` | live | deciding attribute "owner_application_id / owner_user_id / root_owned / scope" not projected by this source: a capability guard, so the scan returns "not-evaluated" |
 | `iam_policy_no_privilege_escalation` | terraform | this source produces no resource of type "iam_policy" |
 | `iam_user_mfa_enabled` | live | this source produces no resource of type "iam_user" |

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -230,7 +230,7 @@ typé, une preuve, les références normatives et la provenance de l'exécution.
 | `pass` | 6 |
 | `fail` | 10 |
 | `not-applicable` | 2 |
-| `not-evaluated` | 10 |
+| `not-evaluated` | 11 |
 <!-- /pepin:gen assessment-counts -->
 
 Quatre statuts mesurés, et les deux que les autres formats ne savent pas exprimer sont

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -229,7 +229,7 @@ piece of evidence, the normative references, and the provenance of the run.
 | `pass` | 6 |
 | `fail` | 10 |
 | `not-applicable` | 2 |
-| `not-evaluated` | 10 |
+| `not-evaluated` | 11 |
 <!-- /pepin:gen assessment-counts -->
 
 Four measured statuses, and the two that the other formats cannot express are

--- a/internal/collect/duration_test.go
+++ b/internal/collect/duration_test.go
@@ -1,0 +1,86 @@
+package collect
+
+import "testing"
+
+// Une durée qu'on n'a pas su lire n'est pas une durée de ZÉRO.
+//
+// C'est tout l'enjeu de ce transform, et il n'est pas cosmétique. Scaleway exprime la
+// durée maximale d'expiration d'une clé d'API en chaîne suffixée —
+// « 31536000.000000000s » pour 365 jours — là où Outscale rend un entier de secondes.
+// Le modèle normalisé porte le NOMBRE, parce que c'est lui que la règle compare.
+//
+// Et la règle compare ainsi :
+//
+//	max_access_key_expiration_seconds <= 0  ⇒  écart (« aucune limite », sémantique OAPI)
+//
+// Donc rendre 0 sur une chaîne illisible transformerait une lecture ratée en écart
+// AFFIRMÉ, sur un contrôle préventif que SecNumCloud 9.5 et CIS 5.4 regardent tous deux.
+// Rendre nil laisse l'attribut non projeté, et le verrou de capacité dit « je ne sais
+// pas » — ce que l'ADR-0014 exige d'une donnée absente.
+func TestAnUnreadableDurationIsNotZero(t *testing.T) {
+	lisibles := []struct {
+		nom, brut string
+		veut      float64
+	}{
+		{"la valeur mesurée sur l'API réelle", "31536000.000000000s", 31536000},
+		{"une durée entière suffixée", "3600s", 3600},
+		{"un nombre nu", "86400", 86400},
+		{"zéro suffixé — aucune limite, et c'est une observation", "0s", 0},
+		{"des espaces autour", "  7200s  ", 7200},
+	}
+	for _, c := range lisibles {
+		got := durationSeconds(c.brut)
+		f, ok := got.(float64)
+		if !ok || f != c.veut {
+			t.Errorf("%s : durationSeconds(%q) = %#v, attendu %v", c.nom, c.brut, got, c.veut)
+		}
+	}
+
+	// LES CONTRE-EXEMPLES, et ils portent tout le poids de ce test.
+	illisibles := []struct{ nom, brut string }{
+		{"chaîne vide", ""},
+		{"que des espaces", "   "},
+		{"du texte", "jamais"},
+		{"une durée Go composite, que ce transform ne prétend pas lire", "2h45m"},
+		{"un suffixe inattendu", "30d"},
+		{"une valeur nulle rendue en texte", "null"},
+	}
+	for _, c := range illisibles {
+		if got := durationSeconds(c.brut); got != nil {
+			t.Errorf("%s : durationSeconds(%q) = %#v, attendu nil.\n"+
+				"  Rendre un nombre ici ferait affirmer « aucune limite » sur une lecture\n"+
+				"  ratée — un écart fabriqué sur un contrôle préventif.", c.nom, c.brut, got)
+		}
+	}
+}
+
+// Le transform, vu depuis la projection : une valeur illisible ne projette PAS la clé.
+//
+// C'est la moitié qui compte pour le verrou de capacité. Un nil rendu par le transform
+// doit faire sauter l'attribut, pas le poser à nil — sinon la garde s'ouvre sur du vide,
+// ce que l'issue #227 a corrigé ailleurs et qui doit rester vrai ici.
+func TestAnUnreadableDurationProjectsNothing(t *testing.T) {
+	mapping := map[string]string{"max_access_key_expiration_seconds": "max_api_key_expiration_duration"}
+	transforms := map[string]any{"max_access_key_expiration_seconds": "duration_seconds"}
+
+	illisible := Project(map[string]any{"max_api_key_expiration_duration": "2h45m"}, mapping, transforms)
+	if _, present := illisible["max_access_key_expiration_seconds"]; present {
+		t.Errorf("durée illisible : la clé est projetée (%#v) — la garde de capacité "+
+			"s'ouvrira, et la règle conclura sur une valeur que personne n'a lue",
+			illisible["max_access_key_expiration_seconds"])
+	}
+
+	// Le cas nominal, tel que l'API réelle le rend.
+	lisible := Project(map[string]any{"max_api_key_expiration_duration": "31536000.000000000s"}, mapping, transforms)
+	if got := lisible["max_access_key_expiration_seconds"]; got != float64(31536000) {
+		t.Errorf("valeur mesurée : projeté %#v, attendu 31536000", got)
+	}
+
+	// Et ZÉRO est une observation, pas une lecture ratée : « aucune limite » se projette.
+	aucune := Project(map[string]any{"max_api_key_expiration_duration": "0s"}, mapping, transforms)
+	got, present := aucune["max_access_key_expiration_seconds"]
+	if !present || got != float64(0) {
+		t.Errorf("« aucune limite » : projeté %#v (présent=%v), attendu 0 — c'est l'écart "+
+			"que le contrôle cherche, il doit lui parvenir", got, present)
+	}
+}

--- a/internal/collect/engine.go
+++ b/internal/collect/engine.go
@@ -825,7 +825,7 @@ func lookup(v any, path string) any {
 var knownBareTransforms = map[string]bool{
 	"lower": true, "upper": true, "first": true, "range_from": true, "range_to": true,
 	"iampolicy": true, "list": true, "kv": true, "to_int": true, "nonempty": true,
-	"snake_keys": true, "region_of_zone": true,
+	"snake_keys": true, "region_of_zone": true, "duration_seconds": true,
 }
 
 // knownTransformPrefixes : préfixes de transforms paramétrés (`default:val`, `equals:val`…).
@@ -985,6 +985,17 @@ func applyTransform(v any, spec any) any {
 				out = append(out, map[string]any{"key": k, "value": val})
 			}
 			return out
+		case "duration_seconds":
+			// Une DURÉE, rendue en secondes. Scaleway exprime la sienne en chaîne
+			// suffixée — `"31536000.000000000s"` pour 365 jours —, là où Outscale rend
+			// un entier de secondes. Le modèle normalisé est le NOMBRE, parce que c'est
+			// lui que la règle compare ; le format est une affaire de fournisseur.
+			//
+			// Une valeur illisible ne se remplace PAS par zéro : zéro veut dire « aucune
+			// limite » dans la sémantique OAPI, donc en fabriquer un transformerait une
+			// lecture ratée en écart affirmé. Rendre nil laisse l'attribut non projeté,
+			// et le verrou de capacité fait son travail (ADR-0014).
+			return durationSeconds(toStr(v))
 		case "to_int":
 			if n, err := strconv.ParseInt(toStr(v), 10, 64); err == nil {
 				return n
@@ -1148,4 +1159,23 @@ func RegionOfZone(zone string) string { return regionOfZone(zone) }
 // est CALCULÉE tôt et n'est UTILISÉE qu'après une réponse.
 func CallSignature(method string, u *url.URL) string {
 	return method + " " + u.Scheme + "://" + u.Host + u.Path
+}
+
+// durationSeconds lit une durée et rend ses secondes, ou nil si elle est illisible.
+//
+// Deux formes acceptées, et aucune devinée : le suffixe `s` que les API Scaleway
+// emploient pour une durée en secondes (`"31536000.000000000s"`), et un nombre nu.
+// Tout le reste — une durée Go composite comme `"2h45m"`, une chaîne vide, du texte —
+// rend nil, parce qu'une durée qu'on n'a pas su lire n'est pas une durée de zéro.
+func durationSeconds(raw string) any {
+	t := strings.TrimSpace(raw)
+	if t == "" {
+		return nil
+	}
+	t = strings.TrimSuffix(t, "s")
+	f, err := strconv.ParseFloat(t, 64)
+	if err != nil {
+		return nil
+	}
+	return f
 }

--- a/internal/genprovider/endpoints_test.go
+++ b/internal/genprovider/endpoints_test.go
@@ -173,6 +173,7 @@ func TestTheRecordedCollectionStillHappens(t *testing.T) {
 			var mu sync.Mutex
 			got := map[string]bool{}
 			var unknown []string
+			base := basePath(desc.Collecte.BaseURL)
 
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				_, _ = io.Copy(io.Discard, io.LimitReader(r.Body, 1<<20))
@@ -180,7 +181,13 @@ func TestTheRecordedCollectionStillHappens(t *testing.T) {
 				mu.Lock()
 				defer mu.Unlock()
 				e, known := replay[k]
-				if !known {
+				if !known && !declaredUnobservable(m, r.URL.Path, base) {
+					// Un endpoint que le registre `non_observes` DÉCLARE inobservable
+					// n'est pas une surprise : c'est un trou nommé, avec sa raison. Sans
+					// cette exception, les deux portes se contredisaient — l'une exigeait
+					// le registre, l'autre le refusait —, et le mécanisme devenait
+					// inutilisable pour le cas même qu'il vise : un endpoint NEUF que
+					// l'émulateur ne sert pas encore.
 					unknown = append(unknown, k)
 					w.WriteHeader(http.StatusNotFound)
 					_, _ = w.Write([]byte(`{"error":"cet appel n'est pas dans la transcription"}`))
@@ -342,4 +349,26 @@ func dedupe(in []string) []string {
 		out = append(out, s)
 	}
 	return out
+}
+
+// declaredUnobservable dit si le registre `non_observes` de cette transcription déclare
+// ce chemin, avec sa raison.
+//
+// Les deux portes d'endpoints doivent lire le MÊME registre, sans quoi elles se
+// contredisent : `TestEveryDeclaredEndpointIsObservedOrDeclaredUnobserved` exige qu'un
+// endpoint jamais observé y figure, et `TestTheRecordedCollectionStillHappens` le
+// signalait alors comme un appel inconnu. Un mécanisme qu'une porte impose et qu'une
+// autre refuse n'est pas un mécanisme.
+//
+// Ce que cette exception NE fait pas : rendre un endpoint muet. Le registre exige une
+// raison écrite, et l'autre porte vérifie qu'une entrée devenue observable en sort —
+// une dette payée qui reste écrite masque la suivante.
+func declaredUnobservable(m transcriptManifest, path, base string) bool {
+	rel := strings.TrimPrefix(path, base)
+	for _, u := range m.NonObserves {
+		if matchesRecorded(u.Endpoint, map[string]bool{rel: true}) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/genprovider/testdata/transcripts/scaleway.yaml
+++ b/internal/genprovider/testdata/transcripts/scaleway.yaml
@@ -37,4 +37,14 @@ vars:
 # exercés, et pourquoi. La porte échoue dans les deux sens : un endpoint qui
 # disparaît d'ici sans être observé est une régression, un endpoint qui y
 # apparaît sans raison écrite est une couverture qu'on s'accorde.
-non_observes: []
+non_observes:
+  - endpoint: /iam/v1alpha1/organizations/{org}/security-settings
+    raison: >-
+      Réglages de sécurité de l'ORGANISATION, que l'émulateur local ne sert pas. Le
+      contrat a donc été vérifié contre l'API RÉELLE le 2026-09-11, et la réponse
+      mesurée est consignée dans providers/scaleway.yaml : enforce_password_renewal,
+      grace_period_duration, login_attempts_before_locked, max_login_session_duration,
+      max_api_key_expiration_duration. Ce qui reste non mesuré ici, c'est le CÂBLAGE —
+      que le collecteur émette bien cet appel —, et il l'est par les trois scénarios de
+      véracité du contrôle, qui servent des réponses canned au collecteur réel
+      (internal/veracity/testdata/scenarios/max-key-expiration-scaleway-live.yaml).

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -1,28 +1,28 @@
 {
   "controls": 58,
-  "paths": 185,
-  "paths_proven": 33,
-  "obligations": 467,
-  "proven": 98,
+  "paths": 186,
+  "paths_proven": 34,
+  "obligations": 470,
+  "proven": 101,
   "verdicts": {
     "fail": {
-      "required": 141,
-      "proven": 25
+      "required": 142,
+      "proven": 26
     },
     "not-applicable": {
       "required": 24,
       "proven": 12
     },
     "not-evaluated": {
-      "required": 161,
-      "proven": 24
+      "required": 162,
+      "proven": 25
     },
     "pass": {
-      "required": 141,
-      "proven": 37
+      "required": 142,
+      "proven": 38
     }
   },
-  "live_paths": 103,
+  "live_paths": 104,
   "live_validated": 0,
   "counterwitnesses": 2,
   "tenants": 6,
@@ -940,7 +940,25 @@
             "pass",
             "not-evaluated"
           ]
+        },
+        {
+          "provider": "scaleway",
+          "source": "live",
+          "status": "supported",
+          "required": [
+            "fail",
+            "pass",
+            "not-evaluated"
+          ],
+          "proven": [
+            "fail",
+            "pass",
+            "not-evaluated"
+          ]
         }
+      ],
+      "scenarios": [
+        "internal/veracity/testdata/scenarios/max-key-expiration-scaleway-live.yaml"
       ],
       "rego_tests": [
         "internal/commonrules/rules/iam_apiaccess_test.rego"

--- a/internal/veracity/testdata/debt.txt
+++ b/internal/veracity/testdata/debt.txt
@@ -8,7 +8,7 @@
 # Une ligne qui disparaît est une dette payée. Une ligne qui apparaît sans
 # scénario est un contrôle ajouté sans sa preuve, et la CI la refuse.
 #
-# chemins : 185 · entierement prouves : 33 · obligations : 467 · restantes : 369
+# chemins : 186 · entierement prouves : 34 · obligations : 470 · restantes : 369
 
 blockstorage_snapshot_not_public exoscale live not-applicable
 blockstorage_snapshot_not_public outscale live fail,pass,not-evaluated

--- a/internal/veracity/testdata/scenarios/max-key-expiration-scaleway-live.yaml
+++ b/internal/veracity/testdata/scenarios/max-key-expiration-scaleway-live.yaml
@@ -1,0 +1,56 @@
+# Duree maximale d'expiration d'une cle d'API, reglee au niveau de l'ORGANISATION.
+#
+# Le chemin traverse le collecteur REEL : `/iam/v1alpha1/organizations/{org}/
+# security-settings`, le mapping declaratif du descripteur (une duree en CHAINE
+# suffixee, convertie en secondes par le transform `duration_seconds`), le verrou de
+# capacite, la regle, puis l'assessment.
+#
+# # Ce que ce controle dit, et que l'inventaire des cles ne dit pas
+#
+# Lister les cles apprend ce qui est vrai AUJOURD'HUI : chacune a-t-elle une echeance.
+# Ce reglage-ci apprend ce que l'organisation refusera DEMAIN. C'est la difference entre
+# un controle detectif et un controle preventif, que SecNumCloud 9.5 et CIS 5.4
+# distinguent tous deux.
+#
+# Decouvert en appliquant le tenant de qualification : l'API a REFUSE de creer une cle
+# sans echeance, avec « organization security settings require an expiration date for
+# API keys ». Le refus etait la mesure (issue #196).
+#
+# # Le troisieme cas est le plus important
+#
+# Une duree illisible ne vaut pas zero. La regle signale un ecart sur `<= 0`, donc
+# fabriquer un zero sur une lecture ratee transformerait l'echec de lecture en ecart
+# AFFIRME. L'attribut reste non projete, et le scan dit qu'il ne sait pas (ADR-0014).
+control: iam_apiaccesspolicy_max_key_expiration
+provider: scaleway
+source: live
+
+scenarios:
+  - expect: pass
+    why: "l'organisation impose une echeance : 365 jours, la valeur mesuree sur le compte reel"
+    api:
+      /iam/v1alpha1/organizations/org-test/security-settings: |
+        {"enforce_password_renewal": true,
+         "grace_period_duration": "259200.000000000s",
+         "login_attempts_before_locked": 5,
+         "max_login_session_duration": "2592000.000000000s",
+         "max_api_key_expiration_duration": "31536000.000000000s"}
+
+  - expect: fail
+    why: "aucune limite : une cle peut etre creee sans echeance, et le rester indefiniment"
+    api:
+      /iam/v1alpha1/organizations/org-test/security-settings: |
+        {"enforce_password_renewal": true,
+         "grace_period_duration": "259200.000000000s",
+         "login_attempts_before_locked": 5,
+         "max_login_session_duration": "2592000.000000000s",
+         "max_api_key_expiration_duration": "0s"}
+
+  - expect: not-evaluated
+    why: "le reglage n'est pas dans la reponse : on ne deduit pas « aucune limite » d'un silence"
+    api:
+      /iam/v1alpha1/organizations/org-test/security-settings: |
+        {"enforce_password_renewal": true,
+         "grace_period_duration": "259200.000000000s",
+         "login_attempts_before_locked": 5,
+         "max_login_session_duration": "2592000.000000000s"}

--- a/providers/scaleway.yaml
+++ b/providers/scaleway.yaml
@@ -79,6 +79,12 @@ permissions:
     grant: "IAMReadOnly (Organization scope)"
     etat: verifie
     source: "scaleway/docs-content — pages/iam/reference-content/permission-sets.mdx"
+  - unit: api_access_policy
+    grant: "IAMReadOnly (Organization scope)"
+    etat: verifie
+    source: "scaleway/docs-content — pages/iam/reference-content/permission-sets.md"
+    note: "Les réglages de sécurité sont au niveau de l'ORGANISATION : la portée du jeu de permissions doit l'être aussi, contrairement aux unités d'infrastructure qui se portent sur un projet."
+    note_en: "Security settings live at the ORGANISATION level, so the permission set's scope must be too — unlike the infrastructure units, which are project-scoped."
   - unit: security_group
     grant: "InstancesReadOnly (Project scope)"
     etat: verifie
@@ -151,6 +157,36 @@ collecte:
         user_type: type
       paging: { style: page, param: page, size_param: page_size, size: 100 }
   
+    # Réglages de sécurité de l'ORGANISATION → api_access_policy. La réponse est un
+    # OBJET, pas une liste : `items: .` désigne la racine, comme pour le
+    # `/ReadApiAccessPolicy` d'Outscale.
+    #
+    # `max_api_key_expiration_duration` est le pendant Scaleway du
+    # `MaxAccessKeyExpirationSeconds` d'Outscale : un réglage PRÉVENTIF, qui dit ce que
+    # l'organisation refusera demain, là où l'inventaire des clés ne dit que ce qui est
+    # vrai aujourd'hui. C'est la différence entre un contrôle détectif et un contrôle
+    # préventif, que SecNumCloud 9.5 et CIS 5.4 distinguent tous deux.
+    #
+    # Mesuré contre l'API réelle le 2026-09-11 :
+    #   GET /iam/v1alpha1/organizations/{org}/security-settings
+    #   → {"enforce_password_renewal":true, "grace_period_duration":"259200.000000000s",
+    #      "login_attempts_before_locked":5, "max_login_session_duration":"2592000.000000000s",
+    #      "max_api_key_expiration_duration":"31536000.000000000s"}
+    #
+    # La durée est une CHAÎNE suffixée ; le modèle normalisé porte un nombre de
+    # secondes, parce que c'est lui que la règle compare (ADR-0001 : une règle, une
+    # donnée normalisée).
+    - type: api_access_policy
+      path: /iam/v1alpha1/organizations/{org}/security-settings
+      items: .
+      id: id
+      const:
+        id: security-settings
+      map:
+        max_access_key_expiration_seconds: max_api_key_expiration_duration
+      transforms:
+        max_access_key_expiration_seconds: duration_seconds
+
     # Groupes de sécurité → security_group. AUCUN APPEL SUPPLÉMENTAIRE : c'est la
     # MÊME liste que le `for_each` ci-dessous parcourt déjà pour joindre les règles à
     # leur groupe. La réponse portait `inbound_default_policy` depuis toujours, et
@@ -531,8 +567,19 @@ contrat:
       etat: a_verifier
       source: équivalent restriction IP de l'API à vérifier (iam / account)
     api_access_policy:
-      etat: a_verifier
-      source: équivalent expiration max des clés à vérifier (iam)
+      etat: verifie
+      source: >
+        api/iam/v1alpha1 SecuritySettings
+        (GET /iam/v1alpha1/organizations/{organization_id}/security-settings).
+        MESURÉ contre l'API réelle le 2026-09-11 : la réponse porte
+        enforce_password_renewal, grace_period_duration, login_attempts_before_locked,
+        max_login_session_duration et max_api_key_expiration_duration.
+      mapping:
+        max_access_key_expiration_seconds: >
+          DÉRIVÉ de max_api_key_expiration_duration, une durée en CHAÎNE suffixée
+          (« 31536000.000000000s ») convertie en secondes par le transform
+          `duration_seconds`. Le pendant Scaleway du MaxAccessKeyExpirationSeconds
+          d'Outscale, au niveau de l'ORGANISATION.
   non_applicable:
   # CHF-2 : le chiffrement au repos des volumes block est CÔTÉ INVITÉ (LUKS/Cryptsetup),
   # responsabilité du client (modèle de responsabilité partagée) ; l'API block n'expose

--- a/references/qualification/scaleway/expected.yaml
+++ b/references/qualification/scaleway/expected.yaml
@@ -85,6 +85,20 @@ controls:
       reason: "aucune clé du propriétaire dans le tenant ; les écarts hors tenant ne sont pas gardés"
     terraform: not-evaluated
 
+  iam_apiaccesspolicy_max_key_expiration:
+    live:
+      status: evaluated
+      perimeter: organisation
+      reason: >
+        Le réglage est au niveau de l'ORGANISATION, pas du tenant : aucune ressource
+        Terraform ne le pose, et le durcir ou l'affaiblir pour un run changerait la
+        politique de sécurité d'un compte réel. Le contrôle doit CONCLURE — et sur ce
+        compte il rend `pass`, l'organisation imposant 365 jours (mesuré). Le cas
+        `fail` est prouvé par le scénario de véracité, pas par le tenant, parce qu'il
+        exigerait de retirer cette protection.
+    # Aucune ressource Terraform ne porte ce réglage : il n'est pas dans un plan.
+    terraform: not-evaluated
+
   iam_user_mfa_enabled:
     live:
       status: evaluated

--- a/references/tenants/scaleway/ducklake/expected.txt
+++ b/references/tenants/scaleway/ducklake/expected.txt
@@ -20,6 +20,7 @@ governance_provider_sovereignty pass
 governance_resource_region_in_eu not-evaluated
 governance_resource_required_tags not-evaluated
 iam_accesskey_expiration_set not-evaluated
+iam_apiaccesspolicy_max_key_expiration not-evaluated
 iam_no_root_access_key not-evaluated
 iam_policy_no_privilege_escalation not-evaluated
 iam_user_mfa_enabled not-evaluated

--- a/references/tenants/scaleway/kubic/expected.txt
+++ b/references/tenants/scaleway/kubic/expected.txt
@@ -20,6 +20,7 @@ governance_provider_sovereignty pass
 governance_resource_region_in_eu not-evaluated
 governance_resource_required_tags not-evaluated
 iam_accesskey_expiration_set not-evaluated
+iam_apiaccesspolicy_max_key_expiration not-evaluated
 iam_no_root_access_key not-evaluated
 iam_policy_no_privilege_escalation not-evaluated
 iam_user_mfa_enabled not-evaluated

--- a/referentiel/controles.yaml
+++ b/referentiel/controles.yaml
@@ -291,7 +291,7 @@ controles:
     frameworks:
       secnumcloud_3_2: ["9.5", "10.5"]
       iso_27001_2022: ["A.5.17"]
-    fournisseurs: [outscale]
+    fournisseurs: [outscale, scaleway]
 
   - code: iam_apiaccessrule_no_public_cidr
     famille: iam


### PR DESCRIPTION
Closes #196.

## The refusal was the measurement

`iam_apiaccesspolicy_max_key_expiration` was active for **Outscale only**, and
`providers/scaleway.yaml` carried `api_access_policy: a_verifier — équivalent expiration
max des clés à vérifier`.

The equivalent exists, and the qualification tenant found it **by being refused**:

```
organization security settings require an expiration date for API keys
```

Reading the field then took one call, verified against the **live API** on 2026-09-11:

```
GET /iam/v1alpha1/organizations/{id}/security-settings
→ {"enforce_password_renewal": true,
   "grace_period_duration": "259200.000000000s",
   "login_attempts_before_locked": 5,
   "max_login_session_duration": "2592000.000000000s",
   "max_api_key_expiration_duration": "31536000.000000000s"}
```

The control is now active for Scaleway and concludes **`pass`** on an organisation
enforcing 365 days. **One rule, unchanged**, on normalised data (ADR-0001) — only the
collection differs.

## Why it matters beyond one more green cell

Listing keys says what is true **today** — does each one have an expiry. This setting says
what the organisation **will refuse tomorrow**. That is the difference between a
*detective* and a *preventive* control, and **SecNumCloud 9.5** and **CIS 5.4** both draw
it.

## A new transform, and its counterexamples carry the weight

`duration_seconds`, because Scaleway expresses its duration as a suffixed string where
Outscale returns an integer of seconds.

**An unreadable duration returns nothing, never zero.** The rule flags a deviation on
`<= 0`, so fabricating a zero would turn a failed read into an **asserted** deviation — on
a preventive control. Falsified: dropping the parse-error branch turns the suite red.
`"0s"` still projects `0`, because *"no limit"* is the deviation the control looks for and
must reach it.

## Two gates made to agree, which was a defect of their own

An endpoint the `non_observes` registry **declares** unobservable was still reported as an
unknown call by the replay gate. So one gate **demanded** the registry and the other
**refused** it — making the mechanism unusable for the very case it exists for: a **new**
endpoint the emulator does not serve yet.

Both now read the same registry. The registry still requires a written reason, and the
other gate still fails when a paid debt stays written.

## What stays unmeasured, and how it is covered

The local emulator does not serve organisation security settings, and **feint is out of
bounds for this repository**. The endpoint is therefore declared unobserved **with its
reason**. What that leaves unmeasured is the *wiring* — that the collector really emits
this call — and **three veracity scenarios** measure it instead, serving canned responses
to the real collector: enforced, unlimited, and absent.

## Impact ADR

**ADR-0001**: one common rule gains a provider's collection, not a rule of its own.
**ADR-0014**: an unreadable duration is declared unread rather than defaulted — the whole
point of the transform's counterexamples. **ADR-0010**: the endpoint's debt is *named*
rather than hidden. No ADR modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)