### PR TITLE
fix(collect): a refusal is classified by its error code, not its status

### DIFF
--- a/CHANGELOG.fr.md
+++ b/CHANGELOG.fr.md
@@ -95,6 +95,45 @@ l'une ni l'autre appartient au `git log`.
 
 ### Corrigé
 
+- **Un refus n'est plus présenté comme une panne, et une clé inconnue n'est plus présentée
+  comme un droit manquant** (issue #91). Outscale répond `400` là où Scaleway répond `401`
+  et Exoscale `403` ; un `4xx` qu'aucune classe plus fine ne réclamait retombait sur
+  `unavailable`, si bien que le relevé de canari rangeait les dix-huit endpoints Outscale
+  en **« service indisponible »** — alors que tous avaient répondu. L'opérateur qui lit ça
+  va consulter une page d'état pendant que le plan de contrôle fonctionne parfaitement.
+
+  La distinction que l'issue laissait ouverte — *un `400`, est-ce une signature invalide ou
+  un droit manquant ?* — ne pouvait pas se trancher avec des identifiants synthétiques, qui
+  ne produisent jamais que le premier cas. Elle a été mesurée le 2026-09-12 sur
+  `eu-west-2`, avec une identité EIM créée pour la mesure ne portant que `api:ReadVms`,
+  puis détruite ; un appel autorisé a été joué d'abord comme témoin, pour qu'un refus ne
+  puisse pas venir de la signature :
+
+  | Situation du compte de scan | HTTP | `Type` · `Code` | Classe |
+  |---|---|---|---|
+  | Clé d'accès inexistante | `400` | `InvalidParameterValue` · `4120` | `unauthenticated` |
+  | Clé existante, signature invalide | `401` | `AccessDenied` · `1` | `unauthenticated` |
+  | Clé valide, droit manquant | `403` | `AccessDenied` · `4` | `permission_denied` |
+
+  Deux classes s'ajoutent à l'état de collecte — `unauthenticated` (l'API n'a pas reconnu
+  les identifiants) et `rejected` (l'API a répondu et refusé la requête) — et un `4xx`
+  n'est plus jamais `unavailable`. Le statut seul ne peut pas porter cette distinction :
+  Outscale documente son erreur d'**authentification** en `400` et son erreur
+  d'**autorisation** en `401` ([table officielle](https://docs.outscale.com/api-errors.html)),
+  si bien qu'un classement par statut se trompe sur les deux, dans les deux sens. C'est le
+  **code** d'erreur qui tranche, et seuls les codes que cette table documente sont mappés —
+  le `403 · 4` mesuré n'en fait pas partie et reste classé par son statut.
+  `InvalidAccessKeyId` et `SignatureDoesNotMatch` sur le chemin du stockage objet passent à
+  `unauthenticated` pour la même raison : élargir une politique ne rend pas connue une clé
+  qui ne l'est pas. **Aucun verdict ne bouge sur un tenant inchangé** — un refus dégradait
+  un contrôle en `not-evaluated` avant, et le fait toujours ; ce qui change, c'est la phrase
+  que lit l'opérateur, et l'erreur qu'elle lui envoie corriger.
+
+  `pepin-inventory` passe en **v14** : le schéma ne bouge pas, mais l'éventail de valeurs
+  que `error` peut prendre, si — et un consommateur qui les énumère doit le savoir
+  (ADR-0003).
+
+
 - **La collecte live Exoscale écrit la zone qu'elle a scannée** (issue #210).
   `governance_resource_region_in_eu` rendait `not-evaluated` sur **toute** organisation
   Exoscale : aucune ressource ne portait de région, donc le contrôle ne pouvait jamais

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,42 @@ belongs in `git log`.
 
 ### Fixed
 
+- **A refusal is no longer reported as an outage, and an unknown key is no longer reported
+  as a missing right** (issue #91). Outscale answers `400` where Scaleway answers `401` and
+  Exoscale `403`; a `4xx` that no finer class claimed fell through to `unavailable`, so the
+  canary record filed all eighteen Outscale endpoints under **"service unavailable"** —
+  every one of which had answered. An operator reading that goes to check a status page
+  while the control plane works perfectly.
+
+  The distinction the issue left open — *is a `400` a bad signature or a missing right?* —
+  could not be settled with synthetic credentials, which only ever produce the first. It
+  was measured on 2026-09-12 against `eu-west-2`, with an EIM identity created for the
+  measurement carrying only `api:ReadVms`, then destroyed; an authorized call was played
+  first as a witness, so that a refusal could not come from the signature:
+
+  | Situation of the scanning account | HTTP | `Type` · `Code` | Class |
+  |---|---|---|---|
+  | Access key does not exist | `400` | `InvalidParameterValue` · `4120` | `unauthenticated` |
+  | Key exists, invalid signature | `401` | `AccessDenied` · `1` | `unauthenticated` |
+  | Valid key, missing right | `403` | `AccessDenied` · `4` | `permission_denied` |
+
+  Two classes are added to the collection state — `unauthenticated` (the API did not
+  recognize the credentials) and `rejected` (the API answered and refused the request) —
+  and a `4xx` is never `unavailable` again. The status alone cannot carry this: Outscale
+  documents its **authentication** error at `400` and its **authorization** error at `401`
+  ([official table](https://docs.outscale.com/api-errors.html)), so classifying by status
+  gets both wrong, in both directions. The error **code** settles it, and only codes that
+  table documents are mapped — the measured `403 · 4` is not among them and is left to its
+  status. `InvalidAccessKeyId` and `SignatureDoesNotMatch` on the object-storage path move
+  to `unauthenticated` for the same reason: widening a policy does not make an unknown key
+  known. **No verdict moves on an unchanged tenant** — a refusal degraded a control to
+  `not-evaluated` before and still does; what changes is the sentence the operator reads,
+  and which mistake it sends them to fix.
+
+  `pepin-inventory` goes to **v14**: the schema is unchanged, but the set of values `error`
+  can take is not, and a consumer enumerating them must be told (ADR-0003).
+
+
 - **Exoscale live now writes the zone it scanned** (issue #210).
   `governance_resource_region_in_eu` returned `not-evaluated` on **every** Exoscale
   organisation: no resource carried a region, so the control could never conclude about

--- a/cmd/testdata/frozen/inventory.json
+++ b/cmd/testdata/frozen/inventory.json
@@ -3004,6 +3004,250 @@
           ]
         }
       }
+    },
+    {
+      "schema_version": 14,
+      "content": {
+        "envelope": {
+          "collection": {
+            "units": [
+              {
+                "attempted": "boolean",
+                "complete": "boolean",
+                "detail": "string",
+                "error": "string",
+                "types": [
+                  "string"
+                ],
+                "unit": "string"
+              }
+            ],
+            "unmapped": [
+              {
+                "count": "number",
+                "type": "string"
+              }
+            ]
+          },
+          "provider": "string",
+          "resources": [
+            {
+              "attributes": {
+                "*": "any"
+              },
+              "id": "string",
+              "name": "string",
+              "provenance": {
+                "*": {
+                  "derived": "boolean",
+                  "observed": "boolean",
+                  "origin": "string",
+                  "path": "string",
+                  "source": "string"
+                }
+              },
+              "provider": "string",
+              "region": "string",
+              "source": {
+                "file": "string",
+                "line": "number",
+                "module": "string"
+              },
+              "type": "string"
+            }
+          ]
+        },
+        "format": "pepin-inventory/v14",
+        "types": {
+          "access_key": [
+            "access_key_id",
+            "creation_date",
+            "expiration_date",
+            "owner_application_id",
+            "owner_user",
+            "owner_user_id",
+            "scope",
+            "state"
+          ],
+          "api_access_policy": [
+            "id",
+            "max_access_key_expiration_seconds",
+            "require_trusted_env"
+          ],
+          "api_access_rule": [
+            "api_access_rule_id",
+            "ca_ids",
+            "cns",
+            "description",
+            "ip_ranges"
+          ],
+          "api_access_summary": [
+            "id",
+            "rule_count"
+          ],
+          "blockstorage_snapshot": [
+            "creation_date",
+            "global_permission",
+            "snapshot_id",
+            "state",
+            "volume_id"
+          ],
+          "blockstorage_volume": [
+            "encrypted",
+            "state",
+            "tags",
+            "volume_id"
+          ],
+          "compute_image": [
+            "image_id",
+            "public",
+            "state",
+            "tags"
+          ],
+          "compute_instance": [
+            "deletion_protection",
+            "nic_public_ips",
+            "public_interface",
+            "public_ip",
+            "security_group_ids",
+            "state",
+            "tags",
+            "user_data",
+            "vm_id"
+          ],
+          "governance_provider": [
+            "capital_control",
+            "eu_established",
+            "extraterritorial_exposure",
+            "jurisdiction",
+            "secnumcloud",
+            "secnumcloud_regions"
+          ],
+          "iam_policy": [
+            "manages_iam",
+            "owner_group",
+            "owner_user",
+            "policy_id",
+            "policy_name",
+            "scope",
+            "statements"
+          ],
+          "iam_role": [
+            "admin_privileges",
+            "editable",
+            "manages_iam",
+            "max_session_ttl",
+            "name",
+            "policy_has_expiration",
+            "provider_managed",
+            "role_id",
+            "source_ip_restricted"
+          ],
+          "iam_user": [
+            "mfa_enabled",
+            "user_id",
+            "user_type",
+            "username"
+          ],
+          "k8s_cluster_role_binding": [
+            "name",
+            "role_ref",
+            "subjects"
+          ],
+          "k8s_crd": [
+            "name"
+          ],
+          "k8s_namespace": [
+            "labels",
+            "name"
+          ],
+          "k8s_network_policy": [
+            "name",
+            "namespace"
+          ],
+          "kubernetes_cluster": [
+            "admin_whitelist",
+            "audit_enabled",
+            "auto_upgrade",
+            "control_plane_multi_az",
+            "deletion_protection",
+            "name",
+            "version"
+          ],
+          "load_balancer": [
+            "access_log",
+            "listeners",
+            "load_balancer_name",
+            "load_balancer_type",
+            "tags"
+          ],
+          "managed_database": [
+            "database_id",
+            "disable_backup",
+            "encryption_at_rest",
+            "ip_filter"
+          ],
+          "network": [
+            "cidr",
+            "description",
+            "name",
+            "network_id",
+            "state",
+            "tags"
+          ],
+          "network_interface": [
+            "nic_id",
+            "public_ip",
+            "security_group_ids",
+            "vm_id"
+          ],
+          "network_peering": [
+            "accepter_account",
+            "peering_id",
+            "source_account",
+            "state"
+          ],
+          "object_storage_bucket": [
+            "acl",
+            "acl_grants",
+            "default_encryption_enabled",
+            "kms_key_id",
+            "name",
+            "object_lock_enabled",
+            "policy_public",
+            "public_via_acl",
+            "sse_kms_enabled",
+            "tags",
+            "versioning"
+          ],
+          "security_group": [
+            "description",
+            "inbound_default_policy",
+            "outbound_default_policy",
+            "security_group_id",
+            "tags"
+          ],
+          "security_group_rule": [
+            "action",
+            "cidrs",
+            "description",
+            "direction",
+            "peer_security_group_ids",
+            "port_from",
+            "port_to",
+            "protocol",
+            "security_group_id",
+            "security_group_name"
+          ],
+          "subnet": [
+            "map_public_ip_on_launch",
+            "network_id",
+            "state",
+            "subnet_id",
+            "tags"
+          ]
+        }
+      }
     }
   ]
 }

--- a/docs/adr/0023-un-statut-http-ne-classe-pas-un-refus.md
+++ b/docs/adr/0023-un-statut-http-ne-classe-pas-un-refus.md
@@ -1,0 +1,125 @@
+# ADR-0023 — Un statut HTTP ne classe pas un refus ; le code d'erreur documenté, si
+
+```yaml
+status: Accepted
+date: 2026-09-12
+scope:
+  - model
+  - collect
+```
+
+## Contexte
+
+L'état de collecte range chaque échec dans une **classe** — `permission_denied`,
+`not_found`, `timeout`… — et cette classe commande la phrase que lit l'opérateur.
+Elle était dérivée du **statut HTTP** seul, avec un repli sur `unavailable` pour
+tout `4xx` non réclamé par une classe plus fine.
+
+Trois observations, faites sur les plans de contrôle réels, ont montré que ce
+raisonnement ne pouvait pas tenir.
+
+**Le statut ne dit pas la même chose d'un fournisseur à l'autre.** Pour un même
+refus, Scaleway répond `401`, Exoscale `403`, Outscale `400` (issue #91).
+
+**Chez un même fournisseur, le statut range les deux erreurs à l'envers.** La
+table officielle d'Outscale documente l'erreur d'**authentification** en `400`
+(code `4120`, `ErrorAuthenticationexception`) et l'erreur d'**autorisation** en
+`401` (code `5`, `ErrorNotAuthorized`). Classer par statut donne donc « service
+indisponible » à la première et « privilège insuffisant » à la seconde : les deux
+erreurs possibles, dans les deux sens.
+
+**Le repli `unavailable` était un mensonge visible.** Le relevé de canari rangeait
+les dix-huit endpoints Outscale en « service indisponible » alors que tous
+avaient répondu — le `4xx` étant précisément la preuve que le service fonctionne.
+
+La distinction signature/droit ne pouvait pas se trancher depuis le dépôt : des
+identifiants synthétiques ne produisent jamais que le refus d'authentification.
+Elle a été mesurée le 2026-09-12 sur `eu-west-2`, avec une identité EIM créée
+pour la mesure, ne portant que `api:ReadVms`, puis détruite — un appel autorisé
+joué d'abord comme témoin.
+
+| Situation du compte de scan | HTTP | `Type` · `Code` |
+|---|---|---|
+| Clé d'accès inexistante | `400` | `InvalidParameterValue` · `4120` |
+| Clé existante, signature invalide | `401` | `AccessDenied` · `1` |
+| Clé valide, droit manquant | `403` | `AccessDenied` · `4` |
+
+## Décision
+
+La classe d'un refus se dérive du **code d'erreur que le fournisseur documente**
+quand il y en a un, et du statut seulement à défaut. Un `4xx` non classé rend
+`rejected` (« l'API a répondu et refusé »), jamais `unavailable`, qui ne désigne
+plus que ce qui n'a pas répondu.
+
+## Justification
+
+L'opérateur ne lit pas une classe : il lit une phrase, et il agit. Les trois
+gestes sont incompatibles — corriger des **identifiants**, corriger des
+**droits**, attendre une **panne**. Une classe qui envoie vers le mauvais geste
+coûte plus que pas de classe du tout, parce qu'elle inspire confiance.
+
+Le statut HTTP est une convention que chaque API applique à sa façon ; le code
+d'erreur est un **contrat écrit**, que le fournisseur publie et tient. Entre une
+convention et un contrat, l'ancrage §2 tranche depuis toujours en faveur du
+contrat.
+
+## Alternatives écartées
+
+**Mapper `400 → permission_denied` chez Outscale.** Rejeté par l'issue #91
+elle-même, avant toute mesure : un vrai défaut de requête serait devenu un
+problème de droits. C'était remplacer un mensonge par le mensonge inverse.
+
+**Garder `unavailable` comme repli des `4xx`.** Rejeté : c'est la formulation qui
+a produit le défaut. Un `4xx` prouve que le service répond.
+
+**Introduire une seule classe « refus, cause indéterminable ».** C'était la piste
+de repli de l'issue, valable tant que la distinction n'était pas mesurée. Elle
+l'est : s'en tenir là aurait jeté une mesure qui a coûté un compte réel.
+
+**Déduire `unauthenticated` d'un `401`, et `permission_denied` d'un `403`, par
+sémantique HTTP.** Rejeté, et c'est le piège le plus séduisant : la table
+d'Outscale place `ErrorNotAuthorized` — un droit manquant — en `401`. La
+sémantique HTTP est ici démentie par la doc du fournisseur lui-même.
+
+**Mapper le `403 · code 4` mesuré.** Rejeté : ce code n'est PAS dans la table
+publiée. Il est mesuré, pas documenté, et l'inscrire dans le code reviendrait à
+affirmer un contrat que personne ne tient (CLAUDE.md §2). Son statut `403` le
+classe déjà correctement.
+
+## Conséquences
+
+Chaque fournisseur dont l'enveloppe d'erreur doit être lue coûte une entrée dans
+la table de correspondance, et cette entrée exige une **source citée**. C'est le
+coût voulu : il rend impossible d'ajouter une correspondance devinée.
+
+L'éventail de valeurs de `error` s'élargit, donc `InventoryFormat` monte (v14) et
+un consommateur qui les énumère doit être averti — ADR-0003.
+
+Ce que la décision ne change pas : aucun verdict ne bouge sur un tenant inchangé.
+Un refus dégradait un contrôle en `not-evaluated` ; il le fait toujours.
+
+## Invariants
+
+- Un `4xx` ne se classe **jamais** `unavailable` ; seul un service qui n'a pas
+  répondu le mérite — *garde : `TestAnAnsweringServiceIsNeverCalledUnavailable`*
+- Une correspondance code → classe cite la table officielle qui la documente ; un
+  code non documenté retombe sur le statut — *garde :
+  `TestTheThreeMeasuredOutscaleRefusalsDoNotMeanTheSameThing`*
+- Un corps que la table ne reconnaît pas ne déplace aucune classe — *garde :
+  `TestAnUnrecognizedBodyLeavesTheStatusInCharge`*
+- Le droit requis ne se nomme que sur `permission_denied` : sur une clé inconnue,
+  il enverrait élargir une politique attachée à une identité absente — *garde :
+  `TestOnlyAMissingRightNamesTheRequiredGrant`*
+
+## Validation
+
+`mise run test`. Le relevé de canari (`references/canary/outscale.yaml`) rejoue la
+mesure contre le vrai plan de contrôle à chaque qualification de release : ses
+endpoints ressortent `unauthenticated`, ce qui est exact — le canari n'a pas de
+clé — et ce qui prouve du même coup qu'il ne peut rien dire du refus de DROIT.
+
+## Liens
+
+Issue #91 · `internal/collect/status.go` · `internal/model/collection.go` ·
+`internal/assess/collection.go` · <https://docs.outscale.com/api-errors.html> ·
+ADR-0003, ADR-0006, ADR-0012.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -88,10 +88,10 @@ Avant d'implémenter, établir si A, B et C ont cessé d'être vraies.
 |---|---|
 | Architecture des règles, providers | [0001](0001-regles-communes-providers-collecteurs.md), [0022](0022-une-reference-declaree-est-une-observation.md) |
 | Moteur, findings, rendu, scoring | [0002](0002-moteur-partage-scankit.md) |
-| Modèle de données, inventaire | [0003](0003-inventaire-contrat-gele.md), [0007](0007-provenance-index-parallele.md), [0017](0017-provenance-atteste-une-recherche.md), [0020](0020-lorigine-declaree-dun-inventaire-fait-foi.md), [0022](0022-une-reference-declaree-est-une-observation.md) |
+| Modèle de données, inventaire | [0003](0003-inventaire-contrat-gele.md), [0007](0007-provenance-index-parallele.md), [0017](0017-provenance-atteste-une-recherche.md), [0020](0020-lorigine-declaree-dun-inventaire-fait-foi.md), [0022](0022-une-reference-declaree-est-une-observation.md), [0023](0023-un-statut-http-ne-classe-pas-un-refus.md) |
 | Référentiel, frameworks normatifs | [0004](0004-index-scsl-gele.md), [0009](0009-configuration-lie-mapping.md) |
 | Codes de sortie, portes de CI | [0005](0005-codes-de-sortie.md), [0008](0008-derogation-nest-pas-conformite.md), [0019](0019-un-profil-filtre-la-porte-jamais-le-rapport.md) |
-| Assessment, verdicts, dégradation | [0006](0006-jamais-un-pass-non-prouve.md), [0014](0014-jamais-fabriquer-une-donnee-absente.md), [0015](0015-une-regle-qui-ne-peut-conclure-le-dit.md), [0017](0017-provenance-atteste-une-recherche.md), [0020](0020-lorigine-declaree-dun-inventaire-fait-foi.md) |
+| Assessment, verdicts, dégradation | [0006](0006-jamais-un-pass-non-prouve.md), [0014](0014-jamais-fabriquer-une-donnee-absente.md), [0015](0015-une-regle-qui-ne-peut-conclure-le-dit.md), [0017](0017-provenance-atteste-une-recherche.md), [0020](0020-lorigine-declaree-dun-inventaire-fait-foi.md), [0023](0023-un-statut-http-ne-classe-pas-un-refus.md) |
 | Tests, preuve, véracité | [0010](0010-dette-de-veracite-comptee.md) |
 | Bundle de preuve, persistance | [0018](0018-ce-quun-bundle-prouve-de-lui-meme.md) |
 | Langue, documentation | [0011](0011-bilinguisme-francais-normatif.md) |

--- a/docs/detection-quality.fr.md
+++ b/docs/detection-quality.fr.md
@@ -67,7 +67,7 @@ Un endpoint qui répond existe et se résout ; un `moved` (404) dit qu'il a boug
 | Fournisseur | Relevé le | Ont répondu | Déplacés | Injoignables |
 |---|---|---:|---:|---:|
 | `exoscale` | 2026-08-21 | 9 | 0 | 0 |
-| `outscale` | 2026-08-21 | 17 | 0 | 0 |
+| `outscale` | 2026-09-12 | 18 | 0 | 0 |
 | `scaleway` | 2026-08-21 | 5 | 0 | 0 |
 
 ## Précision des règles high/critical

--- a/docs/detection-quality.md
+++ b/docs/detection-quality.md
@@ -67,7 +67,7 @@ An endpoint that answers exists and resolves; a `moved` (404) says it has shifte
 | Provider | Recorded | Answered | Moved | Unreachable |
 |---|---|---:|---:|---:|
 | `exoscale` | 2026-08-21 | 9 | 0 | 0 |
-| `outscale` | 2026-08-21 | 17 | 0 | 0 |
+| `outscale` | 2026-09-12 | 18 | 0 | 0 |
 | `scaleway` | 2026-08-21 | 5 | 0 | 0 |
 
 ## Precision of the high/critical rules

--- a/docs/guides/evidence-bundles.fr.md
+++ b/docs/guides/evidence-bundles.fr.md
@@ -58,7 +58,7 @@ et un changement de cette forme incrémente un numéro de version et reçoit sa 
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v13",
+  "inventory_schema": "pepin-inventory/v14",
   "disclaimer": "Ce rapport évalue la configuration d'un tenant (périmètre commanditaire). Les correspondances normatives (SecNumCloud, ISO, CIS) sont indicatives : elles ne constituent pas une preuve de qualification/certification, laquelle porte sur le prestataire de service cloud.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/guides/evidence-bundles.md
+++ b/docs/guides/evidence-bundles.md
@@ -56,7 +56,7 @@ raises a version number and gets a CHANGELOG line.
 ```json
 {
   "format": "pepin-assessment-bundle/v3",
-  "inventory_schema": "pepin-inventory/v13",
+  "inventory_schema": "pepin-inventory/v14",
   "disclaimer": "This report assesses the configuration of a tenant (customer-side scope). The normative mappings (SecNumCloud, ISO, CIS) are indicative: they are not a proof of qualification or certification, which applies to the cloud service provider.",
   "generated": "<timestamp>",
   "tool": {

--- a/docs/reference/cli.fr.md
+++ b/docs/reference/cli.fr.md
@@ -43,7 +43,7 @@ séparément :
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v13** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v14** |
 <!-- /pepin:gen surface-versions -->
 
 Un numéro monte à **tout** changement de forme, ajout compris : il signifie « la surface a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,7 +43,7 @@ independently:
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v13** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v14** |
 <!-- /pepin:gen surface-versions -->
 
 A version rises on **any** shape change, additions included: the number means "the surface has

--- a/docs/reference/inventory.fr.md
+++ b/docs/reference/inventory.fr.md
@@ -12,7 +12,7 @@ gelée, avec les mêmes égards que la surface CLI.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v13
+pepin-inventory/v14
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -58,22 +58,47 @@ rendre : une unité qui a rendu zéro ressource sans erreur est complète — «
 une mesure — alors qu'une unité qui a rendu cent ressources sur mille avant un `403` ne l'est
 pas.
 
-`error` est une classe stable, pas un message : `permission_denied`, `not_found`,
-`rate_limited`, `timeout`, `truncated`, `unreadable`, `unavailable`. Un pipeline doit pouvoir
-distinguer « le compte de scan ne voit pas cette surface » (à corriger sur la politique du
-compte) de « le service n'a pas répondu » (à réessayer). `detail` porte la réponse du
-fournisseur telle quelle, non traduite : c'est une donnée, pas de la prose de Pépin.
+`error` est une classe stable, pas un message : `permission_denied`, `unauthenticated`,
+`rejected`, `not_found`, `rate_limited`, `timeout`, `truncated`, `unreadable`, `unavailable`. Un
+pipeline doit pouvoir distinguer « le compte de scan ne voit pas cette surface » (à corriger sur
+la politique du compte) de « le service n'a pas répondu » (à réessayer). `detail` porte la
+réponse du fournisseur telle quelle, non traduite : c'est une donnée, pas de la prose de Pépin.
+
+Trois classes disent trois gestes différents, et les confondre coûte le temps de qui les lit :
+`unauthenticated` = corriger les **identifiants** (clé inconnue, signature invalide),
+`permission_denied` = corriger les **droits**, `rejected` = l'API a **répondu** et refusé la
+requête, donc le service fonctionne. Un `4xx` n'est jamais rangé en `unavailable`, qui ne
+désigne que ce qui n'a pas répondu du tout.
 
 **Jusqu'où chaque classe est mesurée.** La *correspondance* l'est contre de vraies sockets :
 `internal/collect/status_test.go` pilote un serveur qui refuse vraiment, expire vraiment et
 tronque vraiment une page, et un `403` y ressort bien en `permission_denied`. Une session
 enregistrée contre l'émulateur (`internal/genprovider/testdata/transcripts/`) y ajoute
 `not_found` et `unavailable` observés sur le réseau, y compris à travers l'interface d'erreur du
-SDK AWS sur le chemin du stockage objet. Ce qu'aucun contrôle de ce dépôt n'établit, c'est
-quelle classe un **fournisseur donné** déclenchera : si Outscale répond `403` plutôt que `200`
-accompagné d'un corps `Errors`, si un appel Scaleway limité rend `429` plutôt que `503`.
-L'émulateur ne peut pas trancher non plus, puisqu'il accepte n'importe quel identifiant et ne
-sait donc jamais refuser. Cela reste dû à un scan réel ; voir
+SDK AWS sur le chemin du stockage objet.
+
+**Le refus d'Outscale, lui, a été mesuré sur le vrai plan de contrôle** (2026-09-12, `eu-west-2`,
+identité EIM créée pour la mesure puis détruite, ne portant que `api:ReadVms`) :
+
+| Situation du compte de scan | HTTP | `Type` · `Code` | Classe |
+|---|---|---|---|
+| Clé d'accès inexistante | `400` | `InvalidParameterValue` · `4120` | `unauthenticated` |
+| Clé existante, signature invalide | `401` | `AccessDenied` · `1` | `unauthenticated` |
+| Clé valide, droit manquant | `403` | `AccessDenied` · `4` | `permission_denied` |
+
+Le premier cas est le seul qu'un identifiant synthétique sache produire, et c'est pourquoi il
+avait longtemps été rangé en `unavailable` : le statut `400` ne dit pas qu'il s'agit
+d'authentification, le **code d'erreur** le dit
+([table officielle](https://docs.outscale.com/api-errors.html), `4120` =
+`ErrorAuthenticationexception`). Le troisième cas exigeait un droit réellement manquant sur une
+clé réellement valide ; il n'a donc pu être établi qu'avec un compte. À noter, et c'est une
+limite : le code `4` n'est pas dans la table publiée — il est **mesuré**, pas documenté, et
+Pépin ne s'y adosse pas (le statut `403` suffit).
+
+Ce qu'aucun contrôle de ce dépôt n'établit reste : quelle classe les **autres** fournisseurs
+déclencheront, par exemple si un appel Scaleway limité rend `429` plutôt que `503`. L'émulateur
+ne peut pas trancher, puisqu'il accepte n'importe quel identifiant et ne sait donc jamais
+refuser. Cela reste dû à un scan réel ; voir
 [Limites connues](../known-limitations.fr.md) et
 [Tracer les appels réels](../guides/tracing-api-calls.fr.md).
 

--- a/docs/reference/inventory.md
+++ b/docs/reference/inventory.md
@@ -12,7 +12,7 @@ with the same regard as the CLI surface.
 
 <!-- pepin:gen inventory-format -->
 ```text
-pepin-inventory/v13
+pepin-inventory/v14
 ```
 <!-- /pepin:gen inventory-format -->
 
@@ -57,22 +57,47 @@ types. `complete` is true when the unit returned everything the API had to retur
 returned zero resources without error is complete — "there is nothing" is a measurement — while
 a unit that returned a hundred resources out of a thousand before a `403` is not.
 
-`error` is a stable class, not a message: `permission_denied`, `not_found`, `rate_limited`,
-`timeout`, `truncated`, `unreadable`, `unavailable`. A pipeline must be able to tell "the
-scanning account cannot see this" (fix the account policy) from "the service did not answer"
-(retry). `detail` carries the provider's own response, untranslated — it is data, not Pépin
-prose.
+`error` is a stable class, not a message: `permission_denied`, `unauthenticated`, `rejected`,
+`not_found`, `rate_limited`, `timeout`, `truncated`, `unreadable`, `unavailable`. A pipeline must
+be able to tell "the scanning account cannot see this" (fix the account policy) from "the service
+did not answer" (retry). `detail` carries the provider's own response, untranslated — it is data,
+not Pépin prose.
+
+Three classes name three different actions, and confusing them costs the reader's time:
+`unauthenticated` = fix the **credentials** (unknown key, invalid signature), `permission_denied`
+= fix the **rights**, `rejected` = the API **answered** and refused the request, so the service
+is working. A `4xx` is never filed under `unavailable`, which only names what did not answer at
+all.
 
 **How far each class is measured.** The *mapping* is measured against real sockets:
 `internal/collect/status_test.go` drives a server that really refuses, really times out and
 really truncates a page, and a `403` there really comes out as `permission_denied`. A recorded
 emulator session (`internal/genprovider/testdata/transcripts/`) adds `not_found` and
 `unavailable` on the wire, including through the AWS SDK's error interface on the object-storage
-path. What no check in this repository establishes is which class a **given provider** will
-trigger: whether Outscale answers `403` rather than `200` with an `Errors` body, whether a
-throttled Scaleway call is `429` rather than `503`. The emulator cannot settle it either — it
-accepts every credential and can therefore never refuse. That is owed to a real scan; see
-[Known limitations](../known-limitations.md) and
+path.
+
+**Outscale's refusal, however, was measured against the real control plane** (2026-09-12,
+`eu-west-2`, with an EIM identity created for the measurement and then destroyed, carrying only
+`api:ReadVms`):
+
+| Situation of the scanning account | HTTP | `Type` · `Code` | Class |
+|---|---|---|---|
+| Access key does not exist | `400` | `InvalidParameterValue` · `4120` | `unauthenticated` |
+| Key exists, invalid signature | `401` | `AccessDenied` · `1` | `unauthenticated` |
+| Valid key, missing right | `403` | `AccessDenied` · `4` | `permission_denied` |
+
+The first case is the only one a synthetic credential can produce, which is why it was long
+filed under `unavailable`: the `400` status does not say this is about authentication — the
+**error code** does ([official table](https://docs.outscale.com/api-errors.html), `4120` =
+`ErrorAuthenticationexception`). The third case required a genuinely missing right on a
+genuinely valid key, so it could only be established with an account. One limit worth naming:
+code `4` is not in the published table — it is **measured**, not documented, and Pépin does not
+rely on it (the `403` status is enough).
+
+What no check in this repository establishes remains: which class the **other** providers will
+trigger, for instance whether a throttled Scaleway call is `429` rather than `503`. The emulator
+cannot settle it — it accepts every credential and can therefore never refuse. That is owed to a
+real scan; see [Known limitations](../known-limitations.md) and
 [Tracing real API calls](../guides/tracing-api-calls.md).
 
 Every control that reads a type fed by an incomplete unit becomes `not-evaluated`, with that

--- a/docs/reference/output-formats.fr.md
+++ b/docs/reference/output-formats.fr.md
@@ -30,7 +30,7 @@ verdict. Voir [Codes de sortie](exit-codes.fr.md).
 | `findings` | forme de `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | forme du document `--format assessment` | **v1** |
 | `bundle` | forme du bundle de preuve (fichiers, rôles, manifest) | **v3** |
-| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v13** |
+| `inventory` | forme de l'inventaire normalisé (enveloppe, ressource, types et attributs) | **v14** |
 <!-- /pepin:gen surface-versions -->
 
 « Gelé » signifie qu'un test échoue quand la forme bouge sans que sa version ait suivi : les

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -30,7 +30,7 @@ See [Exit codes](exit-codes.md).
 | `findings` | shape of `--format json` (`findings` + `summary`) | **v1** |
 | `assessment` | shape of the `--format assessment` document | **v1** |
 | `bundle` | shape of the evidence bundle (files, roles, manifest) | **v3** |
-| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v13** |
+| `inventory` | shape of the normalized inventory (envelope, resource, types and attributes) | **v14** |
 <!-- /pepin:gen surface-versions -->
 
 "Frozen" means a test fails when the shape moves and its version has not: field paths and JSON

--- a/internal/assess/collection.go
+++ b/internal/assess/collection.go
@@ -160,6 +160,12 @@ func OutcomeLabel(o model.CollectionOutcome) string {
 			"pagination interrupted (truncated inventory)")
 	case model.OutcomeUnreadable:
 		return i18n.T("réponse illisible", "unreadable response")
+	case model.OutcomeUnauthenticated:
+		return i18n.T("identifiants non reconnus par l'API",
+			"credentials not recognized by the API")
+	case model.OutcomeRejected:
+		return i18n.T("requête refusée par l'API (le service, lui, répond)",
+			"request refused by the API (the service itself is answering)")
 	case model.OutcomeUnavailable:
 		return i18n.T("service indisponible", "service unavailable")
 	}

--- a/internal/assess/refusal_reason_test.go
+++ b/internal/assess/refusal_reason_test.go
@@ -1,0 +1,98 @@
+package assess
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stephrobert/pepin/internal/i18n"
+	"github.com/stephrobert/pepin/internal/model"
+)
+
+// La RAISON lue par l'opérateur, pour chacune des trois classes de refus.
+//
+// L'issue #91 ne portait pas sur le statut d'un contrôle — aucun `pass` ne
+// sortait d'un refus, l'invariant de la vague 4 tenait. Elle portait sur la
+// PHRASE : « service indisponible » là où la vérité était « la clé n'est pas
+// reconnue ». Un statut juste avec une raison trompeuse coûte le temps de celui
+// qui la lit, et c'est ce temps-là que ce test protège.
+//
+// Les trois phrases doivent envoyer vers TROIS gestes différents : corriger les
+// identifiants, corriger les droits, attendre ou signaler une panne. Une phrase
+// qui envoie vers le mauvais geste est un défaut, même adossée au bon statut.
+func TestEachRefusalSendsTheOperatorToTheRightPlace(t *testing.T) {
+	defer i18n.Set(i18n.Current())
+	i18n.Set(i18n.FR)
+
+	cas := []struct {
+		classe   model.CollectionOutcome
+		attendu  string   // ce que la phrase doit contenir
+		interdit []string // ce qu'elle ne doit surtout pas dire
+	}{
+		{
+			classe:   model.OutcomeUnauthenticated,
+			attendu:  "identifiants",
+			interdit: []string{"indisponible", "privilège"},
+		},
+		{
+			classe:   model.OutcomeRejected,
+			attendu:  "refusée",
+			interdit: []string{"indisponible", "privilège"},
+		},
+		{
+			classe:   model.OutcomePermissionDenied,
+			attendu:  "privilège",
+			interdit: []string{"indisponible"},
+		},
+		{
+			classe:   model.OutcomeUnavailable,
+			attendu:  "indisponible",
+			interdit: []string{"privilège", "identifiants"},
+		},
+	}
+	for _, c := range cas {
+		got := OutcomeLabel(c.classe)
+		if !strings.Contains(got, c.attendu) {
+			t.Errorf("classe %q : libellé %q, attendu qu'il contienne %q", c.classe, got, c.attendu)
+		}
+		for _, mot := range c.interdit {
+			if strings.Contains(got, mot) {
+				t.Errorf("classe %q : le libellé %q contient %q — il envoie l'opérateur "+
+					"corriger la mauvaise chose", c.classe, got, mot)
+			}
+		}
+	}
+}
+
+// Le DROIT REQUIS ne se nomme que sur un refus de droit.
+//
+// C'est la moitié la plus facile à casser du correctif. Si `unauthenticated`
+// venait à se ranger sous `permission_denied`, la phrase dirait « privilège
+// insuffisant (droit requis : api:ReadVms) » à un opérateur dont la clé n'existe
+// pas. Il irait attacher une politique à une identité absente — exactement le
+// coût que l'issue #91 décrit, déplacé d'un cran.
+func TestOnlyAMissingRightNamesTheRequiredGrant(t *testing.T) {
+	defer i18n.Set(i18n.Current())
+	i18n.Set(i18n.FR)
+
+	const droit = "api:ReadVms"
+	unite := func(o model.CollectionOutcome) model.CollectionUnit {
+		return model.CollectionUnit{Unit: "security_group", Attempted: true, Error: o}
+	}
+
+	if got := IncompleteReason(unite(model.OutcomePermissionDenied), droit); !strings.Contains(got, droit) {
+		t.Errorf("refus de DROIT : %q ne nomme pas le droit requis — c'est pourtant "+
+			"la seule classe où le nommer aide", got)
+	}
+	for _, o := range []model.CollectionOutcome{
+		model.OutcomeUnauthenticated,
+		model.OutcomeRejected,
+		model.OutcomeUnavailable,
+		model.OutcomeTimeout,
+	} {
+		if got := IncompleteReason(unite(o), droit); strings.Contains(got, droit) {
+			t.Errorf("classe %q : %q nomme le droit %q. Élargir une politique n'y "+
+				"changerait rien, et le suggérer fait élargir des privilèges au hasard.",
+				o, got, droit)
+		}
+	}
+}

--- a/internal/canary/canary.go
+++ b/internal/canary/canary.go
@@ -23,6 +23,13 @@
 // que d'emprunter ce chiffre-ci — un relevé d'accessibilité d'endpoint n'est pas
 // une preuve de verdict.
 //
+// La distinction a été MESURÉE chez Outscale, et le résultat explique pourquoi
+// le canari ne pouvait pas la faire (issue #91, 2026-09-12) : une clé inconnue
+// sort en 400 · code 4120, une clé valide sans le droit en 403 · code 4. Le
+// canari ne produit jamais que le premier, puisqu'il n'a pas de clé. Ce qu'il
+// classe désormais `unauthenticated` est donc juste — et c'est précisément la
+// preuve qu'il ne peut rien dire du second.
+//
 // # Pourquoi la fraîcheur se juge au préflight, et pas en CI
 //
 // Une porte de test qui rougirait avec le temps est une porte qui rougira un

--- a/internal/collect/refusal_test.go
+++ b/internal/collect/refusal_test.go
@@ -1,0 +1,158 @@
+package collect
+
+import (
+	"testing"
+
+	"github.com/stephrobert/pepin/internal/model"
+)
+
+// Les TROIS refus d'Outscale, tels qu'ils ont été mesurés — et ils ne veulent
+// pas dire la même chose.
+//
+// # Pourquoi cette mesure a coûté un compte réel
+//
+// L'issue #91 avait relevé, avec des identifiants SYNTHÉTIQUES, qu'Outscale
+// refuse en 400 là où Scaleway refuse en 401 et Exoscale en 403. Elle s'était
+// arrêtée là, et elle avait raison de s'arrêter : des identifiants synthétiques
+// ne produisent qu'un seul des trois refus. Ils ne peuvent pas distinguer « la
+// clé est inconnue » de « la clé est bonne mais le droit manque », et mapper
+// l'un sur l'autre aurait remplacé un mensonge par le mensonge inverse.
+//
+// Les corps ci-dessous sont les réponses RÉELLES de l'OAPI eu-west-2, relevées
+// le 2026-09-12 avec une identité EIM créée pour la mesure, ne portant que
+// `api:ReadVms`, puis détruite. L'appel AUTORISÉ a été joué d'abord et a rendu
+// 200 : sans ce témoin, un refus aurait pu venir de la signature, et la mesure
+// n'aurait rien mesuré.
+//
+// # Ce que chaque ligne empêche
+//
+// Elles empêchent le classement par STATUT, qui se trompe ici dans les deux
+// sens : l'échec d'authentification sort en 400 (rangé « service
+// indisponible »), l'échec d'autorisation sort en 401 dans la table officielle
+// (rangé « privilège insuffisant », ce qui est juste par accident). Le statut
+// n'est pas le contrat ; le code d'erreur l'est.
+func TestTheThreeMeasuredOutscaleRefusalsDoNotMeanTheSameThing(t *testing.T) {
+	cas := []struct {
+		nom    string
+		status int
+		body   string
+		veut   model.CollectionOutcome
+		parce  string
+	}{
+		{
+			nom:    "clé d'accès inexistante — le cas des identifiants synthétiques",
+			status: 400,
+			body: `{"Errors":[{"Details":"","Type":"InvalidParameterValue","Code":"4120"}],` +
+				`"ResponseContext":{"RequestId":"f7a55666-299a-4c32-8a47-61f0ce9ba5b1"}}`,
+			veut:  model.OutcomeUnauthenticated,
+			parce: "code 4120 = ErrorAuthenticationexception, documenté en 400",
+		},
+		{
+			nom:    "clé existante, signature invalide",
+			status: 401,
+			body: `{"Errors":[{"Details":"","Type":"AccessDenied","Code":"1"}],` +
+				`"ResponseContext":{"RequestId":"cd37784c-ba01-45ed-a6fd-f801d8665b09"}}`,
+			veut:  model.OutcomeUnauthenticated,
+			parce: "code 1 = ErrorAuthenticationFailed : la clé existe, elle signe mal",
+		},
+		{
+			nom:    "clé valide, droit manquant — la mesure que l'issue réclamait",
+			status: 403,
+			body: `{"Errors":[{"Details":"You are not authorized to perform this action.",` +
+				`"Type":"AccessDenied","Code":"4"}],` +
+				`"ResponseContext":{"RequestId":"2d3016ea-5e06-422f-8508-a6ab22e5c9d4"}}`,
+			veut: model.OutcomePermissionDenied,
+			parce: "le seul des trois où élargir la politique du compte de scan " +
+				"change quelque chose",
+		},
+	}
+	for _, c := range cas {
+		got, detail := Classify(&HTTPError{Status: c.status, Call: "POST /api/v1/ReadSecurityGroups", Body: c.body})
+		if got != c.veut {
+			t.Errorf("%s : classé %q, attendu %q (%s)", c.nom, got, c.veut, c.parce)
+		}
+		// Le corps voyage dans le détail : c'est lui que l'opérateur lit quand la
+		// classe ne suffit pas, et il est scellé dans le bundle de preuve.
+		if detail == "" {
+			t.Errorf("%s : détail vide — la réponse du fournisseur doit être conservée", c.nom)
+		}
+	}
+}
+
+// Un 4xx n'est JAMAIS « service indisponible ».
+//
+// C'est le défaut nommé par l'issue #91, et il n'était pas cosmétique : le
+// relevé de canari portait `classified: unavailable` sur les DIX-SEPT endpoints
+// Outscale — tous répondant, aucun en panne. Un opérateur qui lit « service
+// indisponible » va consulter une page d'état pendant que le plan de contrôle
+// répond parfaitement.
+//
+// La borne haute compte autant : un 5xx, lui, reste `unavailable`, parce que là
+// le service n'a vraiment pas répondu.
+func TestAnAnsweringServiceIsNeverCalledUnavailable(t *testing.T) {
+	refus := []int{400, 402, 405, 409, 413, 415, 418, 422, 451, 499}
+	for _, s := range refus {
+		got := outcomeForStatus(s)
+		if got == model.OutcomeUnavailable {
+			t.Errorf("HTTP %d classé %q : le service A RÉPONDU. Dire « indisponible » "+
+				"envoie l'opérateur regarder une page d'état au lieu de sa requête.", s, got)
+		}
+		if got != model.OutcomeRejected {
+			t.Errorf("HTTP %d classé %q, attendu %q", s, got, model.OutcomeRejected)
+		}
+	}
+
+	// Les classes fines gardent la main sur la classe large.
+	fines := map[int]model.CollectionOutcome{
+		401: model.OutcomePermissionDenied,
+		403: model.OutcomePermissionDenied,
+		404: model.OutcomeNotFound,
+		410: model.OutcomeNotFound,
+		408: model.OutcomeTimeout,
+		504: model.OutcomeTimeout,
+		429: model.OutcomeRateLimited,
+	}
+	for s, veut := range fines {
+		if got := outcomeForStatus(s); got != veut {
+			t.Errorf("HTTP %d classé %q, attendu %q — la nouvelle classe large a "+
+				"absorbé une classe fine", s, got, veut)
+		}
+	}
+
+	// ET le contre-exemple : un service qui n'a vraiment pas répondu.
+	for _, s := range []int{500, 502, 503} {
+		if got := outcomeForStatus(s); got != model.OutcomeUnavailable {
+			t.Errorf("HTTP %d classé %q, attendu %q — un 5xx est la seule chose "+
+				"qu'« indisponible » doive désigner", s, got, model.OutcomeUnavailable)
+		}
+	}
+}
+
+// Un corps qui n'est pas l'enveloppe attendue ne change RIEN au classement.
+//
+// La lecture du corps est opportuniste par construction : elle raffine quand
+// elle reconnaît un code documenté, et se tait autrement. Sans cette garantie,
+// un proxy qui renvoie une page HTML, ou un fournisseur dont l'enveloppe
+// ressemble de loin à celle d'Outscale, déplacerait des verdicts.
+func TestAnUnrecognizedBodyLeavesTheStatusInCharge(t *testing.T) {
+	corps := []struct{ nom, body string }{
+		{"corps vide", ""},
+		{"page HTML d'un proxy", "<html><body>502 Bad Gateway</body></html>"},
+		{"JSON sans enveloppe d'erreur", `{"vms":[]}`},
+		{"enveloppe présente mais JSON tronqué", `{"Errors":[{"Code":"4120"`},
+		{"code inconnu de la table documentée", `{"Errors":[{"Type":"DefaultError","Code":"0"}]}`},
+		{"bon code, mauvais type", `{"Errors":[{"Type":"DependencyProblem","Code":"4120"}]}`},
+		{"Errors vide", `{"Errors":[]}`},
+		{"Errors null", `{"Errors":null}`},
+	}
+	for _, c := range corps {
+		if got := outcomeForAPIErrorCode(c.body); got != "" {
+			t.Errorf("%s : le corps a rendu %q alors qu'il ne dit rien de reconnaissable.\n"+
+				"  Raffiner sur un corps non reconnu, c'est deviner.", c.nom, got)
+		}
+		// Et de bout en bout : le statut garde la main.
+		if got, _ := Classify(&HTTPError{Status: 400, Body: c.body}); got != model.OutcomeRejected {
+			t.Errorf("%s : classé %q, attendu %q", c.nom, got, model.OutcomeRejected)
+		}
+	}
+}

--- a/internal/collect/status.go
+++ b/internal/collect/status.go
@@ -83,7 +83,15 @@ func Classify(err error) (model.CollectionOutcome, string) {
 
 	var he *HTTPError
 	if errors.As(err, &he) {
-		return outcomeForStatus(he.Status), detailf("HTTP %d · %s · %s", he.Status, he.Call, he.Body)
+		o := outcomeForStatus(he.Status)
+		// Le CORPS avant le statut, quand il porte un code d'erreur documenté.
+		// Chez Outscale le statut se trompe dans les deux sens (cf.
+		// outcomeForAPIErrorCode), et un statut qui se trompe entraîne une
+		// raison qui se trompe.
+		if refined := outcomeForAPIErrorCode(he.Body); refined != "" {
+			o = refined
+		}
+		return o, detailf("HTTP %d · %s · %s", he.Status, he.Call, he.Body)
 	}
 	var te *TruncatedError
 	if errors.As(err, &te) {
@@ -103,8 +111,12 @@ func Classify(err error) (model.CollectionOutcome, string) {
 	var withCode interface{ ErrorCode() string }
 	if errors.As(err, &withCode) {
 		switch withCode.ErrorCode() {
+		case "InvalidAccessKeyId", "SignatureDoesNotMatch":
+			// La clé n'est pas reconnue, ou elle signe mal : ce n'est pas un droit
+			// qui manque. Élargir une politique n'y changerait rien.
+			return model.OutcomeUnauthenticated, detailf("%s", err.Error())
 		case "AccessDenied", "AccessDeniedException", "AllAccessDisabled", "Forbidden",
-			"UnauthorizedOperation", "InvalidAccessKeyId", "SignatureDoesNotMatch":
+			"UnauthorizedOperation":
 			return model.OutcomePermissionDenied, detailf("%s", err.Error())
 		case "SlowDown", "RequestLimitExceeded", "TooManyRequests", "Throttling":
 			return model.OutcomeRateLimited, detailf("%s", err.Error())
@@ -128,7 +140,13 @@ func Classify(err error) (model.CollectionOutcome, string) {
 
 // outcomeForStatus classe un statut HTTP. 401 et 403 partagent la même classe :
 // des deux côtés, le compte de scan ne voit pas la surface, et c'est la seule
-// chose que l'utilisateur a à corriger.
+// chose que le statut SEUL permette d'affirmer.
+//
+// Un 4xx non classé rend OutcomeRejected, jamais OutcomeUnavailable. Le service
+// a répondu : c'est même la preuve qu'il fonctionne. Le ranger en « service
+// indisponible » envoie l'opérateur consulter une page d'état pendant que le
+// plan de contrôle répond parfaitement — le défaut mesuré par l'issue #91, qui
+// touchait les dix-huit endpoints Outscale du relevé de canari.
 func outcomeForStatus(status int) model.CollectionOutcome {
 	switch {
 	case status == 401 || status == 403:
@@ -139,8 +157,70 @@ func outcomeForStatus(status int) model.CollectionOutcome {
 		return model.OutcomeRateLimited
 	case status == 408 || status == 504:
 		return model.OutcomeTimeout
-	case status >= 400:
+	case status >= 400 && status < 500:
+		return model.OutcomeRejected
+	case status >= 500:
 		return model.OutcomeUnavailable
+	}
+	return ""
+}
+
+// apiErrorEnvelope est l'enveloppe d'erreur de l'API OUTSCALE (OAPI), telle que
+// la réponse la porte. Elle est lue de façon OPPORTUNISTE : un corps qui n'a pas
+// cette forme ne produit rien, et le statut garde le dernier mot.
+type apiErrorEnvelope struct {
+	Errors []struct {
+		Type string `json:"Type"`
+		Code string `json:"Code"`
+	} `json:"Errors"`
+}
+
+// outcomeForAPIErrorCode raffine la classe à partir du CODE d'erreur que le
+// fournisseur documente, pour les seuls cas où le statut HTTP induit en erreur.
+//
+// Source du contrat : table officielle des erreurs de l'API OUTSCALE,
+// https://docs.outscale.com/api-errors.html (relevée le 2026-09-12).
+//
+//	Code 4120 · InvalidParameterValue · ErrorAuthenticationexception · HTTP 400
+//	Code    1 · AccessDenied          · ErrorAuthenticationFailed    · HTTP 401
+//	Code    5 · AccessDenied          · ErrorNotAuthorized           · HTTP 401
+//
+// Ces trois lignes disent pourquoi le statut ne suffit pas, et pourquoi il ne
+// suffira jamais : l'échec d'AUTHENTIFICATION sort en 400 quand la clé est
+// inconnue, et l'échec d'AUTORISATION sort en 401. Un classement par statut
+// range donc le premier en « service indisponible » et le second en « privilège
+// insuffisant » — les deux erreurs possibles, dans les deux sens.
+//
+// # Ce qui a été mesuré, et ce qui ne l'a pas été
+//
+// Mesuré le 2026-09-12 sur eu-west-2, avec une identité EIM créée pour
+// l'occasion puis détruite, ne portant que `api:ReadVms` (issue #91) :
+//
+//	clé inexistante             → 400 · InvalidParameterValue · 4120
+//	clé connue, secret faux     → 401 · AccessDenied          · 1
+//	clé valide, droit manquant  → 403 · AccessDenied          · 4
+//
+// Le troisième cas — celui que l'issue réclamait et qu'aucun identifiant
+// synthétique ne pouvait produire — n'est PAS dans la table publiée : le code 4
+// n'y figure pas, et son voisin documenté `ErrorNotAuthorized` y est donné en
+// 401. Il n'est donc pas mappé ici : le statut 403 le classe déjà
+// permission_denied, ce qui est la bonne réponse, et affirmer un code absent de
+// la doc serait l'inventer (CLAUDE.md §2).
+//
+// Tout code non listé retombe sur le statut. Une classe large et vraie vaut
+// mieux qu'une classe fine et devinée.
+func outcomeForAPIErrorCode(body string) model.CollectionOutcome {
+	var env apiErrorEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		return ""
+	}
+	for _, e := range env.Errors {
+		switch {
+		case e.Code == "4120" && e.Type == "InvalidParameterValue":
+			return model.OutcomeUnauthenticated
+		case e.Code == "1" && e.Type == "AccessDenied":
+			return model.OutcomeUnauthenticated
+		}
 	}
 	return ""
 }

--- a/internal/model/collection.go
+++ b/internal/model/collection.go
@@ -61,6 +61,28 @@ const (
 	// OutcomeUnreadable : la réponse n'était pas le document attendu (JSON
 	// invalide, schéma inconnu).
 	OutcomeUnreadable CollectionOutcome = "unreadable"
+	// OutcomeUnauthenticated : l'API n'a pas RECONNU les identifiants — clé
+	// inconnue, signature invalide. Distinct de OutcomePermissionDenied, et la
+	// distinction est celle de l'action à mener : ici on corrige les
+	// IDENTIFIANTS du compte de scan, là on corrige ses DROITS. Dire
+	// « privilège insuffisant » sur une clé inconnue envoie élargir une
+	// politique attachée à une identité qui n'existe pas.
+	//
+	// Cette classe ne se déduit JAMAIS d'un statut HTTP seul. Outscale place son
+	// erreur d'authentification en 400 (code 4120) et son erreur de DROIT en 401
+	// (code 5, `ErrorNotAuthorized`) : le statut ne sépare pas les deux, et le
+	// croire produirait l'inverse exact du défaut qu'on corrige. Seul un code
+	// d'erreur documenté par le fournisseur y mène.
+	OutcomeUnauthenticated CollectionOutcome = "unauthenticated"
+	// OutcomeRejected : l'API a RÉPONDU et a refusé la requête (4xx non classé
+	// par ailleurs). Le service fonctionne ; c'est la requête, ou ce qu'elle
+	// porte, qu'il n'a pas voulu.
+	//
+	// Elle existe parce que la seule autre issue était un mensonge. Un 400 rangé
+	// en « service indisponible » envoie l'opérateur consulter une page d'état
+	// pendant que le plan de contrôle répond parfaitement — le défaut que
+	// l'issue #91 a mesuré sur les trois fournisseurs.
+	OutcomeRejected CollectionOutcome = "rejected"
 	// OutcomeUnavailable : le service n'a pas répondu (5xx, erreur de transport,
 	// cause non classée).
 	OutcomeUnavailable CollectionOutcome = "unavailable"

--- a/internal/model/schema.go
+++ b/internal/model/schema.go
@@ -182,7 +182,17 @@ import (
 //	bien qu'ajouter un type sans région RETIRE de la couverture au lieu d'en ajouter
 //	— mesuré au premier essai, `governance_resource_region_in_eu` passant de `pass` à
 //	« non évalué ».
-const InventoryFormat = "pepin-inventory/v13"
+//
+// v14 : l'état de collecte peut porter deux classes d'échec de plus,
+//
+//	`unauthenticated` (l'API n'a pas reconnu les identifiants) et `rejected` (l'API
+//	a répondu et refusé la requête). Le SCHÉMA ne change pas — `error` était déjà une
+//	chaîne libre — mais l'ÉVENTAIL de ses valeurs, si, et un consommateur qui
+//	l'énumère doit le savoir. Un 4xx non classé rendait `unavailable`, ce qui faisait
+//	lire « service indisponible » à dix-huit endpoints Outscale qui répondaient tous
+//	(issue #91). Le bump existe pour cette raison : un contrat gelé dont les VALEURS
+//	bougent en silence est un contrat cassé sans avertissement (ADR-0003).
+const InventoryFormat = "pepin-inventory/v14"
 
 // InventorySchemaVersion extrait le N du suffixe `/vN`. Comme pour le bundle, la
 // constante et le signal sur le fil sont la même chose : impossible de faire

--- a/internal/quality/snapshot.json
+++ b/internal/quality/snapshot.json
@@ -37,9 +37,9 @@
     },
     {
       "provider": "outscale",
-      "recorded": "2026-08-21",
+      "recorded": "2026-09-12",
       "authenticated": false,
-      "answered": 17,
+      "answered": 18,
       "moved": 0,
       "unreachable": 0
     },

--- a/references/canary/outscale.yaml
+++ b/references/canary/outscale.yaml
@@ -6,11 +6,11 @@
 #
 # Ce relevé ne porte aucun identifiant : le canari n'en a jamais eu.
 provider: outscale
-recorded: 2026-08-21
-pepin_version: "v0.3.0-2-g1ee97f5"
+recorded: 2026-09-12
+pepin_version: "v0.4.0-11-gbf8bf63-dirty"
 authenticated: false
 summary:
-  answered: 17
+  answered: 18
   moved: 0
   unreachable: 0
 units:
@@ -20,70 +20,70 @@ units:
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadAccessKeys"
-    classified: unavailable
+    classified: unauthenticated
   - unit: api_access_policy
     verdict: answered
     status: 400
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadApiAccessPolicy"
-    classified: unavailable
+    classified: unauthenticated
   - unit: api_access_rule
     verdict: answered
     status: 400
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadApiAccessRules"
-    classified: unavailable
+    classified: unauthenticated
   - unit: api_access_summary
     verdict: answered
     status: 400
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadApiAccessRules"
-    classified: unavailable
+    classified: unauthenticated
   - unit: blockstorage_snapshot
     verdict: answered
     status: 400
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadAccounts"
-    classified: unavailable
+    classified: unauthenticated
   - unit: blockstorage_volume
     verdict: answered
     status: 400
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadVolumes"
-    classified: unavailable
+    classified: unauthenticated
   - unit: compute_image
     verdict: answered
     status: 400
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadAccounts"
-    classified: unavailable
+    classified: unauthenticated
   - unit: compute_instance
     verdict: answered
     status: 400
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadVms"
-    classified: unavailable
+    classified: unauthenticated
   - unit: iam_policy
     verdict: answered
     status: 400
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadPolicies"
-    classified: unavailable
+    classified: unauthenticated
   - unit: iam_policy_inline
     verdict: answered
     status: 400
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadUsers"
-    classified: unavailable
+    classified: unauthenticated
   - unit: kubernetes_cluster
     verdict: answered
     status: 500
@@ -97,21 +97,28 @@ units:
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadLoadBalancers"
-    classified: unavailable
+    classified: unauthenticated
   - unit: network
     verdict: answered
     status: 400
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadNets"
-    classified: unavailable
+    classified: unauthenticated
+  - unit: network_interface
+    verdict: answered
+    status: 400
+    method: POST
+    host: api.eu-west-2.outscale.com
+    path: "/api/v1/ReadVms"
+    classified: unauthenticated
   - unit: network_peering
     verdict: answered
     status: 400
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadNetPeerings"
-    classified: unavailable
+    classified: unauthenticated
   - unit: object_storage_bucket
     verdict: answered
     status: 403
@@ -122,11 +129,11 @@ units:
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadSecurityGroups"
-    classified: unavailable
+    classified: unauthenticated
   - unit: subnet
     verdict: answered
     status: 400
     method: POST
     host: api.eu-west-2.outscale.com
     path: "/api/v1/ReadSubnets"
-    classified: unavailable
+    classified: unauthenticated

--- a/tools/release/canary.sh
+++ b/tools/release/canary.sh
@@ -35,9 +35,11 @@
 #   que le chemin déclaré existe encore     | ce qu'un tenant contient
 #   la classe qu'un refus reçoit            | qu'un droit SUFFISANT rende 200
 #
-# Un refus de SIGNATURE n'est pas un refus de DROIT. Que le fournisseur réponde
-# la même chose à une clé valide sans permission reste dû à un scan authentifié,
-# et le relevé le dit à sa place.
+# Un refus de SIGNATURE n'est pas un refus de DROIT. Chez Outscale, la mesure a
+# été faite (issue #91, 2026-09-12) et elle tranche : clé inconnue → 400 · 4120
+# (`unauthenticated`), clé valide sans le droit → 403 · 4 (`permission_denied`).
+# Le canari ne produit que le premier, faute de clé. Pour les autres
+# fournisseurs, la question reste due à un scan authentifié.
 #
 # ─── CE QU'IL ENVOIE, ET À QUELLE FRÉQUENCE ──────────────────────────────────
 #


### PR DESCRIPTION
Closes #91. Stacked on #248 (`feat/scaleway-api-key-expiration-enforced`) — merge that one first.

## The defect, and why it was not cosmetic

Outscale answers `400` where Scaleway answers `401` and Exoscale `403`. Any `4xx` that no finer class claimed fell through to `unavailable`, so the canary record filed **all eighteen Outscale endpoints** under *"service unavailable"* — every one of which had answered. An operator reading that goes to check a status page while the control plane works perfectly.

No `PASS` ever came out of it — the Wave 4 lock held. What was false is the **reason**, and a true status with a misleading reason costs the reader's time.

## The measurement the issue asked for

The issue stated it plainly:

> Trancher exige d'observer un `400` d'Outscale **sur un appel correctement signé dont le compte n'a pas le droit**, ce que ce dépôt ne peut pas produire sans identifiants réels.

Measured **2026-09-12**, `eu-west-2`, with an EIM identity created for the measurement, carrying only `api:ReadVms`, then destroyed. An **authorized** call was played first as a witness — without it, a refusal could have come from the signature and the probe would have measured nothing:

| Situation of the scanning account | HTTP | `Type` · `Code` | Class |
|---|---|---|---|
| Access key does not exist | `400` | `InvalidParameterValue` · `4120` | `unauthenticated` |
| Key exists, invalid signature | `401` | `AccessDenied` · `1` | `unauthenticated` |
| Valid key, missing right | `403` | `AccessDenied` · `4` | `permission_denied` |

The `400` is therefore neither a missing right nor an outage: it is a **credential the API does not know**. The first row is the only one synthetic credentials can produce, which is exactly why #91 could not settle it.

**Clean-up, per the absolute rule:** access key deactivated then deleted, policy unlinked and deleted, user deleted. Final state verified — `ReadUsers` → `[]`, `ReadPolicies` → `[]`. No probe credential ever printed, and the local profile files were shredded.

## What changes

Two classes join the collection state:

- **`unauthenticated`** — the API did not recognize the credentials.
- **`rejected`** — the API answered and refused the request; the service works.

and a `4xx` is **never** `unavailable` again — that class now names only what did not answer.

**The status alone cannot carry this, and never will.** Outscale's own [error table](https://docs.outscale.com/api-errors.html) documents its **authentication** error at `400` (code `4120`, `ErrorAuthenticationexception`) and its **authorization** error at `401` (code `5`, `ErrorNotAuthorized`). Classifying by status gets both wrong, in both directions. So the **error code** decides, and only codes that table documents are mapped — the measured `403 · 4` is *not* in it, so it is left to its status rather than asserted (`CLAUDE.md` §2).

`InvalidAccessKeyId` and `SignatureDoesNotMatch` on the object-storage path move to `unauthenticated` for the same reason: widening a policy does not make an unknown key known. And the *required grant* hint is now named on `permission_denied` only — suggesting it on an unknown key sends the operator to attach a policy to an identity that does not exist.

**No verdict moves on an unchanged tenant.** A refusal degraded a control to `not-evaluated` before, and still does.

## Verified against the real control plane

`tools/release/canary.sh outscale` was re-run: its eighteen endpoints now record `classified: unauthenticated` instead of `unavailable`. That is exactly right — the canary has no key — and it is what proves the fix end to end, not just in a unit test.

## Falsification

Five gates, each **seen red** before being kept:

| Mutation | Gate |
|---|---|
| a `4xx` goes back to `unavailable` | `TestAnAnsweringServiceIsNeverCalledUnavailable` |
| the body is no longer read | `TestTheThreeMeasuredOutscaleRefusalsDoNotMeanTheSameThing` |
| `4120` filed as a missing right (the inverse lie) | *idem* |
| `unauthenticated` reads "service unavailable" again | `TestEachRefusalSendsTheOperatorToTheRightPlace` |
| the required grant is named on every class | `TestOnlyAMissingRightNamesTheRequiredGrant` |

A sixth mutation — removing the `strings.Contains` fast path — stayed green, which proved the guard guarded nothing. It was deleted rather than kept as decoration.

The measured bodies themselves are the fixtures: `internal/collect/refusal_test.go` carries the three real payloads, request IDs included.

## Impact ADR

- **ADR-0003** (frozen inventory contract) — respected. `pepin-inventory` goes to **v14**: the schema is unchanged, but the set of values `error` can take is not, and a consumer enumerating them must be told. Bump + `frozen-update` + CHANGELOG, both languages.
- **ADR-0006** / **ADR-0015** — untouched. A refusal still degrades to `not-evaluated`; it never passes.
- **ADR-0012** (no credentials in CI) — respected. The measurement is a maintainer gesture, dated and recorded; no credential enters the repository or CI, and the canary that replays it has none by construction.
- **New: ADR-0023** — *un statut HTTP ne classe pas un refus ; le code d'erreur documenté, si*. It records the decision and, in **Alternatives écartées**, the three plausible solutions that must not come back: mapping `400 → permission_denied` (the inverse lie, rejected by #91 itself), keeping `unavailable` as the `4xx` fallback, and deriving the class from HTTP semantics — which Outscale's own documentation contradicts.

## Documentation

`docs/reference/inventory.md` and `.fr.md` carried a paragraph that this measurement makes false — *"what no check in this repository establishes is which class a given provider will trigger: whether Outscale answers `403` rather than `200`…"*. Rewritten in both languages, with the measured table and its limit named: code `4` is measured, not documented. The two comments in `internal/canary/canary.go` and `tools/release/canary.sh` that still declared the question open now cite the measurement, scoped to Outscale — for the other providers it remains owed to an authenticated scan.

## Gates

`mise run validate` · `mise run test` · `mise run audit` · `mise run adr-drift` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
